### PR TITLE
feat(landing): announce free reviews for open source projects

### DIFF
--- a/apps/web/app/(landing)/docs/docs-mobile-menu.tsx
+++ b/apps/web/app/(landing)/docs/docs-mobile-menu.tsx
@@ -17,6 +17,7 @@ import {
   IconShieldLock,
   IconScale,
   IconCookie,
+  IconHeartHandshake,
 } from "@tabler/icons-react";
 import { trackEvent } from "@/lib/analytics";
 import {
@@ -30,6 +31,7 @@ import {
 
 const sidebarItems = [
   { href: "/docs/getting-started", label: "Getting Started", icon: IconRocket },
+  { href: "/docs/open-source", label: "Free for Open Source", icon: IconHeartHandshake },
   { href: "/docs/self-hosting", label: "Self-Hosting", icon: IconServer },
   { href: "/docs/integrations", label: "Integrations", icon: IconPlugConnected },
   { href: "/docs/skills", label: "Skills", icon: IconWand },

--- a/apps/web/app/(landing)/docs/docs-search.tsx
+++ b/apps/web/app/(landing)/docs/docs-search.tsx
@@ -14,6 +14,7 @@ import {
   IconCookie,
   IconQuestionMark,
   IconSearch,
+  IconHeartHandshake,
 } from "@tabler/icons-react";
 import {
   CommandDialog,
@@ -25,6 +26,13 @@ import {
 } from "@/components/ui/command";
 
 const docsPages = [
+  {
+    href: "/docs/open-source",
+    label: "Free for Open Source",
+    description: "Unlimited AI reviews for public OSS repos via the GitHub Action.",
+    icon: IconHeartHandshake,
+    keywords: ["open source", "oss", "free", "github action", "workflow", "yaml", "public repo", "maintainer"],
+  },
   {
     href: "/docs/self-hosting",
     label: "Self-Hosting",

--- a/apps/web/app/(landing)/docs/docs-sidebar.tsx
+++ b/apps/web/app/(landing)/docs/docs-sidebar.tsx
@@ -17,12 +17,14 @@ import {
   IconWand,
   IconBook2,
   IconHistory,
+  IconHeartHandshake,
 } from "@tabler/icons-react";
 import { trackEvent } from "@/lib/analytics";
 import { DocsSearch } from "./docs-search";
 
 const sidebarItems = [
   { href: "/docs/getting-started", label: "Getting Started", icon: IconRocket, description: "Connect your repo, first review" },
+  { href: "/docs/open-source", label: "Free for Open Source", icon: IconHeartHandshake, description: "Unlimited reviews on public repos" },
   { href: "/docs/self-hosting", label: "Self-Hosting", icon: IconServer, description: "Deploy on your infrastructure" },
   { href: "/docs/integrations", label: "Integrations", icon: IconPlugConnected, description: "GitHub, Bitbucket, Slack, Linear" },
   { href: "/docs/skills", label: "Skills", icon: IconWand, description: "AI-powered automation workflows" },

--- a/apps/web/app/(landing)/docs/open-source/page.tsx
+++ b/apps/web/app/(landing)/docs/open-source/page.tsx
@@ -1,0 +1,372 @@
+import Link from "next/link";
+import {
+  IconHeartHandshake,
+  IconBrandGithub,
+  IconChecks,
+  IconArrowRight,
+  IconFileText,
+  IconShieldCheck,
+  IconRocket,
+  IconBolt,
+  IconInfoCircle,
+} from "@tabler/icons-react";
+
+export const metadata = {
+  title: "Free for Open Source | Octopus Docs",
+  description:
+    "Octopus is free for public open source projects. Drop a single GitHub Actions step into your workflow and every pull request gets an AI code review — no credit card, no quota.",
+  alternates: {
+    canonical: "https://octopus-review.ai/docs/open-source",
+  },
+};
+
+const workflowYaml = `# .github/workflows/octopus.yml
+name: Octopus Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octopusreview/action@v1
+`;
+
+export default function OpenSourcePage() {
+  return (
+    <article className="max-w-3xl">
+      <div className="mb-8">
+        <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#10D8BE]">
+          <IconHeartHandshake className="size-4" />
+          Free for Open Source
+        </div>
+        <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          Octopus is free for open source projects
+        </h1>
+        <p className="mt-3 text-lg text-[#888]">
+          Public repositories get unlimited AI code reviews on every pull
+          request — no credit card, no monthly quota, no strings attached. We
+          believe maintainers deserve great tooling.
+        </p>
+      </div>
+
+      {/* Highlight banner */}
+      <div className="mb-10 rounded-2xl border border-[#10D8BE]/25 bg-[#10D8BE]/[0.04] p-6">
+        <div className="flex items-start gap-4">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-[#10D8BE]/10 text-[#10D8BE]">
+            <IconBolt className="size-5" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-white">
+              One workflow file. Reviews on every PR.
+            </h2>
+            <p className="mt-1 text-sm leading-relaxed text-[#aaa]">
+              Drop the YAML below into{" "}
+              <code className="rounded bg-white/[0.06] px-1.5 py-0.5 text-xs text-white">
+                .github/workflows/octopus.yml
+              </code>
+              , commit it, and your next pull request will get an inline review
+              from Octopus with severity-rated findings.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Quick start */}
+      <Section title="Quick start">
+        <Paragraph>
+          The Octopus GitHub Action runs on every <Code>pull_request</Code>{" "}
+          event, posts inline review comments, and exits cleanly when the
+          review is done. You don&apos;t need to install anything else, sign up,
+          or generate API keys — the action handles authentication via the
+          ephemeral <Code>GITHUB_TOKEN</Code>.
+        </Paragraph>
+
+        <CodeBlock filename=".github/workflows/octopus.yml" code={workflowYaml} />
+
+        <Paragraph>
+          That&apos;s the whole setup. Open a pull request and Octopus will
+          comment within a couple of minutes.
+        </Paragraph>
+      </Section>
+
+      {/* What you get */}
+      <Section title="What's included">
+        <div className="mb-4 grid gap-3 sm:grid-cols-2">
+          <FeatureRow
+            icon={<IconChecks className="size-4" />}
+            title="Unlimited PR reviews"
+            description="Every opened or updated pull request gets a context-aware review. No monthly cap."
+          />
+          <FeatureRow
+            icon={<IconRocket className="size-4" />}
+            title="Codebase indexing"
+            description="Your repo is indexed so reviews understand patterns and architecture, not just the diff."
+          />
+          <FeatureRow
+            icon={<IconShieldCheck className="size-4" />}
+            title="Security & bug detection"
+            description="Critical, Major, Minor, Suggestion, and Tip severity levels on every finding."
+          />
+          <FeatureRow
+            icon={<IconFileText className="size-4" />}
+            title="No data retention"
+            description="Source is processed in-memory. We never train on your code or persist diffs."
+          />
+        </div>
+      </Section>
+
+      {/* Eligibility */}
+      <Section title="Who qualifies">
+        <Paragraph>
+          The free tier is for projects that are genuinely open source — public
+          repositories with an OSI-approved license. Specifically:
+        </Paragraph>
+        <ul className="mb-4 space-y-2 text-sm text-[#888]">
+          <EligibilityItem>
+            The repository is <strong className="text-white">public</strong> on
+            GitHub.
+          </EligibilityItem>
+          <EligibilityItem>
+            It has an{" "}
+            <a
+              href="https://opensource.org/licenses"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white underline decoration-white/30 underline-offset-2 transition-colors hover:decoration-white"
+            >
+              OSI-approved license
+            </a>{" "}
+            (MIT, Apache-2.0, GPL, BSD, MPL, etc.).
+          </EligibilityItem>
+          <EligibilityItem>
+            It is not the public mirror of a commercial product gated behind a
+            paid plan.
+          </EligibilityItem>
+        </ul>
+        <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+          <div className="flex items-start gap-3">
+            <IconInfoCircle className="mt-0.5 size-4 shrink-0 text-[#888]" />
+            <p className="text-sm text-[#888]">
+              Working on a private repo or a commercial project? Check the{" "}
+              <DocLink href="/docs/pricing">pricing page</DocLink> for credits
+              and bring-your-own-key options.
+            </p>
+          </div>
+        </div>
+      </Section>
+
+      {/* Tips */}
+      <Section title="Tips for maintainers">
+        <div className="mb-4 space-y-2">
+          <TipRow
+            title="Add an .octopusignore file"
+            description="Skip generated code, fixtures, and vendored dependencies so reviews stay focused."
+            href="/docs/octopusignore"
+          />
+          <TipRow
+            title="Upload a knowledge base"
+            description="Give Octopus your CONTRIBUTING.md or architecture notes for sharper, project-specific reviews."
+            href="/docs/getting-started"
+          />
+          <TipRow
+            title="Combine with the GitHub App"
+            description="Prefer webhook-driven reviews instead of Actions? Install the GitHub App from the integrations page."
+            href="/docs/integrations"
+          />
+        </div>
+      </Section>
+
+      {/* Footer CTAs */}
+      <div className="mt-12 grid gap-3 sm:grid-cols-2">
+        <CtaCard
+          href="https://github.com/marketplace/actions/octopus-review"
+          external
+          icon={<IconBrandGithub className="size-4" />}
+          title="View on GitHub Marketplace"
+          description="Install the action from the marketplace listing."
+        />
+        <CtaCard
+          href="/docs/getting-started"
+          icon={<IconRocket className="size-4" />}
+          title="Read the full setup guide"
+          description="Step-by-step walkthrough for first-time users."
+        />
+      </div>
+    </article>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Sub-components                                                      */
+/* ------------------------------------------------------------------ */
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-10">
+      <h2 className="mb-4 text-xl font-semibold text-white">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function Paragraph({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-3 text-sm leading-relaxed text-[#888]">{children}</p>
+  );
+}
+
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="rounded bg-white/[0.06] px-1.5 py-0.5 text-xs text-white">
+      {children}
+    </code>
+  );
+}
+
+function CodeBlock({
+  filename,
+  code,
+}: {
+  filename?: string;
+  code: string;
+}) {
+  return (
+    <div className="mb-4 overflow-hidden rounded-lg border border-white/[0.08] bg-[#0a0a0a]">
+      {filename && (
+        <div className="border-b border-white/[0.06] px-4 py-2 text-xs text-[#666]">
+          {filename}
+        </div>
+      )}
+      <pre className="overflow-x-auto px-4 py-3 text-xs leading-relaxed text-[#ddd]">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+function DocLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className="text-white underline decoration-white/30 underline-offset-2 transition-colors hover:decoration-white"
+    >
+      {children}
+    </Link>
+  );
+}
+
+function FeatureRow({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+      <div className="mb-2 flex size-8 items-center justify-center rounded-lg bg-white/[0.04] text-[#888]">
+        {icon}
+      </div>
+      <h4 className="text-sm font-medium text-white">{title}</h4>
+      <p className="mt-1 text-xs leading-relaxed text-[#666]">{description}</p>
+    </div>
+  );
+}
+
+function EligibilityItem({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-2">
+      <IconChecks className="mt-0.5 size-4 shrink-0 text-[#10D8BE]" />
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function TipRow({
+  title,
+  description,
+  href,
+}: {
+  title: string;
+  description: string;
+  href: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="group flex items-start justify-between gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-4 py-3 transition-colors hover:border-white/[0.12] hover:bg-white/[0.04]"
+    >
+      <div>
+        <span className="text-sm font-medium text-white">{title}</span>
+        <p className="mt-0.5 text-xs text-[#666]">{description}</p>
+      </div>
+      <IconArrowRight className="mt-1 size-4 shrink-0 text-[#333] transition-colors group-hover:text-white" />
+    </Link>
+  );
+}
+
+function CtaCard({
+  href,
+  external = false,
+  icon,
+  title,
+  description,
+}: {
+  href: string;
+  external?: boolean;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
+  const className =
+    "group flex items-start gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] p-4 transition-colors hover:border-white/[0.12] hover:bg-white/[0.04]";
+  const content = (
+    <>
+      <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-white/[0.04] text-[#888] transition-colors group-hover:text-white">
+        {icon}
+      </div>
+      <div className="flex-1">
+        <h4 className="text-sm font-medium text-white">{title}</h4>
+        <p className="mt-0.5 text-xs text-[#666]">{description}</p>
+      </div>
+      <IconArrowRight className="mt-1 size-4 shrink-0 text-[#333] transition-colors group-hover:text-white" />
+    </>
+  );
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+      >
+        {content}
+      </a>
+    );
+  }
+  return (
+    <Link href={href} className={className}>
+      {content}
+    </Link>
+  );
+}

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -26,7 +26,6 @@ import {
   IconRocket,
   IconBrain,
   IconHeartHandshake,
-  IconBolt,
   IconChecks,
 } from "@tabler/icons-react";
 
@@ -133,6 +132,24 @@ export default async function LandingPage() {
         }}
       />
 
+      {/* Announcement bar — Free for OSS */}
+      <TrackedLink
+        href="#oss-program"
+        event="cta_click"
+        eventParams={{ location: "announcement_bar", label: "free_for_oss" }}
+        className="group fixed inset-x-0 top-0 z-[55] flex items-center justify-center gap-2 border-b border-[#10D8BE]/20 bg-gradient-to-r from-[#10D8BE]/[0.08] via-[#10D8BE]/[0.14] to-[#10D8BE]/[0.08] px-4 py-2 text-xs text-[#d8fffa] backdrop-blur-md transition-colors hover:bg-[#10D8BE]/[0.18] sm:text-sm"
+      >
+        <IconHeartHandshake className="size-4 text-[#10D8BE]" />
+        <span className="font-medium">
+          <span className="hidden sm:inline">New: </span>
+          Reviews for open source projects
+        </span>
+        <span className="inline-flex items-center gap-1 font-semibold text-white transition-transform group-hover:translate-x-0.5">
+          Learn more
+          <IconArrowRight className="size-3.5" />
+        </span>
+      </TrackedLink>
+
       {/* Mobile nav — hamburger menu */}
       <LandingMobileNav isLoggedIn={!!session} />
 
@@ -140,7 +157,7 @@ export default async function LandingPage() {
       <LandingDesktopNav isLoggedIn={!!session} />
 
       {/* Hero — dark bg */}
-      <section className="relative z-10 px-6 pb-20 pt-32 md:px-8 md:pb-28 md:pt-44">
+      <section className="relative z-10 px-6 pb-20 pt-40 md:px-8 md:pb-28 md:pt-52">
         <div className="mx-auto max-w-4xl text-center">
           <h1 className="animate-fade-in text-4xl font-bold leading-[1.1] tracking-tight text-white [animation-delay:100ms] sm:text-5xl md:text-6xl lg:text-7xl">
             Review every PR
@@ -398,10 +415,6 @@ export default async function LandingPage() {
             </div>
 
             <div className="relative">
-              <div className="absolute -left-4 -top-4 hidden items-center gap-2 rounded-full border border-[#10D8BE]/30 bg-[#0c0c0c] px-3 py-1.5 text-[11px] font-medium text-[#a4f3e6] sm:inline-flex">
-                <IconBolt className="size-3.5" />
-                Drop in your workflow
-              </div>
               <div className="overflow-hidden rounded-xl border border-white/[0.08] bg-[#0a0a0a] shadow-2xl shadow-black/30">
                 <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-2.5">
                   <div className="flex items-center gap-2">

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -25,6 +25,9 @@ import {
   IconPlugConnected,
   IconRocket,
   IconBrain,
+  IconHeartHandshake,
+  IconBolt,
+  IconChecks,
 } from "@tabler/icons-react";
 
 const landingFaqs = [
@@ -322,6 +325,111 @@ export default async function LandingPage() {
                 <IconBrandGithub className="size-4" />
                 Star us on GitHub
               </TrackedAnchor>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Free for Open Source — promo banner */}
+      <section id="oss-program" className="relative z-10 scroll-mt-20 px-4 py-6 sm:px-8 md:px-12">
+        <div className="relative mx-auto max-w-6xl overflow-hidden rounded-3xl border border-[#10D8BE]/25 bg-gradient-to-br from-[#10D8BE]/[0.06] via-[#161616] to-[#161616] px-6 py-20 md:px-12 md:py-24">
+          <div
+            className="pointer-events-none absolute inset-0 opacity-40"
+            aria-hidden="true"
+            style={{
+              backgroundImage:
+                "radial-gradient(circle at 15% 20%, rgba(16,216,190,0.15) 0%, transparent 45%)",
+            }}
+          />
+          <div className="relative grid gap-10 lg:grid-cols-[1.05fr_1fr] lg:items-center">
+            <div>
+              <div className="inline-flex items-center gap-2 rounded-full border border-[#10D8BE]/30 bg-[#10D8BE]/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-[#a4f3e6]">
+                <IconHeartHandshake className="size-3.5" />
+                New · Open Source Program
+              </div>
+              <h2 className="mt-5 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+                Free, unlimited reviews
+                <br />
+                for open source projects
+              </h2>
+              <p className="mt-4 max-w-xl text-[#aaa] sm:text-lg">
+                If your repository is public and OSI-licensed, Octopus reviews
+                every pull request — forever, on us. No credit card, no monthly
+                quota. Maintainers deserve great tooling.
+              </p>
+
+              <ul className="mt-6 space-y-2.5 text-sm text-[#bbb]">
+                <li className="flex items-start gap-2">
+                  <IconChecks className="mt-0.5 size-4 shrink-0 text-[#10D8BE]" />
+                  <span>Unlimited PR reviews on every public repo</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <IconChecks className="mt-0.5 size-4 shrink-0 text-[#10D8BE]" />
+                  <span>One-file setup with a GitHub Action</span>
+                </li>
+                <li className="flex items-start gap-2">
+                  <IconChecks className="mt-0.5 size-4 shrink-0 text-[#10D8BE]" />
+                  <span>Source-backed inline comments with severity levels</span>
+                </li>
+              </ul>
+
+              <div className="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+                <TrackedLink
+                  href="/docs/open-source"
+                  event="cta_click"
+                  eventParams={{ location: "oss_program", label: "read_docs" }}
+                  className="inline-flex items-center gap-2 rounded-full bg-[#10D8BE] px-5 py-2.5 text-sm font-medium text-[#0c0c0c] transition-colors hover:bg-[#0fbfa8]"
+                >
+                  Read the docs
+                  <IconArrowRight className="size-4" />
+                </TrackedLink>
+                <TrackedAnchor
+                  href="https://github.com/marketplace/actions/octopus-review"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  event="cta_click"
+                  eventParams={{ location: "oss_program", label: "marketplace" }}
+                  className="inline-flex items-center gap-2 rounded-full border border-white/[0.1] px-5 py-2.5 text-sm font-medium text-[#bbb] transition-colors hover:text-white"
+                >
+                  <IconBrandGithub className="size-4" />
+                  GitHub Marketplace
+                </TrackedAnchor>
+              </div>
+            </div>
+
+            <div className="relative">
+              <div className="absolute -left-4 -top-4 hidden items-center gap-2 rounded-full border border-[#10D8BE]/30 bg-[#0c0c0c] px-3 py-1.5 text-[11px] font-medium text-[#a4f3e6] sm:inline-flex">
+                <IconBolt className="size-3.5" />
+                Drop in your workflow
+              </div>
+              <div className="overflow-hidden rounded-xl border border-white/[0.08] bg-[#0a0a0a] shadow-2xl shadow-black/30">
+                <div className="flex items-center justify-between border-b border-white/[0.06] px-4 py-2.5">
+                  <div className="flex items-center gap-2">
+                    <span className="size-2.5 rounded-full bg-[#ff5f56]/70" />
+                    <span className="size-2.5 rounded-full bg-[#ffbd2e]/70" />
+                    <span className="size-2.5 rounded-full bg-[#27c93f]/70" />
+                  </div>
+                  <span className="text-[11px] text-[#666]">
+                    .github/workflows/octopus.yml
+                  </span>
+                </div>
+                <pre className="overflow-x-auto px-4 py-4 text-[12px] leading-relaxed text-[#ddd]">
+                  <code>{`name: Octopus Review
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octopusreview/action@v1`}</code>
+                </pre>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -76,6 +76,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     },
     {
+      url: `${SITE_URL}/docs/open-source`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
       url: `${SITE_URL}/docs/pricing`,
       lastModified: now,
       changeFrequency: "weekly",

--- a/apps/web/components/landing-desktop-nav.tsx
+++ b/apps/web/components/landing-desktop-nav.tsx
@@ -10,7 +10,7 @@ export function LandingDesktopNav({ isLoggedIn }: { isLoggedIn: boolean }) {
   const [resourcesOpen, setResourcesOpen] = useState(false);
 
   return (
-    <nav className="fixed left-1/2 top-4 z-40 hidden -translate-x-1/2 lg:block">
+    <nav className="fixed left-1/2 top-12 z-40 hidden -translate-x-1/2 lg:block">
       <div className="flex items-center gap-2 rounded-full border border-white/[0.08] bg-white/[0.05] px-3 py-1.5 shadow-lg shadow-black/20 backdrop-blur-xl">
         <Link href="/" className="flex items-center gap-2 px-2">
           <Image src="/logo.svg" alt="Octopus" width={24} height={24} priority />

--- a/apps/web/components/landing-mobile-nav.tsx
+++ b/apps/web/components/landing-mobile-nav.tsx
@@ -10,7 +10,7 @@ export function LandingMobileNav({ isLoggedIn }: { isLoggedIn: boolean }) {
   const [open, setOpen] = useState(false);
 
   return (
-    <nav className="fixed left-0 right-0 top-0 z-40 border-b border-white/[0.06] bg-[#0c0c0c]/80 backdrop-blur-xl lg:hidden">
+    <nav className="fixed left-0 right-0 top-9 z-40 border-b border-white/[0.06] bg-[#0c0c0c]/80 backdrop-blur-xl lg:hidden">
       <div className="flex items-center justify-between px-4 py-3">
         <Link href="/" className="flex items-center gap-2">
           <Image src="/logo.svg" alt="Octopus" width={22} height={22} priority />


### PR DESCRIPTION
Adds a new /docs/open-source documentation page with the one-step
GitHub Actions setup, plus a promotional section on the landing
page (with the YAML snippet visible) so OSS maintainers can
discover and adopt the program quickly. Wired the page into the
docs sidebar, mobile menu, command-palette search, and sitemap.