### PR TITLE
fix(reviews): inline mapping fallback + re-review zero-finding UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Inline comments are now attached for findings whose line range partially misses the diff: the comment snaps to the nearest changed line within ±10 lines, with a small note. Previously these dropped to a summary table even at high severity. (#321)
-- Re-reviews with no new findings now show "✅ No new issues detected since the last review" instead of looking like an empty review.
+- Snap findings whose line range partially misses the diff onto the nearest changed line within ±10 lines, with a small note. Previously high-severity findings could drop to the summary table even when the change was within reach. (#321)
+- Show "✅ No new issues detected since the last review" on re-reviews with zero findings, instead of leaving the comment looking empty. (#321)
 
 ### Changed
-- Tightened the LLM prompt to require finding line numbers be added (`+`) lines in the diff, not context lines. (#321)
+- Tighten the LLM prompt to require finding line numbers reference added (`+`) lines in the diff, not context lines. (#321)
 
 ## [1.0.14] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Inline comments are now attached for findings whose line range partially misses the diff: the comment snaps to the nearest changed line within ±10 lines, with a small note. Previously these dropped to a summary table even at high severity. (#321)
+- Re-reviews with no new findings now show "✅ No new issues detected since the last review" instead of looking like an empty review.
+
+### Changed
+- Tightened the LLM prompt to require finding line numbers be added (`+`) lines in the diff, not context lines. (#321)
+
 ## [1.0.14] - 2026-04-29
 
 ### Added

--- a/apps/web/lib/__tests__/inline-mapping.test.ts
+++ b/apps/web/lib/__tests__/inline-mapping.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "bun:test";
+import { buildInlineComments, NEAREST_LINE_FALLBACK_RADIUS } from "@/lib/review-helpers";
+import type { InlineFinding } from "@/lib/review-dedup";
+
+function f(overrides: Partial<InlineFinding> = {}): InlineFinding {
+  return {
+    severity: "🟠",
+    title: "Test finding",
+    filePath: "src/foo.ts",
+    startLine: 100,
+    endLine: 100,
+    category: "Bug",
+    description: "desc",
+    suggestion: "",
+    confidence: 80,
+    ...overrides,
+  };
+}
+
+describe("buildInlineComments — exact mapping", () => {
+  it("attaches when endLine is in the diff", () => {
+    const diff = new Map([["src/foo.ts", new Set([100, 101, 102])]]);
+    const comments = buildInlineComments([f({ startLine: 100, endLine: 100 })], diff);
+    expect(comments.length).toBe(1);
+    expect(comments[0]?.line).toBe(100);
+    expect(comments[0]?.body).not.toContain("nearest changed line");
+  });
+
+  it("falls back to startLine when endLine is invalid", () => {
+    const diff = new Map([["src/foo.ts", new Set([95])]]);
+    const comments = buildInlineComments([f({ startLine: 95, endLine: 200 })], diff);
+    expect(comments[0]?.line).toBe(95);
+    expect(comments[0]?.body).not.toContain("nearest changed line");
+  });
+
+  it("uses an in-range valid line when neither end matches", () => {
+    const diff = new Map([["src/foo.ts", new Set([102])]]);
+    const comments = buildInlineComments([f({ startLine: 100, endLine: 105 })], diff);
+    expect(comments[0]?.line).toBe(102);
+    expect(comments[0]?.body).not.toContain("nearest changed line");
+  });
+});
+
+describe("buildInlineComments — nearest-line fallback", () => {
+  it("snaps to closest changed line within ±10 (after endLine)", () => {
+    const diff = new Map([["src/foo.ts", new Set([108])]]);
+    const comments = buildInlineComments([f({ startLine: 100, endLine: 100 })], diff);
+    expect(comments.length).toBe(1);
+    expect(comments[0]?.line).toBe(108);
+    expect(comments[0]?.body).toContain("nearest changed line");
+    expect(comments[0]?.body).toContain("L100");
+  });
+
+  it("snaps to closest changed line within ±10 (before startLine)", () => {
+    const diff = new Map([["src/foo.ts", new Set([93])]]);
+    const comments = buildInlineComments([f({ startLine: 100, endLine: 100 })], diff);
+    expect(comments[0]?.line).toBe(93);
+    expect(comments[0]?.body).toContain("nearest changed line");
+  });
+
+  it("prefers smaller delta when both sides have a valid line", () => {
+    const diff = new Map([["src/foo.ts", new Set([95, 105])]]);
+    const comments = buildInlineComments([f({ startLine: 100, endLine: 100 })], diff);
+    // both are 5 away — endLine search runs first (95 negative delta first? no: positive then negative? actually findNearestChangedLine tries -delta then +delta on each delta value, so 95 wins on delta=5)
+    expect([95, 105]).toContain(comments[0]?.line);
+  });
+
+  it("drops the comment when no valid line exists within the radius", () => {
+    const farLine = 100 + NEAREST_LINE_FALLBACK_RADIUS + 5;
+    const diff = new Map([["src/foo.ts", new Set([farLine])]]);
+    const comments = buildInlineComments([f({ startLine: 100, endLine: 100 })], diff);
+    expect(comments.length).toBe(0);
+  });
+
+  it("drops the comment when the file is not in the diff at all", () => {
+    const diff = new Map([["src/bar.ts", new Set([100])]]);
+    const comments = buildInlineComments([f({ filePath: "src/foo.ts" })], diff);
+    expect(comments.length).toBe(0);
+  });
+});

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -285,8 +285,38 @@ export function stripDetailedFindings(reviewBody: string): string {
 
 // ─── Inline Comments ────────────────────────────────────────────────────────
 
+/** Maximum distance (in lines) when snapping a finding to the nearest changed
+ *  line in the same file. Beyond this distance the finding falls back to the
+ *  summary table instead of being attached inline. */
+export const NEAREST_LINE_FALLBACK_RADIUS = 10;
+
+/** Find the changed line in the file closest to a given line number, or null. */
+function findNearestChangedLine(
+  validLines: Set<number>,
+  preferredLine: number,
+  radius: number,
+): number | null {
+  if (validLines.has(preferredLine)) return preferredLine;
+  for (let delta = 1; delta <= radius; delta++) {
+    if (validLines.has(preferredLine - delta)) return preferredLine - delta;
+    if (validLines.has(preferredLine + delta)) return preferredLine + delta;
+  }
+  return null;
+}
+
 /**
  * Convert parsed findings into GitHub review comments, filtering to valid diff lines.
+ *
+ * Mapping order:
+ *   1. Exact match for f.endLine
+ *   2. Exact match for f.startLine
+ *   3. Any valid line within [startLine, endLine]
+ *   4. Nearest changed line within ±NEAREST_LINE_FALLBACK_RADIUS of either
+ *      end of the range (snapped). The finding still attaches inline, with a
+ *      small note indicating the snap.
+ *
+ * If none of the above match, the finding is skipped here and ends up in the
+ * summary table.
  */
 export function buildInlineComments(
   findings: InlineFinding[],
@@ -313,9 +343,27 @@ export function buildInlineComments(
         }
       }
     }
+
+    // Fallback: snap to the nearest changed line within ±radius of the range.
+    let snapped = false;
+    if (!targetLine) {
+      const candidate =
+        findNearestChangedLine(validLines, f.endLine, NEAREST_LINE_FALLBACK_RADIUS) ??
+        findNearestChangedLine(validLines, f.startLine, NEAREST_LINE_FALLBACK_RADIUS);
+      if (candidate !== null) {
+        targetLine = candidate;
+        snapped = true;
+      }
+    }
     if (!targetLine) continue;
 
-    let body = `**${f.severity} ${f.title}**\n\n${f.description}`;
+    const originalRangeText =
+      f.startLine === f.endLine ? `L${f.startLine}` : `L${f.startLine}-L${f.endLine}`;
+    const snapNote = snapped
+      ? `\n\n_Note: original finding referenced ${originalRangeText}; attached to nearest changed line (L${targetLine})._`
+      : "";
+
+    let body = `**${f.severity} ${f.title}**\n\n${f.description}${snapNote}`;
     if (f.suggestion) {
       // GitHub supports native ```suggestion blocks; Bitbucket uses plain code blocks
       const suggestionBlock = provider === "github"

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -357,13 +357,7 @@ export function buildInlineComments(
     }
     if (!targetLine) continue;
 
-    const originalRangeText =
-      f.startLine === f.endLine ? `L${f.startLine}` : `L${f.startLine}-L${f.endLine}`;
-    const snapNote = snapped
-      ? `\n\n_Note: original finding referenced ${originalRangeText}; attached to nearest changed line (L${targetLine})._`
-      : "";
-
-    let body = `**${f.severity} ${f.title}**\n\n${f.description}${snapNote}`;
+    let body = `**${f.severity} ${f.title}**\n\n${f.description}`;
     if (f.suggestion) {
       // GitHub supports native ```suggestion blocks; Bitbucket uses plain code blocks
       const suggestionBlock = provider === "github"
@@ -382,6 +376,15 @@ export function buildInlineComments(
       aiPrompt += `\n\nSuggested fix:\n${f.suggestion}`;
     }
     body += `\n\n<details><summary>🤖 AI Fix Prompt</summary>\n\n\`\`\`\n${aiPrompt}\n\`\`\`\n\n</details>`;
+
+    // Snap note last — it's a footnote-style hint about where the comment
+    // landed, not part of the description or suggestion. Keeping it at the
+    // bottom keeps the description→suggestion→fix-prompt reading order clean.
+    if (snapped) {
+      const originalRangeText =
+        f.startLine === f.endLine ? `L${f.startLine}` : `L${f.startLine}-L${f.endLine}`;
+      body += `\n\n_Note: original finding referenced ${originalRangeText}; attached to nearest changed line (L${targetLine})._`;
+    }
 
     comments.push({
       path: f.filePath,

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1557,9 +1557,9 @@ export async function processReview(pullRequestId: string): Promise<void> {
     // Re-review with zero new findings: surface this as an explicit positive
     // signal instead of letting the developer wonder if the review failed.
     if (isReReview && findingsCount === 0) {
-      const shortSha = pr.headSha ? pr.headSha.slice(0, 7) : "latest commit";
+      const commitSuffix = pr.headSha ? ` (commit \`${pr.headSha.slice(0, 7)}\`)` : "";
       mainCommentBody =
-        `> ✅ No new issues detected since the last review (commit \`${shortSha}\`).\n\n` +
+        `> ✅ No new issues detected since the last review${commitSuffix}.\n\n` +
         mainCommentBody;
     }
 

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1552,7 +1552,16 @@ export async function processReview(pullRequestId: string): Promise<void> {
     });
 
     // 5a: Update placeholder (or create new) with review body (findings stripped — they go inline)
-    const mainCommentBody = stripDetailedFindings(reviewBody);
+    let mainCommentBody = stripDetailedFindings(reviewBody);
+
+    // Re-review with zero new findings: surface this as an explicit positive
+    // signal instead of letting the developer wonder if the review failed.
+    if (isReReview && findingsCount === 0) {
+      const shortSha = pr.headSha ? pr.headSha.slice(0, 7) : "latest commit";
+      mainCommentBody =
+        `> ✅ No new issues detected since the last review (commit \`${shortSha}\`).\n\n` +
+        mainCommentBody;
+    }
 
     if (reviewCommentId) {
       await providerUpdateComment(reviewCommentId, mainCommentBody);

--- a/apps/web/prompts/SYSTEM_PROMPT.md
+++ b/apps/web/prompts/SYSTEM_PROMPT.md
@@ -215,7 +215,7 @@ Field rules:
 - **severity**: One of 🔴 🟠 🟡 🔵 💡
 - **title**: Short descriptive title for the finding
 - **filePath**: Relative file path only — no backticks, no `:L42` line suffix
-- **startLine** / **endLine**: Integer line numbers from the diff (endLine = startLine if single line)
+- **startLine** / **endLine**: Integer line numbers from the diff (endLine = startLine if single line). MUST be lines marked `+` in the diff (added lines) — do NOT reference context lines or unchanged lines. If your finding pertains to a region that includes context lines, pick the NEAREST added line. Findings that don't map to an added line cannot be attached inline and end up in a summary table, which is much less useful for the developer.
 - **category**: Bug | Security | Performance | Style | Architecture | Logic Error | Race Condition
 - **description**: Clear explanation of the issue
 - **suggestion**: Plain code string for the suggested fix (no markdown fences inside JSON). Empty string if no suggestion.


### PR DESCRIPTION
Closes #321

## Summary

### A. Diff mapping fallback
`buildInlineComments` previously dropped a finding to the summary table whenever its line range had no exact match in the diff's added/context line set. In practice this fired often: the LLM tends to point at function headers that sit above the changed body, ending up on a line that is in the file but not a `+` line. High severity findings at #368 (the example in the user's report) ended up with zero inline comments because of this.

New mapping order:
1. Exact match for `endLine`
2. Exact match for `startLine`
3. Any valid line within `[startLine, endLine]`
4. **NEW** — snap to the nearest changed line in the same file within ±10 lines (`NEAREST_LINE_FALLBACK_RADIUS`) of either end of the range. Comment body gets a small note: *"original finding referenced L100; attached to nearest changed line (L108)."*
5. Beyond that distance, finding still falls into the summary table (existing behavior).

### B. Re-review zero-finding UX
Re-reviews returning zero findings used to look like a failed review. Now, when `isReReview && findingsCount === 0`, the main comment opens with:

> ✅ No new issues detected since the last review (commit `abc1234`).

This is the correct outcome from the system-prompt RULE 4 ("don't re-list previously reported findings") — but the UI was confusing the developer.

### C. Tightened LLM prompt
`SYSTEM_PROMPT.md` field rule for `startLine`/`endLine` now says:

> MUST be lines marked `+` in the diff (added lines) — do NOT reference context lines or unchanged lines. If your finding pertains to a region that includes context lines, pick the NEAREST added line.

This way the snap fallback compensates for LLM imprecision rather than masking a permissive prompt.

## Files
- `apps/web/lib/review-helpers.ts` — extended `buildInlineComments`, added `NEAREST_LINE_FALLBACK_RADIUS`, internal `findNearestChangedLine` helper
- `apps/web/lib/reviewer.ts` — re-review zero-finding banner before posting `mainCommentBody`
- `apps/web/prompts/SYSTEM_PROMPT.md` — tightened field rule (one line)
- `apps/web/lib/__tests__/inline-mapping.test.ts` — 8 unit tests covering exact-match, in-range, fallback (after/before), preference, beyond-radius, missing-file

## Test plan
- [x] `bun run --cwd apps/web lint` — no new warnings
- [x] `bun run --cwd apps/web typecheck` — clean
- [x] `bun run --cwd apps/web test` — 249 pass / 0 fail (8 new tests in `inline-mapping.test.ts`)
- [ ] Real PR test: trigger a review on a small PR and verify high-severity findings near (but outside) the diff hunks now attach inline with the snap note
- [ ] Re-review test: push an empty/no-op commit on top, trigger re-review, verify the main comment opens with "✅ No new issues detected"

## Note
This PR conflicts with #325 (`feedback/repo-config`) on `apps/web/prompts/SYSTEM_PROMPT.md` — both touch nearby regions. Trivial textual merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)