### PR TITLE
fix: pass orgId through GitHub OAuth state for reliable org association

### DIFF
--- a/apps/web/app/(app)/settings/integrations/github-integration-card.tsx
+++ b/apps/web/app/(app)/settings/integrations/github-integration-card.tsx
@@ -21,9 +21,11 @@ type GitHubData = {
 export function GitHubIntegrationCard({
   data,
   appSlug,
+  orgId,
 }: {
   data: GitHubData;
   appSlug: string | null;
+  orgId: string;
 }) {
   const [isPending, startTransition] = useTransition();
 
@@ -47,7 +49,7 @@ export function GitHubIntegrationCard({
           {appSlug ? (
             <Button asChild>
               <a
-                href={`https://github.com/apps/${appSlug}/installations/new?state=${encodeURIComponent(`${window.location.origin}/settings/integrations`)}`}
+                href={`https://github.com/apps/${appSlug}/installations/new?state=${encodeURIComponent(`${orgId}|${window.location.origin}/settings/integrations`)}`}
                 onClick={() => trackEvent("cta_click", { location: "settings_integrations", label: "install_github_app" })}
               >
                 <IconBrandGithub className="mr-2 size-4" />
@@ -90,9 +92,7 @@ export function GitHubIntegrationCard({
           {appSlug && (
             <Button size="sm" asChild>
               <a
-                href={`https://github.com/apps/${appSlug}/installations/new`}
-                target="_blank"
-                rel="noopener noreferrer"
+                href={`https://github.com/apps/${appSlug}/installations/new?state=${encodeURIComponent(`${orgId}|${window.location.origin}/settings/integrations`)}`}
               >
                 Manage Repos
               </a>

--- a/apps/web/app/(app)/settings/integrations/page.tsx
+++ b/apps/web/app/(app)/settings/integrations/page.tsx
@@ -85,7 +85,7 @@ export default async function IntegrationsPage({
   return (
     <div className="space-y-6">
       {bbDebug && <BitbucketDebugBanner debugJson={bbDebug} />}
-      <GitHubIntegrationCard data={githubData} appSlug={appSlug} />
+      <GitHubIntegrationCard data={githubData} appSlug={appSlug} orgId={orgId} />
       <BitbucketIntegrationCard data={bitbucketIntegration} />
       <SlackIntegrationCard data={slackIntegration} />
       <LinearIntegrationCard data={linearIntegration} />

--- a/apps/web/app/api/github/callback/route.ts
+++ b/apps/web/app/api/github/callback/route.ts
@@ -12,6 +12,14 @@ export async function GET(request: NextRequest) {
   let stateParam = request.nextUrl.searchParams.get("state");
   console.log("[github/callback] installationId:", installationId, "state:", stateParam);
 
+  // Extract org ID from state if present (format: "orgId|returnUrl")
+  let targetOrgId: string | null = null;
+  if (stateParam?.includes("|")) {
+    const pipeIndex = stateParam.indexOf("|");
+    targetOrgId = stateParam.substring(0, pipeIndex);
+    stateParam = stateParam.substring(pipeIndex + 1);
+  }
+
   // If state contains a full URL origin, forward the callback to that origin
   if (stateParam?.startsWith("http")) {
     try {
@@ -20,7 +28,11 @@ export async function GET(request: NextRequest) {
       if (stateOrigin !== new URL(baseUrl).origin) {
         const forwardUrl = new URL("/api/github/callback", stateOrigin);
         forwardUrl.searchParams.set("installation_id", installationId || "");
-        forwardUrl.searchParams.set("state", stateUrl.pathname + stateUrl.search);
+        // Re-encode orgId in forwarded state so the target origin can use it
+        const forwardedState = targetOrgId
+          ? `${targetOrgId}|${stateUrl.pathname + stateUrl.search}`
+          : stateUrl.pathname + stateUrl.search;
+        forwardUrl.searchParams.set("state", forwardedState);
         if (request.nextUrl.searchParams.get("setup_action")) {
           forwardUrl.searchParams.set("setup_action", request.nextUrl.searchParams.get("setup_action")!);
         }
@@ -48,9 +60,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(new URL("/login", baseUrl));
   }
 
-  // Respect the current org cookie (same logic as dashboard)
+  // Use org ID from state param (reliable, set at flow start) or fall back to cookie
   const cookieStore = await cookies();
-  const currentOrgId = cookieStore.get("current_org_id")?.value;
+  const currentOrgId = targetOrgId || cookieStore.get("current_org_id")?.value;
 
   const membership = await prisma.organizationMember.findFirst({
     where: {
@@ -60,7 +72,7 @@ export async function GET(request: NextRequest) {
     },
     select: { organizationId: true },
   });
-  console.log("[github/callback] currentOrgId cookie:", currentOrgId, "membership:", membership?.organizationId ?? "null");
+  console.log("[github/callback] targetOrgId:", targetOrgId, "cookieOrgId:", cookieStore.get("current_org_id")?.value, "resolved:", membership?.organizationId ?? "null");
 
   if (!membership) {
     return NextResponse.redirect(new URL("/dashboard", baseUrl));
@@ -108,6 +120,7 @@ export async function GET(request: NextRequest) {
           defaultBranch: repo.default_branch,
           installationId: installationIdNum,
           isActive: true,
+          organizationId: membership.organizationId,
         },
       });
     }

--- a/apps/web/app/api/github/callback/route.ts
+++ b/apps/web/app/api/github/callback/route.ts
@@ -72,7 +72,7 @@ export async function GET(request: NextRequest) {
     },
     select: { organizationId: true },
   });
-  console.log("[github/callback] targetOrgId:", targetOrgId, "cookieOrgId:", cookieStore.get("current_org_id")?.value, "resolved:", membership?.organizationId ?? "null");
+  console.log("[github/callback] resolved orgId:", membership?.organizationId ?? "null");
 
   if (!membership) {
     return NextResponse.redirect(new URL("/dashboard", baseUrl));

--- a/apps/web/app/api/github/webhook/route.ts
+++ b/apps/web/app/api/github/webhook/route.ts
@@ -82,8 +82,10 @@ export async function POST(request: NextRequest) {
             update: {
               name: repo.name,
               fullName: repo.full_name,
+              defaultBranch: repo.default_branch ?? "main",
               isActive: true,
               installationId,
+              organizationId: org.id,
             },
           });
         }
@@ -126,6 +128,7 @@ export async function POST(request: NextRequest) {
               defaultBranch: repo.default_branch,
               isActive: true,
               installationId,
+              organizationId: org.id,
             },
           });
         }


### PR DESCRIPTION
## Summary
- Encodes `orgId` in the GitHub OAuth `state` parameter (`orgId|returnUrl` format) when initiating app installation
- Extracts `orgId` from state in callback route, using it as the primary org resolver instead of relying on a cookie
- Forwards `orgId` in state when redirecting across origins
- Sets `organizationId` on repository upserts in both callback and webhook routes

Closes #204

## Files Changed
- `apps/web/app/(app)/settings/integrations/github-integration-card.tsx`
- `apps/web/app/(app)/settings/integrations/page.tsx`
- `apps/web/app/api/github/callback/route.ts`
- `apps/web/app/api/github/webhook/route.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)