### PR TITLE
Use Cloudflare geolocation headers instead of async IP lookup

### DIFF
--- a/apps/web/app/api/auth/device/route.ts
+++ b/apps/web/app/api/auth/device/route.ts
@@ -120,7 +120,6 @@ function parseBrowser(userAgent: string): string {
 function parseCloudflareLocation(h: Headers): string {
   const city = h.get("cf-ipcity");
   const country = h.get("cf-ipcountry");
-  if (city && country) return `${city}, ${country}`;
-  if (country) return country;
-  return "Unknown";
+  const raw = city && country ? `${city}, ${country}` : country || "Unknown";
+  return raw.replace(/[^\w\s,.\-()]/g, "").slice(0, 100);
 }


### PR DESCRIPTION
## Summary

Replace asynchronous IP geolocation API calls with Cloudflare's built-in geolocation headers for faster, more reliable location detection during device registration.

## Changes

- Remove `fetchIpLocation()` async function that called external ipapi.co service
- Add `parseCloudflareLocation()` function to extract location from Cloudflare headers (`cf-ipcity`, `cf-ipcountry`)
- Update device creation to use Cloudflare location synchronously instead of fire-and-forget async update
- Pass location to email notification template immediately (previously would be null or delayed)
- Eliminates external API dependency, rate limiting concerns, and async race conditions

## Test plan

- [ ] Linting passes (`bun run lint`)
- [ ] Type check passes (`bun run typecheck`)
- [ ] Tested locally with device registration flow

https://claude.ai/code/session_014yai8xYNkCbDrZH4oDBXBV