### PR TITLE
fix: prevent redirect poisoning via X-Forwarded-Host header

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -18,10 +18,12 @@ export function middleware(request: NextRequest) {
     request.cookies.get("__Secure-better-auth.session_token")?.value;
 
   if (!sessionToken) {
-    // Use x-forwarded headers or BETTER_AUTH_URL to avoid 0.0.0.0 redirects
-    const proto = request.headers.get("x-forwarded-proto") || "http";
-    const host = request.headers.get("x-forwarded-host") || request.headers.get("host") || "localhost:3000";
-    const loginUrl = new URL("/login", `${proto}://${host}`);
+    // Use configured app URL to prevent redirect poisoning via X-Forwarded-Host
+    const appUrl =
+      process.env.BETTER_AUTH_URL ||
+      process.env.NEXT_PUBLIC_APP_URL ||
+      `http://${request.headers.get("host") || "localhost:3000"}`;
+    const loginUrl = new URL("/login", appUrl);
     const fullPath = pathname + request.nextUrl.search;
     if (fullPath !== "/dashboard") {
       loginUrl.searchParams.set("callbackUrl", fullPath);


### PR DESCRIPTION
## Summary
- Replace X-Forwarded-Host header usage with explicitly configured URLs (BETTER_AUTH_URL or NEXT_PUBLIC_APP_URL)
- Prevents redirect poisoning attacks when headers are spoofed

Closes #106

## Files Changed
- `apps/web/middleware.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)