### PR TITLE
feat(reviewer): route 300+ file PRs to internal-cli worker

### DIFF
--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -280,6 +280,25 @@ export async function createPullRequestReview(
   return data.id as number;
 }
 
+// Thrown when a PR's diff is too large for the standard reviewer path
+// (>300 files for the .diff endpoint, or >30k chars from /files reconstruction).
+// Caller should hand the PR off to the internal-cli worker which clones the
+// repo and computes the diff via `git diff base..head`.
+export class LargePrError extends Error {
+  constructor(
+    message: string,
+    public readonly meta: {
+      owner: string;
+      repo: string;
+      prNumber: number;
+      reason: "too-many-files" | "diff-too-large";
+    },
+  ) {
+    super(message);
+    this.name = "LargePrError";
+  }
+}
+
 export async function getPullRequestDiff(
   installationId: number,
   owner: string,
@@ -299,26 +318,40 @@ export async function getPullRequestDiff(
 
   if (res.ok) {
     const diff = await res.text();
-    return truncateDiff(diff);
+    if (diff.length > MAX_DIFF_CHARS) {
+      throw new LargePrError(
+        `Diff exceeds ${MAX_DIFF_CHARS} chars for ${owner}/${repo}#${prNumber}`,
+        { owner, repo, prNumber, reason: "diff-too-large" },
+      );
+    }
+    return diff;
   }
 
-  // GitHub returns 406 when the diff is too large (e.g. bulk file deletions).
-  // Fall back to paginated /files endpoint to reconstruct the diff.
+  // GitHub returns 406 when the .diff endpoint can't render (>300 files).
+  // Try the /files fallback; if it also overflows, escalate to LargePrError.
   if (res.status === 406) {
     console.warn(
-      `[github] Diff too large for ${owner}/${repo}#${prNumber}, falling back to /files endpoint`,
+      `[github] Diff too large for ${owner}/${repo}#${prNumber} (406), trying /files fallback`,
     );
-    return await getPullRequestDiffViaFiles(token, owner, repo, prNumber);
+    const reconstructed = await getPullRequestDiffViaFiles(token, owner, repo, prNumber);
+    if (reconstructed.endsWith(TRUNCATION_MARKER)) {
+      throw new LargePrError(
+        `/files fallback also truncated for ${owner}/${repo}#${prNumber}`,
+        { owner, repo, prNumber, reason: "too-many-files" },
+      );
+    }
+    return reconstructed;
   }
 
   throw new Error(`Failed to get PR diff: ${res.status}`);
 }
 
 const MAX_DIFF_CHARS = 30_000;
+const TRUNCATION_MARKER = "\n\n[... diff truncated at 30,000 chars]";
 
 function truncateDiff(diff: string): string {
   return diff.length > MAX_DIFF_CHARS
-    ? diff.slice(0, MAX_DIFF_CHARS) + "\n\n[... diff truncated at 30,000 chars]"
+    ? diff.slice(0, MAX_DIFF_CHARS) + TRUNCATION_MARKER
     : diff;
 }
 

--- a/apps/web/lib/large-review-result.ts
+++ b/apps/web/lib/large-review-result.ts
@@ -1,0 +1,307 @@
+import { prisma } from "@octopus/db";
+import { pubby } from "@/lib/pubby";
+import {
+  createPullRequestComment as ghCreatePullRequestComment,
+  updatePullRequestComment as ghUpdatePullRequestComment,
+  createPullRequestReview as ghCreatePullRequestReview,
+  updateCheckRun as ghUpdateCheckRun,
+} from "@/lib/github";
+import { parseFindings } from "@/lib/review-dedup";
+import {
+  buildLowSeveritySummary,
+  stripDetailedFindings,
+  countFindings,
+} from "@/lib/review-helpers";
+import { eventBus } from "@/lib/events";
+
+export type LargeReviewResultJob = {
+  pullRequestId: string;
+  reviewBody: string;
+  durationMs?: number;
+  error?: string;
+};
+
+const SEVERITY_TO_DB: Record<string, string> = {
+  "🔴": "critical",
+  "🟠": "high",
+  "🟡": "medium",
+  "🔵": "low",
+  "💡": "low",
+};
+
+export async function handleLargeReviewResult(
+  data: LargeReviewResultJob,
+): Promise<void> {
+  const pr = await prisma.pullRequest.findUnique({
+    where: { id: data.pullRequestId },
+    include: {
+      repository: { include: { organization: true } },
+    },
+  });
+
+  if (!pr) {
+    console.error(
+      `[large-review-result] PullRequest not found: ${data.pullRequestId}`,
+    );
+    return;
+  }
+
+  const repo = pr.repository;
+  const org = repo.organization;
+  const installationId = repo.installationId ?? org.githubInstallationId;
+  const [owner, repoName] = repo.fullName.split("/");
+  const isGitHub = repo.provider === "github";
+
+  if (!isGitHub || !installationId) {
+    console.error(
+      `[large-review-result] Only GitHub is supported for large reviews — repo ${repo.id} provider=${repo.provider}`,
+    );
+    return;
+  }
+
+  const reviewCommentId = pr.reviewCommentId ? Number(pr.reviewCommentId) : null;
+
+  if (data.error) {
+    const errorBody = [
+      "> 🐙 **Octopus Review** encountered an error while analyzing this large pull request.",
+      ">",
+      `> \`${data.error}\``,
+      ">",
+      "> Please try again by commenting `@octopus` on this PR.",
+    ].join("\n");
+
+    if (reviewCommentId) {
+      await ghUpdatePullRequestComment(
+        installationId,
+        owner,
+        repoName,
+        reviewCommentId,
+        errorBody,
+      ).catch((e) =>
+        console.error("[large-review-result] Failed to update placeholder:", e),
+      );
+    } else {
+      await ghCreatePullRequestComment(
+        installationId,
+        owner,
+        repoName,
+        pr.number,
+        errorBody,
+      ).catch((e) =>
+        console.error("[large-review-result] Failed to create error comment:", e),
+      );
+    }
+
+    await prisma.pullRequest.update({
+      where: { id: pr.id },
+      data: { status: "failed", errorMessage: data.error },
+    });
+
+    eventBus.emit({
+      type: "review-failed",
+      orgId: org.id,
+      prNumber: pr.number,
+      prTitle: pr.title,
+      error: data.error,
+    });
+    return;
+  }
+
+  const reviewBody = data.reviewBody;
+
+  // 1. Parse findings out of the markdown
+  const findings = parseFindings(reviewBody);
+  const findingsCount = countFindings(reviewBody);
+  console.log(
+    `[large-review-result] PR #${pr.number}: ${reviewBody.length} chars, ${findings.length} findings parsed`,
+  );
+
+  // 2. Update placeholder comment with main body (findings JSON stripped — they go inline/summary)
+  const mainCommentBody = stripDetailedFindings(reviewBody);
+  let mainCommentId = reviewCommentId;
+  if (mainCommentId) {
+    try {
+      await ghUpdatePullRequestComment(
+        installationId,
+        owner,
+        repoName,
+        mainCommentId,
+        mainCommentBody,
+      );
+    } catch (err) {
+      // Comment may have been deleted — recreate
+      if (err instanceof Error && err.message.includes("404")) {
+        const newId = await ghCreatePullRequestComment(
+          installationId,
+          owner,
+          repoName,
+          pr.number,
+          mainCommentBody,
+        );
+        mainCommentId = newId;
+        await prisma.pullRequest.update({
+          where: { id: pr.id },
+          data: { reviewCommentId: newId },
+        });
+      } else {
+        throw err;
+      }
+    }
+  } else {
+    const newId = await ghCreatePullRequestComment(
+      installationId,
+      owner,
+      repoName,
+      pr.number,
+      mainCommentBody,
+    );
+    mainCommentId = newId;
+    await prisma.pullRequest.update({
+      where: { id: pr.id },
+      data: { reviewCommentId: newId },
+    });
+  }
+
+  // 3. Post a summary review (no inline comments — internal-cli path doesn't compute
+  // diff line maps. All findings end up in the summary table.)
+  const hasCritical = findings.some((f) => f.severity === "🔴");
+  const hasHigh = findings.some((f) => f.severity === "🟠");
+  const hasMedium = findings.some((f) => f.severity === "🟡");
+  const threshold = org.checkFailureThreshold || "critical";
+  const shouldRequestChanges =
+    threshold !== "none" &&
+    (hasCritical ||
+      (threshold !== "critical" && hasHigh) ||
+      (threshold === "medium" && hasMedium));
+  const reviewEvent: "COMMENT" | "REQUEST_CHANGES" = shouldRequestChanges
+    ? "REQUEST_CHANGES"
+    : "COMMENT";
+
+  const findingsBlock = buildLowSeveritySummary(findings);
+  const summaryHeader = `Large PR — ${findings.length} finding${findings.length !== 1 ? "s" : ""}${
+    mainCommentId && pr.url ? ` | [View details](${pr.url}#issuecomment-${mainCommentId})` : ""
+  }`;
+  const summaryBody = [
+    summaryHeader,
+    findingsBlock,
+    `<details><summary>About</summary>\n\nReviewed via [Octopus Review](https://octopus-review.ai) large-PR pipeline. The diff exceeded GitHub's API limits, so the repository was cloned and reviewed against the full \`git diff\`. Inline comments are not posted on this path.\n\n</details>`,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+
+  try {
+    await ghCreatePullRequestReview(
+      installationId,
+      owner,
+      repoName,
+      pr.number,
+      summaryBody,
+      reviewEvent,
+      [],
+    );
+    console.log(
+      `[large-review-result] PR review submitted (${reviewEvent}, ${findings.length} findings in summary)`,
+    );
+  } catch (err) {
+    console.error(
+      "[large-review-result] Failed to submit review, falling back to comment:",
+      err,
+    );
+    await ghCreatePullRequestComment(
+      installationId,
+      owner,
+      repoName,
+      pr.number,
+      summaryBody,
+    );
+  }
+
+  // 4. Persist findings to review_issues
+  await prisma.reviewIssue.deleteMany({ where: { pullRequestId: pr.id } });
+  if (findings.length > 0) {
+    await prisma.reviewIssue.createMany({
+      data: findings.map((f) => ({
+        title: f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim(),
+        description: f.description || f.category,
+        severity: SEVERITY_TO_DB[f.severity] ?? "medium",
+        filePath: f.filePath || null,
+        lineNumber: f.startLine || null,
+        confidence: f.confidence ? String(f.confidence) : null,
+        pullRequestId: pr.id,
+      })),
+    });
+    console.log(`[large-review-result] Saved ${findings.length} review issues to DB`);
+  }
+
+  // 5. Mark PR completed
+  await prisma.pullRequest.update({
+    where: { id: pr.id },
+    data: { status: "completed", reviewBody, errorMessage: null },
+  });
+
+  // 6. Update check run if PR has headSha (best effort — we don't track checkRunId
+  // across the queue boundary, so we recreate-or-skip via a fresh check run.)
+  if (pr.headSha) {
+    try {
+      const conclusion = shouldRequestChanges ? "failure" : "success";
+      const summaryText = shouldRequestChanges
+        ? hasCritical
+          ? "Critical issues found that must be fixed before merge."
+          : hasHigh
+            ? "High severity issues found that should be fixed before merge."
+            : "Medium severity issues found that should be fixed before merge."
+        : findings.length > 0
+          ? "Review complete. No issues above the configured threshold."
+          : "Review complete. No issues found.";
+
+      const { createCheckRun: ghCreateCheckRun } = await import("@/lib/github");
+      const checkRunId = await ghCreateCheckRun(
+        installationId,
+        owner,
+        repoName,
+        pr.headSha,
+        "Octopus Review (Large PR)",
+      );
+      await ghUpdateCheckRun(
+        installationId,
+        owner,
+        repoName,
+        checkRunId,
+        conclusion,
+        {
+          title: `${findings.length} finding${findings.length !== 1 ? "s" : ""}`,
+          summary: summaryText,
+        },
+      );
+    } catch (err) {
+      console.error("[large-review-result] Check run update failed:", err);
+    }
+  }
+
+  // 7. Pubby + event bus
+  await pubby
+    .trigger(`presence-org-${org.id}`, "review-status", {
+      repoId: repo.id,
+      pullRequestId: pr.id,
+      number: pr.number,
+      status: "completed",
+      step: "completed",
+    })
+    .catch((e) =>
+      console.error("[large-review-result] Pubby trigger failed:", e),
+    );
+
+  eventBus.emit({
+    type: "review-completed",
+    orgId: org.id,
+    prNumber: pr.number,
+    prTitle: pr.title,
+    prUrl: pr.url,
+    findingsCount,
+    filesChanged: 0, // not known on this path; could be passed from internal-cli later
+  });
+
+  console.log(
+    `[large-review-result] Completed PR #${pr.number} (duration ${data.durationMs ?? "?"}ms)`,
+  );
+}

--- a/apps/web/lib/queue-workers.ts
+++ b/apps/web/lib/queue-workers.ts
@@ -1,6 +1,10 @@
 import type { PgBoss } from "pg-boss";
 import { sendWelcomeEmail } from "./emails/welcome";
 import { processReview } from "./reviewer";
+import {
+  handleLargeReviewResult,
+  type LargeReviewResultJob,
+} from "./large-review-result";
 import type { QueueConfig } from "./queue";
 
 export interface WelcomeEmailJob {
@@ -37,5 +41,22 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     },
   );
 
-  console.log("[queue] Workers registered: welcome-email, process-review");
+  // Handle results from internal-cli (large PRs reviewed via clone + claude-cli)
+  await boss.work<LargeReviewResultJob>(
+    "post-large-review-result",
+    { localConcurrency: config.reviewConcurrency },
+    async (jobs) => {
+      for (const job of jobs) {
+        console.log(`[queue] Posting large review result for PR ${job.data.pullRequestId}`);
+        try {
+          await handleLargeReviewResult(job.data);
+        } catch (err) {
+          console.error(`[queue] Large review post failed for PR ${job.data.pullRequestId} (job ${job.id}):`, err);
+          throw err;
+        }
+      }
+    },
+  );
+
+  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result");
 }

