### PR TITLE
fix: reset indexing status when abort controller is missing

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -662,16 +662,16 @@ export async function cancelIndexing(repoId: string): Promise<{ error?: string }
         data: { indexStatus: "pending" },
       });
 
-      pubby.trigger(`presence-org-${repo.organizationId}`, "index-status", {
-        repoId,
-        status: "cancelled",
-      });
-
-      revalidatePath("/");
+      revalidatePath("/repositories");
     } catch (error) {
       console.error(`[abort-indexing] Failed to reset status for repo ${repoId}:`, error);
       return { error: "Failed to cancel indexing. Please try again." };
     }
+
+    pubby.trigger(`presence-org-${repo.organizationId}`, "index-status", {
+      repoId,
+      status: "cancelled",
+    });
   }
 
   return {};


### PR DESCRIPTION
## Summary
- When `abortIndexing()` returns false (no in-memory controller, e.g. after server restart), reset DB status to `pending` and trigger a Pubby event
- Prevents repositories from being stuck in "indexing" state forever

Closes #28

## Files Changed
- `apps/web/app/(app)/actions.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)