### PR TITLE
fix: align Cohere logo height with other provider logos

### DIFF
--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -203,7 +203,7 @@ export default async function LandingPage() {
             <img src="/openai-text.svg" alt="OpenAI" className="h-4 invert brightness-50" />
             <span className="text-white/20">+</span>
             <img src="/cohere-color.svg" alt="Cohere" className="h-4 w-4" />
-            <img src="/cohere-text.svg" alt="Cohere" className="h-3.5 invert brightness-50" />
+            <img src="/cohere-text.svg" alt="Cohere" className="h-4 invert brightness-50" />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Change Cohere text logo height from `h-3.5` to `h-4` to match other provider logos in the hero section

Closes #125

## Files Changed
- `apps/web/app/(landing)/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)