### PR TITLE
feat: admin endpoint to retry stuck PR reviews

### DIFF
--- a/apps/web/app/api/admin/reviews/[id]/retry/route.ts
+++ b/apps/web/app/api/admin/reviews/[id]/retry/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@octopus/db";
+import { enqueue } from "@/lib/queue";
+
+const STALE_REVIEW_MS = 3 * 60 * 1000;
+
+function isAuthorized(request: NextRequest): boolean {
+  const expected = process.env.ADMIN_API_SECRET;
+  if (!expected) return false;
+  const header = request.headers.get("authorization");
+  if (!header) return false;
+  const token = header.startsWith("Bearer ") ? header.slice(7) : header;
+  return token === expected;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const pr = await prisma.pullRequest.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      number: true,
+      status: true,
+      updatedAt: true,
+      repositoryId: true,
+    },
+  });
+
+  if (!pr) {
+    return NextResponse.json({ error: "Pull request not found" }, { status: 404 });
+  }
+
+  // Block retry if a review is actively running (and not stuck) — pg-boss
+  // already retries failed jobs, and processReview's claim logic prevents
+  // duplicate workers, but enqueuing on top of an in-flight review is wasteful.
+  if (pr.status === "reviewing" || pr.status === "pending" || pr.status === "queued") {
+    const elapsed = Date.now() - pr.updatedAt.getTime();
+    if (elapsed < STALE_REVIEW_MS) {
+      return NextResponse.json(
+        { error: `Review is already ${pr.status}` },
+        { status: 409 },
+      );
+    }
+  }
+
+  await prisma.pullRequest.update({
+    where: { id: pr.id },
+    data: {
+      status: "pending",
+      errorMessage: null,
+      reviewBody: null,
+    },
+  });
+
+  await enqueue("process-review", { pullRequestId: pr.id });
+
+  return NextResponse.json({ message: "Review retry enqueued", pullRequestId: pr.id });
+}


### PR DESCRIPTION
## Summary

- New \`POST /api/admin/reviews/:id/retry\` (Bearer \`ADMIN_API_SECRET\`) re-enqueues a stuck or failed PR review.
- Blocks retry when the PR is currently \`reviewing\`/\`pending\`/\`queued\` and was updated within the last 3 minutes (don't stomp a live worker).
- Resets status to \`pending\` and clears stale \`errorMessage\`/\`reviewBody\` before enqueuing.

Closes #353

## Test plan

- [ ] Hit endpoint without auth → 401.
- [ ] Hit with bad PR id → 404.
- [ ] Hit on a PR currently \`reviewing\` updated <3min ago → 409.
- [ ] Hit on a failed PR → 200, job is enqueued, \`status\` becomes \`pending\` then progresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)