### PR TITLE
feat: add blog system with admin CRUD, public pages, and search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ HEARTBEAT.md
 
 # openclaw
 .openclaw/
+
+articles/

--- a/apps/web/app/(app)/admin/admin-nav.tsx
+++ b/apps/web/app/(app)/admin/admin-nav.tsx
@@ -12,6 +12,7 @@ import {
   IconEye,
   IconRobot,
   IconPackage,
+  IconNews,
 } from "@tabler/icons-react";
 
 const items = [
@@ -23,6 +24,7 @@ const items = [
   { href: "/admin/review-defaults", label: "Review Defaults", icon: IconEye },
   { href: "/admin/blocked-authors", label: "Blocked Authors", icon: IconRobot },
   { href: "/admin/safe-packages", label: "Safe Packages", icon: IconPackage },
+  { href: "/admin/blog", label: "Blog Posts", icon: IconNews },
 ];
 
 export function AdminNav() {

--- a/apps/web/app/(app)/admin/blog/[id]/edit/page.tsx
+++ b/apps/web/app/(app)/admin/blog/[id]/edit/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@octopus/db";
+import { BlogEditor } from "../../blog-editor";
+
+export default async function EditBlogPostPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const post = await prisma.blogPost.findUnique({
+    where: { id, deletedAt: null },
+  });
+
+  if (!post) notFound();
+
+  return (
+    <BlogEditor
+      post={{
+        id: post.id,
+        title: post.title,
+        slug: post.slug,
+        excerpt: post.excerpt,
+        content: post.content,
+        coverImageUrl: post.coverImageUrl,
+        status: post.status,
+      }}
+    />
+  );
+}

--- a/apps/web/app/(app)/admin/blog/actions.ts
+++ b/apps/web/app/(app)/admin/blog/actions.ts
@@ -1,0 +1,201 @@
+"use server";
+
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth";
+import { isAdminEmail } from "@/lib/admin";
+import { prisma } from "@octopus/db";
+import { revalidatePath } from "next/cache";
+import { createHash } from "crypto";
+import Anthropic from "@anthropic-ai/sdk";
+
+async function requireAdmin() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session || !isAdminEmail(session.user.email)) {
+    throw new Error("Unauthorized");
+  }
+  return session;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export async function createBlogPost(formData: FormData) {
+  const session = await requireAdmin();
+
+  const title = formData.get("title") as string;
+  const slug = (formData.get("slug") as string) || slugify(title);
+  const excerpt = (formData.get("excerpt") as string) || null;
+  const content = formData.get("content") as string;
+  const coverImageUrl = (formData.get("coverImageUrl") as string) || null;
+  const publish = formData.get("publish") === "true";
+
+  if (!title || !content) {
+    return { error: "Title and content are required" };
+  }
+
+  const existing = await prisma.blogPost.findUnique({ where: { slug } });
+  if (existing) {
+    return { error: "A post with this slug already exists" };
+  }
+
+  const post = await prisma.blogPost.create({
+    data: {
+      title,
+      slug,
+      excerpt,
+      content,
+      coverImageUrl,
+      status: publish ? "published" : "draft",
+      publishedAt: publish ? new Date() : null,
+      authorId: session.user.id,
+      authorName: session.user.name,
+    },
+  });
+
+  revalidatePath("/admin/blog");
+  revalidatePath("/blog");
+  return { success: true, id: post.id };
+}
+
+export async function updateBlogPost(id: string, formData: FormData) {
+  await requireAdmin();
+
+  const title = formData.get("title") as string;
+  const slug = formData.get("slug") as string;
+  const excerpt = (formData.get("excerpt") as string) || null;
+  const content = formData.get("content") as string;
+  const coverImageUrl = (formData.get("coverImageUrl") as string) || null;
+
+  if (!title || !content || !slug) {
+    return { error: "Title, slug, and content are required" };
+  }
+
+  // Check slug uniqueness (excluding current post)
+  const existing = await prisma.blogPost.findUnique({ where: { slug } });
+  if (existing && existing.id !== id) {
+    return { error: "A post with this slug already exists" };
+  }
+
+  await prisma.blogPost.update({
+    where: { id },
+    data: { title, slug, excerpt, content, coverImageUrl },
+  });
+
+  revalidatePath("/admin/blog");
+  revalidatePath("/blog");
+  revalidatePath(`/blog/${slug}`);
+  return { success: true };
+}
+
+export async function publishBlogPost(id: string) {
+  await requireAdmin();
+
+  const post = await prisma.blogPost.update({
+    where: { id },
+    data: { status: "published", publishedAt: new Date() },
+  });
+
+  revalidatePath("/admin/blog");
+  revalidatePath("/blog");
+  revalidatePath(`/blog/${post.slug}`);
+  return { success: true };
+}
+
+export async function unpublishBlogPost(id: string) {
+  await requireAdmin();
+
+  const post = await prisma.blogPost.update({
+    where: { id },
+    data: { status: "draft", publishedAt: null },
+  });
+
+  revalidatePath("/admin/blog");
+  revalidatePath("/blog");
+  revalidatePath(`/blog/${post.slug}`);
+  return { success: true };
+}
+
+export async function deleteBlogPost(id: string) {
+  await requireAdmin();
+
+  const post = await prisma.blogPost.update({
+    where: { id },
+    data: { deletedAt: new Date() },
+  });
+
+  revalidatePath("/admin/blog");
+  revalidatePath("/blog");
+  revalidatePath(`/blog/${post.slug}`);
+  return { success: true };
+}
+
+export async function generateExcerpt(content: string) {
+  await requireAdmin();
+
+  if (!content.trim()) {
+    return { error: "Content is empty" };
+  }
+
+  const client = new Anthropic();
+  const response = await client.messages.create({
+    model: "claude-sonnet-4-20250514",
+    max_tokens: 200,
+    messages: [
+      {
+        role: "user",
+        content: `Write a concise SEO-friendly excerpt (max 150 characters) for this blog post. Return ONLY the excerpt text, nothing else.\n\n${content.slice(0, 4000)}`,
+      },
+    ],
+  });
+
+  const text =
+    response.content[0].type === "text" ? response.content[0].text.trim() : "";
+
+  if (!text) {
+    return { error: "Failed to generate excerpt" };
+  }
+
+  return { success: true, excerpt: text };
+}
+
+// ── Blog API Token Management ───────────────────────────────────────────────
+
+export async function generateBlogApiToken(name: string) {
+  await requireAdmin();
+
+  if (!name.trim()) {
+    return { error: "Token name is required" };
+  }
+
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  const rawToken = `blog_${hex}`;
+  const tokenHash = createHash("sha256").update(rawToken).digest("hex");
+  const tokenPrefix = rawToken.slice(0, 9) + "...";
+
+  await prisma.blogApiToken.create({
+    data: { name, tokenHash, tokenPrefix },
+  });
+
+  revalidatePath("/admin/blog");
+  return { success: true, token: rawToken };
+}
+
+export async function deleteBlogApiToken(id: string) {
+  await requireAdmin();
+
+  await prisma.blogApiToken.update({
+    where: { id },
+    data: { deletedAt: new Date() },
+  });
+
+  revalidatePath("/admin/blog");
+  return { success: true };
+}

