### PR TITLE
feat: add octopus-changelog skill

### DIFF
--- a/apps/web/app/(landing)/docs/skills/page.tsx
+++ b/apps/web/app/(landing)/docs/skills/page.tsx
@@ -8,6 +8,7 @@ import {
   IconReportAnalytics,
   IconArrowsSplit,
   IconBugOff,
+  IconFileText,
 } from "@tabler/icons-react";
 import { SkillCodeBlock } from "./skill-code-block";
 import { SkillCard } from "./skill-card";
@@ -31,6 +32,7 @@ function readSkillFile(filename: string): string {
 export default function SkillsPage() {
   const octopusFixMd = readSkillFile("octopus-fix.md");
   const splitAndShipMd = readSkillFile("split-and-ship.md");
+  const octopusChangelogMd = readSkillFile("octopus-changelog.md");
 
   return (
     <article className="max-w-3xl">
@@ -229,6 +231,72 @@ export default function SkillsPage() {
             filename="octopus-fix.md"
           >
             {octopusFixMd}
+          </SkillCodeBlock>
+        </SkillCard>
+
+        {/* Skill: Octopus Changelog */}
+        <SkillCard
+          icon={<IconFileText className="size-5" />}
+          title="Octopus Changelog"
+          subtitle="Update CHANGELOG.md for a new release based on git history"
+          filename="octopus-changelog.md"
+          content={octopusChangelogMd}
+        >
+          <Paragraph>
+            Keeping a changelog up to date is tedious but essential. This skill
+            reads your git history since the last tag, categorizes commits using
+            the Keep a Changelog standard, and updates your CHANGELOG.md
+            automatically.
+          </Paragraph>
+
+          <SubHeading>How it works</SubHeading>
+          <div className="mb-6 space-y-3">
+            <StepCard
+              step={1}
+              title="Determine Version"
+              description="Detects the latest git tag and suggests the next version, or uses the version you provide."
+            />
+            <StepCard
+              step={2}
+              title="Gather Commits"
+              description="Collects all commits since the last tag and parses conventional commit prefixes."
+            />
+            <StepCard
+              step={3}
+              title="Categorize"
+              description="Groups commits into Added, Fixed, Changed, and more. Skips dependency bumps and trivial changes."
+            />
+            <StepCard
+              step={4}
+              title="Review Draft"
+              description="Presents the formatted changelog entries for your approval before writing anything."
+            />
+            <StepCard
+              step={5}
+              title="Update File"
+              description="Inserts the new version section into CHANGELOG.md with proper formatting and comparison links."
+            />
+          </div>
+
+          <SubHeading>Rules</SubHeading>
+          <ul className="mb-6 space-y-2">
+            <RuleItem text="Never commits or pushes — only updates the file. You commit when ready." />
+            <RuleItem text="Always shows a draft and gets your confirmation before writing." />
+            <RuleItem text="Uses Keep a Changelog format: Added, Fixed, Changed, Removed, Deprecated, Security." />
+            <RuleItem text="Skips dependency bumps, trivial refactors, and CI-only changes." />
+            <RuleItem text="Groups related commits into single entries for readability." />
+          </ul>
+
+          <SubHeading>Skill file</SubHeading>
+          <Paragraph>
+            Copy or download the markdown file below and add it to your project
+            to use this skill with Claude Code.
+          </Paragraph>
+          <SkillCodeBlock
+            title="octopus-changelog.md"
+            filename="octopus-changelog.md"
+          >
+            {octopusChangelogMd}
           </SkillCodeBlock>
         </SkillCard>
       </Section>

--- a/apps/web/public/skills/octopus-changelog.md
+++ b/apps/web/public/skills/octopus-changelog.md
@@ -1,0 +1,89 @@
+---
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Glob, Grep
+description: Update CHANGELOG.md for a new release based on git history
+---
+
+# Changelog Update
+
+Update CHANGELOG.md for a new release using the Keep a Changelog standard.
+
+## Instructions
+
+### Step 1: Determine Version
+
+1. If the user provided a version as argument `$ARGUMENTS`, use that.
+2. Otherwise, get the latest tag: `git tag -l | sort -V | tail -1`
+3. Suggest the next patch version (e.g., v1.0.5 → v1.0.6) and ask the user to confirm or specify a different version.
+
+### Step 2: Gather Commits
+
+1. Get all commits since the latest tag:
+   ```
+   git log --format="%s" <latest-tag>..HEAD
+   ```
+2. Get today's date for the release header.
+3. If there are no new commits since the last tag, inform the user and stop.
+
+### Step 3: Categorize Changes
+
+Parse each commit message and categorize using conventional commit prefixes:
+
+- `feat:` → **Added**
+- `fix:` → **Fixed**
+- `refactor:` / `perf:` → **Changed**
+- `docs:` → Skip (unless significant)
+- `chore:` / `ci:` / `test:` → Skip (unless user-facing)
+- `chore(deps):` / `chore(deps-dev):` → Skip entirely (dependency bumps)
+- Breaking changes → **Breaking Changes** (look for `BREAKING CHANGE` or `!:`)
+
+Rules:
+- Merge/squash commits that describe the same feature into one entry
+- Write entries from the user's perspective, not the developer's
+- Include PR numbers in parentheses when available, e.g., (#42)
+- Remove commit prefixes (feat:, fix:, etc.) from the final text
+- Keep entries concise — one line each
+- Skip trivial changes (typo fixes, minor refactors, dependency bumps)
+
+### Step 4: Present Draft
+
+Show the categorized entries to the user for review before writing:
+
+```
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- ...
+
+### Fixed
+- ...
+
+### Changed
+- ...
+```
+
+Ask the user to confirm, modify, or add/remove entries.
+
+### Step 5: Update CHANGELOG.md
+
+1. Read the current CHANGELOG.md
+2. Insert the new version section after the header (below the "and this project adheres to..." line) and before the previous version
+3. Add the comparison link at the bottom of the file:
+   ```
+   [X.Y.Z]: https://github.com/octopusreview/octopus/compare/vPREVIOUS...vX.Y.Z
+   ```
+4. Update the previous version's link if it pointed to `HEAD`
+
+### Step 6: Summary
+
+Show what was added to CHANGELOG.md and remind the user to:
+- Review the changes
+- Commit and tag when ready
+
+## Important Rules
+
+- **Never commit or push** — only update the file. The user will commit when ready.
+- **Always show the draft first** and get confirmation before writing.
+- **Use Keep a Changelog format** exactly — headers are `### Added`, `### Fixed`, `### Changed`, `### Removed`, `### Deprecated`, `### Security`.
+- **Skip dependency bumps** (Dependabot PRs, `chore(deps):` commits).
+- **Group related commits** — multiple commits for the same feature become one entry.
+- **Be concise** — one line per entry, written for end users.

--- a/apps/web/public/skills/skills.json
+++ b/apps/web/public/skills/skills.json
@@ -2,6 +2,13 @@
   "version": 1,
   "skills": [
     {
+      "name": "octopus-changelog",
+      "title": "Octopus Changelog",
+      "description": "Update CHANGELOG.md for a new release based on git history",
+      "filename": "octopus-changelog.md",
+      "hash": "8234b53878834a59e6776274c6dacae182cb5be56d397b5cfdd54038a81f3c69"
+    },
+    {
       "name": "octopus-fix",
       "title": "Octopus Fix",
       "description": "Check open PRs for review comments, apply fixes, and push updates",


### PR DESCRIPTION
## Summary
- Add octopus-changelog.md skill for automated CHANGELOG.md updates from git history
- Update skills.json manifest (now 3 skills)
- Add Octopus Changelog card to /docs/skills page with workflow steps and rules

Closes #91

## Files Changed
- `apps/web/public/skills/octopus-changelog.md` — Skill file
- `apps/web/public/skills/skills.json` — Updated manifest
- `apps/web/app/(landing)/docs/skills/page.tsx` — Skill card on docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)