### PR TITLE
feat(auth): email validation + Gmail alias normalization

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { signIn, magicLinkSignIn } from "@/lib/auth-client";
+import { normalizeEmail } from "@/lib/email-normalize";
 import { trackEvent } from "@/lib/analytics";
 import { Button } from "@/components/ui/button";
 import {
@@ -52,7 +53,8 @@ function LoginContent() {
     setLoading(true);
 
     const formData = new FormData(e.currentTarget);
-    const emailValue = formData.get("email") as string;
+    const rawEmail = formData.get("email") as string;
+    const emailValue = normalizeEmail(rawEmail);
 
     trackEvent("login_method_click", { method: "magic_link" });
 

--- a/apps/web/app/api/invitations/[token]/accept/route.ts
+++ b/apps/web/app/api/invitations/[token]/accept/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
+import { normalizeEmail } from "@/lib/email-normalize";
 
 const APP_URL = process.env.BETTER_AUTH_URL || process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
@@ -76,7 +77,10 @@ async function handleAccept(
     select: { email: true },
   });
 
-  if (!acceptingUser || acceptingUser.email !== invitation.email) {
+  if (
+    !acceptingUser ||
+    normalizeEmail(acceptingUser.email) !== normalizeEmail(invitation.email)
+  ) {
     return NextResponse.json(
       { error: "This invitation was sent to a different email address. Please sign in with the invited email." },
       { status: 403 }

--- a/apps/web/app/api/orgs/[orgId]/invitations/route.ts
+++ b/apps/web/app/api/orgs/[orgId]/invitations/route.ts
@@ -3,6 +3,7 @@ import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { sendInvitationEmail } from "@/lib/invitation-email";
+import { normalizeEmail } from "@/lib/email-normalize";
 
 const INVITATION_EXPIRY_DAYS = 7;
 const DAYS_TO_MS = 24 * 60 * 60 * 1000;
@@ -37,11 +38,13 @@ export async function POST(
   }
 
   const body = await request.json();
-  const { email, role } = body;
+  const { email: rawEmail, role } = body;
 
-  if (!email || typeof email !== "string") {
+  if (!rawEmail || typeof rawEmail !== "string") {
     return NextResponse.json({ error: "Email is required" }, { status: 400 });
   }
+
+  const email = normalizeEmail(rawEmail);
 
   if (role && !VALID_ROLES.includes(role)) {
     return NextResponse.json({ error: `Invalid role. Must be one of: ${VALID_ROLES.join(", ")}` }, { status: 400 });
@@ -84,11 +87,11 @@ export async function POST(
     },
   });
 
-  // Send email (best effort)
+  // Send email to the raw (typed) address — deliverability equivalent for Gmail
   let emailSent = false;
   try {
     await sendInvitationEmail({
-      email,
+      email: rawEmail,
       token: invitation.token,
       organizationName: org.name,
       inviterName: session.user.name || session.user.email,

--- a/apps/web/lib/__tests__/email-normalize.test.ts
+++ b/apps/web/lib/__tests__/email-normalize.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "bun:test";
+import { normalizeEmail } from "@/lib/email-normalize";
+
+describe("normalizeEmail", () => {
+  it("lowercases and trims the address", () => {
+    expect(normalizeEmail("  FeritArslan@Gmail.COM  ")).toBe("feritarslan@gmail.com");
+  });
+
+  it("strips dots in the Gmail local part", () => {
+    expect(normalizeEmail("fer.it.arslan@gmail.com")).toBe("feritarslan@gmail.com");
+  });
+
+  it("strips the +alias suffix in the Gmail local part", () => {
+    expect(normalizeEmail("feritarslan+hello@gmail.com")).toBe(
+      "feritarslan@gmail.com",
+    );
+  });
+
+  it("applies dot and + stripping together", () => {
+    expect(normalizeEmail("fer.it.arslan+foo.bar@gmail.com")).toBe(
+      "feritarslan@gmail.com",
+    );
+  });
+
+  it("maps googlemail.com to gmail.com", () => {
+    expect(normalizeEmail("feritarslan@googlemail.com")).toBe(
+      "feritarslan@gmail.com",
+    );
+  });
+
+  it("leaves non-Gmail addresses unchanged apart from lowercasing", () => {
+    expect(normalizeEmail("User.Name+tag@outlook.com")).toBe(
+      "user.name+tag@outlook.com",
+    );
+  });
+
+  it("does not touch a plain canonical gmail address", () => {
+    expect(normalizeEmail("feritarslan@gmail.com")).toBe("feritarslan@gmail.com");
+  });
+
+  it("returns the trimmed input unchanged when the local part would be empty", () => {
+    // All dots + alias only — don't strip to empty, preserve original
+    expect(normalizeEmail("+tag@gmail.com")).toBe("+tag@gmail.com");
+  });
+
+  it("returns the trimmed input for malformed addresses", () => {
+    expect(normalizeEmail("noatsign")).toBe("noatsign");
+    expect(normalizeEmail("@nolocal.com")).toBe("@nolocal.com");
+    expect(normalizeEmail("trailing@")).toBe("trailing@");
+  });
+});

--- a/apps/web/lib/__tests__/email-validator.test.ts
+++ b/apps/web/lib/__tests__/email-validator.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "bun:test";
+import { isDisposableDomain } from "@/lib/email-validator";
+
+describe("isDisposableDomain", () => {
+  it("flags a known disposable root domain", () => {
+    expect(isDisposableDomain("mailinator.com")).toBe(true);
+    expect(isDisposableDomain("yopmail.com")).toBe(true);
+  });
+
+  it("flags subdomains of disposable roots", () => {
+    expect(isDisposableDomain("something.mailinator.com")).toBe(true);
+    expect(isDisposableDomain("deep.sub.mailinator.com")).toBe(true);
+  });
+
+  it("is case-insensitive and ignores trailing dots", () => {
+    expect(isDisposableDomain("MAILINATOR.COM")).toBe(true);
+    expect(isDisposableDomain("mailinator.com.")).toBe(true);
+  });
+
+  it("does not flag legitimate providers", () => {
+    expect(isDisposableDomain("gmail.com")).toBe(false);
+    expect(isDisposableDomain("outlook.com")).toBe(false);
+    expect(isDisposableDomain("example.com")).toBe(false);
+  });
+
+  it("requires a dot before the root for subdomain matching (no raw substring)", () => {
+    // Verify the subdomain check uses `.<root>` not raw endsWith.
+    // Construct a domain that shares a suffix with a disposable root but
+    // without the leading dot — it must not match.
+    expect(isDisposableDomain("legitmail.com")).toBe(false);
+  });
+});

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,4 +1,5 @@
 import { betterAuth } from "better-auth";
+import { APIError } from "better-auth/api";
 import { magicLink } from "better-auth/plugins";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { prisma } from "@octopus/db";
@@ -6,6 +7,8 @@ import { sendEmail } from "./email";
 import { writeAuditLog } from "./audit";
 import { renderEmailTemplate } from "./email-renderer";
 import { enqueueAfter } from "./queue";
+import { reasonToMessage, validateEmailForSignup } from "./email-validator";
+import { normalizeEmail } from "./email-normalize";
 
 export const auth = betterAuth({
   trustedOrigins: [process.env.BETTER_AUTH_URL!],
@@ -36,6 +39,23 @@ export const auth = betterAuth({
     },
     user: {
       create: {
+        before: async (user) => {
+          const normalizedEmail = normalizeEmail(user.email);
+          const result = await validateEmailForSignup(normalizedEmail);
+          if (!result.ok) {
+            await writeAuditLog({
+              action: "auth.signup_blocked",
+              category: "auth",
+              actorEmail: normalizedEmail,
+              targetType: "user",
+              metadata: { reason: result.reason, original: user.email },
+            });
+            throw new APIError("BAD_REQUEST", {
+              message: reasonToMessage(result.reason),
+            });
+          }
+          return { data: { ...user, email: normalizedEmail } };
+        },
         after: async (user) => {
           await writeAuditLog({
             action: "auth.signup",
@@ -61,6 +81,31 @@ export const auth = betterAuth({
   plugins: [
     magicLink({
       sendMagicLink: async ({ email, url }) => {
+        const normalizedEmail = normalizeEmail(email);
+        const existing = await prisma.user.findUnique({
+          where: { email: normalizedEmail },
+          select: { id: true },
+        });
+        if (!existing) {
+          const validation = await validateEmailForSignup(normalizedEmail);
+          if (!validation.ok) {
+            await writeAuditLog({
+              action: "auth.signup_blocked",
+              category: "auth",
+              actorEmail: normalizedEmail,
+              targetType: "user",
+              metadata: {
+                reason: validation.reason,
+                source: "magic_link",
+                original: email,
+              },
+            });
+            throw new APIError("BAD_REQUEST", {
+              message: reasonToMessage(validation.reason),
+            });
+          }
+        }
+
         const result = await renderEmailTemplate("magic-link", {
           magicLinkUrl: url,
         });
@@ -75,7 +120,7 @@ export const auth = betterAuth({
         await writeAuditLog({
           action: "email.magic_link_sent",
           category: "email",
-          actorEmail: email,
+          actorEmail: normalizedEmail,
           targetType: "user",
           metadata: { recipient: email },
         });

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -41,6 +41,27 @@ export const auth = betterAuth({
       create: {
         before: async (user) => {
           const normalizedEmail = normalizeEmail(user.email);
+
+          // If an account already owns the canonical identity, fail with a
+          // clear message instead of letting the unique constraint bubble up.
+          const canonicalOwner = await prisma.user.findUnique({
+            where: { email: normalizedEmail },
+            select: { id: true },
+          });
+          if (canonicalOwner) {
+            await writeAuditLog({
+              action: "auth.signup_blocked",
+              category: "auth",
+              actorEmail: normalizedEmail,
+              targetType: "user",
+              metadata: { reason: "canonical_exists", original: user.email },
+            });
+            throw new APIError("BAD_REQUEST", {
+              message:
+                "An account already exists for this email. Please sign in with your existing address.",
+            });
+          }
+
           const result = await validateEmailForSignup(normalizedEmail);
           if (!result.ok) {
             await writeAuditLog({
@@ -82,10 +103,19 @@ export const auth = betterAuth({
     magicLink({
       sendMagicLink: async ({ email, url }) => {
         const normalizedEmail = normalizeEmail(email);
-        const existing = await prisma.user.findUnique({
+        const rawLookupEmail = email.trim().toLowerCase();
+        let existing = await prisma.user.findUnique({
           where: { email: normalizedEmail },
           select: { id: true },
         });
+        // Fallback for legacy accounts registered before normalization landed,
+        // whose stored email is still in the dotted/aliased form.
+        if (!existing && rawLookupEmail !== normalizedEmail) {
+          existing = await prisma.user.findUnique({
+            where: { email: rawLookupEmail },
+            select: { id: true },
+          });
+        }
         if (!existing) {
           const validation = await validateEmailForSignup(normalizedEmail);
           if (!validation.ok) {

--- a/apps/web/lib/email-normalize.ts
+++ b/apps/web/lib/email-normalize.ts
@@ -1,0 +1,18 @@
+const GMAIL_DOMAINS = new Set(["gmail.com", "googlemail.com"]);
+
+export function normalizeEmail(email: string): string {
+  const trimmed = email.trim().toLowerCase();
+  const at = trimmed.lastIndexOf("@");
+  if (at < 1 || at === trimmed.length - 1) return trimmed;
+
+  const local = trimmed.slice(0, at);
+  const domain = trimmed.slice(at + 1);
+
+  if (GMAIL_DOMAINS.has(domain)) {
+    const base = local.split("+")[0].replace(/\./g, "");
+    if (!base) return trimmed;
+    return `${base}@gmail.com`;
+  }
+
+  return trimmed;
+}

--- a/apps/web/lib/email-validator.ts
+++ b/apps/web/lib/email-validator.ts
@@ -1,5 +1,6 @@
 import { promises as dns } from "node:dns";
 import disposableDomains from "disposable-domains";
+import { getRedis } from "./redis";
 
 const DISPOSABLE_LIST = disposableDomains as string[];
 const DISPOSABLE_SET = new Set<string>(DISPOSABLE_LIST);
@@ -22,8 +23,48 @@ const DISPOSABLE_MX_SUFFIXES = [
 type MxCheckResult = "valid" | "invalid" | "disposable_mx";
 type MxCacheEntry = { result: MxCheckResult; expiresAt: number };
 const MX_CACHE = new Map<string, MxCacheEntry>();
-const MX_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const MX_CACHE_TTL_SECONDS = 24 * 60 * 60;
 const MX_LOOKUP_TIMEOUT_MS = 2000;
+const MX_CACHE_KEY_PREFIX = "mx:v1:";
+
+const VALID_RESULTS: readonly MxCheckResult[] = ["valid", "invalid", "disposable_mx"];
+
+async function readMxCache(domain: string): Promise<MxCheckResult | null> {
+  const redis = getRedis();
+  if (redis) {
+    try {
+      const val = await redis.get(MX_CACHE_KEY_PREFIX + domain);
+      if (val && (VALID_RESULTS as readonly string[]).includes(val)) {
+        return val as MxCheckResult;
+      }
+    } catch (err) {
+      console.error("[email-validator] redis get failed:", (err as Error).message);
+    }
+  }
+  const entry = MX_CACHE.get(domain);
+  if (entry && entry.expiresAt > Date.now()) return entry.result;
+  return null;
+}
+
+async function writeMxCache(domain: string, result: MxCheckResult): Promise<void> {
+  const redis = getRedis();
+  if (redis) {
+    try {
+      await redis.set(
+        MX_CACHE_KEY_PREFIX + domain,
+        result,
+        "EX",
+        MX_CACHE_TTL_SECONDS,
+      );
+    } catch (err) {
+      console.error("[email-validator] redis set failed:", (err as Error).message);
+    }
+  }
+  MX_CACHE.set(domain, {
+    result,
+    expiresAt: Date.now() + MX_CACHE_TTL_SECONDS * 1000,
+  });
+}
 
 export type EmailValidationResult =
   | { ok: true }
@@ -53,8 +94,8 @@ function isDisposableMxHost(host: string): boolean {
 }
 
 export async function checkMx(domain: string): Promise<MxCheckResult> {
-  const cached = MX_CACHE.get(domain);
-  if (cached && cached.expiresAt > Date.now()) return cached.result;
+  const cached = await readMxCache(domain);
+  if (cached) return cached;
 
   // Fail-open on timeout or transient DNS errors. Only definitive answers
   // (NXDOMAIN, empty MX, or a hit on the disposable-MX suffix list) block signup.
@@ -77,7 +118,7 @@ export async function checkMx(domain: string): Promise<MxCheckResult> {
     ),
   ]);
 
-  MX_CACHE.set(domain, { result, expiresAt: Date.now() + MX_CACHE_TTL_MS });
+  await writeMxCache(domain, result);
   return result;
 }
 

--- a/apps/web/lib/email-validator.ts
+++ b/apps/web/lib/email-validator.ts
@@ -1,0 +1,110 @@
+import { promises as dns } from "node:dns";
+import disposableDomains from "disposable-domains";
+
+const DISPOSABLE_LIST = disposableDomains as string[];
+const DISPOSABLE_SET = new Set<string>(DISPOSABLE_LIST);
+
+const DISPOSABLE_MX_SUFFIXES = [
+  "den.yt",
+  "mail.tm",
+  "mailinator.com",
+  "guerrillamail.com",
+  "yopmail.com",
+  "tempmail.dev",
+  "maildrop.cc",
+  "dropmail.me",
+  "fakemailgenerator.com",
+  "temp-mail.org",
+  "tmmbt.net",
+  "emailondeck.com",
+];
+
+type MxCheckResult = "valid" | "invalid" | "disposable_mx";
+type MxCacheEntry = { result: MxCheckResult; expiresAt: number };
+const MX_CACHE = new Map<string, MxCacheEntry>();
+const MX_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const MX_LOOKUP_TIMEOUT_MS = 2000;
+
+export type EmailValidationResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: "invalid_format" | "disposable" | "disposable_mx" | "no_mx";
+    };
+
+function extractDomain(email: string): string | null {
+  const trimmed = email.trim().toLowerCase();
+  const at = trimmed.lastIndexOf("@");
+  if (at < 1 || at === trimmed.length - 1) return null;
+  return trimmed.slice(at + 1);
+}
+
+export function isDisposableDomain(domain: string): boolean {
+  const normalized = domain.toLowerCase().replace(/\.$/, "");
+  if (DISPOSABLE_SET.has(normalized)) return true;
+  return DISPOSABLE_LIST.some((d) => normalized.endsWith("." + d));
+}
+
+function isDisposableMxHost(host: string): boolean {
+  const normalized = host.toLowerCase().replace(/\.$/, "");
+  return DISPOSABLE_MX_SUFFIXES.some(
+    (suffix) => normalized === suffix || normalized.endsWith("." + suffix),
+  );
+}
+
+export async function checkMx(domain: string): Promise<MxCheckResult> {
+  const cached = MX_CACHE.get(domain);
+  if (cached && cached.expiresAt > Date.now()) return cached.result;
+
+  // Fail-open on timeout or transient DNS errors. Only definitive answers
+  // (NXDOMAIN, empty MX, or a hit on the disposable-MX suffix list) block signup.
+  const result = await Promise.race<MxCheckResult>([
+    dns
+      .resolveMx(domain)
+      .then<MxCheckResult>((records) => {
+        if (records.length === 0) return "invalid";
+        if (records.some((r) => isDisposableMxHost(r.exchange)))
+          return "disposable_mx";
+        return "valid";
+      })
+      .catch((err: NodeJS.ErrnoException): MxCheckResult => {
+        if (err.code === "ENOTFOUND" || err.code === "ENODATA")
+          return "invalid";
+        return "valid";
+      }),
+    new Promise<MxCheckResult>((resolve) =>
+      setTimeout(() => resolve("valid"), MX_LOOKUP_TIMEOUT_MS),
+    ),
+  ]);
+
+  MX_CACHE.set(domain, { result, expiresAt: Date.now() + MX_CACHE_TTL_MS });
+  return result;
+}
+
+export async function validateEmailForSignup(
+  email: string,
+): Promise<EmailValidationResult> {
+  const domain = extractDomain(email);
+  if (!domain) return { ok: false, reason: "invalid_format" };
+  if (isDisposableDomain(domain)) return { ok: false, reason: "disposable" };
+
+  const mx = await checkMx(domain);
+  if (mx === "disposable_mx") return { ok: false, reason: "disposable_mx" };
+  if (mx === "invalid") return { ok: false, reason: "no_mx" };
+
+  return { ok: true };
+}
+
+export function reasonToMessage(
+  reason: Exclude<EmailValidationResult, { ok: true }>["reason"],
+): string {
+  switch (reason) {
+    case "disposable":
+    case "disposable_mx":
+      return "Disposable email addresses are not allowed.";
+    case "no_mx":
+      return "This email domain cannot receive mail.";
+    case "invalid_format":
+      return "Invalid email address.";
+  }
+}

--- a/apps/web/lib/redis.ts
+++ b/apps/web/lib/redis.ts
@@ -1,0 +1,31 @@
+import Redis, { type RedisOptions } from "ioredis";
+
+let client: Redis | null = null;
+let disabled = false;
+
+function buildClient(): Redis | null {
+  const url = process.env.REDIS_URL;
+  if (!url) return null;
+
+  const opts: RedisOptions = {
+    lazyConnect: false,
+    maxRetriesPerRequest: 2,
+    enableOfflineQueue: false,
+    retryStrategy: (times) => Math.min(times * 200, 2000),
+  };
+
+  const r = new Redis(url, opts);
+  r.on("error", (err) => {
+    console.error("[redis] error:", err.message);
+  });
+  return r;
+}
+
+export function getRedis(): Redis | null {
+  if (disabled) return null;
+  if (!client) {
+    client = buildClient();
+    if (!client) disabled = true;
+  }
+  return client;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "cohere-ai": "^7.20.0",
+    "disposable-domains": "^2.0.1",
     "dotenv": "^17.4.0",
     "ignore": "^7.0.5",
     "jdenticon": "^3.3.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
     "disposable-domains": "^2.0.1",
     "dotenv": "^17.4.0",
     "ignore": "^7.0.5",
+    "ioredis": "^5.10.1",
     "jdenticon": "^3.3.0",
     "mermaid": "^11.12.3",
     "next": "16.2.3",

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "disposable-domains": "^2.0.1",
         "dotenv": "^17.4.0",
         "ignore": "^7.0.5",
+        "ioredis": "^5.10.1",
         "jdenticon": "^3.3.0",
         "mermaid": "^11.12.3",
         "next": "16.2.3",
@@ -480,6 +481,8 @@
     "@inquirer/figures": ["@inquirer/figures@1.0.15", "", {}, "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g=="],
 
     "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -1279,6 +1282,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
@@ -1791,6 +1796,8 @@
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
+    "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
+
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
@@ -1986,6 +1993,10 @@
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
     "lodash.clonedeep": ["lodash.clonedeep@4.5.0", "", {}, "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="],
+
+    "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
+
+    "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
@@ -2385,6 +2396,10 @@
 
     "recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
 
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
     "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
@@ -2522,6 +2537,8 @@
     "sqlstring": ["sqlstring@2.3.3", "", {}, "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "cohere-ai": "^7.20.0",
+        "disposable-domains": "^2.0.1",
         "dotenv": "^17.4.0",
         "ignore": "^7.0.5",
         "jdenticon": "^3.3.0",
@@ -1470,6 +1471,8 @@
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
 
+    "disposable-domains": ["disposable-domains@2.0.1", "", { "dependencies": { "lodash": "^4.17.21", "top-level-domains": "^1.0.2", "validator": "^13.7.0" } }, "sha512-HHFOvipnCiPKQyFRClxViWYHoeLVYYdBXecpJ59MzdYtlxvC/u/eFJW+ZIGw8Lk01Fp+kmUlxJPwgaRudtqJCQ=="],
+
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
@@ -2620,6 +2623,8 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "top-level-domains": ["top-level-domains@1.0.10", "", {}, "sha512-dMFXw9iNF6wkfjuaEubHFgm9V5w7FJ63JJNnF4w0s1MASQc1JBNgORLnIfFgpus2abUGaQn2cTjqVj9+VKEozg=="],
+
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
@@ -2723,6 +2728,8 @@
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
+
+    "validator": ["validator@13.15.35", "", {}, "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 


### PR DESCRIPTION
## Summary
- **Email validation on signup**: format + MX check. Fail-open on transient DNS errors; only definitive negatives (NXDOMAIN, empty MX) block signup.
- **Disposable-domain blocking** via the maintained `disposable-domains` package (replacement for the deprecated `disposable-email-domains`). Matching is subdomain-aware, so `*.mailinator.com` is covered alongside the root. An MX-suffix fallback catches throwaway providers that rotate domains.
- **Gmail alias normalization**: `feritarslan@gmail.com`, `fer.it.arslan@gmail.com`, `feritarslan+foo@gmail.com`, and `feritarslan@googlemail.com` now resolve to one canonical identity. Applied at `user.create.before`, magic-link lookup, login submission, invitation create, and invitation accept, so aliased addresses can't create duplicate accounts or duplicate memberships.

Closes #262

## Test plan
- [ ] Signup with a Gmail dotted/aliased form; user stored as canonical `*@gmail.com`.
- [ ] Second signup attempt with a different alias variant collides with the first account (does not create a duplicate).
- [ ] Magic link sent to dotted/aliased form still signs into the canonical account.
- [ ] Signup attempt with a `@mailinator.com` or `*.mailinator.com` address is rejected.
- [ ] Signup attempt with a nonexistent domain (no MX) is rejected; transient DNS timeouts do not block.
- [ ] Invitation sent to an aliased Gmail address is accepted by the canonical account holder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)