### PR TITLE
chore: add .octopusignore with sensible defaults

### DIFF
--- a/.octopusignore
+++ b/.octopusignore
@@ -1,6 +1,3 @@
-# Example
-# Generated code
-**/generated/**
 # Generated code
 **/generated/**
 **/*.generated.ts

--- a/.octopusignore
+++ b/.octopusignore
@@ -1,4 +1,6 @@
-Example
+# Example
+# Generated code
+**/generated/**
 # Generated code
 **/generated/**
 **/*.generated.ts

--- a/.octopusignore
+++ b/.octopusignore
@@ -1,0 +1,19 @@
+Example
+# Generated code
+**/generated/**
+**/*.generated.ts
+
+# Lockfiles
+pnpm-lock.yaml
+package-lock.json
+bun.lock
+
+# Test snapshots 
+**/__snapshots__/**
+
+# Large data files
+*.csv
+*.parquet
+
+# Re-include a specific file even if its folder is ignored
+!docs/API.md


### PR DESCRIPTION
## Summary

- Add a root `.octopusignore` that skips generated code, lockfiles (pnpm/npm/bun), test snapshots, and large data files (`*.csv`, `*.parquet`), plus a `!docs/API.md` re-include example.

## Why

We never committed a `.octopusignore` for our own repo, so every review ends up processing files (lockfiles, generated output) that dilute findings and burn credits.

## Test plan

- [ ] Run an Octopus review on a PR that touches one of the ignored paths — the file is skipped.
- [ ] Touch `docs/API.md` — the re-include keeps it in scope.

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)