### PR TITLE
fix(octopus-ignore): match artifact dirs by path segment

### DIFF
--- a/apps/web/lib/__tests__/octopus-ignore.test.ts
+++ b/apps/web/lib/__tests__/octopus-ignore.test.ts
@@ -170,4 +170,76 @@ diff --git a/coverage/lcov.info b/coverage/lcov.info
     const bad = detectBadCommits(diff);
     expect(bad.length).toBe(1);
   });
+
+  it("does not flag Rust build.rs nested under a directory containing 'build' as substring", () => {
+    // Regression: scripts/axbuild/src/test/build.rs was flagged because
+    // 'axbuild/' contains the substring 'build/'.
+    const diff = `diff --git a/scripts/axbuild/src/test/build.rs b/scripts/axbuild/src/test/build.rs
++++ b/scripts/axbuild/src/test/build.rs`;
+    expect(detectBadCommits(diff)).toEqual([]);
+  });
+
+  it("does not flag build.rs in any directory", () => {
+    const diff = `diff --git a/crates/foo/build.rs b/crates/foo/build.rs
++++ b/crates/foo/build.rs`;
+    expect(detectBadCommits(diff)).toEqual([]);
+  });
+
+  it("does not flag Cargo.toml or Cargo.lock", () => {
+    const diff = `diff --git a/Cargo.toml b/Cargo.toml
++++ b/Cargo.toml
+diff --git a/Cargo.lock b/Cargo.lock
++++ b/Cargo.lock`;
+    expect(detectBadCommits(diff)).toEqual([]);
+  });
+
+  it("flags real Rust build artifacts in target/", () => {
+    const diff = `diff --git a/target/debug/foo b/target/debug/foo
++++ b/target/debug/foo`;
+    const bad = detectBadCommits(diff);
+    expect(bad).toContain("target/debug/foo");
+  });
+
+  it("flags files inside build/ directory but not files merely named build.*", () => {
+    const diff = `diff --git a/build/output.o b/build/output.o
++++ b/build/output.o`;
+    expect(detectBadCommits(diff)).toContain("build/output.o");
+  });
+
+  it("does not flag root-level config files (package.json, go.mod, pyproject.toml)", () => {
+    const diff = `diff --git a/package.json b/package.json
++++ b/package.json
+diff --git a/go.mod b/go.mod
++++ b/go.mod
+diff --git a/pyproject.toml b/pyproject.toml
++++ b/pyproject.toml`;
+    expect(detectBadCommits(diff)).toEqual([]);
+  });
+
+  it("flags config-named files when they appear inside an artifact dir (no whitelist bypass)", () => {
+    // A file named go.sum / Cargo.toml / package.json must NOT be allowed to
+    // smuggle itself in via node_modules/, target/, etc.
+    const diff = `diff --git a/node_modules/evil/go.sum b/node_modules/evil/go.sum
++++ b/node_modules/evil/go.sum
+diff --git a/target/junk/Cargo.toml b/target/junk/Cargo.toml
++++ b/target/junk/Cargo.toml
+diff --git a/dist/some/package.json b/dist/some/package.json
++++ b/dist/some/package.json`;
+    const bad = detectBadCommits(diff);
+    expect(bad).toContain("node_modules/evil/go.sum");
+    expect(bad).toContain("target/junk/Cargo.toml");
+    expect(bad).toContain("dist/some/package.json");
+  });
+
+  it("does not flag files in a directory whose name merely contains an artifact pattern as substring", () => {
+    // 'rebuild/', 'distribution/', 'mybuild/' all contain artifact names as substrings
+    // but are not themselves the artifact directory.
+    const diff = `diff --git a/rebuild/src/main.rs b/rebuild/src/main.rs
++++ b/rebuild/src/main.rs
+diff --git a/distribution/notes.md b/distribution/notes.md
++++ b/distribution/notes.md
+diff --git a/mybuild/lib.go b/mybuild/lib.go
++++ b/mybuild/lib.go`;
+    expect(detectBadCommits(diff)).toEqual([]);
+  });
 });

--- a/apps/web/lib/octopus-ignore.ts
+++ b/apps/web/lib/octopus-ignore.ts
@@ -21,29 +21,40 @@ export function filterDiff(diff: string, ig: Ignore): string {
 }
 
 /** Detect committed build artifacts / dependency folders that should not be in version control */
-const MUST_NOT_COMMIT = [
-  "node_modules/",
-  ".next/",
-  ".nuxt/",
-  "dist/",
-  "build/",
-  "__pycache__/",
-  ".turbo/",
-  "coverage/",
-  ".svelte-kit/",
-  ".output/",
-  "vendor/",
-  "bin/",
-  "obj/",
+const MUST_NOT_COMMIT_DIRS = [
+  "node_modules",
+  ".next",
+  ".nuxt",
+  "dist",
+  "build",
+  "__pycache__",
+  ".turbo",
+  "coverage",
+  ".svelte-kit",
+  ".output",
+  "vendor",
+  "bin",
+  "obj",
+  "target",
 ];
+
+// Match by exact path segment, not substring. Files like `build.rs` or
+// `Cargo.toml` are never flagged on their own because the filename is the
+// last segment, not a directory segment. A name-based whitelist is
+// intentionally avoided — it would let `node_modules/x/go.sum` slip through.
+function isInsideArtifactDir(filePath: string): boolean {
+  const segments = filePath.split("/");
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (MUST_NOT_COMMIT_DIRS.includes(segments[i])) return true;
+  }
+  return false;
+}
 
 export function detectBadCommits(diff: string): string[] {
   const badFiles: string[] = [];
   for (const match of diff.matchAll(/^diff --git a\/(.+?) b\/(.+)/gm)) {
     const filePath = match[2];
-    if (MUST_NOT_COMMIT.some((p) => filePath.includes(p))) {
-      badFiles.push(filePath);
-    }
+    if (isInsideArtifactDir(filePath)) badFiles.push(filePath);
   }
   return badFiles;
 }


### PR DESCRIPTION
## Summary
- `detectBadCommits` now matches `MUST_NOT_COMMIT` directories by exact path segment instead of substring, so legitimate files like `crates/foo/build.rs`, `scripts/axbuild/...`, `rebuild/`, `distribution/` are no longer falsely flagged.
- Added `target` to the list (Rust build dir).
- No name-based whitelist: `node_modules/evil/go.sum` still gets flagged even though `go.sum` looks safe.

## Test plan
- [x] New unit tests cover: build.rs in any dir, Cargo.toml/Cargo.lock, real build artifacts in target/, files inside build/, root-level config files, configs smuggled inside artifact dirs, and substring-only matches like rebuild/distribution/mybuild.
- [ ] CI green on this branch.

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)