### PR TITLE
feat: add coupon code system for credit redemption

### DIFF
--- a/apps/web/app/(app)/admin/admin-nav.tsx
+++ b/apps/web/app/(app)/admin/admin-nav.tsx
@@ -21,6 +21,7 @@ import {
   IconMail,
   IconSend,
   IconClockPlay,
+  IconTicket,
 } from "@tabler/icons-react";
 
 const sections = [
@@ -31,6 +32,7 @@ const sections = [
       { href: "/admin/users", label: "Users", icon: IconUsers },
       { href: "/admin/organizations", label: "Organizations", icon: IconBuilding },
       { href: "/admin/community", label: "Community", icon: IconWorld },
+      { href: "/admin/coupons", label: "Coupons", icon: IconTicket },
     ],
   },
   {

--- a/apps/web/app/(app)/admin/coupons/actions.ts
+++ b/apps/web/app/(app)/admin/coupons/actions.ts
@@ -32,11 +32,19 @@ export async function createCoupon(formData: FormData) {
     return { error: "Coupon code is required" };
   }
 
+  const code = rawCode.trim().toUpperCase();
+
+  if (code.length > 50) {
+    return { error: "Coupon code must be 50 characters or less" };
+  }
+
+  if (!/^[A-Z0-9_-]+$/.test(code)) {
+    return { error: "Coupon code can only contain letters, numbers, hyphens, and underscores" };
+  }
+
   if (!creditAmount || creditAmount <= 0) {
     return { error: "Credit amount must be greater than 0" };
   }
-
-  const code = rawCode.trim().toUpperCase();
 
   const existing = await prisma.coupon.findFirst({
     where: { code, deletedAt: null },

--- a/apps/web/app/(app)/admin/coupons/actions.ts
+++ b/apps/web/app/(app)/admin/coupons/actions.ts
@@ -1,0 +1,126 @@
+"use server";
+
+import { headers } from "next/headers";
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+import { isAdminEmail } from "@/lib/admin";
+import { prisma } from "@octopus/db";
+import { writeAuditLog } from "@/lib/audit";
+
+async function requireAdmin() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session || !isAdminEmail(session.user.email)) {
+    throw new Error("Unauthorized");
+  }
+  return session;
+}
+
+export async function createCoupon(formData: FormData) {
+  const session = await requireAdmin();
+
+  const rawCode = formData.get("code") as string;
+  const creditAmount = Number(formData.get("creditAmount"));
+  const maxRedemptions = formData.get("maxRedemptions")
+    ? Number(formData.get("maxRedemptions"))
+    : null;
+  const expiresAt = formData.get("expiresAt")
+    ? new Date(formData.get("expiresAt") as string)
+    : null;
+  const description = (formData.get("description") as string) || null;
+
+  if (!rawCode?.trim()) {
+    return { error: "Coupon code is required" };
+  }
+
+  if (!creditAmount || creditAmount <= 0) {
+    return { error: "Credit amount must be greater than 0" };
+  }
+
+  const code = rawCode.trim().toUpperCase();
+
+  const existing = await prisma.coupon.findFirst({
+    where: { code, deletedAt: null },
+  });
+
+  if (existing) {
+    return { error: "A coupon with this code already exists" };
+  }
+
+  const coupon = await prisma.coupon.create({
+    data: {
+      code,
+      creditAmount,
+      maxRedemptions,
+      expiresAt,
+      description,
+      createdById: session.user.id,
+    },
+  });
+
+  await writeAuditLog({
+    action: "coupon.created",
+    category: "admin",
+    actorId: session.user.id,
+    actorEmail: session.user.email,
+    targetType: "coupon",
+    targetId: coupon.id,
+    metadata: { code, creditAmount, maxRedemptions },
+  });
+
+  revalidatePath("/admin/coupons");
+  return { success: true };
+}
+
+export async function toggleCouponActive(couponId: string) {
+  const session = await requireAdmin();
+
+  const coupon = await prisma.coupon.findUnique({ where: { id: couponId } });
+  if (!coupon || coupon.deletedAt) {
+    return { error: "Coupon not found" };
+  }
+
+  await prisma.coupon.update({
+    where: { id: couponId },
+    data: { isActive: !coupon.isActive },
+  });
+
+  await writeAuditLog({
+    action: coupon.isActive ? "coupon.deactivated" : "coupon.activated",
+    category: "admin",
+    actorId: session.user.id,
+    actorEmail: session.user.email,
+    targetType: "coupon",
+    targetId: couponId,
+    metadata: { code: coupon.code },
+  });
+
+  revalidatePath("/admin/coupons");
+  return { success: true };
+}
+
+export async function deleteCoupon(couponId: string) {
+  const session = await requireAdmin();
+
+  const coupon = await prisma.coupon.findUnique({ where: { id: couponId } });
+  if (!coupon || coupon.deletedAt) {
+    return { error: "Coupon not found" };
+  }
+
+  await prisma.coupon.update({
+    where: { id: couponId },
+    data: { deletedAt: new Date() },
+  });
+
+  await writeAuditLog({
+    action: "coupon.deleted",
+    category: "admin",
+    actorId: session.user.id,
+    actorEmail: session.user.email,
+    targetType: "coupon",
+    targetId: couponId,
+    metadata: { code: coupon.code },
+  });
+
+  revalidatePath("/admin/coupons");
+  return { success: true };
+}

--- a/apps/web/app/(app)/admin/coupons/coupons-admin.tsx
+++ b/apps/web/app/(app)/admin/coupons/coupons-admin.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  IconPlus,
+  IconTrash,
+  IconLoader2,
+  IconPlayerPause,
+  IconPlayerPlay,
+} from "@tabler/icons-react";
+import { toast } from "sonner";
+import { createCoupon, toggleCouponActive, deleteCoupon } from "./actions";
+
+interface CouponItem {
+  id: string;
+  code: string;
+  description: string | null;
+  creditAmount: number;
+  maxRedemptions: number | null;
+  isActive: boolean;
+  expiresAt: string | null;
+  createdAt: string;
+  redemptionCount: number;
+}
+
+interface Props {
+  coupons: CouponItem[];
+}
+
+function getStatusBadge(coupon: CouponItem) {
+  if (!coupon.isActive) {
+    return <Badge variant="secondary">Inactive</Badge>;
+  }
+  if (coupon.expiresAt && new Date(coupon.expiresAt) < new Date()) {
+    return (
+      <Badge variant="destructive" className="bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400">
+        Expired
+      </Badge>
+    );
+  }
+  if (coupon.maxRedemptions && coupon.redemptionCount >= coupon.maxRedemptions) {
+    return <Badge variant="secondary">Fully Used</Badge>;
+  }
+  return (
+    <Badge className="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 border-green-200 dark:border-green-800">
+      Active
+    </Badge>
+  );
+}
+
+export function CouponsAdmin({ coupons }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [search, setSearch] = useState("");
+
+  const filteredCoupons = search
+    ? coupons.filter(
+        (c) =>
+          c.code.toLowerCase().includes(search.toLowerCase()) ||
+          c.description?.toLowerCase().includes(search.toLowerCase()),
+      )
+    : coupons;
+
+  const handleCreate = (formData: FormData) => {
+    startTransition(async () => {
+      const result = await createCoupon(formData);
+      if (result.error) {
+        toast.error(result.error);
+      } else {
+        toast.success("Coupon created");
+      }
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Create Coupon */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Create Coupon</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form action={handleCreate} className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="code">Code</Label>
+                <Input
+                  id="code"
+                  name="code"
+                  placeholder="e.g. WELCOME50"
+                  required
+                  className="uppercase"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="creditAmount">Credit Amount ($)</Label>
+                <Input
+                  id="creditAmount"
+                  name="creditAmount"
+                  type="number"
+                  min={0.01}
+                  step={0.01}
+                  placeholder="e.g. 50"
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="maxRedemptions">
+                  Max Redemptions{" "}
+                  <span className="text-muted-foreground font-normal">(optional)</span>
+                </Label>
+                <Input
+                  id="maxRedemptions"
+                  name="maxRedemptions"
+                  type="number"
+                  min={1}
+                  placeholder="Unlimited"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="expiresAt">
+                  Expiry Date{" "}
+                  <span className="text-muted-foreground font-normal">(optional)</span>
+                </Label>
+                <Input
+                  id="expiresAt"
+                  name="expiresAt"
+                  type="datetime-local"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">
+                Description{" "}
+                <span className="text-muted-foreground font-normal">(internal note)</span>
+              </Label>
+              <Input
+                id="description"
+                name="description"
+                placeholder="e.g. Welcome campaign Q2 2026"
+              />
+            </div>
+
+            <Button type="submit" disabled={isPending}>
+              {isPending ? (
+                <IconLoader2 className="mr-1 size-4 animate-spin" />
+              ) : (
+                <IconPlus className="mr-1 size-4" />
+              )}
+              Create Coupon
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {/* Coupon List */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Coupons ({coupons.length})</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            placeholder="Search coupons..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+
+          <div className="space-y-2">
+            {filteredCoupons.length === 0 && (
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                No coupons found
+              </p>
+            )}
+            {filteredCoupons.map((coupon) => (
+              <div
+                key={coupon.id}
+                className="flex items-center justify-between rounded-lg border p-3"
+              >
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <code className="text-sm font-bold">{coupon.code}</code>
+                    {getStatusBadge(coupon)}
+                    <span className="text-sm font-medium text-green-600 dark:text-green-400">
+                      ${coupon.creditAmount}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                    <span>
+                      Used: {coupon.redemptionCount}
+                      {coupon.maxRedemptions
+                        ? ` / ${coupon.maxRedemptions}`
+                        : " / unlimited"}
+                    </span>
+                    {coupon.expiresAt && (
+                      <span>
+                        Expires:{" "}
+                        {new Date(coupon.expiresAt).toLocaleDateString()}
+                      </span>
+                    )}
+                    {coupon.description && (
+                      <span className="truncate max-w-48">
+                        {coupon.description}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={isPending}
+                    onClick={() =>
+                      startTransition(async () => {
+                        const result = await toggleCouponActive(coupon.id);
+                        if (result.error) toast.error(result.error);
+                        else
+                          toast.success(
+                            coupon.isActive
+                              ? "Coupon deactivated"
+                              : "Coupon activated",
+                          );
+                      })
+                    }
+                    title={coupon.isActive ? "Deactivate" : "Activate"}
+                  >
+                    {coupon.isActive ? (
+                      <IconPlayerPause className="size-4" />
+                    ) : (
+                      <IconPlayerPlay className="size-4" />
+                    )}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-muted-foreground hover:text-destructive"
+                    disabled={isPending}
+                    onClick={() =>
+                      startTransition(async () => {
+                        const result = await deleteCoupon(coupon.id);
+                        if (result.error) toast.error(result.error);
+                        else toast.success("Coupon deleted");
+                      })
+                    }
+                    title="Delete"
+                  >
+                    <IconTrash className="size-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/admin/coupons/coupons-admin.tsx
+++ b/apps/web/app/(app)/admin/coupons/coupons-admin.tsx
@@ -189,7 +189,7 @@ export function CouponsAdmin({ coupons }: Props) {
                     <code className="text-sm font-bold">{coupon.code}</code>
                     {getStatusBadge(coupon)}
                     <span className="text-sm font-medium text-green-600 dark:text-green-400">
-                      ${coupon.creditAmount}
+                      ${coupon.creditAmount.toFixed(2)}
                     </span>
                   </div>
                   <div className="flex items-center gap-3 text-xs text-muted-foreground">

--- a/apps/web/app/(app)/admin/coupons/page.tsx
+++ b/apps/web/app/(app)/admin/coupons/page.tsx
@@ -1,0 +1,26 @@
+import { prisma } from "@octopus/db";
+import { CouponsAdmin } from "./coupons-admin";
+
+export default async function CouponsPage() {
+  const coupons = await prisma.coupon.findMany({
+    where: { deletedAt: null },
+    include: { _count: { select: { redemptions: true } } },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return (
+    <CouponsAdmin
+      coupons={coupons.map((c) => ({
+        id: c.id,
+        code: c.code,
+        description: c.description,
+        creditAmount: Number(c.creditAmount),
+        maxRedemptions: c.maxRedemptions,
+        isActive: c.isActive,
+        expiresAt: c.expiresAt?.toISOString() ?? null,
+        createdAt: c.createdAt.toISOString(),
+        redemptionCount: c._count.redemptions,
+      }))}
+    />
+  );
+}

--- a/apps/web/app/(app)/coupon/actions.ts
+++ b/apps/web/app/(app)/coupon/actions.ts
@@ -60,14 +60,36 @@ export async function redeemCoupon(code: string) {
 
   const creditAmount = Number(coupon.creditAmount);
 
-  await prisma.couponRedemption.create({
-    data: {
-      couponId: coupon.id,
-      organizationId: orgId,
-      redeemedById: session.user.id,
-      creditAmount: creditAmount,
-    },
-  });
+  // Atomic: create redemption inside transaction with re-checked limits.
+  // Unique constraints on (couponId, organizationId) and (couponId, redeemedById)
+  // provide DB-level protection against concurrent redemptions.
+  try {
+    await prisma.$transaction(async (tx) => {
+      if (coupon.maxRedemptions) {
+        const currentCount = await tx.couponRedemption.count({
+          where: { couponId: coupon.id },
+        });
+        if (currentCount >= coupon.maxRedemptions) {
+          throw new Error("COUPON_LIMIT_REACHED");
+        }
+      }
+
+      await tx.couponRedemption.create({
+        data: {
+          couponId: coupon.id,
+          organizationId: orgId,
+          redeemedById: session.user.id,
+          creditAmount: creditAmount,
+        },
+      });
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message === "COUPON_LIMIT_REACHED") {
+      return { error: "This coupon has reached its usage limit" };
+    }
+    // Unique constraint violation — concurrent redemption
+    return { error: "This coupon has already been redeemed" };
+  }
 
   await addCredits(orgId, creditAmount, "coupon", `Coupon: ${normalizedCode}`);
 

--- a/apps/web/app/(app)/coupon/actions.ts
+++ b/apps/web/app/(app)/coupon/actions.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { headers, cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { addCredits } from "@/lib/credits";
+import { writeAuditLog } from "@/lib/audit";
+
+export async function redeemCoupon(code: string) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return { error: "Not authenticated" };
+  }
+
+  const cookieStore = await cookies();
+  const orgId = cookieStore.get("current_org_id")?.value;
+  if (!orgId) {
+    return { error: "No organization selected" };
+  }
+
+  const normalizedCode = code.trim().toUpperCase();
+  if (!normalizedCode) {
+    return { error: "Please enter a coupon code" };
+  }
+
+  const coupon = await prisma.coupon.findFirst({
+    where: { code: normalizedCode, deletedAt: null, isActive: true },
+    include: { _count: { select: { redemptions: true } } },
+  });
+
+  if (!coupon) {
+    return { error: "Invalid coupon code" };
+  }
+
+  if (coupon.expiresAt && coupon.expiresAt < new Date()) {
+    return { error: "This coupon has expired" };
+  }
+
+  if (coupon.maxRedemptions && coupon._count.redemptions >= coupon.maxRedemptions) {
+    return { error: "This coupon has reached its usage limit" };
+  }
+
+  const [orgRedemption, userRedemption] = await Promise.all([
+    prisma.couponRedemption.findUnique({
+      where: { couponId_organizationId: { couponId: coupon.id, organizationId: orgId } },
+    }),
+    prisma.couponRedemption.findUnique({
+      where: { couponId_redeemedById: { couponId: coupon.id, redeemedById: session.user.id } },
+    }),
+  ]);
+
+  if (orgRedemption) {
+    return { error: "This coupon has already been redeemed by your organization" };
+  }
+
+  if (userRedemption) {
+    return { error: "You have already redeemed this coupon" };
+  }
+
+  const creditAmount = Number(coupon.creditAmount);
+
+  await prisma.couponRedemption.create({
+    data: {
+      couponId: coupon.id,
+      organizationId: orgId,
+      redeemedById: session.user.id,
+      creditAmount: creditAmount,
+    },
+  });
+
+  await addCredits(orgId, creditAmount, "coupon", `Coupon: ${normalizedCode}`);
+
+  await writeAuditLog({
+    action: "coupon.redeemed",
+    category: "billing",
+    actorId: session.user.id,
+    actorEmail: session.user.email,
+    organizationId: orgId,
+    targetType: "coupon",
+    targetId: coupon.id,
+    metadata: { code: normalizedCode, creditAmount },
+  });
+
+  revalidatePath("/usage");
+  revalidatePath("/settings/billing");
+
+  return { success: true, amount: creditAmount };
+}

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -81,6 +81,8 @@ function typeBadgeVariant(type: string) {
       return "outline" as const;
     case "auto_reload":
       return "default" as const;
+    case "coupon":
+      return "outline" as const;
     default:
       return "secondary" as const;
   }
@@ -94,6 +96,8 @@ function typeBadgeClass(type: string) {
       return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 border-blue-200 dark:border-blue-800";
     case "auto_reload":
       return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800";
+    case "coupon":
+      return "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400 border-purple-200 dark:border-purple-800";
     default:
       return "";
   }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -256,6 +256,39 @@ button {
   border-radius: 6px;
 }
 
+.shimmer-border-emerald {
+  position: relative;
+  border-radius: 8px;
+  padding: 1.5px;
+  overflow: hidden;
+}
+
+.shimmer-border-emerald::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 200%;
+  height: 200%;
+  background: conic-gradient(
+    from 0deg,
+    transparent 0%,
+    transparent 55%,
+    #059669 70%,
+    #34d399 80%,
+    #059669 90%,
+    transparent 95%
+  );
+  animation: shimmer-spin 3s linear infinite;
+}
+
+.shimmer-border-emerald > * {
+  position: relative;
+  z-index: 1;
+  display: block;
+  border-radius: 6px;
+}
+
 /* iOS-style auto-hide scrollbar — visible on hover */
 .scrollbar-auto-hide,
 html {

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -33,8 +33,10 @@ import {
   IconLayoutSidebarLeftExpand,
   IconBug,
   IconFileText,
+  IconTicket,
 } from "@tabler/icons-react";
 import { CommandPalette } from "@/components/command-palette";
+import { CouponDialog } from "@/components/coupon-dialog";
 
 const mainNavItems = [
   { href: "/dashboard", label: "Dashboard", icon: IconLayoutDashboard },
@@ -85,6 +87,7 @@ function SidebarContent({
 }: SidebarProps & { collapsed?: boolean; onToggleCollapse?: () => void; onNavigate?: () => void }) {
   const pathname = usePathname();
   const chat = useChat();
+  const [couponOpen, setCouponOpen] = useState(false);
 
   return (
     <div className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
@@ -221,6 +224,39 @@ function SidebarContent({
 
       </nav>
 
+      {/* Coupon Banner */}
+      <div className={cn("py-2", collapsed ? "px-2" : "px-3")}>
+        {collapsed ? (
+          <SidebarTooltip label="Redeem Coupon">
+            <button
+              onClick={() => setCouponOpen(true)}
+              className="flex w-full items-center justify-center rounded-md px-2 py-2 text-emerald-500 transition-colors hover:bg-emerald-500/10"
+            >
+              <IconTicket className="size-4" />
+            </button>
+          </SidebarTooltip>
+        ) : (
+          <div className="shimmer-border-emerald">
+            <button
+              onClick={() => setCouponOpen(true)}
+              className="relative flex w-full items-center gap-2.5 overflow-hidden bg-sidebar px-3 py-2 text-left transition-colors hover:bg-muted"
+            >
+              <svg className="pointer-events-none absolute inset-0 size-full opacity-[0.07] dark:opacity-[0.12]" aria-hidden="true">
+                <filter id="coupon-noise">
+                  <feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="4" stitchTiles="stitch" />
+                </filter>
+                <rect width="100%" height="100%" filter="url(#coupon-noise)" />
+              </svg>
+              <IconTicket className="relative size-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+              <div className="relative min-w-0">
+                <p className="text-xs font-medium text-foreground/90">Got a code?</p>
+                <p className="text-[10px] text-muted-foreground">Redeem credits</p>
+              </div>
+            </button>
+          </div>
+        )}
+      </div>
+
       <div className={cn("space-y-1 py-2", collapsed ? "px-2" : "px-3")}>
         {bottomNavItems.map(({ href, label, icon: Icon }) => {
           const isActive = pathname === href;
@@ -333,6 +369,8 @@ function SidebarContent({
           </UserMenu>
         )}
       </div>
+
+      <CouponDialog open={couponOpen} onOpenChange={setCouponOpen} />
     </div>
   );
 }

--- a/apps/web/components/coupon-dialog.tsx
+++ b/apps/web/components/coupon-dialog.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { IconLoader2 } from "@tabler/icons-react";
+import { toast } from "sonner";
+import { redeemCoupon } from "@/app/(app)/coupon/actions";
+
+export function CouponDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [code, setCode] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const handleRedeem = () => {
+    if (!code.trim()) {
+      setError("Please enter a coupon code");
+      return;
+    }
+    setError(null);
+    startTransition(async () => {
+      const result = await redeemCoupon(code);
+      if (result.error) {
+        setError(result.error);
+      } else if (result.success) {
+        toast.success(`$${result.amount} credits added to your account!`);
+        setCode("");
+        setError(null);
+        onOpenChange(false);
+      }
+    });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) {
+          setCode("");
+          setError(null);
+        }
+        onOpenChange(v);
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Redeem Coupon</DialogTitle>
+          <DialogDescription>
+            Enter your coupon code to add credits to your account.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="coupon-code">Coupon Code</Label>
+            <Input
+              id="coupon-code"
+              type="text"
+              value={code}
+              onChange={(e) => {
+                setCode(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !pending) handleRedeem();
+              }}
+              placeholder="Enter your code"
+              autoComplete="off"
+              autoFocus
+            />
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button
+            onClick={handleRedeem}
+            disabled={pending || !code.trim()}
+            className="w-full"
+          >
+            {pending ? (
+              <>
+                <IconLoader2 className="mr-2 size-4 animate-spin" />
+                Redeeming...
+              </>
+            ) : (
+              "Redeem Code"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -145,6 +145,7 @@ model Organization {
   packageAnalyses       PackageAnalysis[]
   safePackageRequests   SafePackageRequest[]
   packageDeepDives      PackageDeepDive[]
+  couponRedemptions     CouponRedemption[]
 
   @@map("organizations")
 }
@@ -567,7 +568,7 @@ model DaySummary {
 model CreditTransaction {
   id                    String   @id @default(cuid())
   amount                Decimal  @db.Decimal(12, 4)
-  type                  String   // "purchase" | "usage" | "free_credit" | "refund" | "auto_reload"
+  type                  String   // "purchase" | "usage" | "free_credit" | "refund" | "auto_reload" | "coupon"
   description           String?
   stripeSessionId       String?  @unique
   receiptUrl            String?
@@ -1042,4 +1043,39 @@ model UserDevice {
   @@unique([userId, fingerprint])
   @@index([userId])
   @@map("user_devices")
+}
+
+model Coupon {
+  id              String    @id @default(cuid())
+  code            String    @unique // stored UPPERCASE for case-insensitive matching
+  description     String?
+  creditAmount    Decimal   @db.Decimal(12, 4)
+  maxRedemptions  Int?      // null = unlimited
+  expiresAt       DateTime?
+  isActive        Boolean   @default(true)
+  createdById     String?
+  deletedAt       DateTime?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  redemptions CouponRedemption[]
+
+  @@index([code])
+  @@map("coupons")
+}
+
+model CouponRedemption {
+  id             String   @id @default(cuid())
+  couponId       String
+  coupon         Coupon   @relation(fields: [couponId], references: [id], onDelete: Cascade)
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  redeemedById   String
+  creditAmount   Decimal  @db.Decimal(12, 4)
+  createdAt      DateTime @default(now())
+
+  @@unique([couponId, organizationId])
+  @@unique([couponId, redeemedById])
+  @@index([organizationId])
+  @@map("coupon_redemptions")
 }


### PR DESCRIPTION
## Summary
- Add `Coupon` and `CouponRedemption` models with per-org and per-user unique constraints
- Sidebar banner with animated shimmer border and noise texture for coupon redemption
- Dialog for entering coupon codes with case-insensitive matching
- Admin panel CRUD at `/admin/coupons` for creating, toggling, and soft-deleting coupons
- Purple badge for coupon transactions in billing history

Closes #210

## Files Changed
- `packages/db/prisma/schema.prisma`
- `apps/web/components/app-sidebar.tsx`
- `apps/web/components/coupon-dialog.tsx`
- `apps/web/app/(app)/coupon/actions.ts`
- `apps/web/app/(app)/admin/coupons/actions.ts`
- `apps/web/app/(app)/admin/coupons/coupons-admin.tsx`
- `apps/web/app/(app)/admin/coupons/page.tsx`
- `apps/web/app/(app)/admin/admin-nav.tsx`
- `apps/web/app/(app)/settings/billing/billing-settings.tsx`
- `apps/web/app/globals.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)