### PR TITLE
chore(infra): resolve Cloudflare real client IP in nginx

### DIFF
--- a/infra/nginx/cloudflare-real-ip.conf
+++ b/infra/nginx/cloudflare-real-ip.conf
@@ -1,0 +1,36 @@
+# Cloudflare IP ranges — https://www.cloudflare.com/ips/
+# When a request comes from one of these, use CF-Connecting-IP as the real client IP.
+# $remote_addr, access log, and X-Real-IP / X-Forwarded-For all reflect the real IP after this.
+
+# Docker Swarm ingress / overlay networks — in swarm mode, the TCP peer nginx sees
+# is the ingress hop (10.0.0.x), not Cloudflare's IP. Must trust it so real_ip kicks in.
+set_real_ip_from 10.0.0.0/8;
+set_real_ip_from 172.16.0.0/12;
+set_real_ip_from 192.168.0.0/16;
+
+set_real_ip_from 173.245.48.0/20;
+set_real_ip_from 103.21.244.0/22;
+set_real_ip_from 103.22.200.0/22;
+set_real_ip_from 103.31.4.0/22;
+set_real_ip_from 141.101.64.0/18;
+set_real_ip_from 108.162.192.0/18;
+set_real_ip_from 190.93.240.0/20;
+set_real_ip_from 188.114.96.0/20;
+set_real_ip_from 197.234.240.0/22;
+set_real_ip_from 198.41.128.0/17;
+set_real_ip_from 162.158.0.0/15;
+set_real_ip_from 104.16.0.0/13;
+set_real_ip_from 104.24.0.0/14;
+set_real_ip_from 172.64.0.0/13;
+set_real_ip_from 131.0.72.0/22;
+
+set_real_ip_from 2400:cb00::/32;
+set_real_ip_from 2606:4700::/32;
+set_real_ip_from 2803:f800::/32;
+set_real_ip_from 2405:b500::/32;
+set_real_ip_from 2405:8100::/32;
+set_real_ip_from 2a06:98c0::/29;
+set_real_ip_from 2c0f:f248::/32;
+
+real_ip_header CF-Connecting-IP;
+real_ip_recursive on;

--- a/infra/nginx/cloudflare-real-ip.conf
+++ b/infra/nginx/cloudflare-real-ip.conf
@@ -4,6 +4,12 @@
 
 # Docker Swarm ingress / overlay networks — in swarm mode, the TCP peer nginx sees
 # is the ingress hop (10.0.0.x), not Cloudflare's IP. Must trust it so real_ip kicks in.
+#
+# SECURITY: trusting RFC-1918 ranges is only safe because this nginx is
+# behind Cloudflare with no direct public ingress. If you ever expose
+# this nginx directly to the internet (or to a network where untrusted
+# clients can reach it from a private IP), drop these and trust only
+# the exact Swarm overlay subnet.
 set_real_ip_from 10.0.0.0/8;
 set_real_ip_from 172.16.0.0/12;
 set_real_ip_from 192.168.0.0/16;

--- a/infra/nginx/nginx.aws.conf
+++ b/infra/nginx/nginx.aws.conf
@@ -10,6 +10,15 @@ http {
   proxy_read_timeout 900s;
   proxy_send_timeout 900s;
 
+  # Resolve real client IP from Cloudflare's CF-Connecting-IP header
+  include /etc/nginx/cloudflare-real-ip.conf;
+
+  # Access log with real client IP (set by real_ip module above)
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                  '$status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent" cf="$http_cf_connecting_ip"';
+  access_log /var/log/nginx/access.log main;
+
   # Security headers
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options "SAMEORIGIN" always;

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -10,6 +10,15 @@ http {
   proxy_read_timeout 900s;
   proxy_send_timeout 900s;
 
+  # Resolve real client IP from Cloudflare's CF-Connecting-IP header
+  include /etc/nginx/cloudflare-real-ip.conf;
+
+  # Access log with real client IP (set by real_ip module above)
+  log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                  '$status $body_bytes_sent "$http_referer" '
+                  '"$http_user_agent" cf="$http_cf_connecting_ip"';
+  access_log /var/log/nginx/access.log main;
+
   # Security headers
   add_header X-Content-Type-Options "nosniff" always;
   add_header X-Frame-Options "SAMEORIGIN" always;


### PR DESCRIPTION
## Summary

- New \`infra/nginx/cloudflare-real-ip.conf\` with the Cloudflare IPv4 + IPv6 ranges plus Docker Swarm private nets (10/8, 172.16/12, 192.168/16) so the ingress hop is trusted.
- Both nginx configs include the file and add a \`log_format\` that keeps the real IP in \`\$remote_addr\` while also logging \`cf=\$http_cf_connecting_ip\`.

## Why

Behind Cloudflare, \`\$remote_addr\` currently resolves to a Cloudflare edge IP (or, under Swarm, the ingress hop), so access logs and anything derived from it are worthless for abuse triage and rate limiting.

## Test plan

- [ ] Reload nginx on staging — \`nginx -t\` clean, service reloads without errors.
- [ ] Hit the site through Cloudflare from a known IP — access log shows the real IP as \`\$remote_addr\` plus matching \`cf=...\` field.
- [ ] Direct-hit the origin (bypassing Cloudflare from the internal network) — still logs the internal IP, no breakage.

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)