--- a/apps/web/lib/queue.ts
+++ b/apps/web/lib/queue.ts
@@ -70,6 +70,20 @@ export async function startQueue(): Promise<PgBoss> {
     expireInSeconds: config.reviewTimeoutSeconds,
   }).catch(() => {});
 
+  // Large PRs (>30k diff or >300 files) are handed to the internal-cli worker
+  // which clones the repo and runs claude-cli over the full git diff.
+  await boss.createQueue("process-large-review", {
+    retryLimit: 1,
+    expireInSeconds: 1800, // 30 min — covers clone + claude run for big repos
+  }).catch(() => {});
+
+  // internal-cli enqueues this back to the engine when it's done; the engine
+  // worker then parses findings and posts the PR comment + inline review.
+  await boss.createQueue("post-large-review-result", {
+    retryLimit: 2,
+    expireInSeconds: 300,
+  }).catch(() => {});
+
   // Only review-engine containers should register workers. Web containers
   // still need pg-boss started so they can enqueue jobs, but must not consume.
   // The flag must be set explicitly: a missing value is a misconfiguration,

--- a/apps/web/lib/queue.ts
+++ b/apps/web/lib/queue.ts
@@ -5,11 +5,16 @@ import { prisma } from "@octopus/db";
 export interface QueueConfig {
   reviewTimeoutSeconds: number;
   reviewConcurrency: number;
+  // Large reviews (>300 files / >30k diff) hand off to internal-cli, which
+  // clones the repo and runs claude-cli — that's slower than an in-process
+  // review, so it gets a longer timeout.
+  largeReviewTimeoutSeconds: number;
 }
 
 export const QUEUE_CONFIG_DEFAULTS: QueueConfig = {
   reviewTimeoutSeconds: 900,
   reviewConcurrency: 2,
+  largeReviewTimeoutSeconds: 1800,
 };
 
 // Buffer added on top of reviewTimeoutSeconds to decide when an in-flight
