### PR TITLE
feat: async community review pipeline + configurable announcement bar

### DIFF
--- a/apps/web/app/(app)/usage/page.tsx
+++ b/apps/web/app/(app)/usage/page.tsx
@@ -49,10 +49,11 @@ const ACTIVITIES: Activity[] = [
       "cross-file-verification",
       "local-review",
       "local-review-findings-followup",
+      "community-review",
       "generate-issue-content",
       "feedback-classification",
     ],
-    unitOperations: ["review", "local-review"],
+    unitOperations: ["review", "local-review", "community-review"],
     unit: "reviews",
   },
   {

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -16,6 +16,8 @@ import { NewsletterForm } from "@/components/landing-newsletter";
 import { CliInstallSection } from "@/components/landing-cli-install";
 import { LandingStats } from "@/components/landing-stats";
 import { LandingOssWorkflowSnippet } from "@/components/landing-oss-workflow-snippet";
+import { LandingAnnouncementBar } from "@/components/landing-announcement-bar";
+import { loadActiveAnnouncements } from "@/lib/announcements";
 
 import { FaqList } from "@/components/FaqList";
 import {
@@ -100,7 +102,7 @@ const faqJsonLd = {
 };
 
 export default async function LandingPage() {
-  const [session, blogPosts, landingStats] = await Promise.all([
+  const [session, blogPosts, landingStats, announcements] = await Promise.all([
     auth.api.getSession({ headers: await headers() }),
     prisma.blogPost.findMany({
       where: { status: "published", deletedAt: null },
@@ -109,6 +111,7 @@ export default async function LandingPage() {
       select: { title: true, slug: true, excerpt: true, publishedAt: true, authorName: true },
     }),
     getLandingStats(),
+    loadActiveAnnouncements(),
   ]);
   return (
     <div className="dark relative min-h-screen bg-[#0c0c0c] text-[#a0a0a0] selection:bg-white/20">
@@ -133,23 +136,8 @@ export default async function LandingPage() {
         }}
       />
 
-      {/* Announcement bar — Free for OSS */}
-      <TrackedLink
-        href="/open-source"
-        event="cta_click"
-        eventParams={{ location: "announcement_bar", label: "free_for_oss" }}
-        className="group fixed inset-x-0 top-0 z-[55] flex items-center justify-center gap-2 border-b border-[#10D8BE]/20 bg-gradient-to-r from-[#10D8BE]/[0.08] via-[#10D8BE]/[0.14] to-[#10D8BE]/[0.08] px-4 py-2 text-xs text-[#d8fffa] backdrop-blur-md transition-colors hover:bg-[#10D8BE]/[0.18] sm:text-sm"
-      >
-        <IconHeartHandshake className="size-4 text-[#10D8BE]" />
-        <span className="font-medium">
-          <span className="hidden sm:inline">New: </span>
-          Reviews for open source projects
-        </span>
-        <span className="inline-flex items-center gap-1 font-semibold text-white transition-transform group-hover:translate-x-0.5">
-          Learn more
-          <IconArrowRight className="size-3.5" />
-        </span>
-      </TrackedLink>
+      {/* Announcement bar — managed in admin /announcements */}
+      <LandingAnnouncementBar announcements={announcements} />
 
       {/* Mobile nav — hamburger menu */}
       <LandingMobileNav isLoggedIn={!!session} />

--- a/apps/web/app/api/github-action/review/[jobId]/route.ts
+++ b/apps/web/app/api/github-action/review/[jobId]/route.ts
@@ -1,0 +1,78 @@
+import { prisma } from "@octopus/db";
+import { NextRequest } from "next/server";
+
+const LOG = (msg: string, ...rest: unknown[]) =>
+  console.log(`[github-action/poll] ${msg}`, ...rest);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ jobId: string }> },
+) {
+  const { jobId } = await context.params;
+
+  if (!jobId || !UUID_RE.test(jobId)) {
+    return Response.json({ error: "Invalid jobId" }, { status: 400 });
+  }
+
+  // Auth: caller must supply the repoFullName that matches this job.
+  // Querystring keeps the action client simple (no body on GET).
+  const url = new URL(request.url);
+  const repoFullName = url.searchParams.get("repo");
+  if (!repoFullName) {
+    return Response.json(
+      { error: "Missing 'repo' query parameter (owner/name)" },
+      { status: 400 },
+    );
+  }
+
+  const job = await prisma.communityReviewJob.findUnique({ where: { id: jobId } });
+
+  if (!job) {
+    LOG(`jobId=${jobId} not found`);
+    return Response.json({ error: "Job not found" }, { status: 404 });
+  }
+
+  if (job.repoFullName !== repoFullName) {
+    LOG(`jobId=${jobId} repo mismatch: stored=${job.repoFullName} provided=${repoFullName}`);
+    return Response.json({ error: "Repo mismatch" }, { status: 403 });
+  }
+
+  if (job.expiresAt < new Date()) {
+    LOG(`jobId=${jobId} expired (expiresAt=${job.expiresAt.toISOString()})`);
+    return Response.json({ status: "expired", error: "Job expired" }, { status: 410 });
+  }
+
+  if (job.status === "completed") {
+    LOG(`jobId=${jobId} returning completed result`);
+    return Response.json({
+      status: "completed",
+      jobId: job.id,
+      findings: job.findings ?? [],
+      summary: job.summary ?? "",
+      model: job.model ?? "",
+      indexed: job.indexed,
+      community: true,
+      firstCommunityReview: job.firstCommunityReview,
+      usage: job.usage ?? undefined,
+    });
+  }
+
+  if (job.status === "failed") {
+    LOG(`jobId=${jobId} returning failed: ${job.errorMessage}`);
+    return Response.json({
+      status: "failed",
+      jobId: job.id,
+      error: job.errorMessage ?? "Review failed",
+    });
+  }
+
+  // In-flight: indexing | reviewing
+  return Response.json({
+    status: job.status,
+    jobId: job.id,
+    startedAt: job.startedAt,
+    attempts: job.attempts,
+  });
+}

--- a/apps/web/app/api/github-action/review/route.ts
+++ b/apps/web/app/api/github-action/review/route.ts
@@ -7,6 +7,7 @@ import { getRepositoryTree } from "@/lib/github";
 import { eventBus } from "@/lib/events/bus";
 import { enqueue } from "@/lib/queue";
 import { persistCommunityReviewToPR } from "@/lib/community-pr-persist";
+import { encryptString } from "@/lib/crypto";
 import { NextRequest } from "next/server";
 
 const GITHUB_API = "https://api.github.com";
@@ -430,7 +431,10 @@ async function enqueueCommunityReview(params: {
       headSha: headSha ?? null,
       baseBranch: baseBranch ?? null,
       diff,
-      githubToken,
+      // Token is short-lived (1h GitHub Actions token) but still encrypted
+      // at rest so it doesn't leak via DB exports / backups / read replicas.
+      // Decrypted in lib/community-review.ts when the worker runs.
+      githubToken: encryptString(githubToken),
       expiresAt,
     },
   });

--- a/apps/web/app/api/github-action/review/route.ts
+++ b/apps/web/app/api/github-action/review/route.ts
@@ -3,14 +3,19 @@ import { prisma } from "@octopus/db";
 import { generateLocalReview } from "@/lib/review-core";
 import { isOrgOverSpendLimit } from "@/lib/cost";
 import { ORG_TYPE } from "@/lib/org-types";
-import { indexRepository } from "@/lib/indexer";
-import { summarizeRepository } from "@/lib/summarizer";
-import { analyzeRepository } from "@/lib/analyzer";
 import { getRepositoryTree } from "@/lib/github";
 import { eventBus } from "@/lib/events/bus";
+import { enqueue } from "@/lib/queue";
+import { persistCommunityReviewToPR } from "@/lib/community-pr-persist";
 import { NextRequest } from "next/server";
 
 const GITHUB_API = "https://api.github.com";
+const COMMUNITY_JOB_TTL_HOURS = 25;
+
+const LOG = (msg: string, ...rest: unknown[]) =>
+  console.log(`[github-action] ${msg}`, ...rest);
+const ERR = (msg: string, ...rest: unknown[]) =>
+  console.error(`[github-action] ${msg}`, ...rest);
 
 // ─── Community org helpers ──────────────────────────────────────────────────
 
@@ -45,7 +50,6 @@ async function getOrCreateCommunityOrg(githubOwner: string) {
       type: ORG_TYPE.COMMUNITY,
       freeCreditBalance: 0,
     },
-    // Backfill type for community orgs created before type was set on create.
     update: { type: ORG_TYPE.COMMUNITY },
   });
 }
