### PR TITLE
fix: ObfuscatedEmail polymorphic tag to avoid nested anchor elements

### DIFF
--- a/apps/web/app/(landing)/bug-bounty/page.tsx
+++ b/apps/web/app/(landing)/bug-bounty/page.tsx
@@ -385,7 +385,8 @@ export default async function BugBountyPage() {
             <ObfuscatedEmail
               user="security"
               showIcon={false}
-              className="group flex items-start gap-4 rounded-xl border border-white/[0.06] bg-white/[0.02] p-6 transition-colors hover:border-white/[0.12]"
+              className="group flex cursor-pointer items-start gap-4 rounded-xl border border-white/[0.06] bg-white/[0.02] p-6 transition-colors hover:border-white/[0.12]"
+              as="div"
             >
               <IconMail className="mt-0.5 size-6 shrink-0 text-teal-400" />
               <div>

--- a/apps/web/components/obfuscated-email.tsx
+++ b/apps/web/components/obfuscated-email.tsx
@@ -14,11 +14,13 @@ export function ObfuscatedEmail({
   showIcon = true,
   className = "",
   children,
+  as: Tag = "a",
 }: {
   user?: string;
   showIcon?: boolean;
   className?: string;
   children?: React.ReactNode;
+  as?: "a" | "div" | "span";
 }) {
   const reversedUser = user.split("").reverse().join("");
   const reversedDomain = "ia.weiver-supotco";
@@ -31,8 +33,8 @@ export function ObfuscatedEmail({
   }, [reversedUser, reversedDomain]);
 
   return (
-    <a
-      href="#contact"
+    <Tag
+      {...(Tag === "a" ? { href: "#contact" } : { role: "button", tabIndex: 0 })}
       onClick={handleClick}
       className={`inline-flex items-center gap-1.5 ${className}`}
       aria-label="Send email"
@@ -43,6 +45,6 @@ export function ObfuscatedEmail({
           {displayReversed}
         </span>
       )}
-    </a>
+    </Tag>
   )
 }


### PR DESCRIPTION
## Summary
- Add `as` prop to ObfuscatedEmail component (supports "a", "div", "span")
- Prevents invalid HTML from nested `<a>` tags when the component wraps content that itself contains links
- Bug bounty page uses `as="div"` for outer email wrapper + adds cursor-pointer

Closes #140

## Files Changed
- `apps/web/components/obfuscated-email.tsx`
- `apps/web/app/(landing)/bug-bounty/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)