### PR TITLE
feat(knowledge): pin documents to always include in reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Knowledge Center: pin documents to always include in every review, regardless of diff similarity (#317)
+
 ## [1.0.14] - 2026-04-29
 
 ### Added

--- a/apps/web/app/(app)/knowledge/actions.ts
+++ b/apps/web/app/(app)/knowledge/actions.ts
@@ -573,6 +573,60 @@ Output ONLY the enhanced document content. Do not add meta-commentary or explana
   }
 }
 
+export async function setKnowledgeAlwaysInclude(
+  documentId: string,
+  alwaysInclude: boolean,
+): Promise<{ error?: string }> {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+  if (!session) redirect("/login");
+
+  const cookieStore = await cookies();
+  const orgId = cookieStore.get("current_org_id")?.value;
+  if (!orgId) return { error: "No organization selected." };
+
+  const doc = await prisma.knowledgeDocument.findUnique({
+    where: { id: documentId },
+    select: {
+      organizationId: true,
+      organization: {
+        select: {
+          members: {
+            where: { userId: session.user.id, deletedAt: null },
+            select: { id: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!doc || doc.organization.members.length === 0) {
+    return { error: "Document not found." };
+  }
+  if (doc.organizationId !== orgId) {
+    return { error: "Document does not belong to this organization." };
+  }
+
+  await prisma.knowledgeDocument.update({
+    where: { id: documentId },
+    data: { alwaysInclude },
+  });
+
+  await prisma.knowledgeAuditLog.create({
+    data: {
+      action: "updated",
+      details: alwaysInclude ? "Pinned to all reviews" : "Unpinned from all reviews",
+      documentId,
+      userId: session.user.id,
+      organizationId: orgId,
+    },
+  });
+
+  revalidatePath("/knowledge");
+  return {};
+}
+
 export async function getKnowledgeAuditLogs(documentId: string) {
   const session = await auth.api.getSession({
     headers: await headers(),

--- a/apps/web/app/(app)/knowledge/knowledge-content.tsx
+++ b/apps/web/app/(app)/knowledge/knowledge-content.tsx
@@ -65,7 +65,10 @@ import {
   restoreKnowledgeDocument,
   getKnowledgeAuditLogs,
   enhanceKnowledgeContent,
+  setKnowledgeAlwaysInclude,
 } from "./actions";
+import { Switch } from "@/components/ui/switch";
+import { IconPin } from "@tabler/icons-react";
 import { getPubbyClient } from "@/lib/pubby-client";
 import { TemplateBrowser } from "./template-browser";
 
@@ -79,6 +82,7 @@ type Document = {
   totalChunks: number;
   totalVectors: number;
   processingMs: number | null;
+  alwaysInclude: boolean;
   createdAt: string;
 };
 
@@ -319,6 +323,18 @@ export function KnowledgeContent({ documents: initialDocuments, deletedDocuments
     startDeleteTransition(async () => {
       await deleteKnowledgeDocument(documentId);
     });
+  }
+
+  async function handleAlwaysIncludeToggle(documentId: string, next: boolean) {
+    setDocuments((prev) =>
+      prev.map((d) => (d.id === documentId ? { ...d, alwaysInclude: next } : d)),
+    );
+    const result = await setKnowledgeAlwaysInclude(documentId, next);
+    if (result.error) {
+      setDocuments((prev) =>
+        prev.map((d) => (d.id === documentId ? { ...d, alwaysInclude: !next } : d)),
+      );
+    }
   }
 
   function handleRestore(documentId: string) {
@@ -572,6 +588,25 @@ export function KnowledgeContent({ documents: initialDocuments, deletedDocuments
                     {doc.errorMessage}
                   </p>
                 )}
+              </div>
+
+              <div
+                className="flex shrink-0 items-center gap-2"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <label
+                  className="flex items-center gap-1.5 text-xs text-muted-foreground cursor-pointer select-none"
+                  title="Pin: include in every review regardless of diff similarity"
+                >
+                  <IconPin className={`size-3.5 ${doc.alwaysInclude ? "text-primary" : ""}`} />
+                  <span className="hidden sm:inline">Pin</span>
+                  <Switch
+                    checked={doc.alwaysInclude}
+                    onCheckedChange={(v) => handleAlwaysIncludeToggle(doc.id, v)}
+                    disabled={doc.status !== "ready"}
+                    aria-label="Always include in reviews"
+                  />
+                </label>
               </div>
 
               <AlertDialog>

--- a/apps/web/app/(app)/knowledge/page.tsx
+++ b/apps/web/app/(app)/knowledge/page.tsx
@@ -41,6 +41,7 @@ export default async function KnowledgePage() {
         totalChunks: true,
         totalVectors: true,
         processingMs: true,
+        alwaysInclude: true,
         createdAt: true,
       },
       orderBy: { createdAt: "desc" },

--- a/apps/web/lib/__tests__/knowledge-context.test.ts
+++ b/apps/web/lib/__tests__/knowledge-context.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "bun:test";
+import { mergeKnowledgeChunks } from "@/lib/knowledge-context";
+
+describe("mergeKnowledgeChunks", () => {
+  it("places always-include chunks first", () => {
+    const always = [{ title: "Pinned", text: "[Knowledge: Pinned]\nrule A" }];
+    const similarity = [{ title: "Other", text: "[Knowledge: Other]\nrule B", score: 0.9 }];
+    const merged = mergeKnowledgeChunks(always, similarity);
+    expect(merged.length).toBe(2);
+    expect(merged[0]?.title).toBe("Pinned");
+    expect(merged[1]?.title).toBe("Other");
+  });
+
+  it("dedupes similarity chunks whose title matches an always-include chunk", () => {
+    const always = [{ title: "Pinned", text: "full content" }];
+    const similarity = [
+      { title: "Pinned", text: "chunk excerpt", score: 0.95 },
+      { title: "Other", text: "B", score: 0.7 },
+    ];
+    const merged = mergeKnowledgeChunks(always, similarity);
+    expect(merged.length).toBe(2);
+    expect(merged.map((m) => m.title)).toEqual(["Pinned", "Other"]);
+    expect(merged[0]?.text).toBe("full content");
+  });
+
+  it("returns similarity chunks unchanged when nothing is pinned", () => {
+    const similarity = [{ title: "X", text: "x", score: 0.5 }];
+    const merged = mergeKnowledgeChunks([], similarity);
+    expect(merged).toEqual(similarity);
+  });
+
+  it("returns only always-include chunks when similarity is empty", () => {
+    const always = [{ title: "P", text: "p" }];
+    const merged = mergeKnowledgeChunks(always, []);
+    expect(merged).toEqual(always);
+  });
+});

--- a/apps/web/lib/knowledge-context.ts
+++ b/apps/web/lib/knowledge-context.ts
@@ -1,0 +1,57 @@
+import { prisma } from "@octopus/db";
+
+const ALWAYS_INCLUDE_PER_DOC_CHAR_CAP = 8000;
+const ALWAYS_INCLUDE_TOTAL_CHAR_CAP = 24000;
+
+export type KnowledgeChunk = { title: string; text: string; score?: number };
+
+export async function getAlwaysIncludeKnowledge(
+  orgId: string,
+): Promise<KnowledgeChunk[]> {
+  const docs = await prisma.knowledgeDocument.findMany({
+    where: {
+      organizationId: orgId,
+      alwaysInclude: true,
+      deletedAt: null,
+      status: "ready",
+    },
+    select: { title: true, content: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const chunks: KnowledgeChunk[] = [];
+  let total = 0;
+  for (const doc of docs) {
+    if (total >= ALWAYS_INCLUDE_TOTAL_CHAR_CAP) break;
+    const remainingTotal = ALWAYS_INCLUDE_TOTAL_CHAR_CAP - total;
+    const cap = Math.min(ALWAYS_INCLUDE_PER_DOC_CHAR_CAP, remainingTotal);
+    const truncated = doc.content.length > cap;
+    const body = truncated
+      ? doc.content.slice(0, cap) + "\n\n[...truncated]"
+      : doc.content;
+    chunks.push({
+      title: doc.title,
+      text: `[Knowledge: ${doc.title}]\n${body}`,
+    });
+    total += body.length;
+  }
+  return chunks;
+}
+
+/**
+ * Merge always-include knowledge with similarity-search results.
+ * Always-include chunks come first; similarity chunks are appended,
+ * skipping any whose text already appears in always-include chunks.
+ */
+export function mergeKnowledgeChunks(
+  alwaysInclude: KnowledgeChunk[],
+  similarity: KnowledgeChunk[],
+): KnowledgeChunk[] {
+  const seenTitles = new Set(alwaysInclude.map((c) => c.title));
+  const merged: KnowledgeChunk[] = [...alwaysInclude];
+  for (const c of similarity) {
+    if (seenTitles.has(c.title)) continue;
+    merged.push(c);
+  }
+  return merged;
+}

--- a/apps/web/lib/review-core.ts
+++ b/apps/web/lib/review-core.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/qdrant";
 import { createEmbeddings } from "@/lib/embeddings";
 import { rerankDocuments } from "@/lib/reranker";
+import { getAlwaysIncludeKnowledge, mergeKnowledgeChunks } from "@/lib/knowledge-context";
 import {
   type InlineFinding,
   parseFindings,
@@ -205,12 +206,13 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
 
   const rerankQuery = `${title ?? "Local Review"}\n${diff.slice(0, 2000)}`;
 
-  const [rawCodeChunks, rawKnowledgeChunks] = await Promise.all([
+  const [rawCodeChunks, rawKnowledgeChunks, alwaysIncludeKnowledge] = await Promise.all([
     searchSimilarChunks(repo.id, queryVector, 50, rerankQuery),
     searchKnowledgeChunks(org.id, queryVector, 25, rerankQuery).catch(() => [] as { title: string; text: string; score: number }[]),
+    getAlwaysIncludeKnowledge(org.id).catch(() => []),
   ]);
 
-  const [contextChunks, knowledgeChunks] = await Promise.all([
+  const [contextChunks, similarityKnowledgeChunks] = await Promise.all([
     rerankDocuments(rerankQuery, rawCodeChunks, {
       topK: 15,
       scoreThreshold: 0.25,
@@ -227,6 +229,8 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
     }),
   ]);
 
+  const knowledgeChunks = mergeKnowledgeChunks(alwaysIncludeKnowledge, similarityKnowledgeChunks);
+
   const codebaseContext = contextChunks
     .map((c) => `// ${c.filePath}:L${c.startLine}-L${c.endLine}\n${c.text}`)
     .join("\n\n---\n\n");
@@ -236,7 +240,7 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
     : "";
 
   console.log(
-    `[review-core] Context: ${contextChunks.length}/${rawCodeChunks.length} code chunks, ${knowledgeChunks.length}/${rawKnowledgeChunks.length} knowledge chunks (after rerank)`,
+    `[review-core] Context: ${contextChunks.length}/${rawCodeChunks.length} code chunks, ${knowledgeChunks.length} knowledge chunks (${alwaysIncludeKnowledge.length} pinned + ${similarityKnowledgeChunks.length}/${rawKnowledgeChunks.length} from search)`,
   );
 
   // Step 2: Build false positive context from past feedback

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -19,6 +19,7 @@ import { loadQueueConfig, computeStaleReclaimMs, enqueue } from "@/lib/queue";
 import { createEmbeddings } from "@/lib/embeddings";
 import { generateSparseVector } from "@/lib/sparse-vector";
 import { rerankDocuments } from "@/lib/reranker";
+import { getAlwaysIncludeKnowledge, mergeKnowledgeChunks } from "@/lib/knowledge-context";
 import {
   getPullRequestDiff as ghGetPullRequestDiff,
   LargePrError,
@@ -1161,12 +1162,13 @@ export async function processReview(pullRequestId: string): Promise<void> {
     // Over-fetch from Qdrant, then rerank with Cohere
     const rerankQuery = `${pr.title}\n${diff.slice(0, 2000)}`;
 
-    const [rawCodeChunks, rawKnowledgeChunks] = await Promise.all([
+    const [rawCodeChunks, rawKnowledgeChunks, alwaysIncludeKnowledge] = await Promise.all([
       searchSimilarChunks(repo.id, queryVector, 50, rerankQuery),
       searchKnowledgeChunks(org.id, queryVector, 25, rerankQuery).catch(() => [] as { title: string; text: string; score: number }[]),
+      getAlwaysIncludeKnowledge(org.id).catch(() => []),
     ]);
 
-    const [contextChunks, knowledgeChunks] = await Promise.all([
+    const [contextChunks, similarityKnowledgeChunks] = await Promise.all([
       rerankDocuments(rerankQuery, rawCodeChunks, {
         topK: 15,
         scoreThreshold: 0.25,
@@ -1183,6 +1185,8 @@ export async function processReview(pullRequestId: string): Promise<void> {
       }),
     ]);
 
+    const knowledgeChunks = mergeKnowledgeChunks(alwaysIncludeKnowledge, similarityKnowledgeChunks);
+
     const codebaseContext = contextChunks
       .map(
         (c) =>
@@ -1198,11 +1202,11 @@ export async function processReview(pullRequestId: string): Promise<void> {
       ...baseEvent,
       status: "reviewing",
       step: "searching-context",
-      detail: `${contextChunks.length}/${rawCodeChunks.length} code chunks after rerank, ${knowledgeChunks.length}/${rawKnowledgeChunks.length} knowledge chunks after rerank`,
+      detail: `${contextChunks.length}/${rawCodeChunks.length} code chunks after rerank, ${knowledgeChunks.length} knowledge chunks (${alwaysIncludeKnowledge.length} pinned + ${similarityKnowledgeChunks.length}/${rawKnowledgeChunks.length} from search)`,
     });
 
     console.log(
-      `[reviewer] Context: ${contextChunks.length}/${rawCodeChunks.length} code chunks, ${knowledgeChunks.length}/${rawKnowledgeChunks.length} knowledge chunks (after rerank)`,
+      `[reviewer] Context: ${contextChunks.length}/${rawCodeChunks.length} code chunks, ${knowledgeChunks.length} knowledge chunks (${alwaysIncludeKnowledge.length} pinned + ${similarityKnowledgeChunks.length}/${rawKnowledgeChunks.length} from search)`,
     );
 
     // Step 4: Build prompt and call Anthropic

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -307,6 +307,7 @@ model KnowledgeDocument {
   totalVectors   Int      @default(0)
   processingMs   Int?
   templateId     String?
+  alwaysInclude  Boolean  @default(false)
   deletedAt      DateTime?
   deletedById    String?
   createdAt      DateTime @default(now())
@@ -318,6 +319,7 @@ model KnowledgeDocument {
   auditLogs      KnowledgeAuditLog[]
 
   @@index([organizationId, status, deletedAt])
+  @@index([organizationId, alwaysInclude, deletedAt])
   @@map("knowledge_documents")
 }
 


### PR DESCRIPTION
Closes #317

## Summary
- Adds `alwaysInclude` flag on `KnowledgeDocument`. Pinned docs bypass embedding-similarity retrieval and are concatenated into the review's knowledge context every time.
- Per-doc cap 8KB, total cap 24KB, with truncation marker. Dedup against similarity results by title.
- Surfaced as a Pin switch in the Knowledge Center; status `ready` required (so users do not pin docs that are still indexing).
- Recorded in `KnowledgeAuditLog`.

## Why
External feedback (Tsinghua researcher) reported Knowledge Center rules being applied inconsistently. Root cause: rules whose wording is semantically distant from the diff are dropped by the similarity search. Pinning gives users a guaranteed channel for must-have rules without removing the similarity layer.

## Migration
A manual migration is included locally at `packages/db/prisma/migrations/20260430102407_add_knowledge_always_include/migration.sql` (the migrations dir is gitignored — apply via the standard manual deploy flow):

```sql
ALTER TABLE "public"."knowledge_documents" ADD COLUMN "alwaysInclude" BOOLEAN NOT NULL DEFAULT false;
CREATE INDEX "knowledge_documents_organizationId_alwaysInclude_deletedAt_idx"
  ON "public"."knowledge_documents"("organizationId", "alwaysInclude", "deletedAt");
```

## Test plan
- [x] `bun run --cwd apps/web lint` — no new warnings
- [x] `bun run --cwd apps/web typecheck` — clean
- [x] `bun run --cwd apps/web test` — 245 pass / 0 fail (4 new tests in `knowledge-context.test.ts`)
- [ ] Apply migration in dev DB
- [ ] Verify pinned doc appears in `{{KNOWLEDGE_CONTEXT}}` of every review (check log line: `N pinned + M/K from search`)
- [ ] Verify unpinned doc still uses similarity-based retrieval
- [ ] Verify Pin toggle disabled while doc is `processing`/`error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)