### PR TITLE
fix: mobile logo navigation and react version mismatch

### DIFF
--- a/apps/web/components/landing-mobile-nav.tsx
+++ b/apps/web/components/landing-mobile-nav.tsx
@@ -12,10 +12,10 @@ export function LandingMobileNav({ isLoggedIn }: { isLoggedIn: boolean }) {
   return (
     <nav className="fixed left-0 right-0 top-0 z-40 border-b border-white/[0.06] bg-[#0c0c0c]/80 backdrop-blur-xl lg:hidden">
       <div className="flex items-center justify-between px-4 py-3">
-        <div className="flex items-center gap-2">
+        <Link href="/" className="flex items-center gap-2">
           <Image src="/logo.svg" alt="Octopus" width={22} height={22} priority />
           <span className="text-sm font-semibold text-white">Octopus</span>
-        </div>
+        </Link>
         <div className="flex items-center gap-2">
           <button
             onClick={() => window.dispatchEvent(new Event("ask-octopus-open"))}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,7 +37,7 @@
     "nodemailer": "^8.0.4",
     "openai": "^6.32.0",
     "radix-ui": "^1.4.3",
-    "react": "19.2.3",
+    "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",
     "recharts": "^3.7.0",

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
         "nodemailer": "^8.0.4",
         "openai": "^6.32.0",
         "radix-ui": "^1.4.3",
-        "react": "19.2.3",
+        "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-markdown": "^10.1.0",
         "recharts": "^3.7.0",
@@ -2135,7 +2135,7 @@
 
     "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
 
-    "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
+    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 


### PR DESCRIPTION
## Summary
- Fix mobile navbar logo not navigating to home — wrapped `<div>` with `<Link href="/">`
- Fix react/react-dom version mismatch: react 19.2.3 → 19.2.4 to match react-dom

Closes #92

## Files Changed
- `apps/web/components/landing-mobile-nav.tsx` — Logo link fix
- `apps/web/package.json` — React version bump
- `bun.lock` — Updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)