### PR TITLE
feat(reviews): central category list, per-category threshold, pill picker

### DIFF
--- a/apps/web/app/(app)/repositories/[id]/settings/review-config-form.tsx
+++ b/apps/web/app/(app)/repositories/[id]/settings/review-config-form.tsx
@@ -13,6 +13,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { updateReviewConfig } from "../../actions";
+import { REVIEW_CATEGORIES } from "@/lib/review-categories";
 
 type ReviewConfig = {
   maxFindings?: number;
@@ -37,7 +38,7 @@ export function ReviewConfigForm({
   const [success, setSuccess] = useState(false);
 
   const [maxFindings, setMaxFindings] = useState(initialConfig.maxFindings ?? 30);
-  const [inlineThreshold, setInlineThreshold] = useState(initialConfig.inlineThreshold ?? "medium");
+  const [inlineThreshold, setInlineThreshold] = useState(initialConfig.inlineThreshold ?? "low");
   const [enableConflictDetection, setEnableConflictDetection] = useState(
     initialConfig.enableConflictDetection ?? undefined,
   );
@@ -47,9 +48,15 @@ export function ReviewConfigForm({
   const [enableTwoPassReview, setEnableTwoPassReview] = useState(
     initialConfig.enableTwoPassReview ?? false,
   );
-  const [disabledCategories, setDisabledCategories] = useState(
-    (initialConfig.disabledCategories ?? []).join(", "),
+  const [disabledCategories, setDisabledCategories] = useState<string[]>(
+    initialConfig.disabledCategories ?? [],
   );
+
+  const toggleCategory = (cat: string) => {
+    setDisabledCategories((prev) =>
+      prev.includes(cat) ? prev.filter((c) => c !== cat) : [...prev, cat],
+    );
+  };
 
   function handleSubmit() {
     setError(null);
@@ -64,12 +71,8 @@ export function ReviewConfigForm({
       if (enableConflictDetection !== undefined) {
         config.enableConflictDetection = enableConflictDetection;
       }
-      const cats = disabledCategories
-        .split(",")
-        .map((c) => c.trim())
-        .filter(Boolean);
-      if (cats.length > 0) {
-        config.disabledCategories = cats;
+      if (disabledCategories.length > 0) {
+        config.disabledCategories = disabledCategories;
       }
 
       const result = await updateReviewConfig(repoId, config);
@@ -115,6 +118,7 @@ export function ReviewConfigForm({
               <Label>Inline comment threshold</Label>
               <div className="space-y-2">
                 {[
+                  { value: "low", label: "Low & above (default)", desc: "Inline comments for Critical, High, Medium, and Low findings (Nits go to summary)" },
                   { value: "medium", label: "Medium & above", desc: "Inline comments for Critical, High, and Medium findings" },
                   { value: "high", label: "High & above", desc: "Inline comments for Critical and High findings only" },
                   { value: "critical", label: "Critical only", desc: "Inline comments for Critical findings only" },
@@ -207,15 +211,29 @@ export function ReviewConfigForm({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="disabledCategories">Disabled categories</Label>
-              <Input
-                id="disabledCategories"
-                value={disabledCategories}
-                onChange={(e) => setDisabledCategories(e.target.value)}
-                placeholder="e.g. Style, Performance"
-              />
+              <Label>Disabled categories</Label>
+              <div className="flex flex-wrap gap-1.5">
+                {REVIEW_CATEGORIES.map((cat) => {
+                  const active = disabledCategories.includes(cat);
+                  return (
+                    <button
+                      key={cat}
+                      type="button"
+                      onClick={() => toggleCategory(cat)}
+                      className={
+                        "rounded-full border px-3 py-1 text-xs transition-colors " +
+                        (active
+                          ? "border-destructive bg-destructive/10 text-destructive line-through"
+                          : "border-input bg-background hover:bg-accent")
+                      }
+                    >
+                      {cat}
+                    </button>
+                  );
+                })}
+              </div>
               <p className="text-xs text-muted-foreground">
-                Comma-separated list of finding categories to suppress (e.g. Style, Performance).
+                Click a category to suppress its findings. Strikethrough = disabled.
               </p>
             </div>
           </fieldset>

--- a/apps/web/app/(app)/repositories/repositories-content.tsx
+++ b/apps/web/app/(app)/repositories/repositories-content.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
+import { REVIEW_CATEGORIES } from "@/lib/review-categories";
 import {
   Card,
   CardContent,
@@ -1011,15 +1012,20 @@ function RepoDetail({
   const [reviewConfigSaved, setReviewConfigSaved] = useState(false);
   const [reviewConfigError, setReviewConfigError] = useState("");
   const [rcMaxFindings, setRcMaxFindings] = useState<number>((repo.reviewConfig?.maxFindings as number) ?? 30);
-  const [rcInlineThreshold, setRcInlineThreshold] = useState<string>((repo.reviewConfig?.inlineThreshold as string) ?? "medium");
+  const [rcInlineThreshold, setRcInlineThreshold] = useState<string>((repo.reviewConfig?.inlineThreshold as string) ?? "low");
   const [rcConfidenceThreshold, setRcConfidenceThreshold] = useState<string>((repo.reviewConfig?.confidenceThreshold as string) ?? "MEDIUM");
   const [rcEnableConflict, setRcEnableConflict] = useState<string>(
     repo.reviewConfig?.enableConflictDetection === undefined ? "auto" : repo.reviewConfig?.enableConflictDetection ? "always" : "never"
   );
   const [rcTwoPass, setRcTwoPass] = useState<boolean>((repo.reviewConfig?.enableTwoPassReview as boolean) ?? false);
-  const [rcDisabledCategories, setRcDisabledCategories] = useState<string>(
-    ((repo.reviewConfig?.disabledCategories as string[]) ?? []).join(", ")
+  const [rcDisabledCategories, setRcDisabledCategories] = useState<string[]>(
+    (repo.reviewConfig?.disabledCategories as string[]) ?? []
   );
+  const toggleRcCategory = (cat: string) => {
+    setRcDisabledCategories((prev) =>
+      prev.includes(cat) ? prev.filter((c) => c !== cat) : [...prev, cat],
+    );
+  };
   const router = useRouter();
   const isIndexing = repo.indexStatus === "indexing" || indexPending;
   const canAutoReview = (repo.indexStatus === "indexed" || repo.indexStatus === "stale") && (analysisStatus === "analyzed" || analysisStatus === "completed");
@@ -1367,7 +1373,8 @@ function RepoDetail({
                 onChange={(e) => setRcInlineThreshold(e.target.value)}
                 className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm"
               >
-                <option value="medium">Medium & above (default)</option>
+                <option value="low">Low & above (default)</option>
+                <option value="medium">Medium & above</option>
                 <option value="high">High & above</option>
                 <option value="critical">Critical only</option>
               </select>
@@ -1416,13 +1423,28 @@ function RepoDetail({
 
             <div className="space-y-2">
               <Label className="text-sm">Disabled categories</Label>
-              <Input
-                value={rcDisabledCategories}
-                onChange={(e) => setRcDisabledCategories(e.target.value)}
-                placeholder="e.g. Style, Performance"
-              />
+              <div className="flex flex-wrap gap-1.5">
+                {REVIEW_CATEGORIES.map((cat) => {
+                  const active = rcDisabledCategories.includes(cat);
+                  return (
+                    <button
+                      key={cat}
+                      type="button"
+                      onClick={() => toggleRcCategory(cat)}
+                      className={
+                        "rounded-full border px-3 py-1 text-xs transition-colors " +
+                        (active
+                          ? "border-destructive bg-destructive/10 text-destructive line-through"
+                          : "border-input bg-background hover:bg-accent")
+                      }
+                    >
+                      {cat}
+                    </button>
+                  );
+                })}
+              </div>
               <p className="text-xs text-muted-foreground">
-                Comma-separated. Findings in these categories will be suppressed.
+                Click a category to suppress its findings. Strikethrough = disabled.
               </p>
             </div>
 
@@ -1453,8 +1475,7 @@ function RepoDetail({
                   if (rcEnableConflict !== "auto") {
                     config.enableConflictDetection = rcEnableConflict === "always";
                   }
-                  const cats = rcDisabledCategories.split(",").map((c) => c.trim()).filter(Boolean);
-                  if (cats.length > 0) config.disabledCategories = cats;
+                  if (rcDisabledCategories.length > 0) config.disabledCategories = rcDisabledCategories;
 
                   const result = await updateReviewConfig(repo.id, config);
                   if (result.error) {

--- a/apps/web/app/(app)/settings/reviews/org-review-config-form.tsx
+++ b/apps/web/app/(app)/settings/reviews/org-review-config-form.tsx
@@ -13,6 +13,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { updateOrgDefaultReviewConfig } from "../../actions";
+import { REVIEW_CATEGORIES } from "@/lib/review-categories";
 
 type ReviewConfig = {
   maxFindings?: number;
@@ -35,15 +36,21 @@ export function OrgReviewConfigForm({
   const [error, setError] = useState("");
 
   const [maxFindings, setMaxFindings] = useState(initialConfig.maxFindings ?? 30);
-  const [inlineThreshold, setInlineThreshold] = useState(initialConfig.inlineThreshold ?? "medium");
+  const [inlineThreshold, setInlineThreshold] = useState(initialConfig.inlineThreshold ?? "low");
   const [confidenceThreshold, setConfidenceThreshold] = useState(initialConfig.confidenceThreshold ?? "MEDIUM");
   const [enableConflict, setEnableConflict] = useState<string>(
     initialConfig.enableConflictDetection === undefined ? "auto" : initialConfig.enableConflictDetection ? "always" : "never",
   );
   const [twoPass, setTwoPass] = useState(initialConfig.enableTwoPassReview ?? false);
-  const [disabledCategories, setDisabledCategories] = useState(
-    (initialConfig.disabledCategories ?? []).join(", "),
+  const [disabledCategories, setDisabledCategories] = useState<string[]>(
+    initialConfig.disabledCategories ?? [],
   );
+
+  const toggleCategory = (cat: string) => {
+    setDisabledCategories((prev) =>
+      prev.includes(cat) ? prev.filter((c) => c !== cat) : [...prev, cat],
+    );
+  };
 
   const handleSave = () => {
     setError("");
@@ -58,8 +65,7 @@ export function OrgReviewConfigForm({
       if (enableConflict !== "auto") {
         config.enableConflictDetection = enableConflict === "always";
       }
-      const cats = disabledCategories.split(",").map((c) => c.trim()).filter(Boolean);
-      if (cats.length > 0) config.disabledCategories = cats;
+      if (disabledCategories.length > 0) config.disabledCategories = disabledCategories;
 
       const result = await updateOrgDefaultReviewConfig(config);
       if (result.error) {
@@ -101,7 +107,8 @@ export function OrgReviewConfigForm({
                 onChange={(e) => setInlineThreshold(e.target.value)}
                 className="flex h-8 w-full rounded-md border border-input bg-background px-2 py-1 text-sm shadow-sm"
               >
-                <option value="medium">Medium & above (default)</option>
+                <option value="low">Low & above (default)</option>
+                <option value="medium">Medium & above</option>
                 <option value="high">High & above</option>
                 <option value="critical">Critical only</option>
               </select>
@@ -143,14 +150,28 @@ export function OrgReviewConfigForm({
 
           <div className="space-y-1.5">
             <Label className="text-xs">Disabled categories</Label>
-            <Input
-              value={disabledCategories}
-              onChange={(e) => setDisabledCategories(e.target.value)}
-              placeholder="e.g. Style, Performance"
-              className="h-8"
-            />
+            <div className="flex flex-wrap gap-1.5">
+              {REVIEW_CATEGORIES.map((cat) => {
+                const active = disabledCategories.includes(cat);
+                return (
+                  <button
+                    key={cat}
+                    type="button"
+                    onClick={() => toggleCategory(cat)}
+                    className={
+                      "rounded-full border px-2.5 py-0.5 text-xs transition-colors " +
+                      (active
+                        ? "border-destructive bg-destructive/10 text-destructive line-through"
+                        : "border-input bg-background hover:bg-accent")
+                    }
+                  >
+                    {cat}
+                  </button>
+                );
+              })}
+            </div>
             <p className="text-[10px] text-muted-foreground">
-              Comma-separated. Findings in these categories will be suppressed.
+              Click a category to suppress its findings. Strikethrough = disabled.
             </p>
           </div>
 

--- a/apps/web/lib/review-categories.ts
+++ b/apps/web/lib/review-categories.ts
@@ -1,0 +1,46 @@
+/**
+ * Canonical review-finding categories.
+ * The values must match the strings the LLM emits in the `category` field
+ * of each finding (see prompts/SYSTEM_PROMPT.md).
+ */
+export const REVIEW_CATEGORIES = [
+  "Bug",
+  "Security",
+  "Performance",
+  "Style",
+  "Architecture",
+  "Logic Error",
+  "Race Condition",
+] as const;
+
+export type ReviewCategory = (typeof REVIEW_CATEGORIES)[number];
+
+/**
+ * Categories where false negatives are far more costly than false positives.
+ * Findings in these categories get a lower confidence threshold so genuine
+ * security/correctness issues are not silently dropped by validation.
+ */
+export const HIGH_RISK_CATEGORIES: ReadonlySet<string> = new Set<string>([
+  "Bug",
+  "Security",
+  "Logic Error",
+  "Race Condition",
+]);
+
+const HIGH_RISK_THRESHOLD_DELTA = 15;
+const MIN_HIGH_RISK_THRESHOLD = 50;
+
+/**
+ * Per-category confidence threshold. High-risk categories get a relaxed
+ * threshold (base - 15, floor 50) so security/bug findings survive validation.
+ * Style/Performance/Architecture keep the base threshold.
+ */
+export function getCategoryConfidenceThreshold(
+  category: string | undefined,
+  baseThreshold: number,
+): number {
+  if (category && HIGH_RISK_CATEGORIES.has(category)) {
+    return Math.max(MIN_HIGH_RISK_THRESHOLD, baseThreshold - HIGH_RISK_THRESHOLD_DELTA);
+  }
+  return baseThreshold;
+}

--- a/apps/web/lib/review-validation.ts
+++ b/apps/web/lib/review-validation.ts
@@ -9,6 +9,7 @@ import { logAiUsage } from "@/lib/ai-usage";
 import { createAiMessage } from "@/lib/ai-router";
 import type { InlineFinding } from "@/lib/review-dedup";
 import type { CrossFileQuery, VerificationQuery } from "@/lib/review-helpers";
+import { getCategoryConfidenceThreshold } from "@/lib/review-categories";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -297,9 +298,9 @@ Output ONLY the JSON array, nothing else.`,
         }
         return f;
       })
-      .filter((f) => f.confidence >= confidenceThreshold);
+      .filter((f) => f.confidence >= getCategoryConfidenceThreshold(f.category, confidenceThreshold));
 
-    console.log(`${logPrefix} Two-pass validation: ${validated.length}/${findings.length} findings kept (threshold: ${confidenceThreshold})`);
+    console.log(`${logPrefix} Two-pass validation: ${validated.length}/${findings.length} findings kept (base threshold: ${confidenceThreshold}, per-category)`);
     return validated;
   } catch {
     console.warn(`${logPrefix} Failed to parse two-pass validation response, keeping all findings`);

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -65,6 +65,7 @@ import {
   resolveIndexClaimWait,
 } from "@/lib/review-helpers";
 import type { ReviewConfig } from "@/lib/review-helpers";
+import { getCategoryConfidenceThreshold } from "@/lib/review-categories";
 import {
   gatherCrossFileContext,
   gatherVerificationContext,
@@ -1728,7 +1729,9 @@ Rules:
     // Save all parsed findings before filtering — these will be shown in the summary comment
     let allParsedFindings = [...findings];
 
-    // Filter out findings below confidence threshold
+    // Filter out findings below confidence threshold (per-category: high-risk
+    // categories like Security/Bug get a relaxed threshold so genuine issues
+    // are not silently dropped — see review-categories.ts).
     const confidenceThreshold =
       typeof reviewConfig.confidenceThreshold === "number"
         ? reviewConfig.confidenceThreshold
@@ -1736,9 +1739,11 @@ Rules:
           ? 85
           : 70;
     const allFindings = findings;
-    findings = findings.filter((f) => f.confidence >= confidenceThreshold);
+    findings = findings.filter(
+      (f) => f.confidence >= getCategoryConfidenceThreshold(f.category, confidenceThreshold),
+    );
     if (allFindings.length !== findings.length) {
-      console.log(`[reviewer] Filtered out ${allFindings.length - findings.length} findings below confidence threshold (${confidenceThreshold})`);
+      console.log(`[reviewer] Filtered out ${allFindings.length - findings.length} findings below per-category confidence threshold (base ${confidenceThreshold})`);
     }
 
     // Filter out disabled categories
@@ -1911,13 +1916,17 @@ Rules:
       console.log(`[reviewer] Capped findings: showing ${findings.length} of ${findings.length + truncatedCount}`);
     }
 
-    // Split findings: inline (above threshold) vs summary-only (below threshold)
-    const inlineThreshold = reviewConfig.inlineThreshold ?? "medium";
+    // Split findings: inline (above threshold) vs summary-only (below threshold).
+    // Default is "low" so 🔵 findings with a mappable file:line still post inline
+    // (where they're easier to act on); 💡 nits go to the collapsed summary table.
+    const inlineThreshold = reviewConfig.inlineThreshold ?? "low";
     const inlineSeverities = inlineThreshold === "critical"
       ? ["🔴"]
       : inlineThreshold === "high"
         ? ["🔴", "🟠"]
-        : ["🔴", "🟠", "🟡"]; // default: medium
+        : inlineThreshold === "medium"
+          ? ["🔴", "🟠", "🟡"]
+          : ["🔴", "🟠", "🟡", "🔵"]; // default: low
     const inlineFindings = findings.filter((f) => inlineSeverities.includes(f.severity));
 
     console.log(`[reviewer] Split: ${inlineFindings.length} inline (${inlineSeverities.join(",")}), severities: ${findings.map((f) => f.severity).join(",")}`);


### PR DESCRIPTION
## Summary
- New `apps/web/lib/review-categories.ts` is the single source of truth for finding categories. High-risk categories (Bug, Security, Logic Error, Race Condition) get a relaxed confidence threshold (base − 15, floor 50) so genuine issues survive two-pass validation.
- Reviewer logic and two-pass validator both call `getCategoryConfidenceThreshold` per finding instead of one global cutoff.
- Default `inlineThreshold` is now `low` (was `medium`), so 🔵 findings post inline; 💡 nits go to the summary. Updated in `reviewer.ts` and the three config forms.
- Replaced the freeform comma-separated "disabled categories" input in repo settings, repo detail panel, and org review config form with a pill-toggle UI driven by `REVIEW_CATEGORIES`.

## Test plan
- [ ] Open repo settings → Review config: pills render, toggle, persist on save.
- [ ] Open org settings → Reviews: same.
- [ ] Open repo detail panel → Review tab: same.
- [ ] Trigger a review on a PR with known low-confidence Security finding; verify it now survives validation under base threshold 70.
- [ ] Trigger a review with a 🔵 finding; verify inline comment appears (was previously summary-only).

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)