### PR TITLE
fix: show raw numbers for landing page stats

### DIFF
--- a/apps/web/components/landing-stats.tsx
+++ b/apps/web/components/landing-stats.tsx
@@ -49,9 +49,9 @@ function formatNumber(n: number, raw?: boolean): string {
 
 const statsMeta = [
   { key: "chunks" as const, label: "Code Chunks", suffix: "+", raw: true },
-  { key: "findings" as const, label: "Findings", suffix: "+", raw: false },
-  { key: "reviews" as const, label: "PR Reviews", suffix: "+", raw: false },
-  { key: "repositories" as const, label: "Repositories", suffix: "", raw: false },
+  { key: "findings" as const, label: "Findings", suffix: "+", raw: true },
+  { key: "reviews" as const, label: "PR Reviews", suffix: "+", raw: true },
+  { key: "repositories" as const, label: "Repositories", suffix: "", raw: true },
 ];
 
 export function LandingStats({ initial }: { initial: Stats }) {


### PR DESCRIPTION
## Summary
- Set `raw: true` for findings, reviews, and repositories stats on the landing page
- Displays actual numbers instead of abbreviated format

Closes #164

## Files Changed
- `apps/web/components/landing-stats.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)