@@ -74,7 +79,7 @@ export async function startQueue(): Promise<PgBoss> {
   // which clones the repo and runs claude-cli over the full git diff.
   await boss.createQueue("process-large-review", {
     retryLimit: 1,
-    expireInSeconds: 1800, // 30 min — covers clone + claude run for big repos
+    expireInSeconds: config.largeReviewTimeoutSeconds,
   }).catch(() => {});
 
   // internal-cli enqueues this back to the engine when it's done; the engine

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -608,14 +608,24 @@ export async function processReview(pullRequestId: string): Promise<void> {
   }
   // Stale threshold must exceed the pg-boss job timeout so we don't race
   // with a still-running worker that pg-boss is about to kill for timing out.
+  // Two windows: the in-process reviewer's timeout for status='reviewing',
+  // and the longer internal-cli timeout for status='queued' (large-PR jobs
+  // sit in 'queued' for the full clone+claude duration).
   const queueConfig = await loadQueueConfig();
-  const staleBefore = new Date(Date.now() - computeStaleReclaimMs(queueConfig.reviewTimeoutSeconds));
+  const reviewingStale = new Date(Date.now() - computeStaleReclaimMs(queueConfig.reviewTimeoutSeconds));
+  const queuedStale = new Date(Date.now() - computeStaleReclaimMs(queueConfig.largeReviewTimeoutSeconds));
   const claimed = await prisma.pullRequest.updateMany({
     where: {
       id: pullRequestId,
       OR: [
-        { status: { in: ["pending", "queued", "failed"] } },
-        { status: "reviewing", updatedAt: { lt: staleBefore } },
+        // Fresh-claim: never seen / explicitly retryable
+        { status: "pending" },
+        { status: "failed" },
+        // Locked-claim: in-flight reviews block re-claim until their stale window passes.
+        // This prevents webhook retries from double-processing a PR that's still being
+        // reviewed (or whose internal-cli clone+claude is still running).
+        { status: "reviewing", updatedAt: { lt: reviewingStale } },
+        { status: "queued", updatedAt: { lt: queuedStale } },
       ],
     },
     data: { status: "reviewing", updatedAt: new Date() },
@@ -1017,13 +1027,12 @@ export async function processReview(pullRequestId: string): Promise<void> {
       step: "fetching-diff",
     });
 
+    // Fetch the diff first, fall back to internal-cli if oversized, then
+    // fetch the tree. Sequencing avoids orphaning a tree request when the
+    // diff fetch throws (which we want to handle separately for large PRs).
     let rawDiff: string;
-    let repoTree: string[];
     try {
-      [rawDiff, repoTree] = await Promise.all([
-        providerGetDiff(pr.number),
-        providerGetTree(repo.defaultBranch),
-      ]);
+      rawDiff = await providerGetDiff(pr.number);
     } catch (err) {
       // PRs that exceed GitHub's diff size limits get handed off to internal-cli,
       // which clones the repo and computes the diff with `git diff base..head`.
@@ -1064,6 +1073,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
       }
       throw err;
     }
+    const repoTree = await providerGetTree(repo.defaultBranch);
 
     // Detect committed build artifacts / dependency folders
     const badFiles = detectBadCommits(rawDiff);

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -15,12 +15,13 @@ import {
   upsertFeedbackPattern,
 } from "@/lib/qdrant";
 import { extractAllMermaidBlocks, extractNodeLabels, DIAGRAM_TYPE_LABELS } from "@/lib/mermaid-utils";
-import { loadQueueConfig, computeStaleReclaimMs } from "@/lib/queue";
+import { loadQueueConfig, computeStaleReclaimMs, enqueue } from "@/lib/queue";
 import { createEmbeddings } from "@/lib/embeddings";
 import { generateSparseVector } from "@/lib/sparse-vector";
 import { rerankDocuments } from "@/lib/reranker";
 import {
   getPullRequestDiff as ghGetPullRequestDiff,
+  LargePrError,
   createPullRequestComment as ghCreatePullRequestComment,
   updatePullRequestComment as ghUpdatePullRequestComment,
   createPullRequestReview as ghCreatePullRequestReview,
@@ -120,6 +121,7 @@ type ReviewEvent = {
     | "searching-context"
     | "generating-review"
     | "posting-comment"
+    | "delegating-large-pr"
     | "completed"
     | "failed";
   detail?: string;
@@ -1015,10 +1017,48 @@ export async function processReview(pullRequestId: string): Promise<void> {
       step: "fetching-diff",
     });
 
-    const [rawDiff, repoTree] = await Promise.all([
-      providerGetDiff(pr.number),
-      providerGetTree(repo.defaultBranch),
-    ]);
+    let rawDiff: string;
+    let repoTree: string[];
+    try {
+      [rawDiff, repoTree] = await Promise.all([
+        providerGetDiff(pr.number),
+        providerGetTree(repo.defaultBranch),
+      ]);
+    } catch (err) {
+      // PRs that exceed GitHub's diff size limits get handed off to internal-cli,
+      // which clones the repo and computes the diff with `git diff base..head`.
+      // Only GitHub raises LargePrError; Bitbucket has no equivalent yet.
+      if (err instanceof LargePrError && isGitHub && installationId) {
+        console.warn(
+          `[reviewer] Routing PR #${pr.number} to internal-cli (${err.meta.reason})`,
+        );
+        await emitReviewStatus(org.id, {
+          ...baseEvent,
+          status: "reviewing",
+          step: "delegating-large-pr",
+        });
+        await prisma.pullRequest.update({
+          where: { id: pr.id },
+          data: { status: "queued", updatedAt: new Date() },
+        });
+        await enqueue("process-large-review", {
+          pullRequestId: pr.id,
+          orgId: org.id,
+          repositoryId: repo.id,
+          repoFullName: repo.fullName,
+          installationId,
+          prNumber: pr.number,
+          prTitle: pr.title,
+          prAuthor: pr.author,
+          headSha: pr.headSha ?? null,
+          reviewCommentId: reviewCommentId ?? null,
+          checkRunId: checkRunId ?? null,
+          reason: err.meta.reason,
+        });
+        return;
+      }
+      throw err;
+    }
 
     // Detect committed build artifacts / dependency folders
     const badFiles = detectBadCommits(rawDiff);

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1037,10 +1037,11 @@ export async function processReview(pullRequestId: string): Promise<void> {
           status: "reviewing",
           step: "delegating-large-pr",
         });
-        await prisma.pullRequest.update({
-          where: { id: pr.id },
-          data: { status: "queued", updatedAt: new Date() },
-        });
+        // Enqueue BEFORE flipping the PR status so a crash between the two
+        // can't strand the PR in "queued" with no job to process it. If the
+        // enqueue throws we fall through to the outer catch which marks the
+        // PR failed; if the post-update fails we still have a job that will
+        // drive the PR to "completed"/"failed" via post-large-review-result.
         await enqueue("process-large-review", {
           pullRequestId: pr.id,
           orgId: org.id,
@@ -1054,6 +1055,10 @@ export async function processReview(pullRequestId: string): Promise<void> {
           reviewCommentId: reviewCommentId ?? null,
           checkRunId: checkRunId ?? null,
           reason: err.meta.reason,
+        });
+        await prisma.pullRequest.update({
+          where: { id: pr.id },
+          data: { status: "queued", updatedAt: new Date() },
         });
         return;
       }


### PR DESCRIPTION
## Summary
- Large PRs (`.diff` 406 / >30k char fallback) currently get truncated to alphabetically-first files. PR #511 in `WhiteOrg/walletserviceendpoint` (.NET migration) was reviewed as if it only contained two `.claude/skills/` markdown files because the real migration code never made it into the prompt.
- This PR adds a hand-off path: `getPullRequestDiff` now throws `LargePrError` on 406 / 30k-truncation; `reviewer` catches it and enqueues `process-large-review` to a separate `internal-cli` worker (sibling repo, ephemeral container with `gh` + `claude` CLI).
- The internal-cli clones the repo, runs `claude --print` in agentic mode (`Read,Glob,Grep,Bash(git diff:*)`), and enqueues `post-large-review-result` back. The engine handles posting via the new `handleLargeReviewResult` helper.

## What changed
- `apps/web/lib/github.ts` — new `LargePrError`; `getPullRequestDiff` throws it on 406 or when /files reconstruction overflows.
- `apps/web/lib/reviewer.ts` — wraps `providerGetDiff` in try/catch; on `LargePrError`, enqueues `process-large-review` and exits early. Adds `delegating-large-pr` step to `ReviewEvent`.
- `apps/web/lib/queue.ts` — registers `process-large-review` (1800s, retry 1) and `post-large-review-result` (300s, retry 2) queues.
- `apps/web/lib/queue-workers.ts` — registers the `post-large-review-result` worker on engine pods (`ENABLE_REVIEW_WORKERS=true`).
- `apps/web/lib/large-review-result.ts` _(new)_ — simplified result handler: parses findings, posts main comment + summary review, persists to `review_issues`, marks PR completed, emits pubby + event bus. Skips inline comments (no diff line map on this path) and the heavy feedback/embedding pipeline (v1).

## Out of scope (separate work)
- The `internal-cli` sibling repo itself: scaffolded at `../internal-cli` (Dockerfile, `src/{index,clone,claude,db,github-token,poster,prompt}.ts`). Will be its own repo + image (`ghcr.io/octopusreview/internal-cli:latest`).
- `docker-compose.wdc.yml` and `deploy.sh` updates for the new swarm service — those are gitignored deployment files.

## Test plan
- [x] `bun run --cwd apps/web test` — 237 pass / 0 fail
- [x] `bun run --cwd apps/web typecheck` — clean
- [ ] Staging: 350+ file PR routed to internal-cli, summary findings cover the actual migration (not just `.claude/skills/`)
- [ ] Re-review PR #511 (`WhiteOrg/walletserviceendpoint`) — should now produce real migration findings instead of the false "PR description doesn't match diff" critical
- [ ] Regression: <30k diff PRs still go through the existing engine path (no internal-cli detour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)