### PR TITLE
feat(web): repository graph view with structural + semantic edges

### DIFF
--- a/apps/web/app/(app)/repositories/[id]/graph/page.tsx
+++ b/apps/web/app/(app)/repositories/[id]/graph/page.tsx
@@ -1,0 +1,48 @@
+import { headers } from "next/headers";
+import { redirect, notFound } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { RepoGraphView } from "./repo-graph-view";
+
+export default async function RepoGraphPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+  if (!session) redirect("/login");
+
+  const repo = await prisma.repository.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      fullName: true,
+      indexStatus: true,
+      organization: {
+        select: {
+          members: {
+            where: { userId: session.user.id, deletedAt: null },
+            select: { id: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!repo || repo.organization.members.length === 0) notFound();
+
+  return (
+    <div className="container mx-auto py-6 space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold">{repo.fullName}</h1>
+        <p className="text-muted-foreground">
+          Repository graph — nodes are files, solid edges are imports, dashed edges are semantic similarity.
+        </p>
+      </div>
+      <RepoGraphView repoId={repo.id} indexStatus={repo.indexStatus} />
+    </div>
+  );
+}

--- a/apps/web/app/(app)/repositories/[id]/graph/repo-graph-view.tsx
+++ b/apps/web/app/(app)/repositories/[id]/graph/repo-graph-view.tsx
@@ -6,17 +6,7 @@ import dynamic from "next/dynamic";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
-const ForceGraph2D = dynamic(
-  async () => (await import("react-force-graph-2d")).default,
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex h-[70vh] items-center justify-center text-muted-foreground">
-        Loading graph…
-      </div>
-    ),
-  },
-) as unknown as ComponentType<Record<string, unknown>>;
+const LEGEND_MAX = 8;
 
 type GraphNode = {
   id: string;
@@ -49,6 +39,8 @@ type GraphPayload = {
   nodes: GraphNode[];
   edges: GraphEdge[];
   highlights: Highlight[];
+  totalFiles?: number;
+  truncated?: boolean;
 };
 
 type NodeObject = GraphNode & { x?: number; y?: number };
@@ -58,6 +50,45 @@ type ForceGraphHandle = {
   centerAt: (x: number, y: number, durationMs?: number) => void;
   zoom: (k: number, durationMs?: number) => void;
 };
+
+type ForceGraphProps = {
+  ref?: (handle: ForceGraphHandle | null) => void;
+  graphData: { nodes: GraphNode[]; links: LinkObject[] };
+  width: number;
+  height: number;
+  backgroundColor?: string;
+  nodeRelSize?: number;
+  nodeVal?: (n: NodeObject) => number;
+  nodeLabel?: (n: NodeObject) => string;
+  nodeColor?: (n: NodeObject) => string;
+  linkColor?: (l: LinkObject) => string;
+  linkWidth?: (l: LinkObject) => number;
+  linkLineDash?: (l: LinkObject) => number[] | null;
+  linkDirectionalArrowLength?: (l: LinkObject) => number;
+  linkDirectionalArrowRelPos?: number;
+  cooldownTicks?: number;
+  onNodeHover?: (n: NodeObject | null) => void;
+  onNodeClick?: (n: NodeObject) => void;
+  nodeCanvasObjectMode?: (n: NodeObject) => "before" | "after" | "replace";
+  nodeCanvasObject?: (
+    node: NodeObject,
+    ctx: CanvasRenderingContext2D,
+    globalScale: number,
+  ) => void;
+};
+
+const ForceGraph2D = dynamic(
+  async () =>
+    (await import("react-force-graph-2d")).default as unknown as ComponentType<ForceGraphProps>,
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-[70vh] items-center justify-center text-muted-foreground">
+        Loading graph…
+      </div>
+    ),
+  },
+) as ComponentType<ForceGraphProps>;
 
 const DIR_PALETTE = [
   "#60a5fa",
@@ -109,7 +140,7 @@ export function RepoGraphView({
   const [showImports, setShowImports] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
   const graphRef = useRef<ForceGraphHandle | null>(null);
-  const [dims, setDims] = useState({ width: 800, height: 600 });
+  const [dims, setDims] = useState<{ width: number; height: number } | null>(null);
 
   useEffect(() => {
     if (indexStatus !== "indexed") return;
@@ -140,9 +171,15 @@ export function RepoGraphView({
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-    const ro = new ResizeObserver(() => {
-      setDims({ width: el.clientWidth, height: Math.max(500, el.clientHeight) });
-    });
+    const measure = () => {
+      const w = el.clientWidth;
+      const h = el.clientHeight;
+      if (w > 0 && h > 0) {
+        setDims({ width: w, height: Math.max(500, h) });
+      }
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();
   }, []);
@@ -153,7 +190,6 @@ export function RepoGraphView({
   );
 
   const [showAllDirs, setShowAllDirs] = useState(false);
-  const LEGEND_MAX = 8;
   const dirList = useMemo(() => [...dirColors.entries()], [dirColors]);
   const visibleDirs = showAllDirs ? dirList : dirList.slice(0, LEGEND_MAX);
 
@@ -206,7 +242,15 @@ export function RepoGraphView({
         </Button>
         {data && (
           <span className="text-xs text-muted-foreground ml-2">
-            {data.nodes.length} files · {data.edges.length} edges
+            {data.truncated && data.totalFiles
+              ? `${data.nodes.length} of ${data.totalFiles} files`
+              : `${data.nodes.length} files`}{" "}
+            · {data.edges.length} edges
+            {data.truncated && (
+              <span className="ml-2 text-amber-500">
+                (showing largest by chunk count)
+              </span>
+            )}
           </span>
         )}
       </div>
@@ -227,7 +271,7 @@ export function RepoGraphView({
                 {error}
               </div>
             )}
-            {data && !loading && !error && (
+            {data && !loading && !error && dims && (
               <ForceGraph2D
                 ref={(r: ForceGraphHandle | null) => {
                   graphRef.current = r;

--- a/apps/web/app/(app)/repositories/[id]/graph/repo-graph-view.tsx
+++ b/apps/web/app/(app)/repositories/[id]/graph/repo-graph-view.tsx
@@ -1,0 +1,413 @@
+"use client";
+
+import type { ComponentType } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+const ForceGraph2D = dynamic(
+  async () => (await import("react-force-graph-2d")).default,
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-[70vh] items-center justify-center text-muted-foreground">
+        Loading graph…
+      </div>
+    ),
+  },
+) as unknown as ComponentType<Record<string, unknown>>;
+
+type GraphNode = {
+  id: string;
+  path: string;
+  name: string;
+  dir: string;
+  language: string;
+  chunks: number;
+  lines: number;
+};
+
+type GraphEdge = {
+  source: string;
+  target: string;
+  type: "import" | "semantic";
+  weight: number;
+};
+
+type Highlight = {
+  id: string;
+  path: string;
+  title: string;
+  description: string;
+  kind: "entrypoint" | "config" | "hub" | "large";
+  score: number;
+};
+
+type GraphPayload = {
+  repo: { id: string; fullName: string };
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  highlights: Highlight[];
+};
+
+type NodeObject = GraphNode & { x?: number; y?: number };
+type LinkObject = GraphEdge & { source: NodeObject | string; target: NodeObject | string };
+
+type ForceGraphHandle = {
+  centerAt: (x: number, y: number, durationMs?: number) => void;
+  zoom: (k: number, durationMs?: number) => void;
+};
+
+const DIR_PALETTE = [
+  "#60a5fa",
+  "#f472b6",
+  "#34d399",
+  "#fbbf24",
+  "#a78bfa",
+  "#f87171",
+  "#22d3ee",
+  "#fb923c",
+  "#4ade80",
+  "#e879f9",
+];
+
+const KIND_STYLES: Record<Highlight["kind"], { label: string; className: string }> = {
+  entrypoint: { label: "Entry", className: "bg-blue-500/15 text-blue-300 ring-blue-500/30" },
+  config: { label: "Config", className: "bg-amber-500/15 text-amber-300 ring-amber-500/30" },
+  hub: { label: "Hub", className: "bg-fuchsia-500/15 text-fuchsia-300 ring-fuchsia-500/30" },
+  large: { label: "Large", className: "bg-emerald-500/15 text-emerald-300 ring-emerald-500/30" },
+};
+
+function buildDirColorMap(nodes: GraphNode[]): Map<string, string> {
+  const counts = new Map<string, number>();
+  for (const n of nodes) counts.set(n.dir, (counts.get(n.dir) ?? 0) + 1);
+  const sorted = [...counts.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0].localeCompare(b[0]);
+  });
+  const map = new Map<string, string>();
+  sorted.forEach(([dir], i) => {
+    map.set(dir, DIR_PALETTE[i % DIR_PALETTE.length]);
+  });
+  return map;
+}
+
+export function RepoGraphView({
+  repoId,
+  indexStatus,
+}: {
+  repoId: string;
+  indexStatus: string;
+}) {
+  const [data, setData] = useState<GraphPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [hoveredNode, setHoveredNode] = useState<GraphNode | null>(null);
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const [showSemantic, setShowSemantic] = useState(true);
+  const [showImports, setShowImports] = useState(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const graphRef = useRef<ForceGraphHandle | null>(null);
+  const [dims, setDims] = useState({ width: 800, height: 600 });
+
+  useEffect(() => {
+    if (indexStatus !== "indexed") return;
+    let cancelled = false;
+    setLoading(true);
+    fetch(`/api/repositories/${repoId}/graph`)
+      .then(async (r) => {
+        if (!r.ok) {
+          const body = await r.json().catch(() => ({}));
+          throw new Error(body.error ?? `HTTP ${r.status}`);
+        }
+        return r.json();
+      })
+      .then((json: GraphPayload) => {
+        if (cancelled) return;
+        setData(json);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Failed to load graph");
+      })
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId, indexStatus]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      setDims({ width: el.clientWidth, height: Math.max(500, el.clientHeight) });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const dirColors = useMemo(
+    () => (data ? buildDirColorMap(data.nodes) : new Map<string, string>()),
+    [data],
+  );
+
+  const [showAllDirs, setShowAllDirs] = useState(false);
+  const LEGEND_MAX = 8;
+  const dirList = useMemo(() => [...dirColors.entries()], [dirColors]);
+  const visibleDirs = showAllDirs ? dirList : dirList.slice(0, LEGEND_MAX);
+
+  const filtered = useMemo(() => {
+    if (!data) return { nodes: [], links: [] as LinkObject[] };
+    const links = data.edges.filter((e) =>
+      e.type === "semantic" ? showSemantic : showImports,
+    );
+    return { nodes: data.nodes, links: links as LinkObject[] };
+  }, [data, showSemantic, showImports]);
+
+  function focusOn(nodeId: string) {
+    if (!data) return;
+    const node = data.nodes.find((n) => n.id === nodeId) as NodeObject | undefined;
+    if (!node || node.x === undefined || node.y === undefined) {
+      setFocusedId(nodeId);
+      return;
+    }
+    setFocusedId(nodeId);
+    graphRef.current?.centerAt(node.x, node.y, 600);
+    graphRef.current?.zoom(3, 600);
+  }
+
+  if (indexStatus !== "indexed") {
+    return (
+      <Card className="p-6">
+        <p className="text-muted-foreground">
+          This repository is not indexed yet. Once indexing finishes the graph will be available here.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          variant={showImports ? "default" : "outline"}
+          onClick={() => setShowImports((v) => !v)}
+        >
+          Imports
+        </Button>
+        <Button
+          size="sm"
+          variant={showSemantic ? "default" : "outline"}
+          onClick={() => setShowSemantic((v) => !v)}
+        >
+          Semantic
+        </Button>
+        {data && (
+          <span className="text-xs text-muted-foreground ml-2">
+            {data.nodes.length} files · {data.edges.length} edges
+          </span>
+        )}
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <Card className="overflow-hidden p-0">
+          <div
+            ref={containerRef}
+            className="relative h-[70vh] w-full bg-background"
+          >
+            {loading && (
+              <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
+                Building graph…
+              </div>
+            )}
+            {error && (
+              <div className="absolute inset-0 flex items-center justify-center text-destructive">
+                {error}
+              </div>
+            )}
+            {data && !loading && !error && (
+              <ForceGraph2D
+                ref={(r: ForceGraphHandle | null) => {
+                  graphRef.current = r;
+                }}
+                graphData={filtered}
+                width={dims.width}
+                height={dims.height}
+                backgroundColor="transparent"
+                nodeRelSize={4}
+                nodeVal={(n: NodeObject) => Math.max(1, Math.sqrt(n.chunks))}
+                nodeLabel={(n: NodeObject) => n.path}
+                nodeColor={(n: NodeObject) =>
+                  focusedId === n.id
+                    ? "#ffffff"
+                    : dirColors.get(n.dir) ?? DIR_PALETTE[0]
+                }
+                linkColor={(l: LinkObject) =>
+                  l.type === "semantic"
+                    ? "rgba(148,163,184,0.35)"
+                    : "rgba(148,163,184,0.75)"
+                }
+                linkWidth={(l: LinkObject) => (l.type === "semantic" ? 0.5 : 1)}
+                linkLineDash={(l: LinkObject) =>
+                  l.type === "semantic" ? [2, 3] : null
+                }
+                linkDirectionalArrowLength={(l: LinkObject) =>
+                  l.type === "import" ? 3 : 0
+                }
+                linkDirectionalArrowRelPos={1}
+                cooldownTicks={120}
+                onNodeHover={(n: NodeObject | null) => setHoveredNode(n ?? null)}
+                onNodeClick={(n: NodeObject) => focusOn(n.id)}
+                nodeCanvasObjectMode={(n: NodeObject) =>
+                  focusedId === n.id ? "before" : "after"
+                }
+                nodeCanvasObject={(
+                  node: NodeObject,
+                  ctx: CanvasRenderingContext2D,
+                  globalScale: number,
+                ) => {
+                  const r = Math.max(1, Math.sqrt(node.chunks)) * 4;
+                  if (focusedId === node.id) {
+                    ctx.beginPath();
+                    ctx.arc(node.x ?? 0, node.y ?? 0, r + 4, 0, Math.PI * 2);
+                    ctx.fillStyle = "rgba(255,255,255,0.18)";
+                    ctx.fill();
+                  }
+                  if (globalScale < 1.5 && focusedId !== node.id) return;
+                  const label = node.name;
+                  const fontSize = 10 / globalScale;
+                  ctx.font = `${fontSize}px sans-serif`;
+                  ctx.fillStyle = "rgba(255,255,255,0.85)";
+                  ctx.textAlign = "center";
+                  ctx.textBaseline = "top";
+                  ctx.fillText(label, node.x ?? 0, (node.y ?? 0) + r + 1);
+                }}
+              />
+            )}
+            {hoveredNode && (
+              <div className="pointer-events-none absolute bottom-2 left-2 rounded-md bg-background/90 px-3 py-2 text-xs shadow ring-1 ring-border">
+                <div className="font-medium">{hoveredNode.path}</div>
+                <div className="text-muted-foreground">
+                  {hoveredNode.chunks} chunks · {hoveredNode.lines} lines · {hoveredNode.language}
+                </div>
+              </div>
+            )}
+            {data && !loading && !error && (
+              <div className="absolute top-2 right-2 w-56 rounded-md bg-background/90 p-3 text-xs shadow ring-1 ring-border">
+                <div className="mb-2 font-semibold">Legend</div>
+                <div className="mb-2 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-block h-0.5 w-6 bg-slate-300/80" />
+                    <span className="text-muted-foreground">Import (directed)</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <svg width="24" height="2" className="shrink-0">
+                      <line
+                        x1="0"
+                        y1="1"
+                        x2="24"
+                        y2="1"
+                        stroke="rgb(148,163,184)"
+                        strokeOpacity="0.6"
+                        strokeDasharray="2,3"
+                      />
+                    </svg>
+                    <span className="text-muted-foreground">Semantic similarity</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="inline-block rounded-full bg-muted-foreground/40"
+                      style={{ width: 6, height: 6 }}
+                    />
+                    <span
+                      className="inline-block rounded-full bg-muted-foreground/70"
+                      style={{ width: 10, height: 10 }}
+                    />
+                    <span className="text-muted-foreground">Size = chunk count</span>
+                  </div>
+                </div>
+                <div className="border-t pt-2">
+                  <div className="mb-1 text-[11px] uppercase tracking-wide text-muted-foreground">
+                    Top-level folder
+                  </div>
+                  <ul className="space-y-1">
+                    {visibleDirs.map(([dir, color]) => (
+                      <li key={dir} className="flex items-center gap-2">
+                        <span
+                          className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                          style={{ backgroundColor: color }}
+                        />
+                        <span className="truncate">{dir === "." ? "(root)" : dir}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  {dirList.length > LEGEND_MAX && (
+                    <button
+                      type="button"
+                      onClick={() => setShowAllDirs((v) => !v)}
+                      className="mt-2 text-[11px] text-muted-foreground hover:text-foreground"
+                    >
+                      {showAllDirs
+                        ? "Show less"
+                        : `Show ${dirList.length - LEGEND_MAX} more…`}
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </Card>
+
+        <Card className="flex max-h-[70vh] flex-col overflow-hidden">
+          <div className="border-b px-4 py-3">
+            <h3 className="text-sm font-semibold">Highlights</h3>
+            <p className="text-xs text-muted-foreground">
+              Key files for orienting around this repo. Click to focus on the graph.
+            </p>
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            {data?.highlights?.length ? (
+              <ul className="divide-y">
+                {data.highlights.map((h) => {
+                  const style = KIND_STYLES[h.kind];
+                  const isFocused = focusedId === h.id;
+                  return (
+                    <li key={h.id}>
+                      <button
+                        type="button"
+                        onClick={() => focusOn(h.id)}
+                        className={`w-full text-left px-4 py-3 transition-colors hover:bg-muted/50 ${
+                          isFocused ? "bg-muted/70" : ""
+                        }`}
+                      >
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`rounded px-1.5 py-0.5 text-[10px] font-medium ring-1 ${style.className}`}
+                          >
+                            {style.label}
+                          </span>
+                          <span className="truncate text-sm font-medium">
+                            {h.title}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground break-words">
+                          {h.description}
+                        </p>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <div className="p-4 text-sm text-muted-foreground">
+                {loading ? "Analyzing repository…" : "No highlights found."}
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/repositories/repositories-content.tsx
+++ b/apps/web/app/(app)/repositories/repositories-content.tsx
@@ -51,6 +51,7 @@ import {
   IconSettings,
   IconPackage,
   IconMessageCircle,
+  IconAffiliate,
 } from "@tabler/icons-react";
 import {
   Dialog,
@@ -1096,6 +1097,19 @@ function RepoDetail({
               <IconMessageCircle className="mr-1 size-3" />
               Chat
             </Button>
+            {repo.indexStatus === "indexed" && (
+              <Button
+                size="sm"
+                variant="outline"
+                asChild
+                title="Visualize repository graph"
+              >
+                <Link href={`/repositories/${repo.id}/graph`}>
+                  <IconAffiliate className="mr-1 size-3" />
+                  Graph
+                </Link>
+              </Button>
+            )}
             {isIndexing ? (
               <Button
                 size="sm"

--- a/apps/web/app/api/repositories/[id]/graph/route.ts
+++ b/apps/web/app/api/repositories/[id]/graph/route.ts
@@ -1,0 +1,59 @@
+import { headers } from "next/headers";
+import { NextRequest } from "next/server";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { buildRepoGraph } from "@/lib/repo-graph";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const repo = await prisma.repository.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      fullName: true,
+      indexStatus: true,
+      organization: {
+        select: {
+          members: {
+            where: { userId: session.user.id, deletedAt: null },
+            select: { id: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!repo || repo.organization.members.length === 0) {
+    return Response.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (repo.indexStatus !== "indexed") {
+    return Response.json(
+      { error: "Repository is not indexed yet", indexStatus: repo.indexStatus },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const graph = await buildRepoGraph(repo.id);
+    return Response.json({
+      repo: { id: repo.id, fullName: repo.fullName },
+      ...graph,
+    });
+  } catch (err) {
+    console.error("[graph] build failed:", err);
+    return Response.json(
+      { error: "Failed to build graph" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/lib/repo-graph.ts
+++ b/apps/web/lib/repo-graph.ts
@@ -1,0 +1,451 @@
+import { getQdrantClient, COLLECTION_NAME } from "@/lib/qdrant";
+
+export type GraphNode = {
+  id: string;
+  path: string;
+  name: string;
+  dir: string;
+  language: string;
+  chunks: number;
+  lines: number;
+};
+
+export type GraphEdge = {
+  source: string;
+  target: string;
+  type: "import" | "semantic";
+  weight: number;
+};
+
+export type GraphHighlight = {
+  id: string;
+  path: string;
+  title: string;
+  description: string;
+  kind: "entrypoint" | "config" | "hub" | "large";
+  score: number;
+};
+
+export type RepoGraph = {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  highlights: GraphHighlight[];
+};
+
+type ScrollPoint = {
+  id: string | number;
+  payload?: Record<string, unknown> | null;
+  vector?: unknown;
+};
+
+const MAX_CHUNKS_SCANNED = 5000;
+const MAX_NODES = 400;
+const SEMANTIC_TOP_K_PER_NODE = 3;
+const SEMANTIC_MIN_SCORE = 0.55;
+
+const IMPORT_RE =
+  /(?:import\s+[^;'"`]+?from\s+|import\s+|require\(|from\s+)['"]([^'"]+)['"]/g;
+
+async function scrollRepoChunks(
+  repoId: string,
+): Promise<ScrollPoint[]> {
+  const qdrant = getQdrantClient();
+  const points: ScrollPoint[] = [];
+  let offset: string | number | undefined = undefined;
+
+  while (points.length < MAX_CHUNKS_SCANNED) {
+    const result = await qdrant.scroll(COLLECTION_NAME, {
+      filter: { must: [{ key: "repoId", match: { value: repoId } }] },
+      limit: 256,
+      offset,
+      with_payload: true,
+      with_vector: true,
+    });
+
+    points.push(...(result.points as unknown as ScrollPoint[]));
+    const next = result.next_page_offset;
+    if (next === null || next === undefined) break;
+    offset = next as string | number;
+  }
+
+  return points;
+}
+
+function extractVector(vector: unknown): number[] | null {
+  if (!vector) return null;
+  if (Array.isArray(vector) && typeof vector[0] === "number") {
+    return vector as number[];
+  }
+  if (typeof vector === "object") {
+    const named = (vector as Record<string, unknown>)[""];
+    if (Array.isArray(named) && typeof named[0] === "number") {
+      return named as number[];
+    }
+    for (const v of Object.values(vector as Record<string, unknown>)) {
+      if (Array.isArray(v) && typeof v[0] === "number") {
+        return v as number[];
+      }
+    }
+  }
+  return null;
+}
+
+function normalize(v: number[]): number[] {
+  let norm = 0;
+  for (let i = 0; i < v.length; i++) norm += v[i] * v[i];
+  norm = Math.sqrt(norm);
+  if (norm === 0) return v;
+  const out = new Array(v.length);
+  for (let i = 0; i < v.length; i++) out[i] = v[i] / norm;
+  return out;
+}
+
+function dot(a: number[], b: number[]): number {
+  let s = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) s += a[i] * b[i];
+  return s;
+}
+
+function basename(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i === -1 ? p : p.slice(i + 1);
+}
+
+function topDir(p: string): string {
+  const i = p.indexOf("/");
+  return i === -1 ? "." : p.slice(0, i);
+}
+
+function resolveImport(
+  fromFile: string,
+  spec: string,
+  allFiles: Set<string>,
+): string | null {
+  if (!spec.startsWith(".") && !spec.startsWith("/")) return null;
+
+  const fromDir = fromFile.slice(0, fromFile.lastIndexOf("/"));
+  const parts = (spec.startsWith("/") ? spec : `${fromDir}/${spec}`).split("/");
+  const stack: string[] = [];
+  for (const part of parts) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      stack.pop();
+      continue;
+    }
+    stack.push(part);
+  }
+  const base = stack.join("/");
+
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}.js`,
+    `${base}.jsx`,
+    `${base}.mjs`,
+    `${base}.cjs`,
+    `${base}.py`,
+    `${base}.go`,
+    `${base}.rs`,
+    `${base}/index.ts`,
+    `${base}/index.tsx`,
+    `${base}/index.js`,
+    `${base}/index.jsx`,
+    `${base}/__init__.py`,
+    `${base}/mod.rs`,
+  ];
+  for (const c of candidates) {
+    if (allFiles.has(c)) return c;
+  }
+  return null;
+}
+
+export async function buildRepoGraph(repoId: string): Promise<RepoGraph> {
+  const points = await scrollRepoChunks(repoId);
+
+  type FileAgg = {
+    path: string;
+    chunks: number;
+    lines: number;
+    language: string;
+    text: string[];
+    vectorSum: number[] | null;
+    vectorCount: number;
+  };
+
+  const files = new Map<string, FileAgg>();
+
+  for (const p of points) {
+    const payload = p.payload ?? {};
+    const filePath = (payload.filePath as string) ?? "";
+    if (!filePath) continue;
+
+    const endLine = (payload.endLine as number) ?? 0;
+    const text = (payload.text as string) ?? "";
+    const language = (payload.language as string) ?? "unknown";
+
+    let agg = files.get(filePath);
+    if (!agg) {
+      agg = {
+        path: filePath,
+        chunks: 0,
+        lines: 0,
+        language,
+        text: [],
+        vectorSum: null,
+        vectorCount: 0,
+      };
+      files.set(filePath, agg);
+    }
+    agg.chunks += 1;
+    agg.lines = Math.max(agg.lines, endLine);
+    agg.text.push(text);
+
+    const vec = extractVector(p.vector);
+    if (vec) {
+      if (!agg.vectorSum) {
+        agg.vectorSum = vec.slice();
+      } else {
+        for (let i = 0; i < vec.length; i++) agg.vectorSum[i] += vec[i];
+      }
+      agg.vectorCount += 1;
+    }
+  }
+
+  // Sort by chunk count, cap to MAX_NODES
+  const topFiles = [...files.values()]
+    .sort((a, b) => b.chunks - a.chunks)
+    .slice(0, MAX_NODES);
+
+  const allPaths = new Set(topFiles.map((f) => f.path));
+  const pathToId = new Map<string, string>();
+  const nodes: GraphNode[] = topFiles.map((f, idx) => {
+    const id = `n${idx}`;
+    pathToId.set(f.path, id);
+    return {
+      id,
+      path: f.path,
+      name: basename(f.path),
+      dir: topDir(f.path),
+      language: f.language,
+      chunks: f.chunks,
+      lines: f.lines,
+    };
+  });
+
+  const edges: GraphEdge[] = [];
+  const edgeKey = new Set<string>();
+
+  // Structural edges from import statements
+  for (const f of topFiles) {
+    const fromId = pathToId.get(f.path)!;
+    const blob = f.text.join("\n");
+    IMPORT_RE.lastIndex = 0;
+    const seen = new Set<string>();
+    let m: RegExpExecArray | null;
+    while ((m = IMPORT_RE.exec(blob)) !== null) {
+      const spec = m[1];
+      if (seen.has(spec)) continue;
+      seen.add(spec);
+      const resolved = resolveImport(f.path, spec, allPaths);
+      if (!resolved || resolved === f.path) continue;
+      const toId = pathToId.get(resolved);
+      if (!toId) continue;
+      const key = `${fromId}->${toId}:import`;
+      if (edgeKey.has(key)) continue;
+      edgeKey.add(key);
+      edges.push({ source: fromId, target: toId, type: "import", weight: 1 });
+    }
+  }
+
+  // Semantic edges via cosine similarity on averaged embeddings
+  const withVec = topFiles
+    .map((f) => {
+      if (!f.vectorSum || f.vectorCount === 0) return null;
+      const avg = f.vectorSum.map((x) => x / f.vectorCount);
+      return { path: f.path, id: pathToId.get(f.path)!, vec: normalize(avg) };
+    })
+    .filter((x): x is { path: string; id: string; vec: number[] } => !!x);
+
+  for (let i = 0; i < withVec.length; i++) {
+    const a = withVec[i];
+    const scored: { id: string; score: number }[] = [];
+    for (let j = 0; j < withVec.length; j++) {
+      if (i === j) continue;
+      const score = dot(a.vec, withVec[j].vec);
+      if (score >= SEMANTIC_MIN_SCORE) {
+        scored.push({ id: withVec[j].id, score });
+      }
+    }
+    scored.sort((x, y) => y.score - x.score);
+    for (const { id: toId, score } of scored.slice(0, SEMANTIC_TOP_K_PER_NODE)) {
+      const [lo, hi] = a.id < toId ? [a.id, toId] : [toId, a.id];
+      const key = `${lo}~${hi}:semantic`;
+      if (edgeKey.has(key)) continue;
+      // Skip if a structural edge already exists either direction
+      if (
+        edgeKey.has(`${a.id}->${toId}:import`) ||
+        edgeKey.has(`${toId}->${a.id}:import`)
+      ) {
+        continue;
+      }
+      edgeKey.add(key);
+      edges.push({ source: a.id, target: toId, type: "semantic", weight: score });
+    }
+  }
+
+  const highlights = computeHighlights(nodes, edges);
+
+  return { nodes, edges, highlights };
+}
+
+function classifyFile(
+  path: string,
+  name: string,
+): { kind: GraphHighlight["kind"]; title: string; detail: string } | null {
+  const lower = name.toLowerCase();
+
+  if (lower === "schema.prisma") {
+    return { kind: "config", title: "Prisma schema", detail: "Database source of truth — models and relations live here" };
+  }
+  if (lower === "package.json") {
+    return { kind: "config", title: "Package manifest", detail: "Dependencies, scripts, and workspace configuration" };
+  }
+  if (lower === "tsconfig.json" || lower.startsWith("tsconfig.")) {
+    return { kind: "config", title: "TypeScript config", detail: "Compiler options and path aliases" };
+  }
+  if (lower === "next.config.js" || lower === "next.config.ts" || lower === "next.config.mjs") {
+    return { kind: "config", title: "Next.js config", detail: "Framework-level runtime and build configuration" };
+  }
+  if (/\.(config|conf)\.(t|j|mj|cj)s$/.test(lower) || lower.endsWith(".config.json")) {
+    return { kind: "config", title: name, detail: "Tooling configuration" };
+  }
+  if (lower === "middleware.ts" || lower === "middleware.js") {
+    return { kind: "entrypoint", title: "Next.js middleware", detail: "Runs on every matching request before the route handler" };
+  }
+  if (lower === "route.ts" || lower === "route.js") {
+    return { kind: "entrypoint", title: `Route · ${prettyRoute(path)}`, detail: "Next.js API route handler" };
+  }
+  if (lower === "page.tsx" || lower === "page.jsx" || lower === "page.ts" || lower === "page.js") {
+    return { kind: "entrypoint", title: `Page · ${prettyRoute(path)}`, detail: "Next.js app-router page" };
+  }
+  if (lower === "layout.tsx" || lower === "layout.jsx") {
+    return { kind: "entrypoint", title: `Layout · ${prettyRoute(path)}`, detail: "Next.js layout wrapping nested routes" };
+  }
+  if (/^index\.(t|j)sx?$/.test(lower) || /^main\.(t|j)sx?$/.test(lower) || /^app\.(t|j)sx?$/.test(lower)) {
+    return { kind: "entrypoint", title: name, detail: "Module entry point" };
+  }
+  return null;
+}
+
+function prettyRoute(path: string): string {
+  // Extract Next.js route from app-router paths
+  const idx = path.lastIndexOf("/app/");
+  if (idx === -1) return path;
+  const after = path.slice(idx + 5);
+  const withoutFile = after.replace(/\/(page|route|layout)\.[a-z]+$/, "");
+  const cleaned = withoutFile
+    .split("/")
+    .filter((s) => !s.startsWith("(") || !s.endsWith(")"))
+    .join("/");
+  return "/" + cleaned;
+}
+
+function computeHighlights(
+  nodes: GraphNode[],
+  edges: GraphEdge[],
+): GraphHighlight[] {
+  const inDeg = new Map<string, number>();
+  const outDeg = new Map<string, number>();
+  for (const e of edges) {
+    if (e.type !== "import") continue;
+    const src = typeof e.source === "string" ? e.source : (e.source as { id: string }).id;
+    const tgt = typeof e.target === "string" ? e.target : (e.target as { id: string }).id;
+    inDeg.set(tgt, (inDeg.get(tgt) ?? 0) + 1);
+    outDeg.set(src, (outDeg.get(src) ?? 0) + 1);
+  }
+
+  const byPath = new Map(nodes.map((n) => [n.id, n]));
+  const maxChunks = Math.max(1, ...nodes.map((n) => n.chunks));
+
+  type Candidate = {
+    node: GraphNode;
+    kind: GraphHighlight["kind"];
+    title: string;
+    description: string;
+    score: number;
+  };
+
+  const candidates: Candidate[] = [];
+
+  for (const node of nodes) {
+    const classified = classifyFile(node.path, node.name);
+    const inCount = inDeg.get(node.id) ?? 0;
+
+    if (classified) {
+      const usedBy = inCount > 0 ? ` · imported by ${inCount} file${inCount === 1 ? "" : "s"}` : "";
+      candidates.push({
+        node,
+        kind: classified.kind,
+        title: classified.title,
+        description: `${node.path}${usedBy} — ${classified.detail}`,
+        score:
+          (classified.kind === "entrypoint" ? 80 : 70) +
+          inCount * 3 +
+          (node.chunks / maxChunks) * 5,
+      });
+      continue;
+    }
+
+    if (inCount >= 3) {
+      candidates.push({
+        node,
+        kind: "hub",
+        title: node.name,
+        description: `${node.path} — shared module imported by ${inCount} file${inCount === 1 ? "" : "s"}`,
+        score: 40 + inCount * 4,
+      });
+      continue;
+    }
+  }
+
+  // Add "large" candidates for files that aren't already in (top by chunks, not already selected)
+  const selected = new Set(candidates.map((c) => c.node.id));
+  const largeCandidates = [...nodes]
+    .filter((n) => !selected.has(n.id) && n.chunks >= 3)
+    .sort((a, b) => b.chunks - a.chunks)
+    .slice(0, 5)
+    .map((node) => ({
+      node,
+      kind: "large" as const,
+      title: node.name,
+      description: `${node.path} — sizable module (${node.chunks} chunks, ~${node.lines} lines)`,
+      score: 20 + node.chunks,
+    }));
+  candidates.push(...largeCandidates);
+
+  candidates.sort((a, b) => b.score - a.score);
+
+  // Dedup, keep top 12, also ensure we don't have overlapping ids
+  const seen = new Set<string>();
+  const top: Candidate[] = [];
+  for (const c of candidates) {
+    if (seen.has(c.node.id)) continue;
+    seen.add(c.node.id);
+    top.push(c);
+    if (top.length >= 12) break;
+  }
+
+  // Touch byPath to keep it as a semantic reference if needed later
+  void byPath;
+
+  return top.map((c) => ({
+    id: c.node.id,
+    path: c.node.path,
+    title: c.title,
+    description: c.description,
+    kind: c.kind,
+    score: Math.round(c.score * 10) / 10,
+  }));
+}

--- a/apps/web/lib/repo-graph.ts
+++ b/apps/web/lib/repo-graph.ts
@@ -30,6 +30,8 @@ export type RepoGraph = {
   nodes: GraphNode[];
   edges: GraphEdge[];
   highlights: GraphHighlight[];
+  totalFiles: number;
+  truncated: boolean;
 };
 
 type ScrollPoint = {
@@ -40,8 +42,10 @@ type ScrollPoint = {
 
 const MAX_CHUNKS_SCANNED = 5000;
 const MAX_NODES = 400;
+const MAX_SEMANTIC_NODES = 250;
 const SEMANTIC_TOP_K_PER_NODE = 3;
 const SEMANTIC_MIN_SCORE = 0.55;
+const SEMANTIC_YIELD_EVERY = 32;
 
 const IMPORT_RE =
   /(?:import\s+[^;'"`]+?from\s+|import\s+|require\(|from\s+)['"]([^'"]+)['"]/g;
@@ -71,21 +75,18 @@ async function scrollRepoChunks(
   return points;
 }
 
+function isNumberArray(v: unknown): v is number[] {
+  return Array.isArray(v) && v.length > 0 && typeof v[0] === "number";
+}
+
 function extractVector(vector: unknown): number[] | null {
   if (!vector) return null;
-  if (Array.isArray(vector) && typeof vector[0] === "number") {
-    return vector as number[];
-  }
-  if (typeof vector === "object") {
-    const named = (vector as Record<string, unknown>)[""];
-    if (Array.isArray(named) && typeof named[0] === "number") {
-      return named as number[];
-    }
-    for (const v of Object.values(vector as Record<string, unknown>)) {
-      if (Array.isArray(v) && typeof v[0] === "number") {
-        return v as number[];
-      }
-    }
+  if (isNumberArray(vector)) return vector;
+  if (typeof vector !== "object") return null;
+  const named = (vector as Record<string, unknown>)[""];
+  if (isNumberArray(named)) return named;
+  for (const v of Object.values(vector as Record<string, unknown>)) {
+    if (isNumberArray(v)) return v;
   }
   return null;
 }
@@ -237,16 +238,16 @@ export async function buildRepoGraph(repoId: string): Promise<RepoGraph> {
   const edges: GraphEdge[] = [];
   const edgeKey = new Set<string>();
 
-  // Structural edges from import statements
+  // Structural edges from import statements.
+  // Uses matchAll (fresh iterator per call) to avoid global-regex lastIndex carryover.
   for (const f of topFiles) {
-    const fromId = pathToId.get(f.path)!;
+    const fromId = pathToId.get(f.path);
+    if (!fromId) continue;
     const blob = f.text.join("\n");
-    IMPORT_RE.lastIndex = 0;
     const seen = new Set<string>();
-    let m: RegExpExecArray | null;
-    while ((m = IMPORT_RE.exec(blob)) !== null) {
+    for (const m of blob.matchAll(IMPORT_RE)) {
       const spec = m[1];
-      if (seen.has(spec)) continue;
+      if (!spec || seen.has(spec)) continue;
       seen.add(spec);
       const resolved = resolveImport(f.path, spec, allPaths);
       if (!resolved || resolved === f.path) continue;
@@ -259,16 +260,24 @@ export async function buildRepoGraph(repoId: string): Promise<RepoGraph> {
     }
   }
 
-  // Semantic edges via cosine similarity on averaged embeddings
-  const withVec = topFiles
-    .map((f) => {
-      if (!f.vectorSum || f.vectorCount === 0) return null;
-      const avg = f.vectorSum.map((x) => x / f.vectorCount);
-      return { path: f.path, id: pathToId.get(f.path)!, vec: normalize(avg) };
-    })
-    .filter((x): x is { path: string; id: string; vec: number[] } => !!x);
+  // Semantic edges via cosine similarity on averaged embeddings.
+  // Capped to MAX_SEMANTIC_NODES (top files by chunk count) so the O(n²) loop
+  // stays bounded; yields to the event loop periodically so it doesn't block.
+  const withVec: { path: string; id: string; vec: number[] }[] = [];
+  for (const f of topFiles) {
+    if (withVec.length >= MAX_SEMANTIC_NODES) break;
+    if (!f.vectorSum || f.vectorCount === 0) continue;
+    const id = pathToId.get(f.path);
+    if (!id) continue;
+    const avg = new Array(f.vectorSum.length);
+    for (let i = 0; i < f.vectorSum.length; i++) avg[i] = f.vectorSum[i] / f.vectorCount;
+    withVec.push({ path: f.path, id, vec: normalize(avg) });
+  }
 
   for (let i = 0; i < withVec.length; i++) {
+    if (i > 0 && i % SEMANTIC_YIELD_EVERY === 0) {
+      await new Promise<void>((r) => setImmediate(r));
+    }
     const a = withVec[i];
     const scored: { id: string; score: number }[] = [];
     for (let j = 0; j < withVec.length; j++) {
@@ -283,7 +292,6 @@ export async function buildRepoGraph(repoId: string): Promise<RepoGraph> {
       const [lo, hi] = a.id < toId ? [a.id, toId] : [toId, a.id];
       const key = `${lo}~${hi}:semantic`;
       if (edgeKey.has(key)) continue;
-      // Skip if a structural edge already exists either direction
       if (
         edgeKey.has(`${a.id}->${toId}:import`) ||
         edgeKey.has(`${toId}->${a.id}:import`)
@@ -297,7 +305,13 @@ export async function buildRepoGraph(repoId: string): Promise<RepoGraph> {
 
   const highlights = computeHighlights(nodes, edges);
 
-  return { nodes, edges, highlights };
+  return {
+    nodes,
+    edges,
+    highlights,
+    totalFiles: files.size,
+    truncated: files.size > nodes.length,
+  };
 }
 
 function classifyFile(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,7 @@
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "react-email": "^5.2.10",
+    "react-force-graph-2d": "^1.29.1",
     "react-markdown": "^10.1.0",
     "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "react-email": "^5.2.10",
+        "react-force-graph-2d": "^1.29.1",
         "react-markdown": "^10.1.0",
         "recharts": "^3.7.0",
         "remark-gfm": "^4.0.1",
@@ -1134,6 +1135,8 @@
 
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
+    "accessor-fn": ["accessor-fn@1.5.3", "", {}, "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -1208,6 +1211,8 @@
 
     "better-call": ["better-call@1.3.2", "", { "dependencies": { "@better-auth/utils": "^0.3.1", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw=="],
 
+    "bezier-js": ["bezier-js@6.1.4", "", {}, "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg=="],
+
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
@@ -1243,6 +1248,8 @@
     "camera-controls": ["camera-controls@3.1.2", "", { "peerDependencies": { "three": ">=0.126.1" } }, "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001778", "", {}, "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg=="],
+
+    "canvas-color-tracker": ["canvas-color-tracker@1.3.2", "", { "dependencies": { "tinycolor2": "^1.6.0" } }, "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg=="],
 
     "canvas-renderer": ["canvas-renderer@2.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-RrBgVL5qCEDIXpJ6NrzyRNoTnXxYarqm/cS/W6ERhUJts5UQtt/XPEosGN3rqUkZ4fjBArlnCbsISJ+KCFnIAg=="],
 
@@ -1352,6 +1359,8 @@
 
     "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
 
+    "d3-binarytree": ["d3-binarytree@1.0.2", "", {}, "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw=="],
+
     "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
 
     "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
@@ -1374,6 +1383,8 @@
 
     "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
 
+    "d3-force-3d": ["d3-force-3d@3.0.6", "", { "dependencies": { "d3-binarytree": "1", "d3-dispatch": "1 - 3", "d3-octree": "1", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA=="],
+
     "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
 
     "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
@@ -1381,6 +1392,8 @@
     "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
 
     "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-octree": ["d3-octree@1.1.0", "", {}, "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A=="],
 
     "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
 
@@ -1652,7 +1665,11 @@
 
     "flatted": ["flatted@3.4.1", "", {}, "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ=="],
 
+    "float-tooltip": ["float-tooltip@1.7.5", "", { "dependencies": { "d3-selection": "2 - 3", "kapsule": "^1.16", "preact": "10" } }, "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg=="],
+
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
+
+    "force-graph": ["force-graph@1.51.4", "", { "dependencies": { "@tweenjs/tween.js": "18 - 25", "accessor-fn": "1", "bezier-js": "3 - 6", "canvas-color-tracker": "^1.3", "d3-array": "1 - 3", "d3-drag": "2 - 3", "d3-force-3d": "2 - 3", "d3-scale": "1 - 4", "d3-scale-chromatic": "1 - 3", "d3-selection": "2 - 3", "d3-zoom": "2 - 3", "float-tooltip": "^1.7", "index-array-by": "1", "kapsule": "^1.16", "lodash-es": "4" } }, "sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
@@ -1788,6 +1805,8 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "index-array-by": ["index-array-by@1.4.2", "", {}, "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
@@ -1902,6 +1921,8 @@
 
     "jdenticon": ["jdenticon@3.3.0", "", { "dependencies": { "canvas-renderer": "~2.2.0" }, "bin": { "jdenticon": "bin/jdenticon.js" } }, "sha512-DhuBRNRIybGPeAjMjdHbkIfiwZCCmf8ggu7C49jhp6aJ7DYsZfudnvnTY5/1vgUhrGA7JaDAx1WevnpjCPvaGg=="],
 
+    "jerrypick": ["jerrypick@1.1.2", "", {}, "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
@@ -1931,6 +1952,8 @@
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
+
+    "kapsule": ["kapsule@1.16.3", "", { "dependencies": { "lodash-es": "4" } }, "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg=="],
 
     "katex": ["katex@0.16.38", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-cjHooZUmIAUmDsHBN+1n8LaZdpmbj03LtYeYPyuYB7OuloiaeaV6N4LcfjcnHVzGWjVQmKrxxTrpDcmSzEZQwQ=="],
 
@@ -2328,6 +2351,8 @@
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
+    "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
@@ -2374,7 +2399,11 @@
 
     "react-email": ["react-email@5.2.10", "", { "dependencies": { "@babel/parser": "7.27.0", "@babel/traverse": "7.27.0", "chokidar": "^4.0.3", "commander": "^13.0.0", "conf": "^15.0.2", "debounce": "^2.0.0", "esbuild": "0.27.3", "glob": "^13.0.6", "jiti": "2.4.2", "log-symbols": "^7.0.0", "mime-types": "^3.0.0", "normalize-path": "^3.0.0", "nypm": "0.6.2", "ora": "^8.0.0", "prompts": "2.4.2", "socket.io": "^4.8.1", "tsconfig-paths": "4.2.0" }, "bin": { "email": "dist/index.mjs" } }, "sha512-Ys8yR5/a0nXf5u2GlT2UV93PJHC3ZnuMnNebEn7I5UE9XfMFPtlpgDs02mPJOJn49fhJjDTWIUlZD1vmQPDgJg=="],
 
+    "react-force-graph-2d": ["react-force-graph-2d@1.29.1", "", { "dependencies": { "force-graph": "^1.51", "prop-types": "15", "react-kapsule": "^2.5" }, "peerDependencies": { "react": "*" } }, "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ=="],
+
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-kapsule": ["react-kapsule@2.5.7", "", { "dependencies": { "jerrypick": "^1.1.1" }, "peerDependencies": { "react": ">=16.13.1" } }, "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
@@ -2627,6 +2656,8 @@
     "three-stdlib": ["three-stdlib@2.36.1", "", { "dependencies": { "@types/draco3d": "^1.4.0", "@types/offscreencanvas": "^2019.6.4", "@types/webxr": "^0.5.2", "draco3d": "^1.4.1", "fflate": "^0.6.9", "potpack": "^1.0.1" }, "peerDependencies": { "three": ">=0.128.0" } }, "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
+    "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 


### PR DESCRIPTION
## Summary

- Adds an Obsidian-style interactive graph at `/repositories/[id]/graph` for indexed repos, with nodes = files and edges from both `import`/`require`/`from` statements (solid, directed) and cosine similarity on per-file averaged Qdrant embeddings (dashed).
- Right-hand **Highlights** panel surfaces entry points (`page.tsx`, `route.ts`, `layout.tsx`, `middleware`, `index.*`), config files (`schema.prisma`, `package.json`, `tsconfig`, `next.config.*`), hub modules (high in-degree), and large modules. Clicking a highlight smoothly centers and zooms the graph onto that node.
- **Legend** overlay explains edge styles (solid = import, dashed = semantic), node sizing (chunk count), and directory colors; directory palette is deterministic (sorted by file count).
- New **"Graph"** button on the repository list card, visible only once the repo is indexed.

## Implementation notes

- `lib/repo-graph.ts` scrolls up to 5000 chunks, groups by `filePath`, averages embeddings, caps the graph at 400 nodes by chunk count. Semantic edges use top-3 per node with a cosine threshold of 0.55 and are suppressed when a structural edge already exists.
- `/api/repositories/[id]/graph` is session-auth'd and org-membership-checked; returns 409 while the repo is still indexing.
- UI uses `react-force-graph-2d` (canvas, no Three.js dep). Loaded via `next/dynamic` with `ssr: false`.

## Test plan

- [ ] Visit `/repositories` and confirm the **Graph** button only appears for repos whose `indexStatus === "indexed"`.
- [ ] Open the graph page; verify legend, highlights, toggle buttons, and node hover tooltip render.
- [ ] Click a highlight and confirm the graph smoothly centers on the corresponding node with a white ring.
- [ ] Toggle Imports / Semantic buttons and verify edges filter accordingly.
- [ ] Click a node directly in the graph — same focus behavior should trigger.
- [ ] Try a non-indexed repo — page should show the "not indexed yet" placeholder.
- [ ] Try a repo the user is not a member of — API should 404.

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)