### PR TITLE
chore: ignore .vscode/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ pentest/
 
 .omt-env
 .mcp.json
+
+.vscode/**


### PR DESCRIPTION
## Summary
- Add \`.vscode/\` to root \`.gitignore\` so editor-local settings don't accidentally get committed.

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)