### PR TITLE
fix(reviewer): compute resolved count from outdated prior comments

### DIFF
--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1968,10 +1968,15 @@ Rules:
     // This gets set by the GitHub/Bitbucket posting logic below
     let effectiveFindingsCount = 0;
 
+    // Resolved-count signal: only meaningful on a re-review. A prior bot
+    // inline comment is considered resolved when GitHub marks it `isOutdated`
+    // (the diff hunk it lived on has changed since the comment was posted).
+    // First reviews never show a resolved count — there is nothing to resolve.
+    const resolvedCount = isReReview ? botComments.filter((c) => c.isOutdated).length : 0;
+
     // Build the review summary body with non-inline findings embedded
     const buildReviewSummary = (findingsBlock: string, visibleCount: number) => {
       let header = `${filesChanged} file${filesChanged !== 1 ? "s" : ""} reviewed, ${visibleCount} finding${visibleCount !== 1 ? "s" : ""}`;
-      const resolvedCount = Math.max(0, findingsCount - visibleCount);
       if (resolvedCount > 0) {
         header += ` (${resolvedCount} resolved)`;
       }


### PR DESCRIPTION
## Summary
- The previous `Math.max(0, findingsCount - visibleCount)` measured pipeline drops (confidence threshold, disabled categories, dedup, capping), not user-resolved findings. On a first review with 3 dropped findings, users saw "(3 resolved)" with nothing to resolve against.
- Replace with a real signal: count of prior bot inline comments where GitHub set `isOutdated` (the diff hunk changed since the comment was posted).
- Gated behind `isReReview`. First reviews never show a resolved count.

## Test plan
- [ ] First review on a fresh PR → no "(N resolved)" suffix.
- [ ] Re-review where the author fixed code at a previously-flagged line → "(1 resolved)" appears.
- [ ] Re-review where nothing changed → no resolved suffix.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)