### PR TITLE
feat(reliability): boot-time reconcile of stale repo states

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,6 +1,9 @@
 export async function register() {
   // Only start queue workers on the server (not during build or edge runtime)
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { reconcileStaleRepoStates } = await import("./lib/boot-reconciler");
+    await reconcileStaleRepoStates();
+
     const { startQueue } = await import("./lib/queue");
     const boss = await startQueue();
 

--- a/apps/web/lib/boot-reconciler.ts
+++ b/apps/web/lib/boot-reconciler.ts
@@ -19,6 +19,8 @@ export async function reconcileStaleRepoStates() {
       console.log(
         `[boot-reconciler] reset stale rows: indexing=${indexing.count} analyzing=${analyzing.count}`,
       );
+    } else {
+      console.log("[boot-reconciler] no stale rows to reset");
     }
   } catch (err) {
     console.error("[boot-reconciler] failed:", err);

--- a/apps/web/lib/boot-reconciler.ts
+++ b/apps/web/lib/boot-reconciler.ts
@@ -1,0 +1,26 @@
+import { prisma } from "@octopus/db";
+
+const STALE_MS = 10 * 60 * 1000;
+
+export async function reconcileStaleRepoStates() {
+  const cutoff = new Date(Date.now() - STALE_MS);
+
+  try {
+    const indexing = await prisma.repository.updateMany({
+      where: { indexStatus: "indexing", updatedAt: { lt: cutoff } },
+      data: { indexStatus: "pending" },
+    });
+    const analyzing = await prisma.repository.updateMany({
+      where: { analysisStatus: "analyzing", updatedAt: { lt: cutoff } },
+      data: { analysisStatus: "none" },
+    });
+
+    if (indexing.count || analyzing.count) {
+      console.log(
+        `[boot-reconciler] reset stale rows: indexing=${indexing.count} analyzing=${analyzing.count}`,
+      );
+    }
+  } catch (err) {
+    console.error("[boot-reconciler] failed:", err);
+  }
+}


### PR DESCRIPTION
## Summary
- `lib/boot-reconciler.ts`: on server boot, reset `indexStatus = 'indexing'` rows older than 10 min to `'pending'`, and `analysisStatus = 'analyzing'` rows older than 10 min to `'none'`.
- Wired into `instrumentation.register()` so it runs once before queue workers start.
- Logs the count when anything is reset; swallows errors so a DB blip doesn't prevent startup.

Closes #295

## Test plan
- [ ] Start a real indexing job, kill the process, restart — within 10 minutes UI still shows 'indexing'; after 10 minutes (or on next restart with `updatedAt` older than cutoff) the row resets to 'pending'.
- [ ] In-progress jobs (recent `updatedAt`) are untouched on boot.
- [ ] Confirm log line `[boot-reconciler] reset stale rows: indexing=N analyzing=M` when applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)