### PR TITLE
chore: refactor nginx config, add AWS variant and Cloudflare error page

### DIFF
--- a/apps/web/public/cloudflare-error.html
+++ b/apps/web/public/cloudflare-error.html
@@ -67,7 +67,7 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'G-BNFCHLD0BY');
+    gtag('config', '{{GOOGLE_ANALYTICS_ID}}');
     gtag('event', 'cf-error', {
       event_category: 'error',
       event_label: document.title,
@@ -77,7 +77,7 @@
 </head>
 <body>
   <div class="container">
-    <img src="https://{{V0_VERCEL_URL}}/logo.svg" alt="Octopus" class="logo">
+    <img src="https://octopus-review.ai/logo.svg" alt="Octopus" class="logo">
     <div style="display:none">::CLOUDFLARE_ERROR_500XX_MSG::</div>
     <div class="error-code">Something went wrong</div>
     <div class="error-message">

--- a/nginx.aws.conf
+++ b/nginx.aws.conf
@@ -22,6 +22,12 @@ http {
     ssl_certificate /etc/nginx/ssl/ssl.crt;
     ssl_certificate_key /etc/nginx/ssl/ssl.key;
 
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
     # Docker DNS resolver for dynamic upstream resolution
     resolver 127.0.0.11 valid=10s ipv6=off;
 
@@ -69,11 +75,6 @@ http {
     # Everything else -> web
     location / {
       proxy_pass $web_upstream;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Host $host;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
       proxy_buffering off;

--- a/nginx.conf
+++ b/nginx.conf
@@ -65,11 +65,6 @@ http {
     # Everything else -> web
     location / {
       proxy_pass $web_upstream;
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Host $host;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
       proxy_buffering off;


### PR DESCRIPTION
## Summary
- Move proxy headers to server-level defaults, remove `include /etc/nginx/proxy_params` directives
- Add `nginx.aws.conf` with SSL support for AWS deployment
- Add custom Cloudflare 5xx error page with Octopus branding and analytics

Closes #166

## Files Changed
- `nginx.conf`
- `nginx.aws.conf`
- `apps/web/public/cloudflare-error.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)