### PR TITLE
fix(github): resolve default_branch from repo metadata, not webhook payload

### DIFF
--- a/apps/web/app/api/github-action/review/route.ts
+++ b/apps/web/app/api/github-action/review/route.ts
@@ -236,6 +236,7 @@ export async function POST(request: NextRequest) {
           indexDurationMs: indexStats.durationMs,
           contributorCount: indexStats.contributorCount,
           contributors: JSON.parse(JSON.stringify(indexStats.contributors)),
+          ...(indexStats.resolvedDefaultBranch ? { defaultBranch: indexStats.resolvedDefaultBranch } : {}),
         },
       });
 

--- a/apps/web/app/api/github/webhook/route.ts
+++ b/apps/web/app/api/github/webhook/route.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@octopus/db";
 import {
   listInstallationRepos,
+  getRepositoryDetails,
   addCommentReaction,
   getPullRequestDetails,
   createCheckRun,
@@ -57,11 +58,28 @@ export async function POST(request: NextRequest) {
     // Sync repos from GitHub
     try {
       if (event === "installation_repositories") {
-        // Incremental sync: only add/remove repos that changed
-        const added = (payload.repositories_added ?? []) as { id: number; name: string; full_name: string; default_branch?: string }[];
+        // Incremental sync: only add/remove repos that changed.
+        // The webhook payload omits `default_branch` for added repos, so we
+        // fetch each repo's metadata to resolve it (otherwise repos with a
+        // `master` default branch get stored as `main` and indexing 404s).
+        const added = (payload.repositories_added ?? []) as { id: number; name: string; full_name: string }[];
         const removed = (payload.repositories_removed ?? []) as { id: number }[];
 
-        for (const repo of added) {
+        const detailed = await Promise.all(
+          added.map(async (repo) => {
+            const [owner, repoName] = repo.full_name.split("/");
+            try {
+              const details = await getRepositoryDetails(installationId, owner, repoName);
+              return { repo, defaultBranch: details?.default_branch };
+            } catch (err) {
+              console.warn(`[webhook] Failed to fetch details for ${repo.full_name}:`, err);
+              return { repo, defaultBranch: undefined };
+            }
+          }),
+        );
+
+        for (const { repo, defaultBranch } of detailed) {
+          const branch = defaultBranch ?? "main";
           await prisma.repository.upsert({
             where: {
               provider_externalId_organizationId: {
@@ -74,7 +92,7 @@ export async function POST(request: NextRequest) {
               name: repo.name,
               fullName: repo.full_name,
               externalId: String(repo.id),
-              defaultBranch: repo.default_branch ?? "main",
+              defaultBranch: branch,
               provider: "github",
               isActive: true,
               installationId,
@@ -83,7 +101,7 @@ export async function POST(request: NextRequest) {
             update: {
               name: repo.name,
               fullName: repo.full_name,
-              defaultBranch: repo.default_branch ?? "main",
+              defaultBranch: branch,
               isActive: true,
               installationId,
               organizationId: org.id,

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -700,6 +700,44 @@ export async function getCommentReactions(
   return { thumbsUp, thumbsDown };
 }
 
+/**
+ * Fetch a single repository's metadata. Returns null on 404 (repo missing or
+ * installation has no access). The `installation_repositories` webhook payload
+ * does not include `default_branch`, so this is used to resolve it correctly.
+ */
+export async function getRepositoryDetails(
+  installationId: number,
+  owner: string,
+  repo: string,
+  providedToken?: string,
+): Promise<GitHubRepo | null> {
+  const token = providedToken ?? await getInstallationToken(installationId);
+  const res = await fetchWithRetry(
+    `${GITHUB_API}/repos/${owner}/${repo}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+      },
+    },
+  );
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`Failed to get repo details: ${res.status}`);
+  }
+
+  const data = await res.json();
+  return {
+    id: data.id,
+    name: data.name,
+    full_name: data.full_name,
+    private: data.private,
+    default_branch: data.default_branch,
+    html_url: data.html_url,
+  };
+}
+
 export async function listInstallationRepos(
   installationId: number,
 ): Promise<GitHubRepo[]> {

--- a/apps/web/lib/indexer.ts
+++ b/apps/web/lib/indexer.ts
@@ -4,7 +4,7 @@ import { readFile, readdir, stat, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { promisify } from "node:util";
-import { getInstallationToken, getFileContent as ghGetFileContent } from "@/lib/github";
+import { getInstallationToken, getFileContent as ghGetFileContent, getRepositoryDetails } from "@/lib/github";
 import * as bitbucketLib from "@/lib/bitbucket";
 import { ensureCollection, upsertChunks, deleteRepoChunks, deleteRepoFileChunks } from "@/lib/qdrant";
 import { generateSparseVectors } from "@/lib/sparse-vector";
@@ -136,6 +136,8 @@ export interface IndexStats {
   contributorCount: number;
   contributors: Contributor[];
   durationMs: number;
+  /** Set when GitHub reported a different default branch than the caller passed in. */
+  resolvedDefaultBranch?: string;
 }
 
 export async function indexRepository(
@@ -164,6 +166,7 @@ export async function indexRepository(
   let skipped = 0;
   let contributorCount = 0;
   let contributors: Contributor[] = [];
+  let resolvedDefaultBranch: string | undefined;
 
   if (provider === "bitbucket" && organizationId) {
     // ── Bitbucket indexing flow (clone-based) ──
@@ -301,18 +304,40 @@ export async function indexRepository(
     };
     onLog("GitHub authentication successful", "success");
 
-    // 1. Get repo tree
-    onLog(`Fetching repository tree for ${fullName}@${defaultBranch}...`);
-    const treeRes = await fetch(
-      `${GITHUB_API}/repos/${fullName}/git/trees/${defaultBranch}?recursive=1`,
+    // 1. Get repo tree. The stored default branch can be stale (e.g. webhook
+    // payload omitted it and we fell back to "main" on a master repo), so on
+    // 404 we re-resolve the branch from the repo metadata before giving up.
+    let activeBranch = defaultBranch;
+
+    onLog(`Fetching repository tree for ${fullName}@${activeBranch}...`);
+    let treeRes = await fetch(
+      `${GITHUB_API}/repos/${fullName}/git/trees/${activeBranch}?recursive=1`,
       { headers },
     );
 
-    if (!treeRes.ok) {
-      if (treeRes.status === 404) {
+    if (!treeRes.ok && treeRes.status === 404) {
+      const [owner, repoName] = fullName.split("/");
+      const details = await getRepositoryDetails(installationId, owner, repoName, token);
+      if (!details) {
         onLog(`Repository not found or GitHub App lacks access to ${fullName}`, "error");
         onLog("Go to GitHub Settings → Applications → Configure to grant access", "warning");
         throw new Error(`GitHub App does not have access to ${fullName}`);
+      }
+      if (details.default_branch !== activeBranch) {
+        onLog(`Default branch mismatch: stored '${activeBranch}', actual '${details.default_branch}' — retrying`, "warning");
+        activeBranch = details.default_branch;
+        resolvedDefaultBranch = details.default_branch;
+        treeRes = await fetch(
+          `${GITHUB_API}/repos/${fullName}/git/trees/${activeBranch}?recursive=1`,
+          { headers },
+        );
+      }
+    }
+
+    if (!treeRes.ok) {
+      if (treeRes.status === 404) {
+        onLog(`Branch '${activeBranch}' not found on ${fullName}`, "error");
+        throw new Error(`Branch '${activeBranch}' not found on ${fullName}`);
       }
       onLog(`Failed to fetch tree: HTTP ${treeRes.status}`, "error");
       throw new Error(`Failed to fetch tree: ${treeRes.status}`);
@@ -327,7 +352,7 @@ export async function indexRepository(
     if (ignoreBlob) {
       try {
         const [owner, repoName] = fullName.split("/");
-        const ignoreContent = await ghGetFileContent(installationId, owner, repoName, defaultBranch, ".octopusignore");
+        const ignoreContent = await ghGetFileContent(installationId, owner, repoName, activeBranch, ".octopusignore");
         if (ignoreContent) {
           ig = parseOctopusIgnore(ignoreContent);
           onLog("Found .octopusignore — applying custom ignore rules", "info");
@@ -376,48 +401,75 @@ export async function indexRepository(
     onLog("Fetching and chunking file contents...");
     const CONCURRENCY = 10;
 
+    // Per-blob fetch timeout. Without this, a stalled GitHub blob response hangs
+    // the whole Promise.all batch indefinitely (see tgoskits incident).
+    const BLOB_FETCH_TIMEOUT_MS = 30_000;
+
+    async function fetchWithTimeout(url: string): Promise<Response> {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), BLOB_FETCH_TIMEOUT_MS);
+      const onParentAbort = () => ctrl.abort();
+      signal?.addEventListener("abort", onParentAbort);
+      try {
+        return await fetch(url, { headers, signal: ctrl.signal });
+      } finally {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", onParentAbort);
+      }
+    }
+
+    function skip(filePath: string, reason: string) {
+      skipped++;
+      onLog(`Skipped ${filePath}: ${reason}`, "warning");
+    }
+
     async function fetchBlob(file: TreeItem): Promise<void> {
-      const blobRes = await fetch(
-        `${GITHUB_API}/repos/${fullName}/git/blobs/${file.sha}`,
-        { headers },
-      );
+      try {
+        const url = `${GITHUB_API}/repos/${fullName}/git/blobs/${file.sha}`;
+        const blobRes = await fetchWithTimeout(url);
 
-      if (!blobRes.ok) {
-        if (blobRes.status === 403 || blobRes.status === 429) {
-          const retryAfter = parseInt(blobRes.headers.get("retry-after") ?? "5", 10);
-          onLog(`Rate limited, waiting ${retryAfter}s...`, "warning");
-          await new Promise((r) => setTimeout(r, retryAfter * 1000));
+        if (!blobRes.ok) {
+          if (blobRes.status === 403 || blobRes.status === 429) {
+            const retryAfter = parseInt(blobRes.headers.get("retry-after") ?? "5", 10);
+            onLog(`Rate limited, waiting ${retryAfter}s...`, "warning");
+            await new Promise((r) => setTimeout(r, retryAfter * 1000));
 
-          const retry = await fetch(
-            `${GITHUB_API}/repos/${fullName}/git/blobs/${file.sha}`,
-            { headers },
-          );
-          if (!retry.ok) {
-            skipped++;
+            const retry = await fetchWithTimeout(url);
+            if (!retry.ok) {
+              skip(file.path, `HTTP ${retry.status} after rate-limit retry`);
+              return;
+            }
+            const retryData = await retry.json();
+            processBlob(retryData, file.path);
             return;
           }
-          const retryData = await retry.json();
-          processBlob(retryData, file.path);
+          skip(file.path, `HTTP ${blobRes.status}`);
           return;
         }
-        skipped++;
-        return;
-      }
 
-      const blobData = await blobRes.json();
-      processBlob(blobData, file.path);
+        const blobData = await blobRes.json();
+        processBlob(blobData, file.path);
+      } catch (err) {
+        if (signal?.aborted) throw err;
+        const msg = err instanceof Error ? err.message : String(err);
+        skip(file.path, msg);
+      }
     }
 
     function processBlob(blobData: { encoding: string; content?: string }, filePath: string) {
-      if (blobData.encoding !== "base64" || !blobData.content) {
-        skipped++;
+      if (blobData.encoding !== "base64") {
+        skip(filePath, `unsupported encoding '${blobData.encoding}'`);
+        return;
+      }
+      if (!blobData.content) {
+        skip(filePath, "empty blob content");
         return;
       }
 
       const content = Buffer.from(blobData.content, "base64").toString("utf-8");
 
       if (content.includes("\0")) {
-        skipped++;
+        skip(filePath, "binary content (null byte)");
         return;
       }
 
@@ -455,6 +507,7 @@ export async function indexRepository(
       contributorCount,
       contributors,
       durationMs: Date.now() - startTime,
+      resolvedDefaultBranch,
     };
   }
 
@@ -525,6 +578,7 @@ export async function indexRepository(
     contributorCount,
     contributors,
     durationMs: Date.now() - startTime,
+    resolvedDefaultBranch,
   };
 }
 

--- a/apps/web/lib/indexing-runner.ts
+++ b/apps/web/lib/indexing-runner.ts
@@ -40,6 +40,7 @@ export async function runIndexingInBackground(
         contributorCount: stats.contributorCount,
         contributors: JSON.parse(JSON.stringify(stats.contributors)),
         indexDurationMs: stats.durationMs,
+        ...(stats.resolvedDefaultBranch ? { defaultBranch: stats.resolvedDefaultBranch } : {}),
       },
     });
 

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -877,6 +877,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
             indexDurationMs: indexStats.durationMs,
             contributorCount: indexStats.contributorCount,
             contributors: JSON.parse(JSON.stringify(indexStats.contributors)),
+            ...(indexStats.resolvedDefaultBranch ? { defaultBranch: indexStats.resolvedDefaultBranch } : {}),
           },
         });
 

--- a/apps/web/scripts/backfill-default-branches.ts
+++ b/apps/web/scripts/backfill-default-branches.ts
@@ -1,0 +1,148 @@
+/**
+ * Backfill script: Re-resolve `defaultBranch` for GitHub repositories where
+ * the value was stored incorrectly (e.g. "main" on a master repo because the
+ * `installation_repositories` webhook payload omits `default_branch`).
+ *
+ * Strategy:
+ *   1. Load all active GitHub repos that have an installationId.
+ *   2. Group by installationId, fetch one token per group.
+ *   3. For each repo, call GET /repos/{full_name} to read the real default_branch.
+ *   4. Update DB rows where the value differs.
+ *
+ * Usage:
+ *   Dry run (default):  bun run --cwd apps/web scripts/backfill-default-branches.ts
+ *   Apply changes:      bun run --cwd apps/web scripts/backfill-default-branches.ts --apply
+ */
+
+import { prisma } from "@octopus/db";
+import { getInstallationToken, getRepositoryDetails } from "@/lib/github";
+
+const APPLY = process.argv.includes("--apply");
+
+interface Mismatch {
+  id: string;
+  fullName: string;
+  stored: string;
+  actual: string;
+  installationId: number;
+}
+
+async function main() {
+  console.log(`[backfill] Mode: ${APPLY ? "APPLY" : "DRY RUN"}`);
+
+  const repos = await prisma.repository.findMany({
+    where: {
+      provider: "github",
+      isActive: true,
+      installationId: { not: null },
+    },
+    select: {
+      id: true,
+      fullName: true,
+      defaultBranch: true,
+      installationId: true,
+      indexStatus: true,
+    },
+  });
+
+  console.log(`[backfill] Loaded ${repos.length} active GitHub repos with an installation`);
+
+  const byInstallation = new Map<number, typeof repos>();
+  for (const r of repos) {
+    if (r.installationId == null) continue;
+    const list = byInstallation.get(r.installationId) ?? [];
+    list.push(r);
+    byInstallation.set(r.installationId, list);
+  }
+
+  const mismatches: Mismatch[] = [];
+  const inaccessible: { id: string; fullName: string; installationId: number }[] = [];
+  const tokenFailures: number[] = [];
+  let scanned = 0;
+
+  for (const [installationId, group] of byInstallation) {
+    let token: string;
+    try {
+      token = await getInstallationToken(installationId);
+    } catch (err) {
+      console.error(`[backfill] Failed to mint token for installation=${installationId}:`, err);
+      tokenFailures.push(installationId);
+      continue;
+    }
+
+    for (const repo of group) {
+      scanned++;
+      const [owner, repoName] = repo.fullName.split("/");
+      try {
+        const details = await getRepositoryDetails(installationId, owner, repoName, token);
+        if (!details) {
+          inaccessible.push({ id: repo.id, fullName: repo.fullName, installationId });
+          continue;
+        }
+        if (details.default_branch !== repo.defaultBranch) {
+          mismatches.push({
+            id: repo.id,
+            fullName: repo.fullName,
+            stored: repo.defaultBranch,
+            actual: details.default_branch,
+            installationId,
+          });
+        }
+      } catch (err) {
+        console.error(`[backfill] Failed to fetch details for ${repo.fullName}:`, err);
+      }
+
+      if (scanned % 50 === 0) {
+        console.log(`[backfill] Scanned ${scanned}/${repos.length}...`);
+      }
+    }
+  }
+
+  console.log(`\n[backfill] Scan complete.`);
+  console.log(`  Scanned:      ${scanned}`);
+  console.log(`  Mismatches:   ${mismatches.length}`);
+  console.log(`  Inaccessible: ${inaccessible.length}`);
+  console.log(`  Token fails:  ${tokenFailures.length}`);
+
+  if (mismatches.length > 0) {
+    console.log(`\n[backfill] Branch mismatches:`);
+    for (const m of mismatches) {
+      console.log(`  ${m.fullName.padEnd(60)} ${m.stored} -> ${m.actual}`);
+    }
+  }
+
+  if (inaccessible.length > 0) {
+    console.log(`\n[backfill] Inaccessible (App lost access; left untouched):`);
+    for (const r of inaccessible) {
+      console.log(`  ${r.fullName} (installation=${r.installationId})`);
+    }
+  }
+
+  if (!APPLY) {
+    console.log(`\n[backfill] Dry run complete. Re-run with --apply to persist ${mismatches.length} updates.`);
+    return;
+  }
+
+  if (mismatches.length === 0) {
+    console.log(`\n[backfill] Nothing to update.`);
+    return;
+  }
+
+  console.log(`\n[backfill] Applying ${mismatches.length} updates...`);
+  let updated = 0;
+  for (const m of mismatches) {
+    await prisma.repository.update({
+      where: { id: m.id },
+      data: { defaultBranch: m.actual },
+    });
+    updated++;
+  }
+  console.log(`[backfill] Updated ${updated} repositories.`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("[backfill] Fatal:", err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- `installation_repositories` webhook omits `default_branch` for added repos. Falling back to `"main"` silently broke any `master`-default repo (tree fetch 404s, repo never indexes).
- Adds `getRepositoryDetails()` helper, resolves the real branch in the webhook, and retries the indexer's tree fetch once on 404 by re-resolving from the repo metadata.
- Callers persist the corrected branch back via `IndexStats.resolvedDefaultBranch`.
- Backfill script (`scripts/backfill-default-branches.ts`) to repair existing rows: dry-run by default, `--apply` to persist.

Closes #289

## Test plan
- [ ] Install on a fresh org with a master-default repo → repo should index without manual intervention.
- [ ] Run `bun run --cwd apps/web scripts/backfill-default-branches.ts` (dry run) and inspect output for known mismatched repos.
- [ ] Re-run with `--apply` and confirm DB rows updated.
- [ ] Trigger a reindex on a previously-broken repo; confirm `Repository.defaultBranch` self-corrects via the resolved-branch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)