--- a/apps/web/app/(app)/admin/blog/blog-admin.tsx
+++ b/apps/web/app/(app)/admin/blog/blog-admin.tsx
@@ -1,0 +1,580 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  IconPlus,
+  IconPencil,
+  IconTrash,
+  IconEye,
+  IconEyeOff,
+  IconKey,
+  IconCopy,
+  IconCheck,
+  IconApi,
+  IconChevronLeft,
+  IconChevronRight,
+} from "@tabler/icons-react";
+import {
+  publishBlogPost,
+  unpublishBlogPost,
+  deleteBlogPost,
+  generateBlogApiToken,
+  deleteBlogApiToken,
+} from "./actions";
+import { toast } from "sonner";
+
+interface BlogPostItem {
+  id: string;
+  title: string;
+  slug: string;
+  status: string;
+  authorName: string;
+  publishedAt: string | null;
+  createdAt: string;
+}
+
+interface BlogApiTokenItem {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  lastUsedAt: string | null;
+  createdAt: string;
+}
+
+function CopyBlock({ children }: { children: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="group relative">
+      <pre className="rounded bg-muted px-4 py-3 pr-12 text-sm font-mono overflow-x-auto whitespace-pre-wrap">{children}</pre>
+      <button
+        type="button"
+        onClick={() => {
+          navigator.clipboard.writeText(children);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        }}
+        className="absolute right-2 top-2 rounded border border-border bg-background p-1.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+      >
+        {copied ? <IconCheck className="size-3.5" /> : <IconCopy className="size-3.5" />}
+      </button>
+    </div>
+  );
+}
+
+export function BlogAdmin({
+  posts,
+  tokens,
+  page,
+  totalPages,
+}: {
+  posts: BlogPostItem[];
+  tokens: BlogApiTokenItem[];
+  page: number;
+  totalPages: number;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [tokenName, setTokenName] = useState("");
+  const [revealedToken, setRevealedToken] = useState<string | null>(null);
+  const [showApiDocs, setShowApiDocs] = useState(false);
+
+  function handlePublish(id: string) {
+    startTransition(async () => {
+      const result = await publishBlogPost(id);
+      if ("error" in result) toast.error(String(result.error));
+      else toast.success("Post published");
+    });
+  }
+
+  function handleUnpublish(id: string) {
+    startTransition(async () => {
+      const result = await unpublishBlogPost(id);
+      if ("error" in result) toast.error(String(result.error));
+      else toast.success("Post unpublished");
+    });
+  }
+
+  function handleDelete(id: string) {
+    if (!confirm("Are you sure you want to delete this post?")) return;
+    startTransition(async () => {
+      const result = await deleteBlogPost(id);
+      if ("error" in result) toast.error(String(result.error));
+      else toast.success("Post deleted");
+    });
+  }
+
+  function handleGenerateToken() {
+    if (!tokenName.trim()) return;
+    startTransition(async () => {
+      const result = await generateBlogApiToken(tokenName.trim());
+      if ("error" in result) {
+        toast.error(String(result.error));
+      } else {
+        setRevealedToken(result.token);
+        setTokenName("");
+        toast.success("Token generated. Copy it now, it won't be shown again.");
+      }
+    });
+  }
+
+  function handleDeleteToken(id: string) {
+    if (!confirm("Are you sure you want to revoke this token?")) return;
+    startTransition(async () => {
+      const result = await deleteBlogApiToken(id);
+      if ("error" in result) toast.error(String(result.error));
+      else toast.success("Token revoked");
+    });
+  }
+
+  function copyToClipboard(text: string) {
+    navigator.clipboard.writeText(text);
+    toast.success("Copied to clipboard");
+  }
+
+  return (
+    <div className="space-y-10">
+      {/* Posts Section */}
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">Blog Posts</h1>
+          <Button asChild>
+            <Link href="/admin/blog/new">
+              <IconPlus className="mr-2 size-4" />
+              New Post
+            </Link>
+          </Button>
+        </div>
+
+        {posts.length === 0 ? (
+          <p className="text-muted-foreground">No blog posts yet.</p>
+        ) : (
+          <div className="rounded-lg border">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b text-left text-sm text-muted-foreground">
+                  <th className="px-4 py-3 font-medium">Title</th>
+                  <th className="px-4 py-3 font-medium">Slug</th>
+                  <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="px-4 py-3 font-medium">Date</th>
+                  <th className="px-4 py-3 font-medium text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {posts.map((post) => (
+                  <tr key={post.id} className="border-b last:border-0">
+                    <td className="px-4 py-3 font-medium">{post.title}</td>
+                    <td className="px-4 py-3 text-sm text-muted-foreground">
+                      /blog/{post.slug}
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge variant={post.status === "published" ? "default" : "secondary"}>
+                        {post.status}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-muted-foreground">
+                      {post.publishedAt
+                        ? new Date(post.publishedAt).toLocaleDateString()
+                        : new Date(post.createdAt).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-1">
+                        <Button variant="ghost" size="icon" asChild>
+                          <Link href={`/admin/blog/${post.id}/edit`}>
+                            <IconPencil className="size-4" />
+                          </Link>
+                        </Button>
+                        {post.status === "draft" ? (
+                          <Button variant="ghost" size="icon" disabled={isPending} onClick={() => handlePublish(post.id)}>
+                            <IconEye className="size-4" />
+                          </Button>
+                        ) : (
+                          <Button variant="ghost" size="icon" disabled={isPending} onClick={() => handleUnpublish(post.id)}>
+                            <IconEyeOff className="size-4" />
+                          </Button>
+                        )}
+                        <Button variant="ghost" size="icon" disabled={isPending} onClick={() => handleDelete(post.id)}>
+                          <IconTrash className="size-4" />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {totalPages > 1 && (
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page <= 1}
+              asChild={page > 1}
+            >
+              {page > 1 ? (
+                <Link href={page === 2 ? "/admin/blog" : `/admin/blog?page=${page - 1}`}>
+                  <IconChevronLeft className="mr-1 size-4" />
+                  Previous
+                </Link>
+              ) : (
+                <span>
+                  <IconChevronLeft className="mr-1 size-4" />
+                  Previous
+                </span>
+              )}
+            </Button>
+            <span className="text-sm text-muted-foreground">
+              {page} / {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages}
+              asChild={page < totalPages}
+            >
+              {page < totalPages ? (
+                <Link href={`/admin/blog?page=${page + 1}`}>
+                  Next
+                  <IconChevronRight className="ml-1 size-4" />
+                </Link>
+              ) : (
+                <span>
+                  Next
+                  <IconChevronRight className="ml-1 size-4" />
+                </span>
+              )}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* API Tokens Section */}
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-bold flex items-center gap-2">
+            <IconKey className="size-5" />
+            API Tokens
+          </h2>
+          <Button variant="outline" onClick={() => setShowApiDocs(!showApiDocs)}>
+            <IconApi className="mr-2 size-4" />
+            {showApiDocs ? "Hide" : "Show"} API Docs
+          </Button>
+        </div>
+
+        {/* Generate Token */}
+        <div className="flex items-center gap-3">
+          <Input
+            value={tokenName}
+            onChange={(e) => setTokenName(e.target.value)}
+            placeholder="Token name (e.g. blog-agent)"
+            className="max-w-xs"
+            onKeyDown={(e) => e.key === "Enter" && handleGenerateToken()}
+          />
+          <Button disabled={isPending || !tokenName.trim()} onClick={handleGenerateToken}>
+            <IconPlus className="mr-2 size-4" />
+            Generate Token
+          </Button>
+        </div>
+
+        {/* Revealed Token */}
+        {revealedToken && (
+          <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-4">
+            <p className="mb-2 text-sm font-medium text-yellow-500">
+              Copy this token now. It won&apos;t be shown again.
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 rounded bg-muted px-3 py-2 text-sm font-mono break-all">
+                {revealedToken}
+              </code>
+              <Button variant="outline" size="icon" onClick={() => copyToClipboard(revealedToken)}>
+                <IconCopy className="size-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Token List */}
+        {tokens.length > 0 && (
+          <div className="rounded-lg border">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b text-left text-sm text-muted-foreground">
+                  <th className="px-4 py-3 font-medium">Name</th>
+                  <th className="px-4 py-3 font-medium">Token</th>
+                  <th className="px-4 py-3 font-medium">Last Used</th>
+                  <th className="px-4 py-3 font-medium">Created</th>
+                  <th className="px-4 py-3 font-medium text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tokens.map((t) => (
+                  <tr key={t.id} className="border-b last:border-0">
+                    <td className="px-4 py-3 font-medium">{t.name}</td>
+                    <td className="px-4 py-3 text-sm font-mono text-muted-foreground">{t.tokenPrefix}</td>
+                    <td className="px-4 py-3 text-sm text-muted-foreground">
+                      {t.lastUsedAt ? new Date(t.lastUsedAt).toLocaleDateString() : "Never"}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-muted-foreground">
+                      {new Date(t.createdAt).toLocaleDateString()}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <Button variant="ghost" size="icon" disabled={isPending} onClick={() => handleDeleteToken(t.id)}>
+                        <IconTrash className="size-4" />
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* API Documentation */}
+        {showApiDocs && (
+          <div className="rounded-lg border bg-muted/30 p-6 space-y-6">
+            <h3 className="text-lg font-bold">Blog API Documentation</h3>
+
+            <div className="space-y-4">
+              <div>
+                <h4 className="font-semibold mb-2">Endpoints</h4>
+                <div className="space-y-1">
+                  <a href="#api-get" className="block rounded bg-muted px-3 py-2 text-sm font-mono hover:bg-muted/80 transition-colors cursor-pointer">
+                    GET  /api/blog — Search & list posts
+                  </a>
+                  <a href="#api-get-search" className="block rounded bg-muted px-3 py-2 text-sm font-mono hover:bg-muted/80 transition-colors cursor-pointer">
+                    GET  /api/blog/search — Quick search (public, no auth)
+                  </a>
+                  <a href="#api-post" className="block rounded bg-muted px-3 py-2 text-sm font-mono hover:bg-muted/80 transition-colors cursor-pointer">
+                    POST /api/blog — Create a new post
+                  </a>
+                </div>
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-2">AI Agent Prompt Example</h4>
+                <CopyBlock>{`You are a blog content agent for Octopus Review (octopus-review.ai), an open source AI code review tool.
+
+Write a blog post about [TOPIC]. The post should be:
+- Written in markdown format
+- Technical but accessible
+- 800-1500 words
+- Include code examples where relevant
+
+STEP 1: Search existing posts to avoid duplicate topics.
+
+GET https://octopus-review.ai/api/blog?q=[TOPIC_KEYWORDS]&status=published
+Authorization: Bearer [YOUR_TOKEN]
+
+Response:
+{
+  "posts": [{ "title": "...", "slug": "...", "excerpt": "..." }],
+  "pagination": { "page": 1, "limit": 10, "total": 0, "totalPages": 0 }
+}
+
+If similar posts exist, choose a different angle or skip.
+
+STEP 2: Create the blog post.
+
+POST https://octopus-review.ai/api/blog
+Authorization: Bearer [YOUR_TOKEN]
+Content-Type: application/json
+
+{
+  "title": "Your Post Title",
+  "content": "[markdown content]",
+  "slug": "your-post-slug",
+  "authorName": "Octopus Team",
+  "status": "draft",
+  "generateSeo": true
+}
+
+Response:
+{
+  "success": true,
+  "id": "clx...",
+  "slug": "your-post-slug",
+  "status": "draft",
+  "excerpt": "AI-generated excerpt...",
+  "url": "/blog/your-post-slug"
+}
+
+Error responses:
+- 401: { "error": "Unauthorized" }
+- 400: { "error": "title and content are required" }
+- 409: { "error": "A post with this slug already exists" }`}</CopyBlock>
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-2">Headers (all requests)</h4>
+                <code className="block rounded bg-muted px-3 py-2 text-sm font-mono">
+                  Authorization: Bearer blog_xxxxxxxxxxxxx
+                </code>
+              </div>
+
+              <hr className="border-border" />
+
+              <h4 id="api-get" className="font-bold text-base scroll-mt-4">GET /api/blog — Search & List</h4>
+
+              <div>
+                <h4 className="font-semibold mb-2">Query Parameters</h4>
+                <div className="rounded border overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b bg-muted/50 text-left">
+                        <th className="px-3 py-2 font-medium">Param</th>
+                        <th className="px-3 py-2 font-medium">Type</th>
+                        <th className="px-3 py-2 font-medium">Default</th>
+                        <th className="px-3 py-2 font-medium">Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr className="border-b"><td className="px-3 py-2 font-mono">q</td><td className="px-3 py-2">string</td><td className="px-3 py-2">—</td><td className="px-3 py-2">Search query (searches title, excerpt, content)</td></tr>
+                      <tr className="border-b"><td className="px-3 py-2 font-mono">status</td><td className="px-3 py-2">string</td><td className="px-3 py-2">all</td><td className="px-3 py-2">&quot;draft&quot; or &quot;published&quot;</td></tr>
+                      <tr className="border-b"><td className="px-3 py-2 font-mono">page</td><td className="px-3 py-2">number</td><td className="px-3 py-2">1</td><td className="px-3 py-2">Page number</td></tr>
+                      <tr><td className="px-3 py-2 font-mono">limit</td><td className="px-3 py-2">number</td><td className="px-3 py-2">10</td><td className="px-3 py-2">Results per page (max 50)</td></tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-2">Search Example (curl)</h4>
+                <CopyBlock>{`curl "https://octopus-review.ai/api/blog?q=vector+search&status=published&limit=5" \\
+  -H "Authorization: Bearer blog_xxxxxxxxxxxxx"`}</CopyBlock>
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-2">Search Response</h4>
+                <CopyBlock>{`{
+  "posts": [
+    {
+      "id": "clx...",
+      "title": "Building an AI Code Review Tool",
+      "slug": "building-an-ai-code-review-tool",
+      "excerpt": "How we built...",
+      "coverImageUrl": "https://...",
+      "status": "published",
+      "authorName": "Ferit",
+      "publishedAt": "2026-03-24T20:19:14.375Z",
+      "createdAt": "2026-03-24T20:19:14.378Z"
+    }
+  ],
+  "pagination": {
+    "page": 1,
+    "limit": 5,
+    "total": 1,
+    "totalPages": 1
+  }
+}`}</CopyBlock>
+              </div>
+
+              <hr className="border-border" />
+
+              <h4 id="api-get-search" className="font-bold text-base scroll-mt-4">GET /api/blog/search — Quick Search</h4>
+
+              <p className="text-sm text-muted-foreground">
+                Public endpoint (no auth required). Used by the blog search UI. Returns only published posts.
+              </p>
+
+              <div>
+                <h4 className="font-semibold mb-2">Query Parameters</h4>
+                <div className="rounded border overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b bg-muted/50 text-left">
+                        <th className="px-3 py-2 font-medium">Param</th>
+                        <th className="px-3 py-2 font-medium">Type</th>
+                        <th className="px-3 py-2 font-medium">Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr><td className="px-3 py-2 font-mono">q</td><td className="px-3 py-2">string</td><td className="px-3 py-2">Search query (required)</td></tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-2">Example</h4>
+                <CopyBlock>{`curl "https://octopus-review.ai/api/blog/search?q=vector+search"`}</CopyBlock>
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-2">Response</h4>
+                <CopyBlock>{`{
+  "posts": [
+    {
+      "title": "Building an AI Code Review Tool",
+      "slug": "building-an-ai-code-review-tool",
+      "excerpt": "How we built..."
+    }
+  ]
+}`}</CopyBlock>
+              </div>
+
+              <hr className="border-border" />
+
+              <h4 id="api-post" className="font-bold text-base scroll-mt-4">POST /api/blog — Create Post</h4>
+
+              <div>
+                <h4 className="font-semibold mb-2">Body Parameters</h4>
+                <div className="rounded border overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b bg-muted/50 text-left">
+                        <th className="px-3 py-2 font-medium">Field</th>
+                        <th className="px-3 py-2 font-medium">Type</th>
+                        <th className="px-3 py-2 font-medium">Required</th>
+                        <th className="px-3 py-2 font-medium">Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr className="border-b"><td className="px-3 py-2 font-mono">title</td><td className="px-3 py-2">string</td><td className="px-3 py-2">Yes</td><td className="px-3 py-2">Post title</td></tr>
+                      <tr className="border-b"><td className="px-3 py-2 font-mono">content</td><td className="px-3 py-2">string</td><td className="px-3 py-2">Yes</td><td className="px-3 py-2">Markdown content</td></tr>
+                      <tr className="border-b"><td className="px-3 py-2 font-mono">slug</td><td className="px-3 py-2">string</td><td className="px-3 py-2">No</td><td className="px-3 py-2">URL slug (auto-generated from title if not provided)</td></tr>
+                      <tr className="border-b"><td className="px-3 py-2 font-mono">excerpt</td><td className="px-3 py-2">string</td><td className="px-3 py-2">No</td><td className="px-3 py-2">Short summary for SEO</td></tr>
+                      <tr className="border-b"><td className="px-3 py-2 font-mono">coverImageUrl</td><td className="px-3 py-2">string</td><td className="px-3 py-2">No</td><td className="px-3 py-2">Cover image URL (1200x628px recommended)</td></tr>
+                      <tr className="border-b"><td className="px-3 py-2 font-mono">authorName</td><td className="px-3 py-2">string</td><td className="px-3 py-2">No</td><td className="px-3 py-2">Author name (default: &quot;Octopus Team&quot;)</td></tr>
+                      <tr className="border-b"><td className="px-3 py-2 font-mono">status</td><td className="px-3 py-2">string</td><td className="px-3 py-2">No</td><td className="px-3 py-2">&quot;draft&quot; or &quot;published&quot; (default: &quot;draft&quot;)</td></tr>
+                      <tr><td className="px-3 py-2 font-mono">generateSeo</td><td className="px-3 py-2">boolean</td><td className="px-3 py-2">No</td><td className="px-3 py-2">Auto-generate excerpt with AI if not provided (default: false)</td></tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-2">Manual Usage (curl)</h4>
+                <CopyBlock>{`curl -X POST https://octopus-review.ai/api/blog \\
+  -H "Authorization: Bearer blog_xxxxxxxxxxxxx" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "title": "My Blog Post",
+    "content": "# Hello World\\n\\nThis is my **first** post.",
+    "status": "draft",
+    "generateSeo": true
+  }'`}</CopyBlock>
+              </div>
+
+              <div>
+                <h4 className="font-semibold mb-2">Response</h4>
+                <CopyBlock>{`{
+  "success": true,
+  "id": "clx...",
+  "slug": "my-blog-post",
+  "status": "draft",
+  "excerpt": "AI-generated excerpt...",
+  "url": "/blog/my-blog-post"
+}`}</CopyBlock>
+              </div>
+
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/admin/blog/blog-editor.tsx
+++ b/apps/web/app/(app)/admin/blog/blog-editor.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { createBlogPost, updateBlogPost, generateExcerpt } from "./actions";
+import { BlogContent } from "@/components/blog-content";
+import { IconSparkles } from "@tabler/icons-react";
+import { toast } from "sonner";
+
+interface BlogEditorProps {
+  post?: {
+    id: string;
+    title: string;
+    slug: string;
+    excerpt: string | null;
+    content: string;
+    coverImageUrl: string | null;
+    status: string;
+  };
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function BlogEditor({ post }: BlogEditorProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [title, setTitle] = useState(post?.title ?? "");
+  const [slug, setSlug] = useState(post?.slug ?? "");
+  const [excerpt, setExcerpt] = useState(post?.excerpt ?? "");
+  const [content, setContent] = useState(post?.content ?? "");
+  const [coverImageUrl, setCoverImageUrl] = useState(post?.coverImageUrl ?? "");
+  const [showPreview, setShowPreview] = useState(false);
+  const [isGeneratingExcerpt, setIsGeneratingExcerpt] = useState(false);
+
+  async function handleGenerateExcerpt() {
+    setIsGeneratingExcerpt(true);
+    try {
+      const result = await generateExcerpt(content);
+      if ("error" in result) {
+        toast.error(String(result.error));
+      } else {
+        setExcerpt(result.excerpt);
+        toast.success("Excerpt generated");
+      }
+    } catch {
+      toast.error("Failed to generate excerpt");
+    } finally {
+      setIsGeneratingExcerpt(false);
+    }
+  }
+
+  function handleTitleChange(value: string) {
+    setTitle(value);
+    if (!post) {
+      setSlug(slugify(value));
+    }
+  }
+
+  function handleSubmit(publish: boolean) {
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.set("title", title);
+      formData.set("slug", slug);
+      formData.set("excerpt", excerpt);
+      formData.set("content", content);
+      formData.set("coverImageUrl", coverImageUrl);
+
+      let result;
+      if (post) {
+        result = await updateBlogPost(post.id, formData);
+      } else {
+        formData.set("publish", publish ? "true" : "false");
+        result = await createBlogPost(formData);
+      }
+
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(post ? "Post updated" : publish ? "Post published" : "Draft saved");
+        router.push("/admin/blog");
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{post ? "Edit Post" : "New Post"}</h1>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setShowPreview(!showPreview)}
+          >
+            {showPreview ? "Edit" : "Preview"}
+          </Button>
+          <Button
+            variant="outline"
+            disabled={isPending}
+            onClick={() => handleSubmit(false)}
+          >
+            {post ? "Save" : "Save Draft"}
+          </Button>
+          {(!post || post.status === "draft") && (
+            <Button
+              disabled={isPending}
+              onClick={() => handleSubmit(true)}
+            >
+              Publish
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {showPreview ? (
+        <div className="rounded-lg border p-8">
+          <h1 className="mb-4 text-3xl font-bold">{title || "Untitled"}</h1>
+          {excerpt && (
+            <p className="mb-6 text-lg text-muted-foreground">{excerpt}</p>
+          )}
+          <BlogContent content={content} />
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="title">Title</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => handleTitleChange(e.target.value)}
+              placeholder="Post title"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="slug">Slug</Label>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">/blog/</span>
+              <Input
+                id="slug"
+                value={slug}
+                onChange={(e) => setSlug(e.target.value)}
+                placeholder="post-slug"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="excerpt">Excerpt</Label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={!content.trim() || isGeneratingExcerpt}
+                onClick={handleGenerateExcerpt}
+              >
+                <IconSparkles className="mr-1.5 size-3.5" />
+                {isGeneratingExcerpt ? "Generating..." : "Generate with AI"}
+              </Button>
+            </div>
+            <Textarea
+              id="excerpt"
+              value={excerpt}
+              onChange={(e) => setExcerpt(e.target.value)}
+              placeholder="Short summary for SEO and blog cards"
+              rows={2}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="coverImageUrl">Cover Image URL</Label>
+            <Input
+              id="coverImageUrl"
+              value={coverImageUrl}
+              onChange={(e) => setCoverImageUrl(e.target.value)}
+              placeholder="https://... (recommended: 1200x630px)"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="content">Content (Markdown)</Label>
+            <Textarea
+              id="content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="Write your blog post in markdown..."
+              rows={24}
+              className="font-mono text-sm"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(app)/admin/blog/new/page.tsx
+++ b/apps/web/app/(app)/admin/blog/new/page.tsx
@@ -1,0 +1,5 @@
+import { BlogEditor } from "../blog-editor";
+
+export default function NewBlogPostPage() {
+  return <BlogEditor />;
+}

--- a/apps/web/app/(app)/admin/blog/page.tsx
+++ b/apps/web/app/(app)/admin/blog/page.tsx
@@ -1,0 +1,52 @@
+import { prisma } from "@octopus/db";
+import { BlogAdmin } from "./blog-admin";
+
+const POSTS_PER_PAGE = 5;
+
+export default async function AdminBlogPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const { page: pageParam } = await searchParams;
+  const page = Math.max(1, parseInt(pageParam ?? "1", 10) || 1);
+
+  const [posts, totalCount, tokens] = await Promise.all([
+    prisma.blogPost.findMany({
+      where: { deletedAt: null },
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * POSTS_PER_PAGE,
+      take: POSTS_PER_PAGE,
+    }),
+    prisma.blogPost.count({ where: { deletedAt: null } }),
+    prisma.blogApiToken.findMany({
+      where: { deletedAt: null },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
+
+  const totalPages = Math.ceil(totalCount / POSTS_PER_PAGE);
+
+  return (
+    <BlogAdmin
+      posts={posts.map((p) => ({
+        id: p.id,
+        title: p.title,
+        slug: p.slug,
+        status: p.status,
+        authorName: p.authorName,
+        publishedAt: p.publishedAt?.toISOString() ?? null,
+        createdAt: p.createdAt.toISOString(),
+      }))}
+      tokens={tokens.map((t) => ({
+        id: t.id,
+        name: t.name,
+        tokenPrefix: t.tokenPrefix,
+        lastUsedAt: t.lastUsedAt?.toISOString() ?? null,
+        createdAt: t.createdAt.toISOString(),
+      }))}
+      page={page}
+      totalPages={totalPages}
+    />
+  );
+}

--- a/apps/web/app/(landing)/blog/[slug]/page.tsx
+++ b/apps/web/app/(landing)/blog/[slug]/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { LandingFooter } from "@/components/landing-footer";
+import { LandingMobileNav } from "@/components/landing-mobile-nav";
+import { LandingDesktopNav } from "@/components/landing-desktop-nav";
+import { BlogContent } from "@/components/blog-content";
+import { ScrollToTop } from "@/components/scroll-to-top";
+import { IconArrowLeft } from "@tabler/icons-react";
+
+async function getPost(slug: string) {
+  return prisma.blogPost.findFirst({
+    where: { slug, status: "published", deletedAt: null },
+  });
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const post = await getPost(slug);
+  if (!post) return { title: "Post Not Found" };
+
+  const canonicalUrl = `https://octopus-review.ai/blog/${slug}`;
+
+  return {
+    title: `${post.title} — Octopus Blog`,
+    description: post.excerpt ?? undefined,
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      title: post.title,
+      description: post.excerpt ?? undefined,
+      type: "article",
+      publishedTime: post.publishedAt?.toISOString(),
+      images: post.coverImageUrl ? [{ url: post.coverImageUrl }] : [],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.title,
+      description: post.excerpt ?? undefined,
+      images: post.coverImageUrl ? [post.coverImageUrl] : [],
+    },
+  };
+}
+
+export default async function BlogPostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const session = await auth.api.getSession({ headers: await headers() }).catch(() => null);
+  const isLoggedIn = !!session;
+  const post = await getPost(slug);
+
+  if (!post) notFound();
+
+  return (
+    <div className="min-h-screen bg-[#0c0c0c] text-white">
+      <LandingDesktopNav isLoggedIn={isLoggedIn} />
+      <LandingMobileNav isLoggedIn={isLoggedIn} />
+
+      <article className="mx-auto max-w-3xl px-6 pt-32 pb-20">
+        <Link
+          href="/blog"
+          className="mb-8 inline-flex items-center gap-1.5 text-sm text-[#555] transition-colors hover:text-white"
+        >
+          <IconArrowLeft className="size-3.5" />
+          Back to Blog
+        </Link>
+
+        {post.coverImageUrl && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={post.coverImageUrl}
+            alt={post.title}
+            className="mb-8 w-full rounded-xl object-cover"
+            loading="lazy"
+          />
+        )}
+
+        <h1 className="mb-4 text-4xl font-bold tracking-tight">{post.title}</h1>
+
+        <div className="mb-10 flex items-center gap-3 text-sm text-[#555]">
+          <span>{post.authorName}</span>
+          <span>·</span>
+          <time>
+            {post.publishedAt
+              ? new Date(post.publishedAt).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })
+              : ""}
+          </time>
+        </div>
+
+        <div className="text-[#a0a0a0] [&_h1]:text-white [&_h2]:text-white [&_h3]:text-white [&_strong]:text-white [&_a]:text-[#10D8BE] [&_code]:bg-white/[0.06] [&_pre]:bg-white/[0.04] [&_pre]:border [&_pre]:border-white/[0.06] [&_blockquote]:border-[#333] [&_th]:border-[#333] [&_td]:border-[#333] [&_hr]:border-[#333] [&_table]:border-[#333]">
+          <BlogContent content={post.content} />
+        </div>
+      </article>
+
+      <LandingFooter />
+      <ScrollToTop />
+    </div>
+  );
+}

--- a/apps/web/app/(landing)/blog/page.tsx
+++ b/apps/web/app/(landing)/blog/page.tsx
@@ -1,0 +1,236 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { LandingFooter } from "@/components/landing-footer";
+import { LandingMobileNav } from "@/components/landing-mobile-nav";
+import { LandingDesktopNav } from "@/components/landing-desktop-nav";
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import { BlogSearch } from "@/components/blog-search";
+import { ScrollToTop } from "@/components/scroll-to-top";
+
+const POSTS_PER_PAGE = 10;
+
+export const metadata: Metadata = {
+  title: "Blog — Octopus",
+  description:
+    "Engineering insights, product updates, and lessons learned building AI-powered code review tools.",
+  alternates: {
+    canonical: "https://octopus-review.ai/blog",
+  },
+};
+
+export default async function BlogPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string; q?: string }>;
+}) {
+  const { page: pageParam, q: searchQuery } = await searchParams;
+  const page = Math.max(1, parseInt(pageParam ?? "1", 10) || 1);
+  const query = searchQuery?.trim() || "";
+
+  const session = await auth.api.getSession({ headers: await headers() }).catch(() => null);
+  const isLoggedIn = !!session;
+
+  const where = {
+    status: "published" as const,
+    deletedAt: null,
+    ...(query
+      ? {
+          OR: [
+            { title: { contains: query, mode: "insensitive" as const } },
+            { excerpt: { contains: query, mode: "insensitive" as const } },
+            { content: { contains: query, mode: "insensitive" as const } },
+          ],
+        }
+      : {}),
+  };
+
+  const [posts, totalCount] = await Promise.all([
+    prisma.blogPost.findMany({
+      where,
+      orderBy: { publishedAt: "desc" },
+      skip: (page - 1) * POSTS_PER_PAGE,
+      take: POSTS_PER_PAGE,
+      select: {
+        title: true,
+        slug: true,
+        excerpt: true,
+        coverImageUrl: true,
+        publishedAt: true,
+        authorName: true,
+      },
+    }),
+    prisma.blogPost.count({ where }),
+  ]);
+
+  const totalPages = Math.ceil(totalCount / POSTS_PER_PAGE);
+
+  return (
+    <div className="min-h-screen bg-[#0c0c0c] text-white">
+      <LandingDesktopNav isLoggedIn={isLoggedIn} />
+      <LandingMobileNav isLoggedIn={isLoggedIn} />
+
+      <main className="mx-auto max-w-4xl px-6 pt-32 pb-20">
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-4xl font-bold tracking-tight">Blog</h1>
+            <p className="mt-2 text-lg text-[#888]">
+              Engineering insights, product updates, and lessons learned.
+            </p>
+          </div>
+          <BlogSearch />
+        </div>
+
+        {query && (
+          <p className="mb-6 text-sm text-[#555]">
+            {totalCount} result{totalCount !== 1 ? "s" : ""} for &ldquo;{query}&rdquo;
+          </p>
+        )}
+
+        {posts.length === 0 ? (
+          <p className="text-[#555]">{query ? "No posts found." : "No posts yet. Check back soon."}</p>
+        ) : (
+          <div>
+            {/* Featured post (first one) */}
+            {(() => {
+              const featured = posts[0];
+              const rest = posts.slice(1);
+              return (
+                <>
+                  <Link
+                    href={`/blog/${featured.slug}`}
+                    className="group block rounded-xl border border-white/[0.06] p-6 transition-colors hover:border-white/[0.12] hover:bg-white/[0.02]"
+                  >
+                    {featured.coverImageUrl && (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={featured.coverImageUrl}
+                        alt={featured.title}
+                        className="mb-4 w-full rounded-lg"
+                        loading="lazy"
+                      />
+                    )}
+                    <h2 className="mb-2 text-2xl font-semibold text-white group-hover:text-[#10D8BE] transition-colors">
+                      {featured.title}
+                    </h2>
+                    {featured.excerpt && (
+                      <p className="mb-3 text-[#888] line-clamp-2">{featured.excerpt}</p>
+                    )}
+                    <div className="flex items-center gap-3 text-sm text-[#555]">
+                      <span>{featured.authorName}</span>
+                      <span>·</span>
+                      <time>
+                        {featured.publishedAt
+                          ? new Date(featured.publishedAt).toLocaleDateString("en-US", {
+                              year: "numeric",
+                              month: "long",
+                              day: "numeric",
+                            })
+                          : ""}
+                      </time>
+                    </div>
+                  </Link>
+
+                  {/* Compact list for the rest */}
+                  {rest.length > 0 && (
+                    <div className="mt-8 divide-y divide-white/[0.06] rounded-xl border border-white/[0.06]">
+                      {rest.map((post) => (
+                        <Link
+                          key={post.slug}
+                          href={`/blog/${post.slug}`}
+                          className="group flex items-center gap-5 px-6 py-5 transition-colors hover:bg-white/[0.02]"
+                        >
+                          {post.coverImageUrl && (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                              src={post.coverImageUrl}
+                              alt={post.title}
+                              className="hidden size-16 shrink-0 rounded-lg object-cover sm:block"
+                              loading="lazy"
+                            />
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <h2 className="font-semibold text-white transition-colors group-hover:text-[#10D8BE] truncate">
+                              {post.title}
+                            </h2>
+                            {post.excerpt && (
+                              <p className="mt-1 text-sm text-[#888] line-clamp-1">{post.excerpt}</p>
+                            )}
+                          </div>
+                          <div className="hidden shrink-0 text-right text-sm text-[#555] sm:block">
+                            <div>{post.authorName}</div>
+                            <time>
+                              {post.publishedAt
+                                ? new Date(post.publishedAt).toLocaleDateString("en-US", {
+                                    month: "short",
+                                    day: "numeric",
+                                  })
+                                : ""}
+                            </time>
+                          </div>
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                </>
+              );
+            })()}
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (() => {
+          const qs = (p: number) => {
+            const params = new URLSearchParams();
+            if (p > 1) params.set("page", String(p));
+            if (query) params.set("q", query);
+            const str = params.toString();
+            return str ? `/blog?${str}` : "/blog";
+          };
+          return (
+          <div className="mt-12 flex items-center justify-center gap-2">
+            {page > 1 ? (
+              <Link
+                href={qs(page - 1)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-[#888] transition-colors hover:border-white/[0.15] hover:text-white"
+              >
+                <IconChevronLeft className="size-4" />
+                Previous
+              </Link>
+            ) : (
+              <span className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.04] px-4 py-2 text-sm text-[#333] cursor-not-allowed">
+                <IconChevronLeft className="size-4" />
+                Previous
+              </span>
+            )}
+
+            <span className="px-4 py-2 text-sm text-[#555]">
+              {page} / {totalPages}
+            </span>
+
+            {page < totalPages ? (
+              <Link
+                href={qs(page + 1)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-[#888] transition-colors hover:border-white/[0.15] hover:text-white"
+              >
+                Next
+                <IconChevronRight className="size-4" />
+              </Link>
+            ) : (
+              <span className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.04] px-4 py-2 text-sm text-[#333] cursor-not-allowed">
+                Next
+                <IconChevronRight className="size-4" />
+              </span>
+            )}
+          </div>
+          );
+        })()}
+      </main>
+
+      <LandingFooter />
+      <ScrollToTop />
+    </div>
+  );
+}

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
 import { FloatingOctopus } from "@/components/landing-unicorn-section";
 import { LandingFeatures } from "@/components/landing-features";
 import { TrackedLink, TrackedAnchor } from "@/components/tracked-link";
@@ -96,7 +97,15 @@ const faqJsonLd = {
 };
 
 export default async function LandingPage() {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const [session, blogPosts] = await Promise.all([
+    auth.api.getSession({ headers: await headers() }),
+    prisma.blogPost.findMany({
+      where: { status: "published", deletedAt: null },
+      orderBy: { publishedAt: "desc" },
+      take: 3,
+      select: { title: true, slug: true, excerpt: true, publishedAt: true, authorName: true },
+    }),
+  ]);
   return (
     <div className="dark relative min-h-screen bg-[#0c0c0c] text-[#a0a0a0] selection:bg-white/20">
       <script
@@ -302,6 +311,67 @@ export default async function LandingPage() {
           </div>
         </div>
       </section>
+
+      {/* Blog */}
+      {blogPosts.length > 0 && (
+        <section className="relative z-10 px-4 py-8 sm:px-8 md:px-12">
+          <div className="mx-auto max-w-6xl overflow-hidden rounded-3xl border border-white/[0.06] bg-[#161616] px-6 py-20 md:px-12 md:py-28">
+            <div className="mx-auto max-w-5xl">
+              <div className="mx-auto max-w-2xl text-center">
+                <span className="text-xs font-semibold uppercase tracking-[0.2em] text-[#555]">Blog</span>
+                <h2 className="mt-4 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+                  From the blog
+                </h2>
+                <p className="mt-4 text-[#888]">
+                  Engineering insights and lessons from building Octopus.
+                </p>
+              </div>
+
+              <div className="mt-14 grid gap-4 md:grid-cols-3">
+                {blogPosts.map((post) => (
+                  <Link
+                    key={post.slug}
+                    href={`/blog/${post.slug}`}
+                    className="group rounded-xl border border-white/[0.06] p-6 transition-colors hover:border-white/[0.12] hover:bg-white/[0.02]"
+                  >
+                    <h3 className="font-semibold text-white transition-colors group-hover:text-[#10D8BE]">
+                      {post.title}
+                    </h3>
+                    {post.excerpt && (
+                      <p className="mt-2 text-sm text-[#888] line-clamp-2">{post.excerpt}</p>
+                    )}
+                    <div className="mt-4 flex items-center gap-2 text-xs text-[#555]">
+                      <span>{post.authorName}</span>
+                      <span>·</span>
+                      <time>
+                        {post.publishedAt
+                          ? new Date(post.publishedAt).toLocaleDateString("en-US", {
+                              year: "numeric",
+                              month: "short",
+                              day: "numeric",
+                            })
+                          : ""}
+                      </time>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+
+              <div className="mt-10 text-center">
+                <TrackedLink
+                  href="/blog"
+                  event="blog_click"
+                  eventParams={{ label: "view_all_posts" }}
+                  className="inline-flex items-center gap-2 text-sm text-[#666] transition-colors hover:text-white"
+                >
+                  View all posts
+                  <IconArrowRight className="size-3.5" />
+                </TrackedLink>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* FAQ */}
       <section id="faq" className="relative z-10 scroll-mt-20 px-4 py-8 sm:px-8 md:px-12">

--- a/apps/web/app/api/blog/route.ts
+++ b/apps/web/app/api/blog/route.ts
@@ -1,0 +1,195 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@octopus/db";
+import { createHash } from "crypto";
+import { revalidatePath } from "next/cache";
+import Anthropic from "@anthropic-ai/sdk";
+
+async function authenticateBlogToken(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+
+  const token = authHeader.slice(7);
+  const tokenHash = createHash("sha256").update(token).digest("hex");
+
+  const apiToken = await prisma.blogApiToken.findUnique({
+    where: { tokenHash, deletedAt: null },
+  });
+
+  if (!apiToken) return null;
+
+  // Update lastUsedAt
+  prisma.blogApiToken.update({
+    where: { id: apiToken.id },
+    data: { lastUsedAt: new Date() },
+  }).catch(() => {});
+
+  return apiToken;
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export async function GET(request: NextRequest) {
+  const token = await authenticateBlogToken(request);
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = request.nextUrl;
+  const q = searchParams.get("q")?.trim() || "";
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10) || 1);
+  const limit = Math.min(50, Math.max(1, parseInt(searchParams.get("limit") ?? "10", 10) || 10));
+  const status = searchParams.get("status") || undefined;
+
+  const where = {
+    deletedAt: null,
+    ...(status ? { status } : {}),
+    ...(q
+      ? {
+          OR: [
+            { title: { contains: q, mode: "insensitive" as const } },
+            { excerpt: { contains: q, mode: "insensitive" as const } },
+            { content: { contains: q, mode: "insensitive" as const } },
+          ],
+        }
+      : {}),
+  };
+
+  const [posts, total] = await Promise.all([
+    prisma.blogPost.findMany({
+      where,
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+      select: {
+        id: true,
+        title: true,
+        slug: true,
+        excerpt: true,
+        coverImageUrl: true,
+        status: true,
+        authorName: true,
+        publishedAt: true,
+        createdAt: true,
+      },
+    }),
+    prisma.blogPost.count({ where }),
+  ]);
+
+  return NextResponse.json({
+    posts,
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit),
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const token = await authenticateBlogToken(request);
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const {
+      title,
+      slug,
+      content,
+      excerpt,
+      coverImageUrl,
+      authorName = "Octopus Team",
+      status = "draft",
+      generateSeo = false,
+    } = body as {
+      title?: string;
+      slug?: string;
+      content?: string;
+      excerpt?: string;
+      coverImageUrl?: string;
+      authorName?: string;
+      status?: string;
+      generateSeo?: boolean;
+    };
+
+    if (!title || !content) {
+      return NextResponse.json(
+        { error: "title and content are required" },
+        { status: 400 },
+      );
+    }
+
+    const finalSlug = slug || slugify(title);
+
+    // Check slug uniqueness
+    const existing = await prisma.blogPost.findUnique({ where: { slug: finalSlug } });
+    if (existing) {
+      return NextResponse.json(
+        { error: "A post with this slug already exists" },
+        { status: 409 },
+      );
+    }
+
+    // Generate SEO excerpt if requested and not provided
+    let finalExcerpt = excerpt;
+    if (generateSeo && !excerpt) {
+      try {
+        const client = new Anthropic();
+        const response = await client.messages.create({
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 200,
+          messages: [
+            {
+              role: "user",
+              content: `Write a concise SEO-friendly excerpt (max 150 characters) for this blog post. Return ONLY the excerpt text, nothing else.\n\n${content.slice(0, 4000)}`,
+            },
+          ],
+        });
+        const text = response.content[0].type === "text" ? response.content[0].text.trim() : "";
+        if (text) finalExcerpt = text;
+      } catch {
+        // SEO generation failed, continue without excerpt
+      }
+    }
+
+    const isPublished = status === "published";
+
+    const post = await prisma.blogPost.create({
+      data: {
+        title,
+        slug: finalSlug,
+        excerpt: finalExcerpt ?? null,
+        content,
+        coverImageUrl: coverImageUrl ?? null,
+        status: isPublished ? "published" : "draft",
+        publishedAt: isPublished ? new Date() : null,
+        authorId: "api",
+        authorName,
+      },
+    });
+
+    revalidatePath("/blog");
+    revalidatePath("/admin/blog");
+
+    return NextResponse.json({
+      success: true,
+      id: post.id,
+      slug: post.slug,
+      status: post.status,
+      excerpt: post.excerpt,
+      url: `/blog/${post.slug}`,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to create blog post" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/blog/search/route.ts
+++ b/apps/web/app/api/blog/search/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@octopus/db";
+
+export async function GET(request: NextRequest) {
+  const q = request.nextUrl.searchParams.get("q")?.trim() || "";
+
+  if (!q) {
+    return NextResponse.json({ posts: [] });
+  }
+
+  const posts = await prisma.blogPost.findMany({
+    where: {
+      status: "published",
+      deletedAt: null,
+      OR: [
+        { title: { contains: q, mode: "insensitive" } },
+        { excerpt: { contains: q, mode: "insensitive" } },
+        { content: { contains: q, mode: "insensitive" } },
+      ],
+    },
+    orderBy: { publishedAt: "desc" },
+    take: 10,
+    select: {
+      title: true,
+      slug: true,
+      excerpt: true,
+    },
+  });
+
+  return NextResponse.json({ posts });
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,8 +1,11 @@
 import type { MetadataRoute } from "next";
+import { prisma } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
 
 const SITE_URL = "https://octopus-review.ai";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
 
   const staticPages: MetadataRoute.Sitemap = [
@@ -13,7 +16,31 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
+      url: `${SITE_URL}/blog`,
+      lastModified: now,
+      changeFrequency: "daily",
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/brand`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${SITE_URL}/docs`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
       url: `${SITE_URL}/docs/about`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/docs/getting-started`,
       lastModified: now,
       changeFrequency: "monthly",
       priority: 0.8,
@@ -49,6 +76,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: `${SITE_URL}/docs/skills`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/docs/glossary`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
       url: `${SITE_URL}/docs/octopusignore`,
       lastModified: now,
       changeFrequency: "monthly",
@@ -74,5 +113,25 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
   ];
 
-  return staticPages;
+  // Fetch all published blog posts from database
+  // Wrapped in try/catch because DB may not be available during build
+  let blogPages: MetadataRoute.Sitemap = [];
+  try {
+    const blogPosts = await prisma.blogPost.findMany({
+      where: { status: "published", deletedAt: null },
+      select: { slug: true, publishedAt: true, updatedAt: true },
+      orderBy: { publishedAt: "desc" },
+    });
+
+    blogPages = blogPosts.map((post) => ({
+      url: `${SITE_URL}/blog/${post.slug}`,
+      lastModified: post.updatedAt ?? post.publishedAt ?? now,
+      changeFrequency: "monthly" as const,
+      priority: 0.7,
+    }));
+  } catch {
+    // DB unavailable during build — blog posts will be included at runtime
+  }
+
+  return [...staticPages, ...blogPages];
 }

--- a/apps/web/components/blog-content.tsx
+++ b/apps/web/components/blog-content.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export function BlogContent({ content }: { content: string }) {
+  return (
+    <Markdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        h1: ({ children }) => (
+          <h1 className="mb-4 mt-8 text-3xl font-bold first:mt-0">{children}</h1>
+        ),
+        h2: ({ children }) => (
+          <h2 className="mb-3 mt-8 text-2xl font-semibold">{children}</h2>
+        ),
+        h3: ({ children }) => (
+          <h3 className="mb-2 mt-6 text-xl font-semibold">{children}</h3>
+        ),
+        p: ({ children }) => (
+          <p className="mb-4 leading-relaxed">{children}</p>
+        ),
+        ul: ({ children }) => (
+          <ul className="mb-4 list-disc space-y-1 pl-6">{children}</ul>
+        ),
+        ol: ({ children }) => (
+          <ol className="mb-4 list-decimal space-y-1 pl-6">{children}</ol>
+        ),
+        li: ({ children }) => (
+          <li className="leading-relaxed">{children}</li>
+        ),
+        a: ({ href, children }) => (
+          <a
+            href={href}
+            target={href?.startsWith("http") ? "_blank" : undefined}
+            rel={href?.startsWith("http") ? "noopener noreferrer" : undefined}
+            className="text-primary underline underline-offset-4 hover:opacity-80"
+          >
+            {children}
+          </a>
+        ),
+        blockquote: ({ children }) => (
+          <blockquote className="mb-4 border-l-4 border-primary/30 pl-4 italic text-muted-foreground">
+            {children}
+          </blockquote>
+        ),
+        code: ({ className, children }) => {
+          const isInline = !className;
+          if (isInline) {
+            return (
+              <code className="rounded bg-muted px-1.5 py-0.5 text-sm font-mono">
+                {children}
+              </code>
+            );
+          }
+          return (
+            <code className={className}>{children}</code>
+          );
+        },
+        pre: ({ children }) => (
+          <pre className="mb-4 overflow-x-auto rounded-lg bg-muted p-4 text-sm">
+            {children}
+          </pre>
+        ),
+        img: ({ src, alt }) => (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={src}
+            alt={alt ?? ""}
+            className="mb-4 rounded-lg"
+            loading="lazy"
+          />
+        ),
+        table: ({ children }) => (
+          <div className="mb-4 overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              {children}
+            </table>
+          </div>
+        ),
+        th: ({ children }) => (
+          <th className="border border-border px-3 py-2 text-left font-semibold">
+            {children}
+          </th>
+        ),
+        td: ({ children }) => (
+          <td className="border border-border px-3 py-2">{children}</td>
+        ),
+        hr: () => <hr className="my-8 border-border" />,
+        strong: ({ children }) => (
+          <strong className="font-semibold">{children}</strong>
+        ),
+      }}
+    >
+      {content}
+    </Markdown>
+  );
+}

--- a/apps/web/components/blog-search.tsx
+++ b/apps/web/components/blog-search.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { IconSearch, IconLoader2, IconFileText } from "@tabler/icons-react";
+
+type SearchResult = {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+};
+
+export function BlogSearch() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Cmd+K shortcut
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => inputRef.current?.focus(), 10);
+    } else {
+      setQuery("");
+      setResults([]);
+      setActiveIndex(0);
+    }
+  }, [open]);
+
+  const search = useCallback(async (q: string) => {
+    if (!q.trim()) {
+      setResults([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/blog/search?q=${encodeURIComponent(q.trim())}`);
+      if (res.ok) {
+        const data = await res.json();
+        setResults(data.posts ?? []);
+        setActiveIndex(0);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  function handleQueryChange(value: string) {
+    setQuery(value);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => search(value), 300);
+  }
+
+  function handleSelect(slug: string) {
+    setOpen(false);
+    router.push(`/blog/${slug}`);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      setOpen(false);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter" && results.length > 0) {
+      e.preventDefault();
+      handleSelect(results[activeIndex].slug);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex shrink-0 items-center gap-2 rounded-lg border border-white/[0.08] bg-white/[0.03] px-3 py-2 text-sm text-[#555] transition-colors hover:border-white/[0.15] hover:bg-white/[0.05]"
+      >
+        <IconSearch className="size-3.5" />
+        <span>Search</span>
+        <kbd className="hidden rounded border border-white/[0.1] bg-white/[0.05] px-1.5 py-0.5 text-[10px] text-[#555] sm:inline-block">
+          ⌘K
+        </kbd>
+      </button>
+
+      {open && (
+        <>
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 z-50 bg-black/50 backdrop-blur-xs animate-in fade-in-0 duration-100"
+            onClick={() => setOpen(false)}
+          />
+
+          {/* Dialog */}
+          <div className="fixed left-1/2 top-[20%] z-50 w-full max-w-lg -translate-x-1/2 animate-in fade-in-0 zoom-in-95 duration-100">
+            <div className="rounded-xl border border-white/[0.1] bg-[#161616] shadow-2xl">
+              {/* Input */}
+              <div className="flex items-center gap-3 border-b border-white/[0.06] px-4">
+                <IconSearch className="size-4 shrink-0 text-[#555]" />
+                <input
+                  ref={inputRef}
+                  type="text"
+                  value={query}
+                  onChange={(e) => handleQueryChange(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Search blog posts..."
+                  className="flex-1 bg-transparent py-3.5 text-sm text-white placeholder-[#555] outline-none"
+                />
+                {loading && <IconLoader2 className="size-4 animate-spin text-[#555]" />}
+              </div>
+
+              {/* Results */}
+              <div className="max-h-72 overflow-y-auto p-2">
+                {!loading && query.trim() && results.length === 0 && (
+                  <p className="py-6 text-center text-sm text-[#555]">No posts found.</p>
+                )}
+
+                {results.map((post, i) => (
+                  <button
+                    key={post.slug}
+                    type="button"
+                    onClick={() => handleSelect(post.slug)}
+                    onMouseEnter={() => setActiveIndex(i)}
+                    className={`flex w-full flex-col items-start gap-1 rounded-lg px-3 py-2.5 text-left transition-colors ${
+                      i === activeIndex ? "bg-white/[0.06]" : ""
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <IconFileText className="size-4 shrink-0 text-[#555]" />
+                      <span className="text-sm font-medium text-white">{post.title}</span>
+                    </div>
+                    {post.excerpt && (
+                      <span className="pl-6 text-xs text-[#666] line-clamp-1">{post.excerpt}</span>
+                    )}
+                  </button>
+                ))}
+
+                {!loading && !query.trim() && (
+                  <p className="py-6 text-center text-sm text-[#555]">
+                    Start typing to search...
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/apps/web/components/landing-desktop-nav.tsx
+++ b/apps/web/components/landing-desktop-nav.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { TrackedLink } from "@/components/tracked-link";
-import { IconArrowRight, IconBook, IconBrandGithub, IconPalette, IconCoin } from "@tabler/icons-react";
+import { IconArrowRight, IconBook, IconBrandGithub, IconPalette, IconCoin, IconNews } from "@tabler/icons-react";
 
 export function LandingDesktopNav({ isLoggedIn }: { isLoggedIn: boolean }) {
   const [resourcesOpen, setResourcesOpen] = useState(false);
@@ -70,6 +70,15 @@ export function LandingDesktopNav({ isLoggedIn }: { isLoggedIn: boolean }) {
                 >
                   <IconPalette className="size-4 shrink-0 text-[#555]" />
                   Brand Guidelines
+                </TrackedLink>
+                <TrackedLink
+                  href="/blog"
+                  event="nav_click"
+                  eventParams={{ label: "blog" }}
+                  className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-[#888] transition-colors hover:bg-white/[0.06] hover:text-white"
+                >
+                  <IconNews className="size-4 shrink-0 text-[#555]" />
+                  Blog
                 </TrackedLink>
                 <TrackedLink
                   href="/docs/pricing"

--- a/apps/web/components/landing-footer.tsx
+++ b/apps/web/components/landing-footer.tsx
@@ -135,6 +135,16 @@ export function LandingFooter() {
               </li>
               <li>
                 <TrackedLink
+                  href="/blog"
+                  event="footer_click"
+                  eventParams={{ label: "blog" }}
+                  className="text-sm text-[#666] transition-colors hover:text-white"
+                >
+                  Blog
+                </TrackedLink>
+              </li>
+              <li>
+                <TrackedLink
                   href="/login"
                   event="footer_click"
                   eventParams={{ label: "get_started" }}

--- a/apps/web/components/landing-mobile-nav.tsx
+++ b/apps/web/components/landing-mobile-nav.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { TrackedLink } from "@/components/tracked-link";
-import { IconMenu2, IconX, IconBrandGithub, IconBook, IconPalette, IconCoin } from "@tabler/icons-react";
+import { IconMenu2, IconX, IconBrandGithub, IconBook, IconPalette, IconCoin, IconNews } from "@tabler/icons-react";
 
 export function LandingMobileNav({ isLoggedIn }: { isLoggedIn: boolean }) {
   const [open, setOpen] = useState(false);
@@ -87,6 +87,16 @@ export function LandingMobileNav({ isLoggedIn }: { isLoggedIn: boolean }) {
                 >
                   <IconPalette className="size-4 text-[#555]" />
                   Brand Guidelines
+                </TrackedLink>
+                <TrackedLink
+                  href="/blog"
+                  event="nav_click"
+                  eventParams={{ label: "blog" }}
+                  onClick={() => setOpen(false)}
+                  className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-[#888] transition-colors hover:bg-white/[0.06] hover:text-white"
+                >
+                  <IconNews className="size-4 text-[#555]" />
+                  Blog
                 </TrackedLink>
                 <TrackedLink
                   href="/docs/pricing"

--- a/apps/web/components/scroll-to-top.tsx
+++ b/apps/web/components/scroll-to-top.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { IconArrowUp } from "@tabler/icons-react";
+
+export function ScrollToTop() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    function onScroll() {
+      setVisible(window.scrollY > 400);
+    }
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <button
+      type="button"
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      aria-label="Scroll to top"
+      className={`fixed bottom-6 right-6 z-40 flex size-10 items-center justify-center rounded-full border border-[#10D8BE]/50 bg-[#161616] text-[#10D8BE] shadow-lg shadow-[#10D8BE]/10 transition-all hover:border-[#10D8BE] hover:text-white hover:bg-[#10D8BE]/20 ${
+        visible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0 pointer-events-none"
+      }`}
+    >
+      <IconArrowUp className="size-4" />
+    </button>
+  );
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-const publicPrefixes = ["/login", "/blocked", "/brand", "/docs", "/api/auth", "/api/github", "/api/bitbucket/webhook", "/api/pubby", "/api/version", "/api/invitations", "/api/slack/commands", "/api/stripe", "/api/cli", "/api/newsletter", "/api/analyze-deps"];
+const publicPrefixes = ["/login", "/blocked", "/brand", "/blog", "/docs", "/api/auth", "/api/github", "/api/bitbucket/webhook", "/api/pubby", "/api/version", "/api/invitations", "/api/slack/commands", "/api/stripe", "/api/cli", "/api/newsletter", "/api/analyze-deps", "/api/blog"];
 const publicExact = ["/"];
 
 export function middleware(request: NextRequest) {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -731,3 +731,35 @@ model PackageDeepDive {
   @@index([analysisId])
   @@map("package_deep_dives")
 }
+
+model BlogPost {
+  id            String    @id @default(cuid())
+  title         String
+  slug          String    @unique
+  excerpt       String?
+  content       String    @db.Text
+  coverImageUrl String?
+  status        String    @default("draft") // "draft" | "published"
+  publishedAt   DateTime?
+  authorId      String
+  authorName    String
+  deletedAt     DateTime?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+
+  @@index([status, publishedAt])
+  @@map("blog_posts")
+}
+
+model BlogApiToken {
+  id          String    @id @default(cuid())
+  name        String
+  tokenHash   String    @unique
+  tokenPrefix String
+  lastUsedAt  DateTime?
+  deletedAt   DateTime?
+  createdAt   DateTime  @default(now())
+
+  @@index([tokenHash])
+  @@map("blog_api_tokens")
+}


### PR DESCRIPTION
## Summary
- Add BlogPost and BlogApiToken Prisma models for blog content management
- Admin panel: create, edit, publish/unpublish, delete blog posts with markdown editor and AI excerpt generation
- Public pages: blog listing with pagination/search, individual post pages with markdown rendering
- Blog API with external token-based CRUD for headless publishing
- Blog section on landing page showing latest 3 posts
- Nav links (desktop, mobile, footer) and sitemap entries for blog

Closes #55

## Files Changed
- `packages/db/prisma/schema.prisma` — BlogPost, BlogApiToken models
- `apps/web/app/(app)/admin/blog/` — 6 admin blog files
- `apps/web/app/(landing)/blog/` — 2 public blog pages
- `apps/web/app/api/blog/` — blog API + search routes
- `apps/web/components/blog-content.tsx`, `blog-search.tsx`, `scroll-to-top.tsx`
- `apps/web/app/(landing)/page.tsx` — blog section
- `apps/web/components/landing-desktop-nav.tsx`, `landing-mobile-nav.tsx`, `landing-footer.tsx` — blog links
- `apps/web/app/sitemap.ts`, `apps/web/middleware.ts`, `apps/web/app/(app)/admin/admin-nav.tsx`
- `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)