@@ -56,7 +60,7 @@ async function getCommunityReviewCountToday(orgId: string): Promise<number> {
   return prisma.aiUsage.count({
     where: {
       organizationId: orgId,
-      operation: "review",
+      operation: "community-review",
       createdAt: { gte: startOfDay },
     },
   });
@@ -65,7 +69,7 @@ async function getCommunityReviewCountToday(orgId: string): Promise<number> {
 // ─── Main handler ───────────────────────────────────────────────────────────
 
 export async function POST(request: NextRequest) {
-  // Validate action secret
+  // Validate action secret (when configured)
   const actionSecret = process.env.OCTOPUS_ACTION_SECRET;
   if (actionSecret) {
     const headerSecret = request.headers.get("x-octopus-action-secret");
@@ -87,6 +91,8 @@ export async function POST(request: NextRequest) {
     prNumber,
     prTitle,
     prAuthor,
+    headSha,
+    baseBranch,
     diff,
     githubToken,
     forceReindex,
@@ -105,7 +111,6 @@ export async function POST(request: NextRequest) {
     reindexThresholdHours?: number;
   };
 
-  // Validate required fields
   if (!owner || !repoName || !diff || !githubToken) {
     return Response.json(
       { error: "Missing required fields: owner, repo, diff, githubToken" },
@@ -126,16 +131,13 @@ export async function POST(request: NextRequest) {
   let communityDailyLimit = 5;
 
   if (apiAuth) {
-    // Mode 1: API key present → use real org
     orgId = apiAuth.org.id;
   } else if (hasAuthHeader) {
-    // Token was sent but invalid/expired/banned — do NOT fall back to community.
     return Response.json(
       { error: "Invalid or expired octopus-api-key" },
       { status: 401 },
     );
   } else {
-    // Mode 2: No API key → community mode (public repos only)
     const repoInfo = await fetchGitHubRepoInfo(githubToken, owner, repoName);
     if (!repoInfo) {
       return Response.json(
@@ -185,7 +187,7 @@ export async function POST(request: NextRequest) {
     },
   });
 
-  // ── Community rate limit ──────────────────────────────────────────────────
+  // ── Community rate limit ─────────────────────────────────────────────────
 
   if (isCommunityMode) {
     const todayCount = await getCommunityReviewCountToday(orgId);
@@ -197,24 +199,48 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // ── Spend limit (for authenticated orgs) ──────────────────────────────────
-
-  if (!isCommunityMode && await isOrgOverSpendLimit(orgId)) {
+  if (!isCommunityMode && (await isOrgOverSpendLimit(orgId))) {
     return Response.json({ error: "Monthly spend limit reached" }, { status: 402 });
   }
 
-  // ── Indexing ──────────────────────────────────────────────────────────────
+  // ── Decide flow: queued (community + not indexed) vs sync ────────────────
+
+  const thresholdHours = reindexThresholdHours ?? 24;
+  const stale =
+    repo.indexedAt != null &&
+    Date.now() - repo.indexedAt.getTime() > thresholdHours * 60 * 60 * 1000;
+  const needsIndex = repo.indexStatus !== "indexed" || forceReindex === true || stale;
+
+  // For community mode without an existing index → enqueue + poll.
+  // Authenticated orgs keep the legacy sync flow (they can have higher CF
+  // timeouts or the action runs internally), and indexed community repos are
+  // fast enough to stay sync.
+  if (isCommunityMode && needsIndex) {
+    return await enqueueCommunityReview({
+      repo,
+      orgId,
+      fullName,
+      prNumber,
+      prTitle,
+      prAuthor,
+      headSha,
+      baseBranch,
+      diff,
+      githubToken,
+    });
+  }
+
+  // ── Sync flow (indexed already, or paid org) ─────────────────────────────
 
   let indexed = false;
-  const thresholdHours = reindexThresholdHours ?? 24;
-  const needsIndex =
-    repo.indexStatus !== "indexed" ||
-    forceReindex ||
-    (repo.indexedAt && Date.now() - repo.indexedAt.getTime() > thresholdHours * 60 * 60 * 1000);
-
   if (needsIndex) {
+    LOG(`[sync] indexing ${fullName} inline (paid org)`);
+    // Paid org sync indexing — keep legacy behavior since they're not on the
+    // public Cloudflare 100s timeout path.
     try {
-      console.log(`[github-action] Indexing ${fullName}...`);
+      const { indexRepository } = await import("@/lib/indexer");
+      const { summarizeRepository } = await import("@/lib/summarizer");
+      const { analyzeRepository } = await import("@/lib/analyzer");
 
       await prisma.repository.update({
         where: { id: repo.id },
@@ -225,12 +251,12 @@ export async function POST(request: NextRequest) {
         repo.id,
         fullName,
         ghRepoInfo.defaultBranch,
-        0, // installationId not needed — using providedToken
-        () => {}, // onLog
-        undefined, // signal
+        0,
+        () => {},
+        undefined,
         "github",
         orgId,
-        githubToken, // providedToken
+        githubToken,
       );
 
       await prisma.repository.update({
@@ -249,80 +275,70 @@ export async function POST(request: NextRequest) {
         },
       });
 
-      console.log(`[github-action] Indexing complete: ${indexStats.indexedFiles} files, ${indexStats.totalVectors} vectors`);
-
-      // Summarize & analyze (best-effort, don't fail review if these fail)
       try {
         const { summary, purpose } = await summarizeRepository(repo.id, fullName, orgId);
-        await prisma.repository.update({
-          where: { id: repo.id },
-          data: { summary, purpose },
-        });
+        await prisma.repository.update({ where: { id: repo.id }, data: { summary, purpose } });
       } catch (err) {
-        console.error("[github-action] Summarize failed:", err);
+        ERR("summarize failed:", err);
       }
-
       try {
         const analysis = await analyzeRepository(repo.id, fullName, orgId);
         await prisma.repository.update({
           where: { id: repo.id },
           data: { analysis, analysisStatus: "analyzed", analyzedAt: new Date() },
         });
-        eventBus.emit({
-          type: "repo-analyzed",
-          orgId,
-          repoFullName: fullName,
-        });
+        eventBus.emit({ type: "repo-analyzed", orgId, repoFullName: fullName });
       } catch (err) {
-        console.error("[github-action] Analyze failed:", err);
+        ERR("analyze failed:", err);
       }
-
       indexed = true;
     } catch (err) {
-      console.error("[github-action] Indexing failed:", err);
-      await prisma.repository.update({
-        where: { id: repo.id },
-        data: { indexStatus: "failed" },
-      });
-      // Continue with review even if indexing failed — generateLocalReview works without index
+      ERR("inline indexing failed:", err);
+      await prisma.repository.update({ where: { id: repo.id }, data: { indexStatus: "failed" } });
     }
   }
 
-  // ── Fetch file tree ───────────────────────────────────────────────────────
-
-  const [ownerPart, repoPart] = fullName.split("/");
   let fileTree: string[] | undefined;
   try {
-    fileTree = await getRepositoryTree(
-      0, // installationId not needed
-      ownerPart,
-      repoPart,
-      ghRepoInfo.defaultBranch,
-      githubToken,
-    );
+    const [ownerPart, repoPart] = fullName.split("/");
+    fileTree = await getRepositoryTree(0, ownerPart, repoPart, ghRepoInfo.defaultBranch, githubToken);
   } catch {
-    console.warn("[github-action] Failed to fetch file tree, continuing without it");
+    // ignore
   }
-
-  // ── Generate review ───────────────────────────────────────────────────────
 
   try {
     const reviewResult = await generateLocalReview({
       diff,
       repoId: repo.id,
-      orgId: orgId,
+      orgId,
       title: typeof prTitle === "string" ? prTitle : undefined,
       author: typeof prAuthor === "string" ? prAuthor : undefined,
       fileTree,
+      operation: isCommunityMode ? "community-review" : "local-review",
+      prNumber: typeof prNumber === "number" ? prNumber : undefined,
     });
 
-    // Check if this is the first community review for this repo
     let firstCommunityReview = false;
     if (isCommunityMode) {
-      const existingPRCount = await prisma.pullRequest.count({
-        where: { repositoryId: repo.id },
-      });
+      const existingPRCount = await prisma.pullRequest.count({ where: { repositoryId: repo.id } });
       firstCommunityReview = existingPRCount === 0;
+
+      if (typeof prNumber === "number") {
+        try {
+          await persistCommunityReviewToPR({
+            repositoryId: repo.id,
+            fullName,
+            prNumber,
+            prTitle: typeof prTitle === "string" ? prTitle : null,
+            prAuthor: typeof prAuthor === "string" ? prAuthor : null,
+            headSha: typeof headSha === "string" ? headSha : null,
+            summary: reviewResult.summary,
+            findings: reviewResult.findings,
+          });
+        } catch (persistErr) {
+          ERR("persist community PR failed (non-fatal):", persistErr);
+        }
+      }
 
       eventBus.emit({
         type: "community-review",
@@ -334,6 +350,7 @@ export async function POST(request: NextRequest) {
     }
 
     return Response.json({
+      status: "completed",
       findings: reviewResult.findings,
       summary: reviewResult.summary,
       model: reviewResult.model,
@@ -343,7 +360,106 @@ export async function POST(request: NextRequest) {
       usage: reviewResult.usage,
     });
   } catch (err) {
-    console.error("[github-action] Review generation failed:", err);
+    ERR("review generation failed:", err);
     return Response.json({ error: "Review generation failed" }, { status: 500 });
   }
+}
+
+// ─── Queued path helpers ────────────────────────────────────────────────────
+
+async function enqueueCommunityReview(params: {
+  repo: { id: string; defaultBranch: string };
+  orgId: string;
+  fullName: string;
+  prNumber?: number;
+  prTitle?: string;
+  prAuthor?: string;
+  headSha?: string;
+  baseBranch?: string;
+  diff: string;
+  githubToken: string;
+}) {
+  const {
+    repo,
+    orgId,
+    fullName,
+    prNumber,
+    prTitle,
+    prAuthor,
+    headSha,
+    baseBranch,
+    diff,
+    githubToken,
+  } = params;
+
+  // De-dupe: same repo + PR + headSha already in flight → return existing job.
+  if (typeof prNumber === "number" && headSha) {
+    const existing = await prisma.communityReviewJob.findFirst({
+      where: {
+        repositoryId: repo.id,
+        prNumber,
+        headSha,
+        status: { in: ["indexing", "reviewing"] },
+        expiresAt: { gt: new Date() },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    if (existing) {
+      LOG(`[queue] dedup hit jobId=${existing.id} repo=${fullName} PR=${prNumber}`);
+      return Response.json({
+        status: "queued",
+        jobId: existing.id,
+        existing: true,
+        community: true,
+        message: "Review is already queued for this PR + commit. Poll the job to get the result.",
+      });
+    }
+  }
+
+  const expiresAt = new Date(Date.now() + COMMUNITY_JOB_TTL_HOURS * 60 * 60 * 1000);
+
+  const job = await prisma.communityReviewJob.create({
+    data: {
+      status: "indexing",
+      repoFullName: fullName,
+      repositoryId: repo.id,
+      organizationId: orgId,
+      prNumber: prNumber ?? null,
+      prTitle: prTitle ?? null,
+      prAuthor: prAuthor ?? null,
+      headSha: headSha ?? null,
+      baseBranch: baseBranch ?? null,
+      diff,
+      githubToken,
+      expiresAt,
+    },
+  });
+
+  LOG(`[queue] created jobId=${job.id} repo=${fullName} PR=${prNumber ?? "?"} sha=${headSha ?? "?"}`);
+
+  await prisma.auditLog.create({
+    data: {
+      action: "community_review.queued",
+      category: "review",
+      targetType: "community_review_job",
+      targetId: job.id,
+      organizationId: orgId,
+      metadata: {
+        repoFullName: fullName,
+        prNumber: prNumber ?? null,
+        headSha: headSha ?? null,
+        diffSize: diff.length,
+      },
+    },
+  }).catch((err) => ERR("audit log create failed (non-fatal):", err));
+
+  await enqueue("community-review", { jobId: job.id });
+
+  return Response.json({
+    status: "queued",
+    jobId: job.id,
+    existing: false,
+    community: true,
+    message: "Repository is not indexed yet. Indexing in background; poll the job for results.",
+  });
 }

--- a/apps/web/components/landing-announcement-bar.tsx
+++ b/apps/web/components/landing-announcement-bar.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useEffect, useState, type CSSProperties } from "react";
+import Link from "next/link";
+import {
+  IconHeartHandshake,
+  IconRocket,
+  IconSparkles,
+  IconBell,
+  IconSpeakerphone,
+  IconInfoCircle,
+  IconGift,
+  IconFlame,
+  IconArrowRight,
+} from "@tabler/icons-react";
+import { trackEvent } from "@/lib/analytics";
+import type { Announcement, AnnouncementIcon, AnnouncementTone } from "@/lib/announcements";
+
+const ICON_MAP: Record<AnnouncementIcon, typeof IconBell> = {
+  "heart-handshake": IconHeartHandshake,
+  rocket: IconRocket,
+  sparkles: IconSparkles,
+  bell: IconBell,
+  megaphone: IconSpeakerphone,
+  info: IconInfoCircle,
+  gift: IconGift,
+  flame: IconFlame,
+};
+
+interface ToneStyle {
+  bg: string;
+  border: string;
+  accent: string;
+  text: string;
+  hover: string;
+}
+
+const TONE_MAP: Record<AnnouncementTone, ToneStyle> = {
+  teal: {
+    bg: "linear-gradient(to right, rgb(16 216 190 / 0.08), rgb(16 216 190 / 0.14), rgb(16 216 190 / 0.08))",
+    border: "rgb(16 216 190 / 0.20)",
+    accent: "#10D8BE",
+    text: "#d8fffa",
+    hover: "rgb(16 216 190 / 0.12)",
+  },
+  amber: {
+    bg: "linear-gradient(to right, rgb(245 185 74 / 0.08), rgb(245 185 74 / 0.16), rgb(245 185 74 / 0.08))",
+    border: "rgb(245 185 74 / 0.25)",
+    accent: "#F5B94A",
+    text: "#fff1d4",
+    hover: "rgb(245 185 74 / 0.14)",
+  },
+  violet: {
+    bg: "linear-gradient(to right, rgb(167 139 250 / 0.08), rgb(167 139 250 / 0.16), rgb(167 139 250 / 0.08))",
+    border: "rgb(167 139 250 / 0.25)",
+    accent: "#C4B5FD",
+    text: "#ece9ff",
+    hover: "rgb(167 139 250 / 0.14)",
+  },
+  rose: {
+    bg: "linear-gradient(to right, rgb(244 114 182 / 0.08), rgb(244 114 182 / 0.16), rgb(244 114 182 / 0.08))",
+    border: "rgb(244 114 182 / 0.25)",
+    accent: "#F9A8D4",
+    text: "#ffe4f1",
+    hover: "rgb(244 114 182 / 0.14)",
+  },
+  emerald: {
+    bg: "linear-gradient(to right, rgb(52 211 153 / 0.08), rgb(52 211 153 / 0.16), rgb(52 211 153 / 0.08))",
+    border: "rgb(52 211 153 / 0.22)",
+    accent: "#34D399",
+    text: "#d6fbe8",
+    hover: "rgb(52 211 153 / 0.14)",
+  },
+  sky: {
+    bg: "linear-gradient(to right, rgb(56 189 248 / 0.08), rgb(56 189 248 / 0.16), rgb(56 189 248 / 0.08))",
+    border: "rgb(56 189 248 / 0.25)",
+    accent: "#7DD3FC",
+    text: "#dbf3ff",
+    hover: "rgb(56 189 248 / 0.14)",
+  },
+};
+
+const ROTATE_INTERVAL_MS = 5000;
+const SLIDE_DURATION_MS = 500;
+
+export function LandingAnnouncementBar({
+  announcements,
+}: {
+  announcements: Announcement[];
+}) {
+  const [index, setIndex] = useState(0);
+  const [animating, setAnimating] = useState(false);
+
+  const count = announcements.length;
+  const multiple = count > 1;
+
+  useEffect(() => {
+    if (!multiple) return;
+    const tick = setInterval(() => {
+      setAnimating(true);
+      setTimeout(() => {
+        setIndex((i) => (i + 1) % count);
+        setAnimating(false);
+      }, SLIDE_DURATION_MS);
+    }, ROTATE_INTERVAL_MS);
+    return () => clearInterval(tick);
+  }, [multiple, count]);
+
+  if (count === 0) return null;
+
+  const current = announcements[index];
+  const next = announcements[(index + 1) % count];
+  const currentTone = TONE_MAP[current.tone] ?? TONE_MAP.teal;
+
+  const outerStyle: CSSProperties = {
+    borderColor: currentTone.border,
+    transition: `border-color ${SLIDE_DURATION_MS}ms cubic-bezier(0.65, 0, 0.35, 1)`,
+  };
+
+  if (!multiple) {
+    return (
+      <div
+        className="fixed inset-x-0 top-0 z-[55] overflow-hidden border-b backdrop-blur-md"
+        style={outerStyle}
+      >
+        <div className="relative h-9 sm:h-10">
+          <AnnouncementRow announcement={current} />
+        </div>
+      </div>
+    );
+  }
+
+  const transition = animating
+    ? `transform ${SLIDE_DURATION_MS}ms cubic-bezier(0.65, 0, 0.35, 1)`
+    : "none";
+
+  return (
+    <div
+      className="fixed inset-x-0 top-0 z-[55] overflow-hidden border-b backdrop-blur-md"
+      style={outerStyle}
+    >
+      <div className="relative h-9 sm:h-10">
+        <div
+          className="absolute inset-0"
+          style={{
+            transform: animating ? "translateY(-100%)" : "translateY(0)",
+            transition,
+          }}
+        >
+          <AnnouncementRow announcement={current} />
+        </div>
+        <div
+          className="absolute inset-0"
+          style={{
+            transform: animating ? "translateY(0)" : "translateY(100%)",
+            transition,
+          }}
+        >
+          <AnnouncementRow announcement={next} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AnnouncementRow({ announcement }: { announcement: Announcement }) {
+  const Icon = ICON_MAP[announcement.icon] ?? IconSpeakerphone;
+  const tone = TONE_MAP[announcement.tone] ?? TONE_MAP.teal;
+  const inner = (
+    <div
+      className="flex h-9 w-full items-center justify-center gap-2 px-4 text-xs font-medium sm:h-10 sm:text-sm"
+      style={{ background: tone.bg, color: tone.text }}
+    >
+      <Icon className="size-4 shrink-0" style={{ color: tone.accent }} />
+      <span className="truncate">
+        {announcement.prefix && (
+          <span className="hidden sm:inline">{announcement.prefix} </span>
+        )}
+        {announcement.message}
+      </span>
+      {announcement.ctaLabel && (
+        <span className="inline-flex shrink-0 items-center gap-1 font-semibold text-white">
+          {announcement.ctaLabel}
+          <IconArrowRight className="size-3.5" />
+        </span>
+      )}
+    </div>
+  );
+
+  if (!announcement.href) return inner;
+
+  const isExternal = /^https?:\/\//.test(announcement.href);
+  const onClick = () =>
+    trackEvent("cta_click", {
+      location: "announcement_bar",
+      label: announcement.id,
+    });
+
+  if (isExternal) {
+    return (
+      <a
+        href={announcement.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={onClick}
+        className="group block"
+      >
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={announcement.href} onClick={onClick} className="group block">
+      {inner}
+    </Link>
+  );
+}

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -7,6 +7,24 @@ export async function register() {
     const { startQueue } = await import("./lib/queue");
     const boss = await startQueue();
 
+    // Recover orphaned community-review jobs (server restart, worker death, etc.)
+    // Must run after startQueue so enqueue() works.
+    const { recoverCommunityReviewJobs, cleanupExpiredCommunityReviewJobs } = await import(
+      "./lib/community-review-recovery"
+    );
+    if (process.env.ENABLE_REVIEW_WORKERS === "true") {
+      await recoverCommunityReviewJobs();
+      await cleanupExpiredCommunityReviewJobs();
+
+      // Periodic TTL cleanup (every hour)
+      const cleanupTimer = setInterval(() => {
+        cleanupExpiredCommunityReviewJobs().catch((err) =>
+          console.error("[community-review/recovery] periodic cleanup failed:", err),
+        );
+      }, 60 * 60 * 1000);
+      cleanupTimer.unref?.();
+    }
+
     // Graceful shutdown: wait for active jobs (e.g. in-progress reviews) to finish
     const shutdown = async () => {
       console.log("[queue] Graceful shutdown, waiting for active jobs...");

--- a/apps/web/lib/announcements.ts
+++ b/apps/web/lib/announcements.ts
@@ -1,0 +1,95 @@
+import { prisma } from "@octopus/db";
+
+export type AnnouncementIcon =
+  | "heart-handshake"
+  | "rocket"
+  | "sparkles"
+  | "bell"
+  | "megaphone"
+  | "info"
+  | "gift"
+  | "flame";
+
+export type AnnouncementTone =
+  | "teal"
+  | "amber"
+  | "violet"
+  | "rose"
+  | "emerald"
+  | "sky";
+
+export interface Announcement {
+  id: string;
+  message: string;
+  prefix?: string;
+  ctaLabel?: string;
+  href?: string;
+  icon: AnnouncementIcon;
+  tone: AnnouncementTone;
+  enabled: boolean;
+  sortOrder: number;
+}
+
+const VALID_ICONS: AnnouncementIcon[] = [
+  "heart-handshake",
+  "rocket",
+  "sparkles",
+  "bell",
+  "megaphone",
+  "info",
+  "gift",
+  "flame",
+];
+
+const VALID_TONES: AnnouncementTone[] = [
+  "teal",
+  "amber",
+  "violet",
+  "rose",
+  "emerald",
+  "sky",
+];
+
+function isValidIcon(v: unknown): v is AnnouncementIcon {
+  return typeof v === "string" && (VALID_ICONS as string[]).includes(v);
+}
+
+function isValidTone(v: unknown): v is AnnouncementTone {
+  return typeof v === "string" && (VALID_TONES as string[]).includes(v);
+}
+
+function normalize(raw: unknown): Announcement | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  const message = typeof o.message === "string" ? o.message.trim() : "";
+  if (!message) return null;
+  return {
+    id: typeof o.id === "string" && o.id ? o.id : Math.random().toString(36).slice(2),
+    message,
+    prefix: typeof o.prefix === "string" && o.prefix.trim() ? o.prefix.trim() : undefined,
+    ctaLabel:
+      typeof o.ctaLabel === "string" && o.ctaLabel.trim() ? o.ctaLabel.trim() : undefined,
+    href: typeof o.href === "string" && o.href.trim() ? o.href.trim() : undefined,
+    icon: isValidIcon(o.icon) ? o.icon : "megaphone",
+    tone: isValidTone(o.tone) ? o.tone : "teal",
+    enabled: o.enabled !== false,
+    sortOrder: typeof o.sortOrder === "number" ? o.sortOrder : 0,
+  };
+}
+
+export async function loadActiveAnnouncements(): Promise<Announcement[]> {
+  try {
+    const row = await prisma.systemConfig.findUnique({
+      where: { id: "singleton" },
+      select: { announcements: true },
+    });
+    const raw = row?.announcements;
+    if (!Array.isArray(raw)) return [];
+    return raw
+      .map(normalize)
+      .filter((a): a is Announcement => a !== null && a.enabled)
+      .sort((a, b) => a.sortOrder - b.sortOrder);
+  } catch {
+    return [];
+  }
+}

--- a/apps/web/lib/announcements.ts
+++ b/apps/web/lib/announcements.ts
@@ -58,6 +58,18 @@ function isValidTone(v: unknown): v is AnnouncementTone {
   return typeof v === "string" && (VALID_TONES as string[]).includes(v);
 }
 
+// Allowlist hrefs to absolute http(s) and same-origin paths starting with "/".
+// Blocks javascript:, data:, vbscript:, and other URI schemes from a
+// compromised or misconfigured admin entry rendering an XSS / open redirect.
+function sanitizeHref(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const trimmed = v.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith("/") && !trimmed.startsWith("//")) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return undefined;
+}
+
 function normalize(raw: unknown): Announcement | null {
   if (!raw || typeof raw !== "object") return null;
   const o = raw as Record<string, unknown>;
@@ -69,7 +81,7 @@ function normalize(raw: unknown): Announcement | null {
     prefix: typeof o.prefix === "string" && o.prefix.trim() ? o.prefix.trim() : undefined,
     ctaLabel:
       typeof o.ctaLabel === "string" && o.ctaLabel.trim() ? o.ctaLabel.trim() : undefined,
-    href: typeof o.href === "string" && o.href.trim() ? o.href.trim() : undefined,
+    href: sanitizeHref(o.href),
     icon: isValidIcon(o.icon) ? o.icon : "megaphone",
     tone: isValidTone(o.tone) ? o.tone : "teal",
     enabled: o.enabled !== false,

--- a/apps/web/lib/community-pr-persist.ts
+++ b/apps/web/lib/community-pr-persist.ts
@@ -1,0 +1,81 @@
+import { prisma } from "@octopus/db";
+import type { InlineFinding } from "@/lib/review-dedup";
+
+const SEVERITY_MAP: Record<string, string> = {
+  "🔴": "critical",
+  "🟠": "high",
+  "🟡": "medium",
+  "🔵": "low",
+  "💡": "low",
+};
+
+export type CommunityPRPersistInput = {
+  repositoryId: string;
+  fullName: string;
+  prNumber: number;
+  prTitle?: string | null;
+  prAuthor?: string | null;
+  headSha?: string | null;
+  summary: string;
+  findings: InlineFinding[];
+};
+
+/**
+ * Persist a completed community review as a PullRequest + ReviewIssue rows
+ * so it shows up in the admin panel alongside App-webhook reviews.
+ *
+ * Idempotent on (repositoryId, number): re-running for the same PR replaces
+ * the prior findings with the latest review's findings.
+ */
+export async function persistCommunityReviewToPR(input: CommunityPRPersistInput): Promise<void> {
+  const {
+    repositoryId,
+    fullName,
+    prNumber,
+    prTitle,
+    prAuthor,
+    headSha,
+    summary,
+    findings,
+  } = input;
+
+  const url = `https://github.com/${fullName}/pull/${prNumber}`;
+
+  const pr = await prisma.pullRequest.upsert({
+    where: { repositoryId_number: { repositoryId, number: prNumber } },
+    create: {
+      repositoryId,
+      number: prNumber,
+      title: prTitle ?? `PR #${prNumber}`,
+      url,
+      author: prAuthor ?? "unknown",
+      status: "completed",
+      headSha: headSha ?? null,
+      reviewBody: summary,
+    },
+    update: {
+      title: prTitle ?? undefined,
+      author: prAuthor ?? undefined,
+      headSha: headSha ?? undefined,
+      status: "completed",
+      reviewBody: summary,
+      errorMessage: null,
+    },
+  });
+
+  await prisma.reviewIssue.deleteMany({ where: { pullRequestId: pr.id } });
+
+  if (findings.length > 0) {
+    await prisma.reviewIssue.createMany({
+      data: findings.map((f) => ({
+        pullRequestId: pr.id,
+        title: f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim(),
+        description: f.description || f.category,
+        severity: SEVERITY_MAP[f.severity] ?? "medium",
+        filePath: f.filePath || null,
+        lineNumber: f.startLine || null,
+        confidence: f.confidence ? String(f.confidence) : null,
+      })),
+    });
+  }
+}

--- a/apps/web/lib/community-review-recovery.ts
+++ b/apps/web/lib/community-review-recovery.ts
@@ -1,0 +1,139 @@
+import { prisma } from "@octopus/db";
+import { enqueue } from "./queue";
+
+const LOG = (msg: string, ...rest: unknown[]) =>
+  console.log(`[community-review/recovery] ${msg}`, ...rest);
+const ERR = (msg: string, ...rest: unknown[]) =>
+  console.error(`[community-review/recovery] ${msg}`, ...rest);
+
+// Jobs whose updatedAt is older than this without progressing are considered
+// orphaned (worker died, server restarted mid-flight, etc.) and re-enqueued.
+const STALE_MS = 5 * 60 * 1000;
+
+/**
+ * Boot-time recovery for community-review jobs.
+ *
+ * Scenarios this handles:
+ * - Server restarted while a job was indexing/reviewing → updatedAt freezes,
+ *   this re-enqueues so the worker resumes.
+ * - Job past expiresAt → mark failed + audit (TTL enforcement).
+ *
+ * Periodic cleanup (delete expired completed/failed rows) is handled
+ * separately so old jobs don't accumulate forever.
+ */
+export async function recoverCommunityReviewJobs() {
+  try {
+    const now = new Date();
+    const staleCutoff = new Date(now.getTime() - STALE_MS);
+
+    // 1. Expire jobs past their TTL while still in flight.
+    const expired = await prisma.communityReviewJob.findMany({
+      where: {
+        status: { in: ["indexing", "reviewing"] },
+        expiresAt: { lt: now },
+      },
+      select: { id: true, repoFullName: true, organizationId: true },
+    });
+
+    if (expired.length > 0) {
+      LOG(`expiring ${expired.length} in-flight jobs past TTL`);
+      for (const job of expired) {
+        await prisma.communityReviewJob.update({
+          where: { id: job.id },
+          data: {
+            status: "failed",
+            errorMessage: "Job exceeded TTL while in flight",
+            completedAt: now,
+            githubToken: null,
+          },
+        });
+        await prisma.auditLog.create({
+          data: {
+            action: "community_review.expired",
+            category: "review",
+            targetType: "community_review_job",
+            targetId: job.id,
+            organizationId: job.organizationId,
+            metadata: { repoFullName: job.repoFullName, reason: "ttl_exceeded_in_flight" },
+          },
+        }).catch(() => {});
+      }
+    }
+
+    // 2. Re-enqueue orphaned in-flight jobs (server restart recovery).
+    const orphans = await prisma.communityReviewJob.findMany({
+      where: {
+        status: { in: ["indexing", "reviewing"] },
+        updatedAt: { lt: staleCutoff },
+        expiresAt: { gt: now },
+      },
+      select: { id: true, repoFullName: true, status: true, attempts: true },
+    });
+
+    if (orphans.length > 0) {
+      LOG(`re-enqueueing ${orphans.length} orphaned jobs`);
+      for (const job of orphans) {
+        try {
+          await enqueue("community-review", { jobId: job.id });
+          LOG(`re-enqueued jobId=${job.id} repo=${job.repoFullName} status=${job.status} prevAttempts=${job.attempts}`);
+        } catch (err) {
+          ERR(`failed to re-enqueue jobId=${job.id}:`, err);
+        }
+      }
+    } else {
+      LOG("no orphan jobs to recover");
+    }
+  } catch (err) {
+    ERR("recovery failed:", err);
+  }
+}
+
+/**
+ * Hard cleanup: delete community-review rows whose expiresAt is past.
+ * Writes one audit log per cleanup batch (not per row) to stay cheap.
+ */
+export async function cleanupExpiredCommunityReviewJobs() {
+  try {
+    const now = new Date();
+
+    // Pull a batch first so we can audit which IDs we're deleting.
+    const batch = await prisma.communityReviewJob.findMany({
+      where: { expiresAt: { lt: now } },
+      select: { id: true, status: true, repoFullName: true, organizationId: true },
+      take: 500,
+    });
+
+    if (batch.length === 0) {
+      LOG("cleanup: nothing to delete");
+      return { deleted: 0 };
+    }
+
+    const ids = batch.map((b) => b.id);
+    const { count } = await prisma.communityReviewJob.deleteMany({
+      where: { id: { in: ids } },
+    });
+
+    LOG(`cleanup: deleted ${count} expired jobs`);
+
+    await prisma.auditLog.create({
+      data: {
+        action: "community_review.cleanup",
+        category: "system",
+        targetType: "community_review_job",
+        metadata: {
+          deletedCount: count,
+          jobIds: ids,
+          breakdown: batch.reduce<Record<string, number>>((acc, b) => {
+            acc[b.status] = (acc[b.status] ?? 0) + 1;
+            return acc;
+          }, {}),
+        },
+      },
+    }).catch((err) => ERR("cleanup audit log failed (non-fatal):", err));
+
+    return { deleted: count };
+  } catch (err) {
+    ERR("cleanup failed:", err);
+    return { deleted: 0, error: err };
+  }
+}

--- a/apps/web/lib/community-review.ts
+++ b/apps/web/lib/community-review.ts
@@ -6,6 +6,7 @@ import { analyzeRepository } from "@/lib/analyzer";
 import { getRepositoryTree } from "@/lib/github";
 import { eventBus } from "@/lib/events/bus";
 import { persistCommunityReviewToPR } from "@/lib/community-pr-persist";
+import { decryptString } from "@/lib/crypto";
 
 const LOG = (jobId: string, msg: string, ...rest: unknown[]) =>
   console.log(`[community-review] [${jobId}] ${msg}`, ...rest);
@@ -51,9 +52,15 @@ export async function processCommunityReview(jobId: string): Promise<void> {
     const repo = await prisma.repository.findUnique({ where: { id: job.repositoryId } });
     if (!repo) throw new Error(`Repository ${job.repositoryId} not found`);
 
-    const githubToken = job.githubToken;
-    if (!githubToken) {
+    if (!job.githubToken) {
       throw new Error("githubToken missing on job (cannot fetch repo); job rejected");
+    }
+    let githubToken: string;
+    try {
+      githubToken = decryptString(job.githubToken);
+    } catch (err) {
+      ERR(jobId, "githubToken decrypt failed:", err);
+      throw new Error("githubToken decrypt failed");
     }
 
     const fullName = job.repoFullName;

--- a/apps/web/lib/community-review.ts
+++ b/apps/web/lib/community-review.ts
@@ -1,0 +1,267 @@
+import { prisma } from "@octopus/db";
+import { generateLocalReview } from "@/lib/review-core";
+import { indexRepository } from "@/lib/indexer";
+import { summarizeRepository } from "@/lib/summarizer";
+import { analyzeRepository } from "@/lib/analyzer";
+import { getRepositoryTree } from "@/lib/github";
+import { eventBus } from "@/lib/events/bus";
+import { persistCommunityReviewToPR } from "@/lib/community-pr-persist";
+
+const LOG = (jobId: string, msg: string, ...rest: unknown[]) =>
+  console.log(`[community-review] [${jobId}] ${msg}`, ...rest);
+const ERR = (jobId: string, msg: string, ...rest: unknown[]) =>
+  console.error(`[community-review] [${jobId}] ${msg}`, ...rest);
+
+export interface CommunityReviewJobData {
+  jobId: string;
+}
+
+export async function processCommunityReview(jobId: string): Promise<void> {
+  LOG(jobId, "starting");
+
+  const job = await prisma.communityReviewJob.findUnique({ where: { id: jobId } });
+  if (!job) {
+    ERR(jobId, "job not found, abort");
+    return;
+  }
+
+  if (job.status === "completed" || job.status === "failed") {
+    LOG(jobId, `already in terminal state (${job.status}), skipping`);
+    return;
+  }
+
+  if (job.expiresAt < new Date()) {
+    LOG(jobId, "expired before processing, marking failed");
+    await prisma.communityReviewJob.update({
+      where: { id: jobId },
+      data: { status: "failed", errorMessage: "Job expired before processing", completedAt: new Date() },
+    });
+    return;
+  }
+
+  await prisma.communityReviewJob.update({
+    where: { id: jobId },
+    data: {
+      startedAt: job.startedAt ?? new Date(),
+      attempts: { increment: 1 },
+    },
+  });
+
+  try {
+    const repo = await prisma.repository.findUnique({ where: { id: job.repositoryId } });
+    if (!repo) throw new Error(`Repository ${job.repositoryId} not found`);
+
+    const githubToken = job.githubToken;
+    if (!githubToken) {
+      throw new Error("githubToken missing on job (cannot fetch repo); job rejected");
+    }
+
+    const fullName = job.repoFullName;
+    LOG(jobId, `repo=${fullName} indexStatus=${repo.indexStatus}`);
+
+    // ── Phase 1: Indexing (with atomic claim) ─────────────────────────────
+
+    let needsIndex = repo.indexStatus !== "indexed";
+
+    if (needsIndex) {
+      // Atomic claim
+      const claim = await prisma.repository.updateMany({
+        where: { id: repo.id, indexStatus: { notIn: ["indexed", "indexing"] } },
+        data: { indexStatus: "indexing" },
+      });
+
+      if (claim.count === 0) {
+        // Either already indexed or another worker is indexing
+        const fresh = await prisma.repository.findUnique({
+          where: { id: repo.id },
+          select: { indexStatus: true },
+        });
+        const cur = fresh?.indexStatus ?? "failed";
+        LOG(jobId, `claim lost, current indexStatus=${cur}`);
+
+        if (cur === "indexing") {
+          // Yield: throw so pg-boss retries after a delay.
+          throw new Error("Repository is currently being indexed by another worker — will retry");
+        }
+        if (cur !== "indexed") {
+          // failed/stale: try to reclaim
+          const reclaim = await prisma.repository.updateMany({
+            where: { id: repo.id, indexStatus: { notIn: ["indexed", "indexing"] } },
+            data: { indexStatus: "indexing" },
+          });
+          if (reclaim.count === 0) {
+            throw new Error(`Could not reclaim indexing for ${fullName}`);
+          }
+        } else {
+          needsIndex = false;
+        }
+      }
+
+      if (needsIndex) {
+        await prisma.communityReviewJob.update({
+          where: { id: jobId },
+          data: { status: "indexing" },
+        });
+
+        LOG(jobId, "indexing repository...");
+        try {
+          const indexStats = await indexRepository(
+            repo.id,
+            fullName,
+            repo.defaultBranch,
+            0,
+            (msg, level) => LOG(jobId, `[index] ${level ?? "info"}: ${msg}`),
+            undefined,
+            "github",
+            job.organizationId,
+            githubToken,
+          );
+
+          await prisma.repository.update({
+            where: { id: repo.id },
+            data: {
+              indexStatus: "indexed",
+              indexedAt: new Date(),
+              indexedFiles: indexStats.indexedFiles,
+              totalFiles: indexStats.totalFiles,
+              totalChunks: indexStats.totalChunks,
+              totalVectors: indexStats.totalVectors,
+              indexDurationMs: indexStats.durationMs,
+              contributorCount: indexStats.contributorCount,
+              contributors: JSON.parse(JSON.stringify(indexStats.contributors)),
+              ...(indexStats.resolvedDefaultBranch
+                ? { defaultBranch: indexStats.resolvedDefaultBranch }
+                : {}),
+            },
+          });
+
+          LOG(jobId, `index done: ${indexStats.indexedFiles} files, ${indexStats.totalVectors} vectors`);
+
+          // Best-effort summarize + analyze
+          try {
+            const { summary, purpose } = await summarizeRepository(repo.id, fullName, job.organizationId);
+            await prisma.repository.update({
+              where: { id: repo.id },
+              data: { summary, purpose },
+            });
+            LOG(jobId, "summarize done");
+          } catch (err) {
+            ERR(jobId, "summarize failed (non-fatal):", err);
+          }
+
+          try {
+            const analysis = await analyzeRepository(repo.id, fullName, job.organizationId);
+            await prisma.repository.update({
+              where: { id: repo.id },
+              data: { analysis, analysisStatus: "analyzed", analyzedAt: new Date() },
+            });
+            eventBus.emit({
+              type: "repo-analyzed",
+              orgId: job.organizationId,
+              repoFullName: fullName,
+            });
+            LOG(jobId, "analyze done");
+          } catch (err) {
+            ERR(jobId, "analyze failed (non-fatal):", err);
+          }
+        } catch (err) {
+          ERR(jobId, "indexing failed:", err);
+          await prisma.repository.update({
+            where: { id: repo.id },
+            data: { indexStatus: "failed" },
+          });
+          // Continue — generateLocalReview works without index
+        }
+      }
+    }
+
+    // ── Phase 2: Review ───────────────────────────────────────────────────
+
+    await prisma.communityReviewJob.update({
+      where: { id: jobId },
+      data: { status: "reviewing" },
+    });
+
+    let fileTree: string[] | undefined;
+    try {
+      const [ownerPart, repoPart] = fullName.split("/");
+      fileTree = await getRepositoryTree(0, ownerPart, repoPart, repo.defaultBranch, githubToken);
+    } catch (err) {
+      LOG(jobId, "fileTree fetch failed (non-fatal):", err);
+    }
+
+    LOG(jobId, "generating review...");
+    const reviewResult = await generateLocalReview({
+      diff: job.diff,
+      repoId: repo.id,
+      orgId: job.organizationId,
+      title: job.prTitle ?? undefined,
+      author: job.prAuthor ?? undefined,
+      fileTree,
+      operation: "community-review",
+      prNumber: job.prNumber ?? undefined,
+    });
+
+    let firstCommunityReview = false;
+    const existingPRCount = await prisma.pullRequest.count({
+      where: { repositoryId: repo.id },
+    });
+    firstCommunityReview = existingPRCount === 0;
+
+    if (job.prNumber != null) {
+      try {
+        await persistCommunityReviewToPR({
+          repositoryId: repo.id,
+          fullName,
+          prNumber: job.prNumber,
+          prTitle: job.prTitle,
+          prAuthor: job.prAuthor,
+          headSha: job.headSha,
+          summary: reviewResult.summary,
+          findings: reviewResult.findings,
+        });
+      } catch (persistErr) {
+        ERR(jobId, "persist community PR failed (non-fatal):", persistErr);
+      }
+    }
+
+    eventBus.emit({
+      type: "community-review",
+      orgId: job.organizationId,
+      repoFullName: fullName,
+      prNumber: job.prNumber ?? undefined,
+      findingsCount: reviewResult.findings.length,
+    });
+
+    await prisma.communityReviewJob.update({
+      where: { id: jobId },
+      data: {
+        status: "completed",
+        findings: JSON.parse(JSON.stringify(reviewResult.findings)),
+        summary: reviewResult.summary,
+        model: reviewResult.model,
+        indexed: needsIndex,
+        firstCommunityReview,
+        usage: reviewResult.usage ? JSON.parse(JSON.stringify(reviewResult.usage)) : undefined,
+        completedAt: new Date(),
+        // Clear short-lived secret once we no longer need it
+        githubToken: null,
+      },
+    });
+
+    LOG(jobId, `completed: ${reviewResult.findings.length} findings`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ERR(jobId, "fatal:", err);
+    await prisma.communityReviewJob.update({
+      where: { id: jobId },
+      data: {
+        status: "failed",
+        errorMessage: message.slice(0, 1000),
+        completedAt: new Date(),
+        githubToken: null,
+      },
+    });
+    throw err;
+  }
+}

--- a/apps/web/lib/queue-workers.ts
+++ b/apps/web/lib/queue-workers.ts
@@ -5,6 +5,7 @@ import {
   handleLargeReviewResult,
   type LargeReviewResultJob,
 } from "./large-review-result";
+import { processCommunityReview, type CommunityReviewJobData } from "./community-review";
 import type { QueueConfig } from "./queue";
 
 export interface WelcomeEmailJob {
@@ -58,5 +59,21 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     },
   );
 
-  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result");
+  await boss.work<CommunityReviewJobData>(
+    "community-review",
+    { localConcurrency: config.reviewConcurrency },
+    async (jobs) => {
+      for (const job of jobs) {
+        console.log(`[queue] Processing community-review jobId=${job.data.jobId}`);
+        try {
+          await processCommunityReview(job.data.jobId);
+        } catch (err) {
+          console.error(`[queue] community-review failed for jobId=${job.data.jobId} (job ${job.id}):`, err);
+          throw err;
+        }
+      }
+    },
+  );
+
+  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review");
 }

--- a/apps/web/lib/queue.ts
+++ b/apps/web/lib/queue.ts
@@ -89,6 +89,16 @@ export async function startQueue(): Promise<PgBoss> {
     expireInSeconds: 300,
   }).catch(() => {});
 
+  // Community-tier (no API key) async review pipeline.
+  // Indexing can take minutes for first-touch repos, so the action enqueues
+  // and polls; the worker indexes + reviews and writes the result back to
+  // the CommunityReviewJob row. Retry once on transient failure.
+  await boss.createQueue("community-review", {
+    retryLimit: 2,
+    retryDelay: 30,
+    expireInSeconds: 1800, // 30 min hard cap per attempt
+  }).catch(() => {});
+
   // Only review-engine containers should register workers. Web containers
   // still need pg-boss started so they can enqueue jobs, but must not consume.
   // The flag must be set explicitly: a missing value is a misconfiguration,

--- a/apps/web/lib/review-core.ts
+++ b/apps/web/lib/review-core.ts
@@ -44,6 +44,10 @@ export type LocalReviewParams = {
   fileTree?: string[];
   /** Optional .octopusignore content to apply before reviewing */
   octopusIgnoreContent?: string;
+  /** Operation tag for ai_usages (default "local-review"). Community github-action passes "community-review" so daily limits and reporting can target it. */
+  operation?: "local-review" | "community-review";
+  /** PR number for the SYSTEM_PROMPT.md {{PR_NUMBER}} template. Defaults to 0 (used by CLI / non-PR flows). */
+  prNumber?: number;
 };
 
 export type LocalReviewResult = {
@@ -324,7 +328,7 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
     .replace("{{CODEBASE_CONTEXT}}", codebaseContext)
     .replace("{{FILE_TREE}}", fileTreeStr)
     .replace("{{KNOWLEDGE_CONTEXT}}", knowledgeContext)
-    .replace("{{PR_NUMBER}}", "0")
+    .replace("{{PR_NUMBER}}", String(params.prNumber ?? 0))
     .replace("{{USER_INSTRUCTION}}", "")
     .replace("{{PROVIDER}}", "local")
     .replace("{{FALSE_POSITIVE_CONTEXT}}", falsePositiveContext)
@@ -352,7 +356,7 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
   await logAiUsage({
     provider: response.provider,
     model: reviewModel,
-    operation: "local-review",
+    operation: params.operation ?? "local-review",
     inputTokens: response.usage.inputTokens,
     outputTokens: response.usage.outputTokens,
     cacheReadTokens: response.usage.cacheReadTokens,

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1225,7 +1225,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
     });
 
     const userInstruction = extractUserInstruction(
-      pr.triggerCommentBody,
+      pr.triggerCommentBody ?? "",
     );
 
     // Fetch past feedback (disliked = false positive, liked = valuable) for this repo

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -102,7 +102,7 @@ model Organization {
   googleApiKey         String?
   defaultModelId       String?
   defaultEmbedModelId  String?
-  monthlySpendLimitUsd    Float?   @default(150)
+  monthlySpendLimitUsd    Float?
   checkFailureThreshold   String   @default("critical") // "critical" | "high" | "medium" | "none"
   reviewsPaused           Boolean  @default(false)
   blockedAuthors          Json     @default("[]") // string[] of PR author usernames to skip review
@@ -267,8 +267,9 @@ model PullRequest {
   url                String
   author             String
   status             String    @default("pending") // pending | reviewing | completed | failed
-  triggerCommentId   BigInt
-  triggerCommentBody String
+  // Nullable: community PRs (github-action endpoint) aren't triggered by a comment.
+  triggerCommentId   BigInt?
+  triggerCommentBody String?
   headSha            String?
   reviewCommentId    BigInt?
   reviewBody         String?
@@ -714,6 +715,7 @@ model SystemConfig {
   defaultReviewConfig Json @default("{}")
   blockedAuthors      Json @default("[]") // string[] of globally blocked PR author usernames
   queueConfig         Json @default("{}") // { reviewTimeoutSeconds, reviewConcurrency }
+  announcements       Json @default("[]") // landing-page announcement bar entries (see lib/announcements types)
   updatedAt DateTime @updatedAt
 
   @@map("system_config")
@@ -1138,4 +1140,54 @@ model CouponRedemption {
   @@unique([couponId, redeemedById])
   @@index([organizationId])
   @@map("coupon_redemptions")
+}
+
+// ── Community Review Job ─────────────────────────────────────────────────────
+// Async job for the public github-action endpoint when a repo isn't indexed
+// yet. Endpoint queues a job, action polls /api/github-action/review/:id.
+// Lifecycle is bounded by expiresAt (default 25h after creation).
+
+model CommunityReviewJob {
+  id                   String   @id @default(uuid())
+  status               String   // "indexing" | "reviewing" | "completed" | "failed"
+
+  // Auth: poll endpoint requires (jobId, repoFullName) tuple to match.
+  repoFullName         String
+  repositoryId         String
+  organizationId       String
+
+  // Request payload (so the worker can replay the review without the action retransmitting)
+  prNumber             Int?
+  prTitle              String?
+  prAuthor             String?
+  headSha              String?
+  baseBranch           String?
+  diff                 String   @db.Text
+  fileTree             Json?
+
+  // GitHub token captured at request time. Short-lived (1h GitHub Actions token);
+  // worker uses it for indexing fetch. Cleared once worker completes.
+  githubToken          String?
+
+  // Output (populated when status = "completed")
+  findings             Json?
+  summary              String?  @db.Text
+  model                String?
+  indexed              Boolean  @default(false)
+  firstCommunityReview Boolean  @default(false)
+  usage                Json?
+
+  errorMessage         String?
+  attempts             Int      @default(0)
+
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+  startedAt            DateTime?
+  completedAt          DateTime?
+  expiresAt            DateTime
+
+  @@index([repositoryId, status])
+  @@index([status, createdAt])
+  @@index([expiresAt])
+  @@map("community_review_jobs")
 }


### PR DESCRIPTION
## Summary

Two related changes bundled because they share a single Prisma migration on \`schema.prisma\`.

### Async community review pipeline

Public \`/api/github-action/review\` can take minutes to index a first-touch repo, exceeding Cloudflare's 100s timeout. Community-tier (no API key) requests now enqueue and the action polls:

- Action POSTs and gets \`{status: \"queued\", jobId}\`.
- Action polls \`GET /api/github-action/review/:jobId?repo=owner/name\`.
- Worker indexes + reviews + writes results back to the new \`CommunityReviewJob\` row.
- New \`community-review\` pg-boss queue (retryLimit 2, expireInSeconds 1800).
- Boot-time recovery for orphaned jobs (server restart, worker death) + periodic TTL cleanup.
- \`persistCommunityReviewToPR\` so completed community reviews appear in the admin panel.
- \`PullRequest.triggerCommentId\`/\`triggerCommentBody\` now nullable.
- \`ai_usage\` gains a \`community-review\` operation tag (counted as a review on \`/usage\`).
- De-dupe: same \`(repoId, prNumber, headSha)\` already in flight returns the existing jobId.

### Configurable announcement bar

- New \`SystemConfig.announcements\` JSON column.
- New \`<LandingAnnouncementBar />\` with multi-icon / multi-tone support.
- Replaces the hard-coded \"Free for OSS\" announcement on the landing page.

Closes #351

## Test plan

- [ ] DB migration applies cleanly (\`bun run db:migrate\`).
- [ ] Hit \`/api/github-action/review\` for a community repo not yet indexed → \`{status: \"queued\", jobId}\`.
- [ ] Poll \`/api/github-action/review/:jobId?repo=owner/name\` until \`status: \"completed\"\` and verify findings.
- [ ] Repeat the same call before completion → returns same jobId (de-dupe).
- [ ] Authenticated org call (with \`octopus-api-key\`) still uses sync flow and returns \`status: \"completed\"\`.
- [ ] Restart server during an in-flight job → \`recoverCommunityReviewJobs\` re-enqueues it.
- [ ] Job past \`expiresAt\` returns 410 from poll endpoint.
- [ ] Completed community review shows up as a PullRequest row in the admin panel.
- [ ] \`/usage\` reviews unit counts \`community-review\` operations.
- [ ] Landing page renders the configured announcement bar; if \`announcements\` is empty/missing, no bar renders and layout is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)