### PR TITLE
fix: resolve event bus observer initialization race condition

### DIFF
--- a/apps/web/lib/events/bus.ts
+++ b/apps/web/lib/events/bus.ts
@@ -10,8 +10,10 @@ class EventBus {
   }
 
   emit(event: AppEvent): void {
-    const listenerCount = this.emitter.listenerCount(event.type);
-    console.log(`[event-bus] emit "${event.type}" → ${listenerCount} listener(s)`);
+    if (process.env.NODE_ENV !== "production") {
+      const listenerCount = this.emitter.listenerCount(event.type);
+      console.log(`[event-bus] emit "${event.type}" → ${listenerCount} listener(s)`);
+    }
     this.emitter.emit(event.type, event);
   }
 

--- a/apps/web/lib/events/bus.ts
+++ b/apps/web/lib/events/bus.ts
@@ -10,6 +10,8 @@ class EventBus {
   }
 
   emit(event: AppEvent): void {
+    const listenerCount = this.emitter.listenerCount(event.type);
+    console.log(`[event-bus] emit "${event.type}" → ${listenerCount} listener(s)`);
     this.emitter.emit(event.type, event);
   }
 
@@ -45,7 +47,6 @@ if (process.env.NODE_ENV !== "production") {
   globalForEventBus.eventBus = eventBus;
 }
 
-// Auto-initialize observers on first import
-import("./observers").then(({ initializeObservers }) =>
-  initializeObservers(),
-);
+// Auto-initialize observers on first import (sync to avoid race conditions)
+import { initializeObservers } from "./observers";
+initializeObservers();

--- a/apps/web/lib/events/observers/slack.observer.ts
+++ b/apps/web/lib/events/observers/slack.observer.ts
@@ -19,7 +19,10 @@ async function sendSlackMessage(
     include: { eventConfigs: true },
   });
 
-  if (!integration || !integration.channelId) return;
+  if (!integration || !integration.channelId) {
+    console.log(`[slack-observer] No integration or channelId for org ${orgId}`);
+    return;
+  }
 
   const config = integration.eventConfigs.find(
     (c) => c.eventType === eventType,
@@ -43,6 +46,8 @@ async function sendSlackMessage(
     const data = await res.json();
     if (!data.ok) {
       console.error(`[slack-observer] Failed to post message: ${data.error}`);
+    } else {
+      console.log(`[slack-observer] Message sent to ${integration.channelName} for ${eventType}`);
     }
   } catch (err) {
     console.error("[slack-observer] Error sending Slack notification:", err);

--- a/apps/web/lib/events/observers/slack.observer.ts
+++ b/apps/web/lib/events/observers/slack.observer.ts
@@ -20,7 +20,9 @@ async function sendSlackMessage(
   });
 
   if (!integration || !integration.channelId) {
-    console.log(`[slack-observer] No integration or channelId for org ${orgId}`);
+    if (process.env.NODE_ENV !== "production") {
+      console.log(`[slack-observer] No integration or channelId for org ${orgId}`);
+    }
     return;
   }
 
@@ -46,7 +48,7 @@ async function sendSlackMessage(
     const data = await res.json();
     if (!data.ok) {
       console.error(`[slack-observer] Failed to post message: ${data.error}`);
-    } else {
+    } else if (process.env.NODE_ENV !== "production") {
       console.log(`[slack-observer] Message sent to ${integration.channelName} for ${eventType}`);
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- Switches observer initialization from async dynamic `import()` to synchronous import to prevent race conditions where events fire before observers register
- Adds listener count logging on event bus `emit` for debugging
- Adds debug logging to Slack observer for missing integrations and successful message sends

Closes #206

## Files Changed
- `apps/web/lib/events/bus.ts`
- `apps/web/lib/events/observers/slack.observer.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)