### PR TITLE
fix(reviewer): sanitize mermaid blocks in review body before posting

### DIFF
--- a/apps/web/lib/__tests__/mermaid-utils.test.ts
+++ b/apps/web/lib/__tests__/mermaid-utils.test.ts
@@ -4,6 +4,7 @@ import {
   extractAllMermaidBlocks,
   extractMermaidCode,
   sanitizeMermaidCode,
+  sanitizeMermaidInMarkdown,
   extractNodeLabels,
 } from "@/lib/mermaid-utils";
 
@@ -468,5 +469,63 @@ describe("extractNodeLabels", () => {
     const labels = extractNodeLabels(code);
     expect(labels).not.toContain("x");
     expect(labels).toContain("Login Page");
+  });
+});
+
+describe("sanitizeMermaidInMarkdown", () => {
+  it("balances activate/deactivate inside ```mermaid blocks in markdown", () => {
+    const body = `## Review
+
+Some text.
+
+\`\`\`mermaid
+sequenceDiagram
+    participant A
+    activate A
+    alt branch 1
+        deactivate A
+    else branch 2
+        deactivate A
+    end
+\`\`\`
+
+More text.`;
+    const result = sanitizeMermaidInMarkdown(body);
+    // First deactivate kept (depth 1→0); second dropped (would underflow)
+    const matches = result.match(/deactivate A/g) ?? [];
+    expect(matches.length).toBe(1);
+    // Surrounding markdown intact
+    expect(result).toContain("## Review");
+    expect(result).toContain("More text.");
+  });
+
+  it("handles multiple mermaid blocks", () => {
+    const body = `\`\`\`mermaid
+graph TD
+    A["Use \`fn\` here"]
+\`\`\`
+
+text
+
+\`\`\`mermaid
+sequenceDiagram
+    participant Loop
+\`\`\``;
+    const result = sanitizeMermaidInMarkdown(body);
+    // Block 1: backticks in label replaced with single quotes
+    expect(result).toContain("A[\"Use 'fn' here\"]");
+    // Block 2: reserved keyword 'Loop' renamed
+    expect(result).not.toMatch(/^\s*participant Loop\s*$/m);
+    expect(result).toMatch(/participant Loop_/);
+  });
+
+  it("leaves non-mermaid code blocks untouched", () => {
+    const body = "```ts\nactivate Foo\ndeactivate Foo\ndeactivate Foo\n```";
+    expect(sanitizeMermaidInMarkdown(body)).toBe(body);
+  });
+
+  it("returns input unchanged when there are no mermaid blocks", () => {
+    const body = "Just plain markdown with **bold** and `code`.";
+    expect(sanitizeMermaidInMarkdown(body)).toBe(body);
   });
 });

--- a/apps/web/lib/mermaid-utils.ts
+++ b/apps/web/lib/mermaid-utils.ts
@@ -95,6 +95,21 @@ export function extractMermaidCode(text: string | null | undefined): string | nu
  * 3. Ensure `class` statements are each on their own line
  * 4. Remove trailing whitespace on lines
  */
+/**
+ * Find every ```mermaid block in a markdown body and replace its contents with
+ * the sanitized version. Used to clean up the LLM's review body before posting
+ * to the PR — without this, malformed mermaid (unbalanced activate/deactivate,
+ * reserved-keyword participant IDs, etc.) renders as "Unable to render rich
+ * display" on GitHub even though we already sanitize when storing in vector DB.
+ */
+export function sanitizeMermaidInMarkdown(body: string): string {
+  return body.replace(
+    /(```mermaid\s*\n)([\s\S]*?)(\n```)/g,
+    (_match, open: string, code: string, close: string) =>
+      `${open}${sanitizeMermaidCode(code)}${close}`,
+  );
+}
+
 export function sanitizeMermaidCode(code: string): string {
   let result = code;
 

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -14,7 +14,7 @@ import {
   ensureFeedbackCollection,
   upsertFeedbackPattern,
 } from "@/lib/qdrant";
-import { extractAllMermaidBlocks, extractNodeLabels, DIAGRAM_TYPE_LABELS } from "@/lib/mermaid-utils";
+import { extractAllMermaidBlocks, extractNodeLabels, DIAGRAM_TYPE_LABELS, sanitizeMermaidInMarkdown } from "@/lib/mermaid-utils";
 import { loadQueueConfig, computeStaleReclaimMs } from "@/lib/queue";
 import { createEmbeddings } from "@/lib/embeddings";
 import { generateSparseVector } from "@/lib/sparse-vector";
@@ -1453,6 +1453,13 @@ export async function processReview(pullRequestId: string): Promise<void> {
         return "";
       },
     );
+
+    // Sanitize every mermaid block in the review body — fixes unbalanced
+    // activate/deactivate, reserved-keyword participant IDs, escaped quotes,
+    // etc. that would otherwise render as "Unable to render rich display"
+    // on GitHub. Vector-DB storage already runs the same sanitizer; without
+    // this call, the comment posted to the PR is the unsanitized LLM output.
+    reviewBody = sanitizeMermaidInMarkdown(reviewBody);
 
     // Prepend build artifact warning if bad files were detected in the diff
     if (badFiles.length > 0) {


### PR DESCRIPTION
## Summary
- Octopus already runs `sanitizeMermaidCode` when storing diagrams in the vector DB, but the **review body posted to GitHub is the raw LLM output** — never sanitized.
- LLMs routinely emit unbalanced `activate`/`deactivate` inside `alt/else` branches, reserved-keyword participant IDs, escaped quotes, etc. GitHub then shows **"Unable to render rich display — Trying to inactivate an inactive participant"** in the Diagram section.
- Add `sanitizeMermaidInMarkdown(body)` which walks every \`\`\`mermaid block in a markdown body and replaces its contents with the sanitized version. Apply it in `reviewer.ts` after the existing fence-cleanup steps.

## Why now
Surfaced by Octopus's own review of #309 — the `### Diagram` section had an unbalanced sequence diagram and rendered as a parse error in the PR comment. The sanitizer for this exact bug already exists (`balanceSequenceActivations` in `mermaid-utils.ts`), it just wasn't wired into the post path.

## Test plan
- [x] `bun run --cwd apps/web typecheck` clean
- [x] `bun run --cwd apps/web test` — 241 pass / 0 fail (4 new tests in `mermaid-utils.test.ts` covering balanced activations, multiple blocks, non-mermaid fences, and no-op on plain markdown)
- [ ] Re-trigger a review on a PR known to produce alt/else sequence diagrams; confirm GitHub renders the diagram instead of "Unable to render rich display"

🤖 Generated with [Claude Code](https://claude.com/claude-code)