### PR TITLE
fix: add org membership validation to pubby auth and trigger endpoints

### DIFF
--- a/apps/web/app/api/pubby/auth/route.ts
+++ b/apps/web/app/api/pubby/auth/route.ts
@@ -62,17 +62,44 @@ export async function POST(req: Request) {
       if (!membership) {
         return new Response("Not a member of this organization", { status: 403 });
       }
+
+      const authResponse = pubby.authenticatePresenceChannel(
+        socket_id,
+        channel_name,
+        session.user.id,
+        { name: session.user.name, image: session.user.image }
+      );
+      return Response.json(authResponse);
     }
 
-    const authResponse = pubby.authenticatePresenceChannel(
-      socket_id,
-      channel_name,
-      session.user.id,
-      { name: session.user.name, image: session.user.image }
-    );
-    return Response.json(authResponse);
+    // Validate presence-org-{orgId} channels
+    const orgMatch = channel_name.match(/^presence-org-(.+)$/);
+    if (orgMatch) {
+      const orgId = orgMatch[1];
+      const membership = await prisma.organizationMember.findFirst({
+        where: {
+          organizationId: orgId,
+          userId: session.user.id,
+          deletedAt: null,
+        },
+      });
+      if (!membership) {
+        return new Response("Not a member of this organization", { status: 403 });
+      }
+
+      const authResponse = pubby.authenticatePresenceChannel(
+        socket_id,
+        channel_name,
+        session.user.id,
+        { name: session.user.name, image: session.user.image }
+      );
+      return Response.json(authResponse);
+    }
+
+    // Deny unrecognized presence channel patterns
+    return new Response("Channel not allowed", { status: 403 });
   }
 
-  const authResponse = pubby.authenticatePrivateChannel(socket_id, channel_name);
-  return Response.json(authResponse);
+  // Deny all other channels for session users
+  return new Response("Channel not allowed", { status: 403 });
 }

--- a/apps/web/app/api/pubby/trigger/route.ts
+++ b/apps/web/app/api/pubby/trigger/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import { pubby } from "@/lib/pubby";
+import { prisma } from "@octopus/db";
 import { headers } from "next/headers";
 
 export async function POST(req: Request) {
@@ -10,7 +11,55 @@ export async function POST(req: Request) {
 
   const { channel, event, data } = await req.json();
 
-  await pubby.trigger(channel, event, data);
+  // Validate channel access: presence-chat-{conversationId}
+  const chatMatch = channel.match(/^presence-chat-(.+)$/);
+  if (chatMatch) {
+    const conversationId = chatMatch[1];
+    const conversation = await prisma.chatConversation.findFirst({
+      where: {
+        id: conversationId,
+        isShared: true,
+        deletedAt: null,
+      },
+      select: { organizationId: true },
+    });
+    if (!conversation) {
+      return new Response("Conversation not found or not shared", { status: 403 });
+    }
+    const membership = await prisma.organizationMember.findFirst({
+      where: {
+        organizationId: conversation.organizationId,
+        userId: session.user.id,
+        deletedAt: null,
+      },
+    });
+    if (!membership) {
+      return new Response("Not a member of this organization", { status: 403 });
+    }
 
-  return Response.json({ ok: true });
+    await pubby.trigger(channel, event, data);
+    return Response.json({ ok: true });
+  }
+
+  // Validate channel access: presence-org-{orgId}
+  const orgMatch = channel.match(/^presence-org-(.+)$/);
+  if (orgMatch) {
+    const orgId = orgMatch[1];
+    const membership = await prisma.organizationMember.findFirst({
+      where: {
+        organizationId: orgId,
+        userId: session.user.id,
+        deletedAt: null,
+      },
+    });
+    if (!membership) {
+      return new Response("Not a member of this organization", { status: 403 });
+    }
+
+    await pubby.trigger(channel, event, data);
+    return Response.json({ ok: true });
+  }
+
+  // Deny all other channel patterns
+  return new Response("Channel not allowed", { status: 403 });
 }


### PR DESCRIPTION
## Summary
- Fix IDOR vulnerability in `/api/pubby/auth`: `presence-org-*` channels were authenticated without verifying org membership, allowing any authenticated user to subscribe to any org's real-time event stream
- Fix missing channel validation in `/api/pubby/trigger`: any authenticated user could trigger events on any channel
- Restructure both endpoints to deny-by-default for unrecognized channel patterns
- Move `authenticatePresenceChannel` call inside validated `presence-chat-*` block to prevent fallthrough

## Files Changed
- `apps/web/app/api/pubby/auth/route.ts`
- `apps/web/app/api/pubby/trigger/route.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)