### PR TITLE
fix(sidebar): scrollable sidebar with safe-area inset

### DIFF
--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -295,7 +295,7 @@ function SidebarContent({
   const [couponOpen, setCouponOpen] = useState(false);
 
   return (
-    <div className="flex h-full flex-col bg-sidebar text-sidebar-foreground">
+    <div className="flex h-full flex-col overflow-y-auto bg-sidebar text-sidebar-foreground">
       {collapsed ? (
         <div className="flex flex-col items-center gap-2 border-b py-3">
           {onToggleCollapse && (
@@ -391,7 +391,7 @@ function SidebarContent({
 
       <CommandPalette orgId={currentOrg.id} />
 
-      <nav className={cn("flex-1 space-y-1 py-4", collapsed ? "px-2" : "px-3")}>
+      <nav className={cn("space-y-1 py-4", collapsed ? "px-2" : "px-3")}>
         {collapsed && (
           <SidebarTooltip label="Search (⌘K)">
             <button
@@ -456,7 +456,7 @@ function SidebarContent({
 
       </nav>
 
-      <div className={cn("space-y-1 py-2", collapsed ? "px-2" : "px-3")}>
+      <div className={cn("mt-auto space-y-1 py-2", collapsed ? "px-2" : "px-3")}>
         {bottomNavItems.map(({ href, label, icon: Icon }) => {
           const isActive = pathname === href;
           const link = (
@@ -554,7 +554,7 @@ function SidebarContent({
         )}
       </div>
 
-      <div className={cn("border-t py-3", collapsed ? "px-2" : "px-3")}>
+      <div className={cn("border-t py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]", collapsed ? "px-2" : "px-3")}>
         {collapsed ? (
           <SidebarTooltip label={user.name}>
             <div>


### PR DESCRIPTION
## Summary
- Sidebar root is `overflow-y-auto` so a tall org list/nav can scroll instead of clipping.
- Bottom nav uses `mt-auto` instead of `flex-1` on the main nav so it stays at the bottom when there is room and doesn't get pushed off when there isn't.
- Account row applies `pb-[max(0.75rem,env(safe-area-inset-bottom))]` to clear the iOS home indicator.

Closes #307

## Test plan
- [ ] Resize the window vertically: sidebar scrolls smoothly; bottom nav stays accessible.
- [ ] On iOS Safari (or DevTools device emulation), the account row sits above the home indicator.
- [ ] Collapsed sidebar still renders the bottom group correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)