### PR TITLE
fix: improve spend limit banner with detailed status

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -8,7 +8,7 @@ import { PermissionBanner } from "@/components/permission-banner";
 import { SpendLimitBanner } from "@/components/spend-limit-banner";
 import { getInstallationPermissions } from "@/lib/github";
 import { isAdminEmail } from "@/lib/admin";
-import { isOrgOverSpendLimit } from "@/lib/cost";
+import { getOrgSpendLimitStatus } from "@/lib/cost";
 import { OrgCookieSync } from "@/components/org-cookie-sync";
 import { DeviceReporter } from "@/components/device-reporter";
 import { createOrgForUser } from "./complete-profile/actions";
@@ -148,7 +148,7 @@ export default async function AppLayout({
   }
 
   // Check spend limit for current org (only if no own API key)
-  const spendOverLimit = await isOrgOverSpendLimit(currentOrg.id);
+  const spendStatus = await getOrgSpendLimitStatus(currentOrg.id);
 
   return (
     <ChatWrapper orgId={currentOrg.id} userId={session.user.id} userName={session.user.name}>
@@ -161,7 +161,7 @@ export default async function AppLayout({
             orgs={orgsNeedingPermission.map((o) => ({ id: o.id, name: o.name }))}
           />
         )}
-        <SpendLimitBanner isOverLimit={spendOverLimit} />
+        <SpendLimitBanner spendStatus={spendStatus} />
         <div className="flex min-h-0 flex-1 flex-col md:flex-row">
           <AppSidebar {...sidebarProps} />
           <div className="flex min-h-0 flex-1 flex-col">

--- a/apps/web/components/spend-limit-banner.tsx
+++ b/apps/web/components/spend-limit-banner.tsx
@@ -7,10 +7,14 @@ import type { SpendLimitResult } from "@/lib/cost";
 export function SpendLimitBanner({ spendStatus }: { spendStatus: SpendLimitResult }) {
   if (!spendStatus.blocked) return null;
 
-  const message =
-    spendStatus.reason === "no_credits"
-      ? "Credit balance is $0."
-      : `Monthly AI usage limit reached ($${spendStatus.limitUsd}).`;
+  let message: string;
+  if (spendStatus.reason === "no_credits") {
+    message = "Credit balance is $0.";
+  } else if (spendStatus.limitUsd === 0) {
+    message = "Monthly AI usage limit is set to $0.";
+  } else {
+    message = `Monthly AI usage limit reached ($${spendStatus.limitUsd}).`;
+  }
 
   return (
     <div className="sticky top-0 z-50">

--- a/apps/web/components/spend-limit-banner.tsx
+++ b/apps/web/components/spend-limit-banner.tsx
@@ -2,9 +2,15 @@
 
 import Link from "next/link";
 import { IconAlertTriangle } from "@tabler/icons-react";
+import type { SpendLimitResult } from "@/lib/cost";
 
-export function SpendLimitBanner({ isOverLimit }: { isOverLimit: boolean }) {
-  if (!isOverLimit) return null;
+export function SpendLimitBanner({ spendStatus }: { spendStatus: SpendLimitResult }) {
+  if (!spendStatus.blocked) return null;
+
+  const message =
+    spendStatus.reason === "no_credits"
+      ? "Credit balance is $0."
+      : `Monthly AI usage limit reached ($${spendStatus.limitUsd}).`;
 
   return (
     <div className="sticky top-0 z-50">
@@ -12,16 +18,24 @@ export function SpendLimitBanner({ isOverLimit }: { isOverLimit: boolean }) {
         <div className="flex items-center gap-2 overflow-hidden">
           <IconAlertTriangle className="size-3.5 shrink-0 text-amber-400" />
           <p className="truncate text-xs text-amber-200">
-            <span className="font-medium">Monthly AI usage limit reached ($150).</span>{" "}
-            Enter your own API keys or upgrade to continue.
+            <span className="font-medium">{message}</span>{" "}
+            Enter your own API keys or purchase credits to continue.
           </p>
         </div>
-        <Link
-          href="/settings/api-keys"
-          className="inline-flex shrink-0 items-center gap-1 rounded bg-amber-500/20 px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors hover:bg-amber-500/30"
-        >
-          Go to Settings
-        </Link>
+        <div className="flex shrink-0 items-center gap-2">
+          <Link
+            href="/settings/billing"
+            className="inline-flex items-center gap-1 rounded bg-amber-400/90 px-2 py-0.5 text-[11px] font-medium text-amber-950 transition-colors hover:bg-amber-400"
+          >
+            Purchase Credits
+          </Link>
+          <Link
+            href="/settings/api-keys"
+            className="inline-flex items-center gap-1 rounded bg-amber-500/20 px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors hover:bg-amber-500/30"
+          >
+            API Keys
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -101,7 +101,12 @@ export async function getOrgMonthlySpend(orgId: string): Promise<number> {
   return total;
 }
 
-export async function isOrgOverSpendLimit(orgId: string): Promise<boolean> {
+export type SpendLimitResult =
+  | { blocked: false }
+  | { blocked: true; reason: "no_credits" }
+  | { blocked: true; reason: "spend_limit"; limitUsd: number };
+
+export async function getOrgSpendLimitStatus(orgId: string): Promise<SpendLimitResult> {
   const org = await prisma.organization.findUnique({
     where: { id: orgId },
     select: {
@@ -114,20 +119,29 @@ export async function isOrgOverSpendLimit(orgId: string): Promise<boolean> {
     },
   });
 
-  if (!org) return false;
+  if (!org) return { blocked: false };
 
   // Orgs with their own keys for all LLM providers have no platform limit
-  if (org.anthropicApiKey && org.openaiApiKey && org.googleApiKey) return false;
+  if (org.anthropicApiKey && org.openaiApiKey && org.googleApiKey) return { blocked: false };
 
   // Check credit balance — if both free and purchased are <= 0, block usage
   const totalCredits = Number(org.creditBalance) + Number(org.freeCreditBalance);
-  if (totalCredits <= 0) return true;
+  if (totalCredits <= 0) return { blocked: true, reason: "no_credits" };
 
   // null limit means unlimited
-  if (org.monthlySpendLimitUsd == null) return false;
+  if (org.monthlySpendLimitUsd == null) return { blocked: false };
 
   const spend = await getOrgMonthlySpend(orgId);
-  return spend >= org.monthlySpendLimitUsd;
+  if (spend >= org.monthlySpendLimitUsd) {
+    return { blocked: true, reason: "spend_limit", limitUsd: org.monthlySpendLimitUsd };
+  }
+
+  return { blocked: false };
+}
+
+export async function isOrgOverSpendLimit(orgId: string): Promise<boolean> {
+  const status = await getOrgSpendLimitStatus(orgId);
+  return status.blocked;
 }
 
 export function formatUsd(n: number): string {


### PR DESCRIPTION
## Summary
- Add `getOrgSpendLimitStatus()` returning typed `SpendLimitResult` with specific reason (`no_credits` vs `spend_limit`)
- Show different banner messages based on reason
- Add prominent "Purchase Credits" button alongside "API Keys" link
- Keep `isOrgOverSpendLimit()` as backward-compatible wrapper

Closes #212

## Files Changed
- `apps/web/lib/cost.ts`
- `apps/web/components/spend-limit-banner.tsx`
- `apps/web/app/(app)/layout.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)