### PR TITLE
fix: include pending status in duplicate review guard

### DIFF
--- a/apps/web/lib/webhook-shared.ts
+++ b/apps/web/lib/webhook-shared.ts
@@ -95,7 +95,7 @@ export async function startReviewFlow(params: {
     select: { id: true, status: true, headSha: true, updatedAt: true },
   });
 
-  if (existingPr && existingPr.status === "reviewing") {
+  if (existingPr && (existingPr.status === "reviewing" || existingPr.status === "pending")) {
     const stuckThresholdMs = 3 * 60 * 1000; // 3 minutes
     const isStuck = Date.now() - existingPr.updatedAt.getTime() > stuckThresholdMs;
 
@@ -106,7 +106,7 @@ export async function startReviewFlow(params: {
         data: { status: "failed", errorMessage: "Review timed out after 3 minutes" },
       });
     } else if (existingPr.headSha === headSha) {
-      console.log(`[webhook] Review already in progress for PR #${prNumber} (same SHA), skipping`);
+      console.log(`[webhook] Review already in progress/queued for PR #${prNumber} (same SHA), skipping`);
       return;
     } else {
       console.log(`[webhook] New SHA detected for PR #${prNumber}, restarting review`);


### PR DESCRIPTION
## Summary
- Add `"pending"` to the duplicate-review status check alongside `"reviewing"` to prevent duplicate reviews when a webhook arrives while a PR is queued
- Update log message to reflect broader guard scope

Closes #161

## Files Changed
- `apps/web/lib/webhook-shared.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)