### PR TITLE
feat: reduce false positives and improve review validation

### DIFF
--- a/apps/web/lib/review-core.ts
+++ b/apps/web/lib/review-core.ts
@@ -461,7 +461,7 @@ Rules:
       ? reviewConfig.confidenceThreshold
       : reviewConfig.confidenceThreshold === "HIGH"
         ? 85
-        : 65;
+        : 70;
   findings = findings.filter((f) => f.confidence >= confidenceThreshold);
 
   // Filter out disabled categories
@@ -485,7 +485,7 @@ Rules:
       for (let i = 0; i < findings.length; i++) {
         const matches = await searchFeedbackPatterns(repo.id, findingVectors[i], 3, org.id, findingTexts[i]);
         const falsePositiveMatch = matches.find(
-          (m) => m.feedback === "down" && m.score > 0.85,
+          (m) => m.feedback === "down" && m.score > 0.80,
         );
         if (falsePositiveMatch) {
           suppressedIndexes.add(i);

--- a/apps/web/lib/review-validation.ts
+++ b/apps/web/lib/review-validation.ts
@@ -83,7 +83,7 @@ export async function gatherCrossFileContext(
 
 // ─── Two-Pass Validation ────────────────────────────────────────────────────
 
-export const VALIDATION_MODEL = "claude-haiku-4-5-20251001";
+export const VALIDATION_MODEL = "claude-sonnet-4-6-20250514";
 
 export async function validateFindings(
   findings: InlineFinding[],
@@ -131,6 +131,16 @@ When a finding claims a function call has wrong parameters, a missing import, or
 - Check the "Referenced Code Context" section if available for the actual definition
 - If the context confirms the usage is correct, assign confidence 10-20
 - If the context confirms the issue, keep or raise confidence
+
+When a finding flags a "broad" operation (regex, string replacement, deletion) as over-aggressive:
+- Check whether the input is already constrained by prior code (capture groups, filters, conditionals)
+- If the input is pre-scoped so the broad operation is intentionally exhaustive, assign confidence 10-20
+
+When a finding is based on a general heuristic ("don't replace all X", "avoid broad regex") rather than a concrete traced bug:
+- If no specific incorrect behavior is demonstrated, assign confidence 30-50
+
+When the diff includes comments explaining the domain-specific reason for an approach and the finding contradicts that without concrete counter-evidence:
+- Assign confidence 10-20
 
 For each finding, respond with ONLY a JSON array:
 [{"index": 0, "confidence": 92}, {"index": 1, "confidence": 35}, ...]

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1520,7 +1520,7 @@ Rules:
         ? reviewConfig.confidenceThreshold
         : reviewConfig.confidenceThreshold === "HIGH"
           ? 85
-          : 65;
+          : 70;
     const allFindings = findings;
     findings = findings.filter((f) => f.confidence >= confidenceThreshold);
     if (allFindings.length !== findings.length) {
@@ -1554,7 +1554,7 @@ Rules:
         for (let i = 0; i < allParsedFindings.length; i++) {
           const matches = await searchFeedbackPatterns(repo.id, allFindingVectors[i], 3, org.id, allFindingTexts[i]);
           const falsePositiveMatch = matches.find(
-            (m) => m.feedback === "down" && m.score > 0.85,
+            (m) => m.feedback === "down" && m.score > 0.80,
           );
           if (falsePositiveMatch) {
             suppressedAllIndexes.add(i);

--- a/apps/web/prompts/SYSTEM_PROMPT.md
+++ b/apps/web/prompts/SYSTEM_PROMPT.md
@@ -302,6 +302,22 @@ SCORING RULES:
 23. Always verify file paths before including them in findings. If you reference a file path,
     it MUST match an entry in the file tree or a path visible in the diff. Never invent or
     guess file paths.
+24. Before flagging a code pattern as incorrect or over-broad, trace the full logic chain:
+    - What is the actual input to the flagged operation? (e.g., is a variable already
+      scoped by a prior regex capture group, filter, or type guard?)
+    - Does the surrounding code constrain the input in a way that makes the "broad"
+      pattern intentionally exhaustive?
+    - If the code includes a comment explaining WHY it does something broadly, trust
+      the author's domain knowledge unless you have concrete evidence it's wrong.
+    Example: `.replace(/:/g, "")` looks over-aggressive in isolation, but if the input
+    is already extracted from a specific context where ALL colons are invalid, it's correct.
+25. Do not flag code as wrong based solely on general programming heuristics when the
+    code operates in a domain-specific context (parsers, serializers, protocol handlers,
+    format-specific sanitizers). Domain rules often override general intuitions. If you
+    lack domain expertise to verify, downgrade to a NIT with conditional language.
+26. Self-check before reporting: "Am I flagging this because I traced a concrete bug,
+    or because it LOOKS like a common anti-pattern?" If pattern-matching without
+    verification, either skip the finding or reduce confidence below 50.
 </review_rules>
 
 {{CONFLICT_DETECTION}}


### PR DESCRIPTION
## Summary
- Raise default confidence threshold from 65 to 70
- Lower false positive feedback match threshold from 0.85 to 0.80 for better suppression
- Upgrade validation model from claude-haiku-4-5 to claude-sonnet-4-6
- Add validation rules for broad operations, heuristic-based findings, and domain-specific comments
- Add system prompt rules 24-26: trace logic before flagging, respect domain context, self-check pattern-matching

Closes #149

## Files Changed
- apps/web/lib/review-core.ts
- apps/web/lib/reviewer.ts
- apps/web/lib/review-validation.ts
- apps/web/prompts/SYSTEM_PROMPT.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)