### PR TITLE
fix(github-action): reject invalid api token instead of falling back to community

### DIFF
--- a/apps/web/app/api/github-action/review/route.ts
+++ b/apps/web/app/api/github-action/review/route.ts
@@ -118,6 +118,7 @@ export async function POST(request: NextRequest) {
   // ── Dual auth ─────────────────────────────────────────────────────────────
 
   const apiAuth = await authenticateApiToken(request);
+  const hasAuthHeader = request.headers.get("authorization")?.startsWith("Bearer ") ?? false;
   let orgId: string;
   let isCommunityMode = false;
   let communityDailyLimit = 5;
@@ -125,6 +126,12 @@ export async function POST(request: NextRequest) {
   if (apiAuth) {
     // Mode 1: API key present → use real org
     orgId = apiAuth.org.id;
+  } else if (hasAuthHeader) {
+    // Token was sent but invalid/expired/banned — do NOT fall back to community.
+    return Response.json(
+      { error: "Invalid or expired octopus-api-key" },
+      { status: 401 },
+    );
   } else {
     // Mode 2: No API key → community mode (public repos only)
     const repoInfo = await fetchGitHubRepoInfo(githubToken, owner, repoName);


### PR DESCRIPTION
## Summary
- Distinguish "no Authorization header" from "header sent but token invalid/expired/banned" in the github-action review route.
- A bad token now returns a clean 401; only requests with no Authorization header fall into community mode.

## Test plan
- [ ] Send a request with no Authorization header → community mode (5/day, public only)
- [ ] Send a request with a valid `Bearer oct_...` → org mode
- [ ] Send a request with an invalid/expired `Bearer oct_...` → 401, no community downgrade

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)