### PR TITLE
fix(cost): skip credit check for community orgs

### DIFF
--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@octopus/db";
+import { ORG_TYPE } from "@/lib/org-types";
 
 type ModelPricing = { input: number; output: number };
 
@@ -122,8 +123,8 @@ export async function getOrgSpendLimitStatus(orgId: string): Promise<SpendLimitR
 
   if (!org) return { blocked: false };
 
-  // Community orgs (type=2) get rate-limited via communityDailyReviewLimit, not credits.
-  if (org.type === 2) return { blocked: false };
+  // Community orgs get rate-limited via communityDailyReviewLimit, not credits.
+  if (org.type === ORG_TYPE.COMMUNITY) return { blocked: false };
 
   // Orgs with their own keys for all LLM providers have no platform limit
   if (org.anthropicApiKey && org.openaiApiKey && org.googleApiKey) return { blocked: false };

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -110,6 +110,7 @@ export async function getOrgSpendLimitStatus(orgId: string): Promise<SpendLimitR
   const org = await prisma.organization.findUnique({
     where: { id: orgId },
     select: {
+      type: true,
       anthropicApiKey: true,
       openaiApiKey: true,
       googleApiKey: true,
@@ -120,6 +121,9 @@ export async function getOrgSpendLimitStatus(orgId: string): Promise<SpendLimitR
   });
 
   if (!org) return { blocked: false };
+
+  // Community orgs (type=2) get rate-limited via communityDailyReviewLimit, not credits.
+  if (org.type === 2) return { blocked: false };
 
   // Orgs with their own keys for all LLM providers have no platform limit
   if (org.anthropicApiKey && org.openaiApiKey && org.googleApiKey) return { blocked: false };

--- a/apps/web/lib/org-types.ts
+++ b/apps/web/lib/org-types.ts
@@ -1,0 +1,7 @@
+export const ORG_TYPE = {
+  STANDARD: 1,
+  COMMUNITY: 2,
+  FRIENDLY: 3,
+} as const;
+
+export type OrgType = (typeof ORG_TYPE)[keyof typeof ORG_TYPE];


### PR DESCRIPTION
## Summary
- Community orgs (`type === 2`) bypass the credit/spend-limit gate in `getOrgSpendLimitStatus` because they're rate-limited by `communityDailyReviewLimit` at the route layer.
- Without this, `createEmbeddings` silently returned `[]` for every community review since their `freeCreditBalance` is 0, breaking the public-repo github-action flow.

## Test plan
- [ ] Trigger a github-action review without an `OCTOPUS_API_KEY` (community mode) and confirm embeddings/qdrant calls succeed
- [ ] Confirm paid orgs with no credits still get blocked

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)