### PR TITLE
feat: add server ID to version endpoint

### DIFF
--- a/apps/web/app/api/version/route.ts
+++ b/apps/web/app/api/version/route.ts
@@ -1,3 +1,6 @@
 export function GET() {
-  return Response.json({ buildId: process.env.NEXT_PUBLIC_BUILD_ID });
+  return Response.json({
+    buildId: process.env.NEXT_PUBLIC_BUILD_ID,
+    server: process.env.OCTOPUS_SERVER_ID || "unknown",
+  });
 }


### PR DESCRIPTION
## Summary
- Include `OCTOPUS_SERVER_ID` in `/api/version` response for identifying which server instance is responding
- Defaults to `"unknown"` when env var is not set

Closes #126

## Files Changed
- `apps/web/app/api/version/route.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)