### PR TITLE
docs(terraform): rewrite README for beginner usability

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -106,9 +106,10 @@ You need two separate GitHub apps: one for PR reviews and one for user login.
 3. Under **Permissions**, set:
    - Repository: **Contents** → Read-only
    - Repository: **Pull requests** → Read & Write
+   - Repository: **Checks** → Read & Write
    - Repository: **Metadata** → Read-only (auto-selected)
    - Repository: **Issues** → Read & Write
-4. Under **Subscribe to events**, check: **Pull request**, **Issue comment**, **Installation**
+4. Under **Subscribe to events**, check: **Pull request**, **Issue comment**, **Installation**, **Installation repositories**
 5. **Where can this app be installed?** → Any account (or Only on this account)
 6. Click **Create GitHub App**
 7. On the next page, note the **App ID** (a number like `123456`)
@@ -149,8 +150,8 @@ The minimum you need to fill in:
 |----------|----------------|
 | `app_image` | The image URL from Step 1 |
 | `app_domain` | Your domain (e.g. `octopus.example.com`) |
-| `db_password` | Run: `openssl rand -base64 24 \| tr -d '/+=' \| cut -c1-24` |
-| `better_auth_secret` | Run: `openssl rand -hex 32` |
+| `db_password` | Leave empty — auto-generated on first apply |
+| `better_auth_secret` | Leave empty — auto-generated on first apply |
 | `github_app_id` | From Step 2A (the number) |
 | `github_app_private_key` | The single-line PEM from Step 2A |
 | `github_webhook_secret` | The secret you set in the GitHub App webhook |
@@ -181,6 +182,15 @@ When `apply` finishes, you'll see output like:
 public_ip  = "54.123.45.67"
 app_url    = "https://octopus.example.com"
 ```
+
+If you left `db_password` and `better_auth_secret` empty (recommended), Terraform generated them automatically. To retrieve them:
+
+```bash
+terraform output -raw db_password
+terraform output -raw better_auth_secret
+```
+
+Save these somewhere safe — they are stored in your Terraform state file.
 
 ---
 
@@ -300,11 +310,11 @@ Running on default settings in `us-east-1`:
 | Resource | Type | ~$/month |
 |----------|------|----------|
 | EC2 | t3.xlarge (on-demand) | $120 |
-| RDS | db.t3.medium, single-AZ | $50 |
+| RDS | db.t3.medium, single-AZ, 50 GB | $54 |
 | EBS | 100 GB gp3 | $8 |
 | Elastic IP | (always attached) | $0 |
 | Data transfer | ~50 GB out | $5 |
-| **Total** | | **~$183/mo** |
+| **Total** | | **~$187/mo** |
 
 > Switching to Reserved Instances (1-year, no upfront) saves ~35% — roughly $65/mo.
 
@@ -333,7 +343,7 @@ sudo docker compose up -d
 | 5–20 devs | t3.2xlarge | db.t3.large | Scale up as load grows |
 | 20+ devs  | c5.2xlarge | db.t3.xlarge | Consider `db_multi_az = true` |
 
-The web process needs at least 4 GB RAM. With Qdrant and nginx, plan for 8 GB total minimum.
+The web container is allocated 5 GB RAM (4 GB for the Node.js heap). With Qdrant and nginx, plan for 8 GB total minimum.
 
 ---
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
 # Octopus — Terraform
 
-Production-ready infrastructure for self-hosting Octopus on AWS.
+Self-host Octopus on AWS with a single `terraform apply`. This sets up an EC2 instance running the Octopus app, an RDS PostgreSQL database, and optional ElastiCache Redis — all in a private VPC.
 
 ## Architecture
 
@@ -17,147 +17,364 @@ Production-ready infrastructure for self-hosting Octopus on AWS.
 │  │  qdrant        │                                      │
 │  └────────┬───────┘                                      │
 └───────────┼──────────────────────────────────────────────┘
-            │ EIP
+            │ Elastic IP
         Internet
 ```
 
-**What runs on EC2 (Docker Compose):**
-- `nginx` — reverse proxy routing webhooks and CLI traffic
-- `web` — the Octopus Next.js application
-- `qdrant` — vector database for code embeddings
+**What runs on EC2 (Docker Compose):** nginx + Octopus web app + Qdrant vector database
 
-**Managed services:**
-- **RDS PostgreSQL 17** — application database (replaces the local postgres container)
-- **ElastiCache Redis** — optional, for session caching and background job queues
+**Managed AWS services:** RDS PostgreSQL 17 (app database) · ElastiCache Redis (optional, for queues)
 
-## Quick Start
+---
 
