### PR TITLE
fix(billing): transaction history pagination shows correct total

### DIFF
--- a/apps/web/app/(app)/settings/billing/actions.ts
+++ b/apps/web/app/(app)/settings/billing/actions.ts
@@ -145,7 +145,17 @@ export async function loadMoreTransactions(
   orgId: string,
   offset: number,
   limit: number = 20,
-) {
+): Promise<
+  {
+    id: string;
+    amount: number;
+    type: string;
+    description: string | null;
+    receiptUrl: string | null;
+    balanceAfter: number;
+    createdAt: string;
+  }[]
+> {
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) return [];
 
@@ -159,10 +169,20 @@ export async function loadMoreTransactions(
 
   if (!member) return [];
 
-  return prisma.creditTransaction.findMany({
+  const rows = await prisma.creditTransaction.findMany({
     where: { organizationId: orgId },
     orderBy: { createdAt: "desc" },
     skip: offset,
     take: limit,
   });
+
+  return rows.map((t) => ({
+    id: t.id,
+    amount: Number(t.amount),
+    type: t.type,
+    description: t.description,
+    receiptUrl: t.receiptUrl,
+    balanceAfter: Number(t.balanceAfter),
+    createdAt: t.createdAt.toISOString(),
+  }));
 }

--- a/apps/web/app/(app)/settings/billing/actions.ts
+++ b/apps/web/app/(app)/settings/billing/actions.ts
@@ -141,21 +141,21 @@ export async function updateSpendLimit(
   return { success: true };
 }
 
+export type TransactionDTO = {
+  id: string;
+  amount: number;
+  type: string;
+  description: string | null;
+  receiptUrl: string | null;
+  balanceAfter: number;
+  createdAt: string;
+};
+
 export async function loadMoreTransactions(
   orgId: string,
   offset: number,
   limit: number = 20,
-): Promise<
-  {
-    id: string;
-    amount: number;
-    type: string;
-    description: string | null;
-    receiptUrl: string | null;
-    balanceAfter: number;
-    createdAt: string;
-  }[]
-> {
+): Promise<TransactionDTO[]> {
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) return [];
 

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -29,17 +29,10 @@ import {
   updateBillingEmail,
   updateSpendLimit,
   loadMoreTransactions,
+  type TransactionDTO,
 } from "./actions";
 
-type Transaction = {
-  id: string;
-  amount: number;
-  type: string;
-  description: string | null;
-  receiptUrl: string | null;
-  balanceAfter: number;
-  createdAt: string;
-};
+type Transaction = TransactionDTO;
 
 type PaymentMethod = {
   brand: string;
@@ -140,12 +133,17 @@ export function BillingSettings({
 
   const total = creditBalance + freeCreditBalance;
 
-  const handleLoadMore = async () => {
+  const handleLoadMore = async (): Promise<boolean> => {
     setLoadingMore(true);
     try {
       const more = await loadMoreTransactions(orgId, transactions.length, 20);
-      setTransactions((prev) => [...prev, ...more]);
+      if (more.length > 0) {
+        setTransactions((prev) => [...prev, ...more]);
+      }
       if (more.length < 20) setHasMore(false);
+      return more.length > 0;
+    } catch {
+      return false;
     } finally {
       setLoadingMore(false);
     }
@@ -503,7 +501,8 @@ export function BillingSettings({
                         className="size-8"
                         onClick={async () => {
                           if (needsMoreForNextPage) {
-                            await handleLoadMore();
+                            const loaded = await handleLoadMore();
+                            if (!loaded) return;
                           }
                           setCurrentPage((p) => Math.min(totalPages, p + 1));
                         }}

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -62,6 +62,7 @@ type Props = {
     reloadAmount: number;
   } | null;
   initialTransactions: Transaction[];
+  totalTransactions: number;
   monthlySpend: number;
   paymentMethods: PaymentMethod[];
 };
@@ -113,12 +114,13 @@ export function BillingSettings({
   stripeCustomerId,
   autoReloadConfig,
   initialTransactions,
+  totalTransactions,
   monthlySpend,
   paymentMethods,
 }: Props) {
   const [purchaseOpen, setPurchaseOpen] = useState(false);
   const [transactions, setTransactions] = useState(initialTransactions);
-  const [hasMore, setHasMore] = useState(initialTransactions.length >= 20);
+  const [hasMore, setHasMore] = useState(initialTransactions.length < totalTransactions);
   const [loadingMore, setLoadingMore] = useState(false);
   const [portalLoading, startPortalTransition] = useTransition();
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
@@ -142,17 +144,8 @@ export function BillingSettings({
     setLoadingMore(true);
     try {
       const more = await loadMoreTransactions(orgId, transactions.length, 20);
-      const mapped = more.map((t: { id: string; amount: unknown; type: string; description: string | null; receiptUrl: string | null; balanceAfter: unknown; createdAt: Date }) => ({
-        id: t.id,
-        amount: Number(t.amount),
-        type: t.type,
-        description: t.description,
-        receiptUrl: t.receiptUrl,
-        balanceAfter: Number(t.balanceAfter),
-        createdAt: new Date(t.createdAt).toISOString(),
-      }));
-      setTransactions((prev) => [...prev, ...mapped]);
-      if (mapped.length < 20) setHasMore(false);
+      setTransactions((prev) => [...prev, ...more]);
+      if (more.length < 20) setHasMore(false);
     } finally {
       setLoadingMore(false);
     }
@@ -343,10 +336,14 @@ export function BillingSettings({
             const filtered = typeFilter
               ? transactions.filter((t) => t.type === typeFilter)
               : transactions;
-            const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+            const totalPages = typeFilter
+              ? Math.ceil(filtered.length / PAGE_SIZE)
+              : Math.ceil(totalTransactions / PAGE_SIZE);
             const page = Math.min(currentPage, totalPages || 1);
             const paged = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
             const isLastPage = page >= totalPages;
+            const needsMoreForNextPage =
+              !typeFilter && page * PAGE_SIZE >= transactions.length && hasMore;
 
             return (
               <>
@@ -480,10 +477,12 @@ export function BillingSettings({
                 </div>
 
                 {/* Pagination */}
-                {(totalPages > 1 || (isLastPage && hasMore)) && (
+                {totalPages > 1 && (
                   <div className="flex items-center justify-between pt-3">
                     <span className="text-xs text-muted-foreground">
-                      {filtered.length} transaction{filtered.length !== 1 ? "s" : ""}
+                      {typeFilter
+                        ? `${filtered.length} transaction${filtered.length !== 1 ? "s" : ""}`
+                        : `${totalTransactions} transaction${totalTransactions !== 1 ? "s" : ""}`}
                     </span>
                     <div className="flex items-center gap-1">
                       <Button
@@ -491,41 +490,31 @@ export function BillingSettings({
                         size="icon"
                         className="size-8"
                         onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                        disabled={page <= 1}
+                        disabled={page <= 1 || loadingMore}
                       >
                         <IconChevronLeft className="size-4" />
                       </Button>
                       <span className="text-xs text-muted-foreground px-2">
                         {page} / {totalPages}
                       </span>
-                      {isLastPage && hasMore ? (
-                        <Button
-                          variant="outline"
-                          size="icon"
-                          className="size-8"
-                          onClick={async () => {
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="size-8"
+                        onClick={async () => {
+                          if (needsMoreForNextPage) {
                             await handleLoadMore();
-                            setCurrentPage((p) => p + 1);
-                          }}
-                          disabled={loadingMore}
-                        >
-                          {loadingMore ? (
-                            <IconLoader2 className="size-4 animate-spin" />
-                          ) : (
-                            <IconChevronRight className="size-4" />
-                          )}
-                        </Button>
-                      ) : (
-                        <Button
-                          variant="outline"
-                          size="icon"
-                          className="size-8"
-                          onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-                          disabled={page >= totalPages}
-                        >
+                          }
+                          setCurrentPage((p) => Math.min(totalPages, p + 1));
+                        }}
+                        disabled={isLastPage || loadingMore}
+                      >
+                        {loadingMore ? (
+                          <IconLoader2 className="size-4 animate-spin" />
+                        ) : (
                           <IconChevronRight className="size-4" />
-                        </Button>
-                      )}
+                        )}
+                      </Button>
                     </div>
                   </div>
                 )}

--- a/apps/web/app/(app)/settings/billing/page.tsx
+++ b/apps/web/app/(app)/settings/billing/page.tsx
@@ -41,7 +41,7 @@ export default async function BillingPage() {
   const org = member.organization;
   const isOwner = member.role === "owner" || member.role === "admin";
 
-  const [autoReloadConfig, transactions, monthlySpend, paymentMethods] = await Promise.all([
+  const [autoReloadConfig, transactions, totalTransactions, monthlySpend, paymentMethods] = await Promise.all([
     prisma.autoReloadConfig.findUnique({
       where: { organizationId: org.id },
     }),
@@ -49,6 +49,9 @@ export default async function BillingPage() {
       where: { organizationId: org.id },
       orderBy: { createdAt: "desc" },
       take: 20,
+    }),
+    prisma.creditTransaction.count({
+      where: { organizationId: org.id },
     }),
     getOrgMonthlySpend(org.id),
     org.stripeCustomerId
@@ -84,6 +87,7 @@ export default async function BillingPage() {
         balanceAfter: Number(t.balanceAfter),
         createdAt: t.createdAt.toISOString(),
       }))}
+      totalTransactions={totalTransactions}
       monthlySpend={monthlySpend}
       paymentMethods={paymentMethods}
     />


### PR DESCRIPTION
## Summary
- Fetch real `transactions.count` on the server and compute `totalPages` from that instead of from locally-loaded rows, so the label no longer jumps from `1/1` to `2/2` on first next.
- Unify the next-page button: it triggers `loadMore` transparently when the next page is not yet in memory.
- Serialize Decimal/Date inside `loadMoreTransactions` so the server action can return values across the server/client boundary.

Closes #261

## Test plan
- [ ] Visit `/settings/billing` with more than 20 transactions; label reads correctly (e.g. `1 / 5`).
- [ ] Next/prev buttons navigate without Next.js console errors.
- [ ] Type filter narrows pagination to filtered count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)