### PR TITLE
feat(cancel): redis pub/sub for cross-process abort

### DIFF
--- a/apps/web/lib/analysis-abort.ts
+++ b/apps/web/lib/analysis-abort.ts
@@ -1,8 +1,21 @@
-// In-memory registry of active analysis AbortControllers.
-// Keyed by repoId so we can cancel a specific repo's analysis.
+import { onCancel, publishCancel } from "./cancel-bus";
+
 const controllers = new Map<string, AbortController>();
 
+let listenerRegistered = false;
+function ensureListener() {
+  if (listenerRegistered) return;
+  listenerRegistered = true;
+  onCancel("analysis", (repoId) => {
+    const c = controllers.get(repoId);
+    if (!c) return;
+    c.abort();
+    controllers.delete(repoId);
+  });
+}
+
 export function createAnalysisAbortController(repoId: string): AbortController {
+  ensureListener();
   const existing = controllers.get(repoId);
   if (existing) existing.abort();
 
@@ -12,6 +25,7 @@ export function createAnalysisAbortController(repoId: string): AbortController {
 }
 
 export function abortAnalysis(repoId: string): boolean {
+  publishCancel("analysis", repoId);
   const controller = controllers.get(repoId);
   if (!controller) return false;
   controller.abort();

--- a/apps/web/lib/cancel-bus.ts
+++ b/apps/web/lib/cancel-bus.ts
@@ -1,0 +1,61 @@
+import Redis from "ioredis";
+
+type CancelKind = "analysis" | "indexing";
+type Handler = (repoId: string) => void;
+
+const CHANNEL = "octopus:cancel";
+
+const handlers: Record<CancelKind, Set<Handler>> = {
+  analysis: new Set(),
+  indexing: new Set(),
+};
+
+let publisher: Redis | null = null;
+let subscriber: Redis | null = null;
+let subscribed = false;
+
+function getPublisher(): Redis | null {
+  if (publisher) return publisher;
+  const url = process.env.REDIS_URL;
+  if (!url) return null;
+  publisher = new Redis(url, { lazyConnect: false, maxRetriesPerRequest: 2, enableOfflineQueue: false });
+  publisher.on("error", (err) => console.error("[cancel-bus] publisher error:", err.message));
+  return publisher;
+}
+
+function ensureSubscribed() {
+  if (subscribed) return;
+  const url = process.env.REDIS_URL;
+  if (!url) return;
+  subscriber = new Redis(url, { lazyConnect: false, maxRetriesPerRequest: null });
+  subscriber.on("error", (err) => console.error("[cancel-bus] subscriber error:", err.message));
+  subscriber.subscribe(CHANNEL).catch((err) => console.error("[cancel-bus] subscribe failed:", err));
+  subscriber.on("message", (_channel, raw) => {
+    try {
+      const msg = JSON.parse(raw) as { kind?: CancelKind; repoId?: string };
+      if (!msg.kind || !msg.repoId) return;
+      const set = handlers[msg.kind];
+      if (!set) return;
+      for (const h of set) {
+        try { h(msg.repoId); } catch (err) { console.error("[cancel-bus] handler error:", err); }
+      }
+    } catch (err) {
+      console.error("[cancel-bus] parse error:", err);
+    }
+  });
+  subscribed = true;
+}
+
+export function onCancel(kind: CancelKind, handler: Handler): () => void {
+  ensureSubscribed();
+  handlers[kind].add(handler);
+  return () => handlers[kind].delete(handler);
+}
+
+export function publishCancel(kind: CancelKind, repoId: string) {
+  const pub = getPublisher();
+  if (!pub) return;
+  pub.publish(CHANNEL, JSON.stringify({ kind, repoId })).catch((err) =>
+    console.error("[cancel-bus] publish failed:", err.message),
+  );
+}

--- a/apps/web/lib/cancel-bus.ts
+++ b/apps/web/lib/cancel-bus.ts
@@ -13,6 +13,7 @@ const handlers: Record<CancelKind, Set<Handler>> = {
 let publisher: Redis | null = null;
 let subscriber: Redis | null = null;
 let subscribed = false;
+let subscribing = false;
 
 function getPublisher(): Redis | null {
   if (publisher) return publisher;
@@ -24,12 +25,12 @@ function getPublisher(): Redis | null {
 }
 
 function ensureSubscribed() {
-  if (subscribed) return;
+  if (subscribed || subscribing) return;
   const url = process.env.REDIS_URL;
   if (!url) return;
+  subscribing = true;
   subscriber = new Redis(url, { lazyConnect: false, maxRetriesPerRequest: null });
   subscriber.on("error", (err) => console.error("[cancel-bus] subscriber error:", err.message));
-  subscriber.subscribe(CHANNEL).catch((err) => console.error("[cancel-bus] subscribe failed:", err));
   subscriber.on("message", (_channel, raw) => {
     try {
       const msg = JSON.parse(raw) as { kind?: CancelKind; repoId?: string };
@@ -43,7 +44,18 @@ function ensureSubscribed() {
       console.error("[cancel-bus] parse error:", err);
     }
   });
-  subscribed = true;
+  subscriber.subscribe(CHANNEL).then(
+    () => {
+      subscribed = true;
+      subscribing = false;
+    },
+    (err) => {
+      console.error("[cancel-bus] subscribe failed:", err);
+      subscribing = false;
+      subscriber?.disconnect();
+      subscriber = null;
+    },
+  );
 }
 
 export function onCancel(kind: CancelKind, handler: Handler): () => void {

--- a/apps/web/lib/indexing-abort.ts
+++ b/apps/web/lib/indexing-abort.ts
@@ -1,9 +1,21 @@
-// In-memory registry of active indexing AbortControllers.
-// Keyed by repoId so we can cancel a specific repo's indexing.
+import { onCancel, publishCancel } from "./cancel-bus";
+
 const controllers = new Map<string, AbortController>();
 
+let listenerRegistered = false;
+function ensureListener() {
+  if (listenerRegistered) return;
+  listenerRegistered = true;
+  onCancel("indexing", (repoId) => {
+    const c = controllers.get(repoId);
+    if (!c) return;
+    c.abort();
+    controllers.delete(repoId);
+  });
+}
+
 export function createAbortController(repoId: string): AbortController {
-  // Abort any existing one first
+  ensureListener();
   const existing = controllers.get(repoId);
   if (existing) existing.abort();
 
@@ -13,6 +25,7 @@ export function createAbortController(repoId: string): AbortController {
 }
 
 export function abortIndexing(repoId: string): boolean {
+  publishCancel("indexing", repoId);
   const controller = controllers.get(repoId);
   if (!controller) return false;
   controller.abort();


### PR DESCRIPTION
## Summary
- New `lib/cancel-bus.ts` — Redis pub/sub on `octopus:cancel`, lazily connects only when a publisher or subscriber is needed; falls back to no-op if `REDIS_URL` is not set.
- `analysis-abort.ts` and `indexing-abort.ts` register a one-time subscriber and publish on every abort, so any process holding the controller will abort.
- Local in-process abort still happens synchronously — the bus is purely additive.

Closes #293

## Test plan
- [ ] In dev with two `next dev` instances pointed at the same Redis: start an indexing job on instance A, hit the abort endpoint on instance B → job stops.
- [ ] With `REDIS_URL` unset: no errors logged, local-only behavior intact.
- [ ] Repeated abort calls don't leak listeners (handler set stays bounded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)