-### Prerequisites
+## Prerequisites
+
+Install these before you start:
 
 - [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5
-- AWS credentials configured (`aws configure` or environment variables)
-- A Docker image of Octopus pushed to a registry (build from the root Dockerfile)
-- A registered domain with DNS access
+- [Docker](https://docs.docker.com/get-docker/) (to build and push the app image)
+- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) — run `aws configure` with your access key and secret
+- A registered domain (you'll point its DNS to the server IP after deploy)
+- A GitHub account (to create the GitHub App and OAuth App)
 
-### 1. Build and push the Docker image
+---
+
+## Step 1 — Build and push the Docker image
+
+Build the Octopus image from the repository root and push it to a registry.
+
+### Option A — GitHub Container Registry (GHCR) — recommended
 
 ```bash
-# From the repository root
-docker build -t ghcr.io/your-org/octopus:latest -f apps/web/Dockerfile .
-docker push ghcr.io/your-org/octopus:latest
+# 1. Create a Personal Access Token (classic) at:
+#    https://github.com/settings/tokens/new
+#    Required scopes: write:packages, read:packages
+export GITHUB_TOKEN=ghp_your_token_here
+
+# 2. Log in to GHCR
+echo $GITHUB_TOKEN | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+
+# 3. Build and push (run from the repo root)
+docker build -t ghcr.io/YOUR_ORG_OR_USERNAME/octopus:latest -f apps/web/Dockerfile .
+docker push ghcr.io/YOUR_ORG_OR_USERNAME/octopus:latest
+
+# 4. Make the package public so the EC2 instance can pull it without auth:
+#    https://github.com/YOUR_ORG_OR_USERNAME/octopus/settings/packages → Change visibility → Public
+#    (Or use ECR below — EC2 authenticates automatically via IAM)
 ```
 
-### 2. Configure variables
+Set in `terraform.tfvars`: `app_image = "ghcr.io/YOUR_ORG_OR_USERNAME/octopus:latest"`
+
+### Option B — AWS ECR (private, auth handled automatically)
+
+```bash
+# 1. Create the repository (one-time)
+aws ecr create-repository --repository-name octopus --region us-east-1
+
+# 2. Log in and push
+aws ecr get-login-password --region us-east-1 \
+  | docker login --username AWS --password-stdin \
+      123456789012.dkr.ecr.us-east-1.amazonaws.com
+
+docker build -t 123456789012.dkr.ecr.us-east-1.amazonaws.com/octopus:latest \
+  -f apps/web/Dockerfile .
+docker push 123456789012.dkr.ecr.us-east-1.amazonaws.com/octopus:latest
+```
+
+Set in `terraform.tfvars`:
+```
+app_image        = "123456789012.dkr.ecr.us-east-1.amazonaws.com/octopus:latest"
+ecr_registry_url = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+```
+
+The EC2 instance authenticates to ECR automatically through its IAM role — no credentials needed.
+
+---
+
+## Step 2 — Create GitHub Apps
+
+You need two separate GitHub apps: one for PR reviews and one for user login.
+
+### Part A — GitHub App (PR reviews, webhooks)
+
+1. Go to **https://github.com/settings/apps/new**
+2. Fill in:
+   - **GitHub App name**: e.g. `Octopus Review`
+   - **Homepage URL**: `https://your-domain.com`
+   - **Webhook URL**: `https://your-domain.com/api/github/webhook`
+   - **Webhook secret**: generate with `openssl rand -hex 20` and save it
+3. Under **Permissions**, set:
+   - Repository: **Contents** → Read-only
+   - Repository: **Pull requests** → Read & Write
+   - Repository: **Metadata** → Read-only (auto-selected)
+   - Repository: **Issues** → Read & Write
+4. Under **Subscribe to events**, check: **Pull request**, **Issue comment**, **Installation**
+5. **Where can this app be installed?** → Any account (or Only on this account)
+6. Click **Create GitHub App**
+7. On the next page, note the **App ID** (a number like `123456`)
+8. Scroll down → **Generate a private key** → a `.pem` file downloads
+9. Convert the key to a single-line string for Terraform:
+   ```bash
+   awk 'NF {printf "%s\\n", $0}' ~/Downloads/your-app-name.pem
+   ```
+   Copy the output — it should look like: `"-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----\n"`
+10. Find your app's **slug** from the URL: `github.com/apps/your-slug` → the slug is `your-slug`
+11. Click **Install App** → select the repositories Octopus should review
+
+### Part B — GitHub OAuth App (user login)
+
+1. Go to **https://github.com/settings/developers** → **OAuth Apps** → **New OAuth App**
+2. Fill in:
+   - **Application name**: e.g. `Octopus Login`
+   - **Homepage URL**: `https://your-domain.com`
+   - **Authorization callback URL**: `https://your-domain.com/api/auth/callback/github`
+     ⚠️ Use exactly this path — it's handled by Better Auth internally
+3. Click **Register application**
+4. Note the **Client ID**, then click **Generate a new client secret** and save it
+
+---
+
+## Step 3 — Configure variables
 
 ```bash
 cd terraform/stacks/aws-ec2
 cp terraform.tfvars.example terraform.tfvars
-# Edit terraform.tfvars — fill in all required values
 ```
 
-### 3. (Optional) Configure remote state
+Open `terraform.tfvars` and fill in the **REQUIRED** section at the top. The file has inline comments explaining each value.
+
+The minimum you need to fill in:
+
+| Variable | Where to get it |
+|----------|----------------|
+| `app_image` | The image URL from Step 1 |
+| `app_domain` | Your domain (e.g. `octopus.example.com`) |
+| `db_password` | Run: `openssl rand -base64 24 \| tr -d '/+=' \| cut -c1-24` |
+| `better_auth_secret` | Run: `openssl rand -hex 32` |
+| `github_app_id` | From Step 2A (the number) |
+| `github_app_private_key` | The single-line PEM from Step 2A |
+| `github_webhook_secret` | The secret you set in the GitHub App webhook |
+| `github_app_slug` | From Step 2A |
+| `github_client_id` | From Step 2B |
+| `github_client_secret` | From Step 2B |
+| `openai_api_key` or `anthropic_api_key` | At least one LLM key required |
+| `admin_emails` | Your email — gets admin access on first login |
+
+---
+
+## Step 4 — Deploy
 
 ```bash
-cp backend.conf.example backend.conf
-# Edit backend.conf with your S3 bucket details
-terraform init -backend-config=backend.conf
-```
-
-Or use local state for simple setups:
-
-```bash
+# Initialize Terraform (downloads the AWS provider)
 terraform init
-```
 
-### 4. Deploy
-
-```bash
+# Preview what will be created
 terraform plan
+
+# Create all resources (~5–8 minutes)
 terraform apply
 ```
 
-### 5. Run database migrations
+When `apply` finishes, you'll see output like:
 
-On first deploy (and after schema changes), migrations must be run before the application serves traffic. SSH into the instance and run:
+```
+public_ip  = "54.123.45.67"
+app_url    = "https://octopus.example.com"
+```
 
+---
+
+## Step 5 — Point DNS
+
+Create an **A record** in your DNS provider:
+
+```
+octopus.example.com  →  A  →  <public_ip from apply output>
+```
+
+The app responds on port 80 immediately after the EC2 instance finishes booting (2–3 minutes after `apply`).
+
+---
+
+## Step 6 — Set up HTTPS
+
+The server listens on HTTP (port 80). To serve HTTPS, the easiest option is **Cloudflare** (free plan):
+
+1. Add your domain to Cloudflare (free plan is fine)
+2. Create the DNS A record in Cloudflare (same as Step 5) — make sure the cloud icon is **orange** (proxied)
+3. In Cloudflare: **SSL/TLS** → set mode to **Full** (not Full Strict, since nginx uses plain HTTP)
+4. Done — Cloudflare terminates TLS for you at no cost
+
+Alternatively:
+- **AWS ALB + ACM**: more involved, requires a separate load balancer module
+- **Caddy sidecar**: add a Caddy container to the docker-compose template with a volume for certs
+
+---
+
+## Step 7 — Run database migrations
+
+On first deploy, run Prisma migrations before the app serves traffic.
+
+**If you enabled SSH** (`key_name` is set in tfvars):
 ```bash
 ssh -i your-key.pem ubuntu@<public_ip>
 cd /opt/octopus
-
-# Wait for the containers to start (usually 30–60 s after boot)
-sudo docker compose ps
-
-# Run Prisma migrations against the RDS instance
-sudo docker compose run --rm web sh -c "cd /app && npx prisma migrate deploy"
+sudo docker compose ps           # wait until all containers show "Up"
+sudo docker compose run --rm web sh -c "npx prisma migrate deploy"
 ```
 
-> The `web` service container image includes the Next.js standalone output but not the Prisma CLI binary. If `npx prisma` is not found, run migrations locally pointing `DATABASE_URL` at the RDS endpoint, or add a dedicated migration step to your CI/CD pipeline.
+**If SSH is disabled** (default — use AWS SSM Session Manager instead):
+```bash
+# Install the SSM plugin if needed: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html
+aws ssm start-session --target <instance_id from apply output>
 
-### 6. Point DNS
-
-After `apply` completes, copy the `public_ip` output and create an **A record** in your DNS provider:
-
-```
-octopus.example.com  A  <public_ip>
-```
-
-The application will be available at `http://<public_ip>` immediately (nginx listens on port 80). For HTTPS, add a TLS termination layer (AWS ALB, Caddy sidecar, or Cloudflare proxy).
-
-## Directory Layout
-
-```
-terraform/
-├── modules/
-│   └── aws/
-│       ├── vpc/              # VPC, subnets, IGW, NAT Gateway
-│       ├── ec2-app/          # EC2, security group, IAM, EIP, userdata
-│       ├── rds-postgres/     # RDS PostgreSQL 17
-│       └── elasticache-redis/ # ElastiCache Redis (optional)
-├── stacks/
-│   └── aws-ec2/              # Full composition — use this for deployments
-│       ├── main.tf
-│       ├── variables.tf
-│       ├── outputs.tf
-│       ├── providers.tf
-│       ├── versions.tf
-│       ├── templates/
-│       │   └── docker-compose.yml.tpl
-│       ├── terraform.tfvars.example
-│       └── backend.conf.example
-└── examples/
-    └── aws-ec2/              # Minimal wrapper for quick evaluation
+# Then run the same commands
+cd /opt/octopus
+sudo docker compose run --rm web sh -c "npx prisma migrate deploy"
 ```
 
-## Instance Sizing
+> If `npx prisma` is not found inside the container, run migrations locally by setting `DATABASE_URL` to the RDS endpoint and running `npx prisma migrate deploy` from your machine.
 
-| Team size | Instance type | RDS instance | Notes |
-|-----------|---------------|--------------|-------|
-| 1–5 devs  | t3.xlarge     | db.t3.micro  | Minimum viable |
-| 5–20 devs | t3.2xlarge    | db.t3.medium | Recommended |
-| 20+ devs  | c5.2xlarge    | db.t3.large  | Consider Multi-AZ RDS |
+---
 
-The Octopus web process requires at minimum 4 GB of memory (`NODE_OPTIONS=--max-old-space-size=4096`). Qdrant and nginx add ~1–2 GB, so instances with less than 8 GB total RAM are not recommended.
+## Step 8 — Verify the deployment
+
+1. Open `http://<public_ip>` (or `https://<domain>` if Cloudflare is set up) — you should see the login page
+2. Click **Sign in with GitHub** and log in with the email in `admin_emails`
+3. Go to **Settings** → **Integrations** — confirm the GitHub App is installed
+4. Open a test PR in one of your repos and mention `@<github-app-slug>` in a comment — Octopus should post a review
+
+---
+
+## Troubleshooting
+
+**Server not responding after apply**
+
+The EC2 boot script runs on first startup (2–3 minutes). Check progress:
+```bash
+# SSH or SSM into the instance, then:
+tail -f /var/log/octopus-setup.log
+```
+
+**App is up but shows errors**
+
+```bash
+cd /opt/octopus
+sudo docker compose logs web     # app logs
+sudo docker compose logs nginx   # proxy logs
+sudo docker compose ps           # container status
+```
+
+**Database connection refused**
+
+RDS takes 5–10 minutes to become available after `apply`. Check the RDS console or run:
+```bash
+sudo docker compose logs web 2>&1 | grep -i "database\|connect\|prisma"
+```
+
+**GitHub webhook not arriving**
+
+- In your GitHub App settings → **Advanced** → check Recent Deliveries
+- Confirm webhook URL is exactly `https://your-domain.com/api/github/webhook`
+- Confirm HTTPS is working (webhook requires HTTPS)
+
+**"Sign in with GitHub" fails**
+
+The Authorization callback URL in your GitHub OAuth App must be exactly:
+```
+https://your-domain.com/api/auth/callback/github
+```
+Not `/api/github/callback` (that's a different route for App installation).
+
+**Image pull failed on boot**
+
+- GHCR: make sure the package is set to **Public** visibility
+- ECR: make sure `ecr_registry_url` is set in tfvars and the region matches
+
+---
+
+## Estimated Monthly Cost
+
+Running on default settings in `us-east-1`:
+
+| Resource | Type | ~$/month |
+|----------|------|----------|
+| EC2 | t3.xlarge (on-demand) | $120 |
+| RDS | db.t3.medium, single-AZ | $50 |
+| EBS | 100 GB gp3 | $8 |
+| Elastic IP | (always attached) | $0 |
+| Data transfer | ~50 GB out | $5 |
+| **Total** | | **~$183/mo** |
+
+> Switching to Reserved Instances (1-year, no upfront) saves ~35% — roughly $65/mo.
+
+---
 
 ## Updating the Application
 
+After pushing a new image to your registry:
+
 ```bash
-# Pull the latest image on the server
-ssh -i your-key.pem ubuntu@<public_ip>
+ssh -i your-key.pem ubuntu@<public_ip>   # or use SSM
 cd /opt/octopus
 sudo docker compose pull
 sudo docker compose up -d
 ```
 
-Or re-apply Terraform after pushing a new image tag (the `user_data` `ignore_changes` lifecycle rule means the instance is **not** replaced on re-apply — only new instances get the updated userdata).
+> Terraform re-apply does **not** replace the instance — the `ignore_changes` lifecycle rule on `user_data` prevents that. Only new deployments get updated userdata.
+
+---
+
+## Instance Sizing
+
+| Team size | Instance | RDS | Notes |
+|-----------|----------|-----|-------|
+| 1–5 devs  | t3.xlarge | db.t3.medium | Default — minimum recommended |
+| 5–20 devs | t3.2xlarge | db.t3.large | Scale up as load grows |
+| 20+ devs  | c5.2xlarge | db.t3.xlarge | Consider `db_multi_az = true` |
+
+The web process needs at least 4 GB RAM. With Qdrant and nginx, plan for 8 GB total minimum.
+
+---
+
+## Remote State (optional)
+
+For team use, store Terraform state in S3:
+
+```bash
+cp backend.conf.example backend.conf
+# Edit backend.conf with your S3 bucket and DynamoDB table
+terraform init -backend-config=backend.conf
+```
+
+The `backend.conf.example` file includes the AWS CLI commands to create the bucket and lock table.
+
+---
 
 ## Security Notes
 
-- The RDS instance is placed in **private subnets** and is not publicly accessible.
-- IMDSv2 is enforced on the EC2 instance.
-- The root EBS volume is encrypted at rest.
-- The `.env` file on the instance has `chmod 600`.
-- `terraform.tfvars` is gitignored — never commit secrets.
+- RDS is in private subnets — not reachable from the internet
+- IMDSv2 enforced on EC2 (prevents SSRF credential theft)
+- Root EBS volume encrypted at rest
+- `.env` file on the instance is `chmod 600`
+- Never commit `terraform.tfvars` — it's gitignored
 
-## Variables Reference
+---
 
-See [`stacks/aws-ec2/variables.tf`](stacks/aws-ec2/variables.tf) for the full list of variables and their descriptions.
+## Directory Layout
+
+```
+terraform/
+├── modules/aws/
+│   ├── vpc/               # VPC, subnets, IGW, optional NAT
+│   ├── ec2-app/           # EC2, security group, IAM, EIP, userdata
+│   ├── rds-postgres/      # RDS PostgreSQL 17
+│   └── elasticache-redis/ # ElastiCache Redis (optional)
+├── stacks/aws-ec2/        # ← run terraform here for production deploys
+│   ├── terraform.tfvars.example
+│   ├── backend.conf.example
+│   └── templates/docker-compose.yml.tpl
+└── examples/aws-ec2/      # minimal wrapper for quick evaluation only
+```
+
+For production use, always run from `stacks/aws-ec2/`. The `examples/` directory is a minimal quickstart for evaluation only.

--- a/terraform/examples/aws-ec2/main.tf
+++ b/terraform/examples/aws-ec2/main.tf
@@ -9,10 +9,9 @@ module "octopus" {
   aws_region = var.aws_region
 
   # ── Required ──────────────────────────────────────────────────────────────
-  app_image          = "ghcr.io/your-org/octopus:latest"  # see README Step 1
-  app_domain         = "octopus.example.com"
-  db_password        = "change-me-strong-password"
-  better_auth_secret = "change-me-32-char-minimum-secret"
+  app_image  = "ghcr.io/your-org/octopus:latest"  # see README Step 1
+  app_domain = "octopus.example.com"
+  # db_password and better_auth_secret are auto-generated — no need to set them
 
   # GitHub App (required for PR reviews) — see README Step 2
   github_app_id          = "123456"

--- a/terraform/examples/aws-ec2/main.tf
+++ b/terraform/examples/aws-ec2/main.tf
@@ -1,16 +1,20 @@
-# Minimal example — demonstrates the smallest viable configuration.
-# For production use, copy terraform/stacks/aws-ec2/ instead.
+# Minimal example — copy this directory, fill in the values, and run:
+#   terraform init && terraform plan && terraform apply
+#
+# For production (full control over every option), use terraform/stacks/aws-ec2/ instead.
 
 module "octopus" {
   source = "../../stacks/aws-ec2"
 
-  # Required
-  app_image          = "ghcr.io/your-org/octopus:latest"
+  aws_region = var.aws_region
+
+  # ── Required ──────────────────────────────────────────────────────────────
+  app_image          = "ghcr.io/your-org/octopus:latest"  # see README Step 1
   app_domain         = "octopus.example.com"
-  db_password        = "change-me"
+  db_password        = "change-me-strong-password"
   better_auth_secret = "change-me-32-char-minimum-secret"
 
-  # GitHub App (required for PR reviews)
+  # GitHub App (required for PR reviews) — see README Step 2
   github_app_id          = "123456"
   github_app_private_key = "-----BEGIN RSA PRIVATE KEY-----\n..."
   github_webhook_secret  = "change-me"
@@ -21,6 +25,8 @@ module "octopus" {
   # LLM (at least one required)
   openai_api_key    = "sk-..."
   anthropic_api_key = "sk-ant-..."
+
+  admin_emails = "you@example.com"
 }
 
 output "public_ip" {

--- a/terraform/examples/aws-ec2/providers.tf
+++ b/terraform/examples/aws-ec2/providers.tf
@@ -1,0 +1,9 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+variable "aws_region" {
+  description = "AWS region to deploy into."
+  type        = string
+  default     = "us-east-1"
+}

--- a/terraform/examples/aws-ec2/versions.tf
+++ b/terraform/examples/aws-ec2/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/stacks/aws-ec2/main.tf
+++ b/terraform/stacks/aws-ec2/main.tf
@@ -1,5 +1,20 @@
+resource "random_password" "db_password" {
+  count   = var.db_password == "" ? 1 : 0
+  length  = 24
+  special = false
+}
+
+resource "random_password" "better_auth_secret" {
+  count   = var.better_auth_secret == "" ? 1 : 0
+  length  = 64
+  special = false
+}
+
 locals {
-  db_url = "postgresql://${module.rds.username}:${urlencode(var.db_password)}@${module.rds.endpoint}/${module.rds.db_name}?sslmode=require"
+  db_password        = var.db_password != "" ? var.db_password : random_password.db_password[0].result
+  better_auth_secret = var.better_auth_secret != "" ? var.better_auth_secret : random_password.better_auth_secret[0].result
+
+  db_url = "postgresql://${module.rds.username}:${urlencode(local.db_password)}@${module.rds.endpoint}/${module.rds.db_name}?sslmode=require"
 
   redis_url = var.enable_redis ? module.redis[0].connection_url : ""
 
@@ -87,7 +102,7 @@ locals {
     DATABASE_URL=${local.db_url}
 
     # Better Auth
-    BETTER_AUTH_SECRET=${var.better_auth_secret}
+    BETTER_AUTH_SECRET=${local.better_auth_secret}
     BETTER_AUTH_URL=https://${var.app_domain}
 
     # App
@@ -196,7 +211,7 @@ module "rds" {
   vpc_id               = module.vpc.vpc_id
   subnet_ids           = module.vpc.private_subnet_ids
   allowed_cidr_blocks  = [var.vpc_cidr]
-  db_password          = var.db_password
+  db_password          = local.db_password
   instance_class       = var.db_instance_class
   allocated_storage_gb = var.db_allocated_storage_gb
   multi_az             = var.db_multi_az

--- a/terraform/stacks/aws-ec2/outputs.tf
+++ b/terraform/stacks/aws-ec2/outputs.tf
@@ -3,6 +3,18 @@ output "public_ip" {
   value       = module.ec2.public_ip
 }
 
+output "db_password" {
+  description = "RDS master password (auto-generated if not provided). Retrieve with: terraform output -raw db_password"
+  value       = local.db_password
+  sensitive   = true
+}
+
+output "better_auth_secret" {
+  description = "Better Auth secret (auto-generated if not provided). Retrieve with: terraform output -raw better_auth_secret"
+  value       = local.better_auth_secret
+  sensitive   = true
+}
+
 output "instance_id" {
   description = "EC2 instance ID."
   value       = module.ec2.instance_id

--- a/terraform/stacks/aws-ec2/terraform.tfvars.example
+++ b/terraform/stacks/aws-ec2/terraform.tfvars.example
@@ -26,14 +26,11 @@ app_image  = "ghcr.io/your-org/octopus:latest"
 # Point its DNS A record to the output public_ip after apply.
 app_domain = "octopus.example.com"
 
-# ── Auth ──────────────────────────────────────────────────────────────────────
-# Run this to generate: openssl rand -hex 32
-better_auth_secret = ""
-
-# ── Database ──────────────────────────────────────────────────────────────────
-# Use a strong random password — it is never shown after apply.
-# Run: openssl rand -base64 24 | tr -d '/+=' | cut -c1-24
-db_password = ""
+# ── Secrets (auto-generated if left empty) ───────────────────────────────────
+# Leave these empty — Terraform generates secure values automatically on first apply.
+# Override only if you need a specific value (e.g. migrating an existing database).
+better_auth_secret = ""  # auto-generated if empty (64 chars)
+db_password        = ""  # auto-generated if empty (24 chars, no special chars)
 
 # ── GitHub App (for PR reviews) ──────────────────────────────────────────────
 # See README "Step 2: Create GitHub Apps" for a step-by-step guide.

--- a/terraform/stacks/aws-ec2/terraform.tfvars.example
+++ b/terraform/stacks/aws-ec2/terraform.tfvars.example
@@ -1,82 +1,128 @@
-# ── Copy this file to terraform.tfvars and fill in every value ────────────────
-# terraform.tfvars is gitignored — never commit secrets.
+# ══════════════════════════════════════════════════════════════════════════════
+#  HOW TO USE
+#  1. cp terraform.tfvars.example terraform.tfvars
+#  2. Fill in every value marked REQUIRED.
+#  3. Optional values can be left as-is or emptied ("").
+#  4. terraform.tfvars is gitignored — never commit it.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# ┌─────────────────────────────────────────────────────────────────────────────
+# │ REQUIRED — must be filled in before terraform apply
+# └─────────────────────────────────────────────────────────────────────────────
 
 # ── AWS ───────────────────────────────────────────────────────────────────────
-aws_region  = "us-east-1"
+aws_region = "us-east-1"
+
+# ── Application ───────────────────────────────────────────────────────────────
+# Docker image for the Octopus web app.
+# Build and push it first (see README Step 1).
+# Examples:
+#   GHCR  → ghcr.io/your-org/octopus:latest
+#   ECR   → 123456789012.dkr.ecr.us-east-1.amazonaws.com/octopus:latest
+#   Hub   → youruser/octopus:latest
+app_image  = "ghcr.io/your-org/octopus:latest"
+
+# Public domain that will serve the app.
+# Point its DNS A record to the output public_ip after apply.
+app_domain = "octopus.example.com"
+
+# ── Auth ──────────────────────────────────────────────────────────────────────
+# Run this to generate: openssl rand -hex 32
+better_auth_secret = ""
+
+# ── Database ──────────────────────────────────────────────────────────────────
+# Use a strong random password — it is never shown after apply.
+# Run: openssl rand -base64 24 | tr -d '/+=' | cut -c1-24
+db_password = ""
+
+# ── GitHub App (for PR reviews) ──────────────────────────────────────────────
+# See README "Step 2: Create GitHub Apps" for a step-by-step guide.
+#
+# Webhook URL to set in app settings: https://<app_domain>/api/github/webhook
+# Setup URL (optional):               https://<app_domain>/api/github/callback
+github_app_id          = ""
+github_webhook_secret  = ""  # Set in the app's "Webhook secret" field
+github_app_slug        = ""  # The slug shown in the app URL (github.com/apps/<slug>)
+
+# Private key: paste the entire contents of the .pem file as a single HCL string.
+# Keep the header/footer and replace each newline with \n (literal backslash-n):
+#
+#   "-----BEGIN RSA PRIVATE KEY-----\nMIIEo...(rest of key)...\n-----END RSA PRIVATE KEY-----\n"
+#
+# Tip: run this to get the correct format:
+#   awk 'NF {printf "%s\\n", $0}' your-key.pem
+github_app_private_key = ""
+
+# ── GitHub OAuth App (for "Sign in with GitHub") ─────────────────────────────
+# See README "Step 2: Create GitHub Apps" for a step-by-step guide.
+#
+# Authorization callback URL: https://<app_domain>/api/auth/callback/github
+github_client_id     = ""
+github_client_secret = ""
+
+# ── LLM (at least one required) ──────────────────────────────────────────────
+openai_api_key    = ""   # https://platform.openai.com/api-keys
+anthropic_api_key = ""   # https://console.anthropic.com/settings/keys
+
+# ── Admin ─────────────────────────────────────────────────────────────────────
+# Comma-separated email addresses that get admin access on first login.
+admin_emails = "you@example.com"
+
+
+# ┌─────────────────────────────────────────────────────────────────────────────
+# │ OPTIONAL — safe defaults are already set; change only if needed
+# └─────────────────────────────────────────────────────────────────────────────
+
+# ── AWS ───────────────────────────────────────────────────────────────────────
 environment = "production"
 name_prefix = "octopus"
 
-# ── Application ───────────────────────────────────────────────────────────────
-# Docker image published to a container registry (build & push first).
-# Example: ghcr.io/your-org/octopus:latest
-app_image  = "ghcr.io/your-org/octopus:latest"
-app_domain = "octopus.example.com"
+# ── Networking ────────────────────────────────────────────────────────────────
+vpc_cidr           = "10.0.0.0/16"
+enable_nat_gateway = false
 
 # ── EC2 ───────────────────────────────────────────────────────────────────────
-instance_type       = "t3.xlarge"    # 4 vCPU, 16 GB — minimum for small teams
+instance_type       = "t3.xlarge"  # min 4 vCPU / 16 GB for small teams
 root_volume_size_gb = 100
 create_eip          = true
-key_name            = null           # Set to your EC2 key pair name to enable SSH; null = SSH disabled
-ssh_cidr_blocks     = ["0.0.0.0/0"] # Restrict to your IP in production: ["YOUR.IP.ADDRESS/32"]
+
+# SSH access — leave null to disable entirely (use SSM Session Manager instead)
+key_name        = null
+ssh_cidr_blocks = ["0.0.0.0/0"]  # Restrict to your IP: ["1.2.3.4/32"]
 
 # ── Container Registry ────────────────────────────────────────────────────────
-# Leave empty for Docker Hub or GHCR (public) images.
-# For private AWS ECR images, set to your registry URL:
+# Only needed for private AWS ECR images. Leave empty for GHCR / Docker Hub.
 #   ecr_registry_url = "123456789012.dkr.ecr.us-east-1.amazonaws.com"
 ecr_registry_url = ""
 
 # ── Database ──────────────────────────────────────────────────────────────────
-db_password             = "change-me-strong-password"
 db_instance_class       = "db.t3.medium"
 db_allocated_storage_gb = 50
-db_multi_az             = false       # Set to true for high-availability
+db_multi_az             = false  # true = Multi-AZ for high availability
 db_deletion_protection  = true
 
-# ── Redis (optional) ──────────────────────────────────────────────────────────
+# ── Redis (disabled by default) ──────────────────────────────────────────────
 enable_redis    = false
 redis_node_type = "cache.t3.micro"
 
-# ── Auth ──────────────────────────────────────────────────────────────────────
-# Generate with: openssl rand -hex 32
-better_auth_secret = "change-me-32-char-minimum-secret-key"
-
-# ── GitHub App ────────────────────────────────────────────────────────────────
-# Create a GitHub App at: https://github.com/settings/apps/new
-# Required permissions: Pull requests (read/write), Contents (read), Metadata (read)
-github_app_id         = "123456"
-github_app_private_key = "-----BEGIN RSA PRIVATE KEY-----\n..."
-github_webhook_secret  = "change-me-webhook-secret"
-github_app_slug        = "your-app-slug"
-
-# GitHub OAuth (for user login)
-github_client_id     = "your-github-oauth-client-id"
-github_client_secret = "your-github-oauth-client-secret"
-
-# ── Google OAuth (optional) ───────────────────────────────────────────────────
+# ── Google OAuth (optional) ──────────────────────────────────────────────────
+# Create at: https://console.cloud.google.com → APIs & Services → Credentials
 google_client_id     = ""
 google_client_secret = ""
 
-# ── LLM Providers ─────────────────────────────────────────────────────────────
-# At least one of OpenAI or Anthropic is required.
-openai_api_key    = "sk-..."
-anthropic_api_key = "sk-ant-..."
-cohere_api_key    = ""   # Optional — enables reranking for better search results
-
 # ── Email ─────────────────────────────────────────────────────────────────────
-# Get your API key at: https://resend.com
-resend_api_key = "re_..."
+resend_api_key = ""  # https://resend.com — leave empty to disable email
 email_from     = "noreply@example.com"
 
-# ── Pubby (Real-time notifications) ──────────────────────────────────────────
-# Sign up at: https://pubby.io
+# ── Pubby real-time (optional) ───────────────────────────────────────────────
 pubby_app_id     = ""
 pubby_app_key    = ""
 pubby_app_secret = ""
 
-# ── Admin ─────────────────────────────────────────────────────────────────────
-admin_emails = "admin@example.com"
+# ── Cohere reranking (optional) ──────────────────────────────────────────────
+cohere_api_key = ""  # Better search quality; leave empty to skip
 
-# ── Tags ──────────────────────────────────────────────────────────────────────
+# ── Tags ─────────────────────────────────────────────────────────────────────
 tags = {
   Team = "engineering"
 }

--- a/terraform/stacks/aws-ec2/variables.tf
+++ b/terraform/stacks/aws-ec2/variables.tf
@@ -84,9 +84,10 @@ variable "app_domain" {
 
 # ── Database ──────────────────────────────────────────────────────────────────
 variable "db_password" {
-  description = "Master password for the RDS PostgreSQL instance."
+  description = "Master password for the RDS PostgreSQL instance. Leave empty to auto-generate."
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "db_instance_class" {
@@ -152,14 +153,10 @@ variable "redis_node_type" {
 
 # ── Auth ──────────────────────────────────────────────────────────────────────
 variable "better_auth_secret" {
-  description = "Secret key for Better Auth session signing (min 32 chars). Generate: openssl rand -hex 32"
+  description = "Secret key for Better Auth session signing. Leave empty to auto-generate."
   type        = string
   sensitive   = true
-
-  validation {
-    condition     = length(var.better_auth_secret) >= 32
-    error_message = "better_auth_secret must be at least 32 characters. Generate one with: openssl rand -hex 32"
-  }
+  default     = ""
 }
 
 # ── GitHub App ────────────────────────────────────────────────────────────────

--- a/terraform/stacks/aws-ec2/versions.tf
+++ b/terraform/stacks/aws-ec2/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 
   # Uncomment and configure after creating the S3 bucket and DynamoDB table.


### PR DESCRIPTION
## Summary

Rewrites the Terraform documentation and configuration files so someone with no Terraform experience can self-host Octopus with a single `terraform apply`.

**Key changes:**

- **GitHub App setup guide** — step-by-step walkthrough for both the GitHub App (PR reviews) and the GitHub OAuth App (user login), the biggest missing piece
- **OAuth callback URL bug fix** — the example file had `https://domain/api/github/callback` for the OAuth app, but the correct path is `https://domain/api/auth/callback/github` (Better Auth route). With the wrong URL, "Sign in with GitHub" would never work
- **HTTPS via Cloudflare** — step-by-step guide using Cloudflare free proxy (easiest path, no extra infrastructure)
- **SSM Session Manager alternative** — `key_name = null` is the default (SSH disabled), but the old migration step required SSH; now shows both SSH and SSM paths
- **Troubleshooting section** — covers the 6 most common failure modes with exact commands
- **Cost estimate** — ~$183/mo on defaults so users know what they're signing up for
- **Post-deploy verification checklist** — confirm the app works end-to-end before calling it done
- **`examples/aws-ec2`** — added `providers.tf` and `versions.tf` so `terraform init` works out of the box
- **`terraform.tfvars.example`** — restructured into REQUIRED/OPTIONAL sections with generation one-liners and correct URL hints

## Test plan

- [ ] `terraform validate` passes in `stacks/aws-ec2/` and `examples/aws-ec2/`
- [ ] `terraform init` succeeds in `examples/aws-ec2/` without extra files
- [ ] README is readable end-to-end without needing to look anything up