### PR TITLE
chore: Dockerfile lint suppression and deploy scripts

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,3 +1,4 @@
+# check=skip=SecretsUsedInArgOrEnv
 FROM oven/bun:1-alpine AS base
 
 # --- deps ---

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "db:push": "bun --filter @octopus/db db:push",
     "db:studio": "bun --filter @octopus/db db:studio",
     "skills:generate": "bun run apps/web/scripts/generate-skills-json.ts",
-    "simulate:review": "bun run --cwd apps/web scripts/review-simulator.ts"
+    "simulate:review": "bun run --cwd apps/web scripts/review-simulator.ts",
+    "deploy:wdc": "./deploy.sh all --host wdc",
+    "deploy:aws": "./deploy.sh all --host aws --skip-build",
+    "deploy:all": "./deploy.sh all --host wdc && ./deploy.sh all --host aws --skip-build"
   },
   "trustedDependencies": [
     "@prisma/engines",


### PR DESCRIPTION
## Summary
- Add `# check=skip=SecretsUsedInArgOrEnv` to Dockerfile to suppress false positive lint warning
- Add `deploy:wdc`, `deploy:aws`, `deploy:all` convenience scripts to root package.json

Closes #151

## Files Changed
- apps/web/Dockerfile
- package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)