### PR TITLE
feat: add GitLab integration (OAuth, webhook, MR review)

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -181,6 +181,11 @@ export default async function DashboardPage({
     select: { workspaceName: true },
   });
   const bitbucketConnected = !!bitbucketIntegration;
+  const gitlabIntegration = await prisma.gitlabIntegration.findUnique({
+    where: { organizationId: org.id },
+    select: { namespaceName: true },
+  });
+  const gitlabConnected = !!gitlabIntegration;
   const bannerDismissed = cookieStore.get("providers_banner_dismissed")?.value === "1";
 
   const hasIndexedRepo = repos.some((r) => r.indexStatus === "indexed");
@@ -489,10 +494,11 @@ export default async function DashboardPage({
         Overview of your repositories and integrations.
       </p>
 
-      {(!githubConnected || !bitbucketConnected) && !bannerDismissed && (
+      {(!githubConnected || !bitbucketConnected || !gitlabConnected) && !bannerDismissed && (
         <ProvidersBanner
           githubConnected={githubConnected}
           bitbucketConnected={bitbucketConnected}
+          gitlabConnected={gitlabConnected}
           githubAppSlug={githubAppSlug}
         />
       )}

--- a/apps/web/app/(app)/repositories/repositories-content.tsx
+++ b/apps/web/app/(app)/repositories/repositories-content.tsx
@@ -48,6 +48,7 @@ import {
   IconChevronLeft,
   IconChevronRight,
   IconBrandBitbucket,
+  IconBrandGitlab,
   IconFilter,
   IconSettings,
   IconPackage,
@@ -135,6 +136,14 @@ const providerConfig: Record<
   github: {
     icon: IconBrandGithub,
     repoUrl: (fullName) => `https://github.com/${fullName}`,
+  },
+  bitbucket: {
+    icon: IconBrandBitbucket,
+    repoUrl: (fullName) => `https://bitbucket.org/${fullName}`,
+  },
+  gitlab: {
+    icon: IconBrandGitlab,
+    repoUrl: (fullName) => `https://gitlab.com/${fullName}`,
   },
 };
 
@@ -715,7 +724,7 @@ function AnalysisSection({
             )}
           </div>
           <div className="flex items-center gap-2">
-            {repo.provider !== "bitbucket" && (
+            {repo.provider === "github" && (
               <Link href={`/package-analyzer?repo=${encodeURIComponent(`https://github.com/${repo.fullName}`)}&repoId=${repo.id}`}>
                 <Button size="sm" variant="outline" className="h-7 text-xs">
                   <IconPackage className="mr-1 size-3" />

--- a/apps/web/app/(app)/settings/integrations/actions.ts
+++ b/apps/web/app/(app)/settings/integrations/actions.ts
@@ -116,6 +116,139 @@ export async function toggleSlackEvent(
   return {};
 }
 
+// ── GitLab Actions ──
+
+function normalizeGitlabHost(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  let host = raw.trim();
+  if (!host) return null;
+  if (!/^https?:\/\//i.test(host)) host = `https://${host}`;
+  host = host.replace(/\/+$/, "");
+  try {
+    const url = new URL(host);
+    if (url.pathname !== "/" && url.pathname !== "") return null;
+    if (url.search || url.hash) return null;
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return null;
+  }
+}
+
+const GITLAB_OAUTH_INIT_COOKIE = "gitlab_oauth_init";
+
+export async function startGitlabOAuth(formData: FormData): Promise<void> {
+  const ctx = await getAdminOrg();
+  if (!ctx) {
+    redirect("/settings/integrations?error=forbidden");
+  }
+
+  const namespacePath = String(formData.get("namespace") ?? "").trim();
+  const hostInput = String(formData.get("host") ?? "");
+  const customClientId = String(formData.get("clientId") ?? "").trim();
+  const customClientSecret = String(formData.get("clientSecret") ?? "");
+
+  if (!namespacePath) {
+    redirect("/settings/integrations?error=missing_namespace");
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9_./-]*$/.test(namespacePath) || namespacePath.length > 200) {
+    redirect("/settings/integrations?error=invalid_namespace");
+  }
+
+  const gitlabHost = normalizeGitlabHost(hostInput) ?? "https://gitlab.com";
+  const isCloud = gitlabHost === "https://gitlab.com";
+
+  // Pick OAuth credentials: per-org for self-hosted, env defaults for gitlab.com
+  let clientId: string;
+  let clientSecretToStore: string | null = null;
+
+  if (!isCloud || customClientId) {
+    if (!customClientId || !customClientSecret) {
+      redirect("/settings/integrations?error=missing_oauth_creds");
+    }
+    clientId = customClientId;
+    clientSecretToStore = customClientSecret;
+  } else {
+    const envClientId = process.env.GITLAB_CLIENT_ID;
+    if (!envClientId) {
+      redirect("/settings/integrations?error=not_configured");
+    }
+    clientId = envClientId;
+  }
+
+  const redirectUri = process.env.GITLAB_REDIRECT_URI;
+  if (!redirectUri) {
+    redirect("/settings/integrations?error=not_configured");
+  }
+
+  // Encrypted, short-lived cookie carries the secret + nonce + context.
+  // Never put the secret in the OAuth state URL.
+  const { encryptJson } = await import("@/lib/crypto");
+  const cryptoNode = await import("node:crypto");
+  const nonce = cryptoNode.randomBytes(16).toString("hex");
+
+  const cookiePayload = encryptJson({
+    nonce,
+    orgId: ctx.orgId,
+    namespacePath,
+    gitlabHost,
+    clientId,
+    clientSecret: clientSecretToStore,
+    issuedAt: Date.now(),
+  });
+
+  const cookieStore = await cookies();
+  cookieStore.set(GITLAB_OAUTH_INIT_COOKIE, cookiePayload, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: 10 * 60,
+  });
+
+  // State carries only the nonce — callback re-derives everything else from the cookie.
+  const state = Buffer.from(JSON.stringify({ nonce })).toString("base64url");
+  const params = new URLSearchParams({
+    client_id: clientId,
+    response_type: "code",
+    redirect_uri: redirectUri,
+    state,
+    scope: "api read_api read_user read_repository write_repository",
+  });
+
+  redirect(`${gitlabHost}/oauth/authorize?${params.toString()}`);
+}
+
+export async function disconnectGitlab(): Promise<{ error?: string }> {
+  const ctx = await getAdminOrg();
+  if (!ctx) return { error: "Insufficient permissions." };
+
+  const integration = await prisma.gitlabIntegration.findUnique({
+    where: { organizationId: ctx.orgId },
+    select: { id: true },
+  });
+
+  if (!integration) return { error: "No GitLab integration found." };
+
+  // We don't track per-project hook IDs, so webhooks are left as-is on
+  // GitLab and will simply 401 against the rotated secret. That's safe and
+  // matches the "minimal" Bitbucket-style disconnect flow.
+
+  await prisma.gitlabIntegration.delete({
+    where: { id: integration.id },
+  });
+
+  await prisma.repository.updateMany({
+    where: {
+      organizationId: ctx.orgId,
+      provider: "gitlab",
+    },
+    data: { isActive: false },
+  });
+
+  revalidatePath("/settings/integrations");
+  return {};
+}
+
 // ── Bitbucket Actions ──
 
 export async function disconnectBitbucket(): Promise<{ error?: string }> {

--- a/apps/web/app/(app)/settings/integrations/bitbucket-debug-banner.tsx
+++ b/apps/web/app/(app)/settings/integrations/bitbucket-debug-banner.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-export function BitbucketDebugBanner({ debugJson }: { debugJson: string }) {
+export function BitbucketDebugBanner({
+  debugJson,
+  title = "Bitbucket Connect Debug",
+}: { debugJson: string; title?: string }) {
   let steps: string[] = [];
   try {
     steps = JSON.parse(decodeURIComponent(debugJson));
@@ -11,7 +14,7 @@ export function BitbucketDebugBanner({ debugJson }: { debugJson: string }) {
   return (
     <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm font-mono dark:border-blue-800 dark:bg-blue-950">
       <p className="mb-2 font-semibold text-blue-800 dark:text-blue-200">
-        Bitbucket Connect Debug
+        {title}
       </p>
       <ul className="space-y-1 text-blue-700 dark:text-blue-300">
         {steps.map((step, i) => (

--- a/apps/web/app/(app)/settings/integrations/gitlab-integration-card.tsx
+++ b/apps/web/app/(app)/settings/integrations/gitlab-integration-card.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { IconBrandGitlab, IconArrowRight } from "@tabler/icons-react";
+import { disconnectGitlab, startGitlabOAuth } from "./actions";
+
+type GitlabData = {
+  namespaceName: string;
+  namespacePath: string;
+  gitlabHost: string;
+} | null;
+
+const DEFAULT_HOST = "https://gitlab.com";
+
+export function GitlabIntegrationCard({ data }: { data: GitlabData }) {
+  const [isPending, startTransition] = useTransition();
+  const [host, setHost] = useState(DEFAULT_HOST);
+
+  const isSelfHosted =
+    host.trim() !== "" && host.replace(/\/+$/, "") !== DEFAULT_HOST;
+
+  if (!data) {
+    return (
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center">
+              <IconBrandGitlab className="size-6 text-[#FC6D26]" />
+            </div>
+            <div>
+              <CardTitle className="text-base">GitLab</CardTitle>
+              <CardDescription>
+                Connect your GitLab group or self-hosted instance for code reviews.
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="border-t pt-4">
+            <p className="text-sm font-medium mb-3">How it works</p>
+            <ol className="text-sm text-muted-foreground space-y-1.5 list-decimal list-inside mb-5">
+              <li>Enter your GitLab host and group/user namespace</li>
+              <li>Self-hosted instances: register an OAuth application on your GitLab and paste its credentials below</li>
+              <li>Authorize Octopus on GitLab — projects sync automatically</li>
+            </ol>
+
+            <form action={startGitlabOAuth} className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="gl-host">GitLab host</Label>
+                <Input
+                  id="gl-host"
+                  name="host"
+                  placeholder={DEFAULT_HOST}
+                  value={host}
+                  onChange={(e) => setHost(e.target.value)}
+                  onBlur={(e) => setHost(e.target.value.trim() || DEFAULT_HOST)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="gl-namespace">Namespace (group, subgroup or username)</Label>
+                <Input
+                  id="gl-namespace"
+                  name="namespace"
+                  placeholder="my-group or my-group/team"
+                  required
+                />
+              </div>
+
+              {isSelfHosted && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950">
+                  <p className="text-amber-800 dark:text-amber-200 text-xs font-medium mb-2">
+                    Self-hosted instance — paste your GitLab OAuth application credentials
+                  </p>
+                  <p className="text-amber-700 dark:text-amber-300 text-xs mb-3">
+                    Create one at <span className="font-mono">{host.replace(/\/+$/, "")}/admin/applications</span>{" "}
+                    (or User Settings → Applications). Redirect URI must match this app&apos;s callback URL.
+                  </p>
+                  <div className="space-y-2">
+                    <Input
+                      name="clientId"
+                      placeholder="Application ID (Client ID)"
+                      autoComplete="off"
+                      required
+                    />
+                    <Input
+                      name="clientSecret"
+                      type="password"
+                      placeholder="Secret (Client Secret)"
+                      autoComplete="off"
+                      required
+                    />
+                  </div>
+                </div>
+              )}
+
+              <Button className="w-full" size="lg" type="submit">
+                <IconBrandGitlab className="mr-2 size-4" />
+                Connect GitLab
+                <IconArrowRight className="ml-2 size-4" />
+              </Button>
+
+              <p className="text-muted-foreground text-center text-xs">
+                Secure access only - we never store your code.
+              </p>
+            </form>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center">
+              <IconBrandGitlab className="size-6 text-[#FC6D26]" />
+            </div>
+            <div>
+              <CardTitle className="text-base">GitLab</CardTitle>
+              <CardDescription>
+                Connected to <span className="font-medium">{data.namespaceName}</span>
+                {" "}
+                <span className="text-muted-foreground">({data.namespacePath})</span>
+                {data.gitlabHost !== DEFAULT_HOST ? (
+                  <span className="text-muted-foreground"> at {data.gitlabHost}</span>
+                ) : null}
+              </CardDescription>
+            </div>
+          </div>
+          <Badge variant="secondary" className="text-green-700 bg-green-100">
+            Connected
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="border-t pt-4">
+          <Button
+            variant="destructive"
+            size="sm"
+            disabled={isPending}
+            onClick={() => {
+              startTransition(() => {
+                disconnectGitlab();
+              });
+            }}
+          >
+            Disconnect GitLab
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/(app)/settings/integrations/page.tsx
+++ b/apps/web/app/(app)/settings/integrations/page.tsx
@@ -6,6 +6,7 @@ import { GitHubIntegrationCard } from "./github-integration-card";
 import { SlackIntegrationCard } from "./slack-integration-card";
 import { BitbucketIntegrationCard } from "./bitbucket-integration-card";
 import { BitbucketDebugBanner } from "./bitbucket-debug-banner";
+import { GitlabIntegrationCard } from "./gitlab-integration-card";
 import { LinearIntegrationCard } from "./linear-integration-card";
 import { JiraIntegrationCard } from "./jira-integration-card";
 
@@ -29,6 +30,7 @@ export default async function IntegrationsPage({
 }) {
   const params = await searchParams;
   const bbDebug = typeof params.bb_debug === "string" ? params.bb_debug : null;
+  const glDebug = typeof params.gl_debug === "string" ? params.gl_debug : null;
   const rawError = typeof params.error === "string" ? params.error : null;
   const githubError: GitHubErrorCode | null =
     rawError && (ALLOWED_GITHUB_ERRORS as readonly string[]).includes(rawError)
@@ -58,6 +60,7 @@ export default async function IntegrationsPage({
   const [
     slackIntegration,
     bitbucketIntegration,
+    gitlabIntegration,
     githubData,
     ,
     linearIntegration,
@@ -79,6 +82,14 @@ export default async function IntegrationsPage({
       select: {
         workspaceName: true,
         workspaceSlug: true,
+      },
+    }),
+    prisma.gitlabIntegration.findUnique({
+      where: { organizationId: orgId },
+      select: {
+        namespaceName: true,
+        namespacePath: true,
+        gitlabHost: true,
       },
     }),
     prisma.organization
@@ -114,12 +125,14 @@ export default async function IntegrationsPage({
   return (
     <div className="space-y-6">
       {bbDebug && <BitbucketDebugBanner debugJson={bbDebug} />}
+      {glDebug && <BitbucketDebugBanner debugJson={glDebug} title="GitLab Connect Debug" />}
       <GitHubIntegrationCard
         data={githubData}
         appSlug={appSlug}
         error={githubError}
       />
       <BitbucketIntegrationCard data={bitbucketIntegration} />
+      <GitlabIntegrationCard data={gitlabIntegration} />
       <SlackIntegrationCard data={slackIntegration} />
       <LinearIntegrationCard data={linearIntegration} />
       <JiraIntegrationCard data={jiraIntegration} />

--- a/apps/web/app/api/gitlab/callback/route.ts
+++ b/apps/web/app/api/gitlab/callback/route.ts
@@ -1,0 +1,273 @@
+import crypto from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { headers, cookies } from "next/headers";
+import { prisma } from "@octopus/db";
+import { auth } from "@/lib/auth";
+import { listNamespaceProjects, createProjectWebhook } from "@/lib/gitlab";
+import { decryptJson, encryptString } from "@/lib/crypto";
+
+const GITLAB_OAUTH_INIT_COOKIE = "gitlab_oauth_init";
+const COOKIE_MAX_AGE_MS = 10 * 60 * 1000;
+
+type InitPayload = {
+  nonce: string;
+  orgId: string;
+  namespacePath: string;
+  gitlabHost: string;
+  clientId: string;
+  clientSecret: string | null;
+  issuedAt: number;
+};
+
+export async function GET(request: NextRequest) {
+  const baseUrl = process.env.BETTER_AUTH_URL || request.url;
+  const code = request.nextUrl.searchParams.get("code");
+  const stateParam = request.nextUrl.searchParams.get("state");
+  const error = request.nextUrl.searchParams.get("error");
+
+  const cookieStore = await cookies();
+  const initCookieValue = cookieStore.get(GITLAB_OAUTH_INIT_COOKIE)?.value;
+  // Always clear the init cookie — single-use even on error
+  cookieStore.delete(GITLAB_OAUTH_INIT_COOKIE);
+
+  if (error) {
+    console.error("[gitlab-callback] OAuth error:", error);
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=gitlab_denied", baseUrl),
+    );
+  }
+
+  if (!code || !stateParam || !initCookieValue) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=missing_params", baseUrl),
+    );
+  }
+
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=unauthorized", baseUrl),
+    );
+  }
+
+  let stateNonce: string;
+  try {
+    const parsed = JSON.parse(Buffer.from(stateParam, "base64url").toString("utf-8"));
+    stateNonce = parsed.nonce;
+    if (!stateNonce) throw new Error("Missing nonce");
+  } catch {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=invalid_state", baseUrl),
+    );
+  }
+
+  let init: InitPayload;
+  try {
+    init = decryptJson<InitPayload>(initCookieValue);
+  } catch {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=invalid_init", baseUrl),
+    );
+  }
+
+  if (init.nonce !== stateNonce) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=state_mismatch", baseUrl),
+    );
+  }
+  if (Date.now() - init.issuedAt > COOKIE_MAX_AGE_MS) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=init_expired", baseUrl),
+    );
+  }
+
+  const { orgId, namespacePath, gitlabHost, clientId, clientSecret } = init;
+
+  const member = await prisma.organizationMember.findFirst({
+    where: { userId: session.user.id, organizationId: orgId, deletedAt: null },
+    select: { role: true },
+  });
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=forbidden", baseUrl),
+    );
+  }
+
+  // Resolve the secret used for the token exchange: prefer per-org from cookie,
+  // else env default (gitlab.com cloud).
+  const effectiveClientSecret = clientSecret ?? process.env.GITLAB_CLIENT_SECRET;
+  const redirectUri = process.env.GITLAB_REDIRECT_URI;
+  if (!effectiveClientSecret || !redirectUri) {
+    console.error("[gitlab-callback] Missing GitLab OAuth secret or redirect URI");
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=not_configured", baseUrl),
+    );
+  }
+
+  const tokenResponse = await fetch(`${gitlabHost}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: effectiveClientSecret,
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  const tokenData = await tokenResponse.json();
+  if (!tokenResponse.ok || tokenData.error) {
+    console.error("[gitlab-callback] Token exchange failed:", tokenData);
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=token_exchange", baseUrl),
+    );
+  }
+
+  const accessToken = tokenData.access_token as string | undefined;
+  const refreshToken = tokenData.refresh_token as string | undefined;
+  if (!accessToken || !refreshToken) {
+    console.error("[gitlab-callback] Missing tokens in response");
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=token_exchange", baseUrl),
+    );
+  }
+
+  const expiresIn = (tokenData.expires_in as number) ?? 7200;
+  const scopes = (tokenData.scope as string) ?? null;
+  const tokenExpiresAt = new Date(Date.now() + expiresIn * 1000);
+
+  // Verify the namespace exists
+  const apiBase = `${gitlabHost.replace(/\/+$/, "")}/api/v4`;
+  let namespaceName = namespacePath;
+  const groupRes = await fetch(
+    `${apiBase}/groups/${encodeURIComponent(namespacePath)}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  if (groupRes.ok) {
+    const data = await groupRes.json();
+    namespaceName = (data.name as string) || namespacePath;
+  } else if (groupRes.status === 404) {
+    const userRes = await fetch(
+      `${apiBase}/users?username=${encodeURIComponent(namespacePath)}`,
+      { headers: { Authorization: `Bearer ${accessToken}` } },
+    );
+    if (userRes.ok) {
+      const arr = (await userRes.json()) as Array<{ name?: string }>;
+      namespaceName = arr[0]?.name ?? namespacePath;
+    } else {
+      console.error("[gitlab-callback] Namespace not found:", namespacePath);
+      return NextResponse.redirect(
+        new URL("/settings/integrations?error=namespace_not_found", baseUrl),
+      );
+    }
+  } else {
+    const body = await groupRes.text().catch(() => "");
+    console.error("[gitlab-callback] Namespace lookup failed:", groupRes.status, body);
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=namespace_not_found", baseUrl),
+    );
+  }
+
+  const webhookSecret = crypto.randomBytes(32).toString("hex");
+  const debugLog: string[] = [];
+  debugLog.push(`host: ${gitlabHost}`);
+  debugLog.push(`namespace: ${namespacePath} (${namespaceName})`);
+  if (clientSecret) debugLog.push("oauth: per-org credentials");
+
+  // Persist OAuth creds (encrypted) only for self-hosted (non-env) flow,
+  // so refresh can use them later.
+  const persistOauthClientId = clientSecret ? clientId : null;
+  const persistOauthClientSecretEnc = clientSecret ? encryptString(clientSecret) : null;
+
+  await prisma.gitlabIntegration.upsert({
+    where: { organizationId: orgId },
+    create: {
+      gitlabHost,
+      namespacePath,
+      namespaceName,
+      oauthClientId: persistOauthClientId,
+      oauthClientSecretEnc: persistOauthClientSecretEnc,
+      accessToken,
+      refreshToken,
+      tokenExpiresAt,
+      scopes,
+      webhookSecret,
+      organizationId: orgId,
+    },
+    update: {
+      gitlabHost,
+      namespacePath,
+      namespaceName,
+      oauthClientId: persistOauthClientId,
+      oauthClientSecretEnc: persistOauthClientSecretEnc,
+      accessToken,
+      refreshToken,
+      tokenExpiresAt,
+      scopes,
+      webhookSecret,
+    },
+  });
+  debugLog.push("integration upserted OK");
+
+  const appUrl = process.env.BETTER_AUTH_URL || "http://localhost:3000";
+  const callbackUrl = `${appUrl}/api/gitlab/webhook`;
+  debugLog.push(`webhook target: ${callbackUrl}`);
+
+  let projectCount = 0;
+  let hookCount = 0;
+  try {
+    const projects = await listNamespaceProjects(orgId, namespacePath);
+    projectCount = projects.length;
+    for (const project of projects) {
+      await prisma.repository.upsert({
+        where: {
+          provider_externalId_organizationId: {
+            provider: "gitlab",
+            externalId: String(project.id),
+            organizationId: orgId,
+          },
+        },
+        create: {
+          name: project.name,
+          fullName: project.path_with_namespace,
+          externalId: String(project.id),
+          defaultBranch: project.default_branch ?? "main",
+          provider: "gitlab",
+          isActive: true,
+          organizationId: orgId,
+        },
+        update: {
+          name: project.name,
+          fullName: project.path_with_namespace,
+          defaultBranch: project.default_branch ?? "main",
+          isActive: true,
+        },
+      });
+
+      try {
+        const hookId = await createProjectWebhook(
+          orgId,
+          project.path_with_namespace,
+          callbackUrl,
+          webhookSecret,
+        );
+        if (hookId) hookCount += 1;
+      } catch (err) {
+        console.warn(`[gitlab-callback] Hook creation failed for ${project.path_with_namespace}:`, err);
+      }
+    }
+    debugLog.push(`projects synced: ${projectCount}`);
+    debugLog.push(`hooks created: ${hookCount}`);
+    console.log(`[gitlab-callback] Synced ${projectCount} projects, ${hookCount} hooks for ${namespacePath}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    debugLog.push(`project sync FAILED: ${msg}`);
+    console.error("[gitlab-callback] Project sync failed:", err);
+  }
+
+  const debugParam = encodeURIComponent(JSON.stringify(debugLog));
+  return NextResponse.redirect(
+    new URL(`/settings/integrations?success=gitlab&gl_debug=${debugParam}`, baseUrl),
+  );
+}

--- a/apps/web/app/api/gitlab/callback/route.ts
+++ b/apps/web/app/api/gitlab/callback/route.ts
@@ -139,7 +139,7 @@ export async function GET(request: NextRequest) {
 
   // Verify the namespace exists
   const apiBase = `${gitlabHost.replace(/\/+$/, "")}/api/v4`;
-  let namespaceName = namespacePath;
+  let namespaceName: string;
   const groupRes = await fetch(
     `${apiBase}/groups/${encodeURIComponent(namespacePath)}`,
     { headers: { Authorization: `Bearer ${accessToken}` } },

--- a/apps/web/app/api/gitlab/webhook/route.ts
+++ b/apps/web/app/api/gitlab/webhook/route.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@octopus/db";
 import { getPullRequestDetails } from "@/lib/gitlab";
@@ -47,7 +48,9 @@ export async function POST(request: NextRequest) {
   }
 
   // GitLab uses a shared-secret token, not an HMAC signature.
-  if (tokenHeader !== integration.webhookSecret) {
+  const expected = Buffer.from(integration.webhookSecret, "utf8");
+  const actual = Buffer.from(tokenHeader ?? "", "utf8");
+  if (expected.length !== actual.length || !crypto.timingSafeEqual(expected, actual)) {
     return NextResponse.json({ error: "Invalid token" }, { status: 401 });
   }
 

--- a/apps/web/app/api/gitlab/webhook/route.ts
+++ b/apps/web/app/api/gitlab/webhook/route.ts
@@ -1,0 +1,188 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@octopus/db";
+import { getPullRequestDetails } from "@/lib/gitlab";
+import { startReviewFlow } from "@/lib/webhook-shared";
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+  const event = request.headers.get("x-gitlab-event");
+  const tokenHeader = request.headers.get("x-gitlab-token");
+
+  if (!event) {
+    return NextResponse.json({ error: "Missing event header" }, { status: 400 });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+  }
+
+  const project = payload.project as Record<string, unknown> | undefined;
+  const projectId = project?.id;
+  if (typeof projectId !== "number") {
+    return NextResponse.json({ error: "Missing project id" }, { status: 400 });
+  }
+
+  // Look up repository by external id, then the integration via its org
+  const repo = await prisma.repository.findFirst({
+    where: { provider: "gitlab", externalId: String(projectId) },
+    select: { id: true, organizationId: true, autoReview: true, fullName: true },
+  });
+
+  if (!repo) {
+    console.warn(`[gitlab-webhook] No repo found for project ${projectId}`);
+    return NextResponse.json({ ok: true });
+  }
+
+  const integration = await prisma.gitlabIntegration.findUnique({
+    where: { organizationId: repo.organizationId },
+    select: { webhookSecret: true },
+  });
+
+  if (!integration?.webhookSecret) {
+    console.error(`[gitlab-webhook] No webhook secret for org ${repo.organizationId}`);
+    return NextResponse.json({ error: "Webhook secret not configured" }, { status: 500 });
+  }
+
+  // GitLab uses a shared-secret token, not an HMAC signature.
+  if (tokenHeader !== integration.webhookSecret) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
+
+  const orgId = repo.organizationId;
+  const repoFullName = repo.fullName;
+
+  // ── Merge Request open/update → auto-review ──
+  if (event === "Merge Request Hook") {
+    const objectAttrs = payload.object_attributes as Record<string, unknown> | undefined;
+    const action = objectAttrs?.action as string | undefined;
+    const state = objectAttrs?.state as string | undefined;
+
+    // Trigger on open, reopen, or push updates
+    if (!objectAttrs || (action !== "open" && action !== "reopen" && action !== "update")) {
+      return NextResponse.json({ ok: true });
+    }
+
+    // For "update" events, only re-review when the source branch was pushed (new commits).
+    // GitLab signals this via oldrev being present in object_attributes.
+    if (action === "update" && !objectAttrs.oldrev) {
+      return NextResponse.json({ ok: true });
+    }
+
+    if (state === "merged" || state === "closed") {
+      return NextResponse.json({ ok: true });
+    }
+
+    const mrIid = objectAttrs.iid as number | undefined;
+    if (!mrIid || typeof mrIid !== "number") {
+      return NextResponse.json({ error: "Missing MR iid" }, { status: 400 });
+    }
+
+    const user = payload.user as Record<string, string> | undefined;
+    const prTitle = (objectAttrs.title as string) ?? `MR !${mrIid}`;
+    const prUrl = (objectAttrs.url as string) ?? "";
+    const prAuthor = user?.name ?? user?.username ?? "unknown";
+    const headSha = (objectAttrs.last_commit as Record<string, string> | undefined)?.id ?? "";
+
+    if (!repo.autoReview) {
+      console.log(`[gitlab-webhook] Auto-review disabled for ${repoFullName}, skipping`);
+      return NextResponse.json({ ok: true });
+    }
+
+    await startReviewFlow({
+      provider: "gitlab",
+      organizationId: orgId,
+      repoFullName,
+      repoId: repo.id,
+      orgId,
+      prNumber: mrIid,
+      prTitle,
+      prUrl,
+      prAuthor,
+      headSha,
+      triggerCommentId: 0,
+      triggerCommentBody: "",
+    });
+
+    console.log(`[gitlab-webhook] Auto-review triggered for ${repoFullName}!${mrIid}`);
+  }
+
+  // ── MR merged → mark as merged ──
+  if (event === "Merge Request Hook") {
+    const objectAttrs = payload.object_attributes as Record<string, unknown> | undefined;
+    const state = objectAttrs?.state as string | undefined;
+    const mrIid = objectAttrs?.iid as number | undefined;
+
+    if (state === "merged" && mrIid && typeof mrIid === "number") {
+      await Promise.all([
+        prisma.pullRequest.updateMany({
+          where: { repositoryId: repo.id, number: mrIid },
+          data: { mergedAt: new Date() },
+        }),
+        prisma.repository.update({
+          where: { id: repo.id },
+          data: { indexStatus: "stale" },
+        }),
+      ]);
+      console.log(`[gitlab-webhook] MR !${mrIid} merged, repo index marked as stale`);
+    }
+  }
+
+  // ── @octopus mention in MR comment ──
+  if (event === "Note Hook") {
+    const objectAttrs = payload.object_attributes as Record<string, unknown> | undefined;
+    const noteableType = objectAttrs?.noteable_type as string | undefined;
+    if (noteableType !== "MergeRequest") {
+      return NextResponse.json({ ok: true });
+    }
+
+    const commentBody = (objectAttrs?.note as string) ?? "";
+    const mentionsOctopus = /@octopus(?:review|-review)?\b/i.test(commentBody);
+    if (!mentionsOctopus) {
+      return NextResponse.json({ ok: true });
+    }
+
+    const mr = payload.merge_request as Record<string, unknown> | undefined;
+    const mrIid = mr?.iid as number | undefined;
+    const commentId = (objectAttrs?.id as number) ?? 0;
+
+    if (!mrIid || typeof mrIid !== "number") {
+      return NextResponse.json({ error: "Missing MR iid" }, { status: 400 });
+    }
+
+    let prTitle = (mr?.title as string) ?? `MR !${mrIid}`;
+    let prUrl = (mr?.url as string) ?? "";
+    const user = payload.user as Record<string, string> | undefined;
+    let prAuthor = user?.name ?? user?.username ?? "unknown";
+    let headSha = (mr?.last_commit as Record<string, string> | undefined)?.id ?? "";
+
+    try {
+      const details = await getPullRequestDetails(orgId, repoFullName, mrIid);
+      prTitle = details.title;
+      prUrl = details.url;
+      prAuthor = details.author;
+      headSha = details.headSha;
+    } catch (err) {
+      console.warn("[gitlab-webhook] Failed to fetch MR details:", err);
+    }
+
+    await startReviewFlow({
+      provider: "gitlab",
+      organizationId: orgId,
+      repoFullName,
+      repoId: repo.id,
+      orgId,
+      prNumber: mrIid,
+      prTitle,
+      prUrl,
+      prAuthor,
+      headSha,
+      triggerCommentId: commentId,
+      triggerCommentBody: commentBody,
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/components/dashboard/providers-banner.tsx
+++ b/apps/web/components/dashboard/providers-banner.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
@@ -14,6 +15,7 @@ import {
 import {
   IconBrandGithub,
   IconBrandBitbucket,
+  IconBrandGitlab,
   IconCircleCheck,
   IconCircle,
   IconX,
@@ -21,6 +23,9 @@ import {
   IconGitPullRequest,
   IconShieldCheck,
 } from "@tabler/icons-react";
+import { startGitlabOAuth } from "@/app/(app)/settings/integrations/actions";
+
+const DEFAULT_GITLAB_HOST = "https://gitlab.com";
 
 function setCookie(name: string, value: string, days: number) {
   const expires = new Date(Date.now() + days * 864e5).toUTCString();
@@ -30,19 +35,25 @@ function setCookie(name: string, value: string, days: number) {
 export function ProvidersBanner({
   githubConnected,
   bitbucketConnected,
+  gitlabConnected,
   githubAppSlug,
 }: {
   githubConnected: boolean;
   bitbucketConnected: boolean;
+  gitlabConnected: boolean;
   githubAppSlug: string | undefined;
 }) {
   const [dismissed, setDismissed] = useState(false);
   const [bbDialogOpen, setBbDialogOpen] = useState(false);
+  const [glDialogOpen, setGlDialogOpen] = useState(false);
   const [workspaceSlug, setWorkspaceSlug] = useState("");
+  const [glHost, setGlHost] = useState(DEFAULT_GITLAB_HOST);
 
   if (dismissed) return null;
 
   const githubInstallUrl = githubAppSlug ? "/api/github/install?returnTo=/dashboard" : null;
+  const isGlSelfHosted =
+    glHost.trim() !== "" && glHost.replace(/\/+$/, "") !== DEFAULT_GITLAB_HOST;
 
   return (
     <>
@@ -66,7 +77,7 @@ export function ProvidersBanner({
           </button>
         </div>
 
-        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {/* GitHub Card */}
           <div className="border-border/60 bg-muted/30 flex flex-col rounded-lg border p-4">
             <div className="flex items-center gap-2.5">
@@ -157,6 +168,48 @@ export function ProvidersBanner({
               )}
             </div>
           </div>
+
+          {/* GitLab Card */}
+          <div className="border-border/60 bg-muted/30 flex flex-col rounded-lg border p-4">
+            <div className="flex items-center gap-2.5">
+              {gitlabConnected ? (
+                <IconCircleCheck className="size-4 shrink-0 text-emerald-500" />
+              ) : (
+                <IconCircle className="size-4 shrink-0 text-muted-foreground" />
+              )}
+              <IconBrandGitlab className="size-5 shrink-0 text-[#FC6D26]" />
+              <span className="text-sm font-medium">GitLab</span>
+            </div>
+            <p className="text-muted-foreground mt-2 text-xs leading-relaxed">
+              Connect a GitLab group via OAuth — supports gitlab.com and self-hosted instances.
+            </p>
+            <div className="mt-3 flex items-center gap-2">
+              <div className="text-muted-foreground flex items-center gap-1 text-[10px]">
+                <IconGitPullRequest className="size-3" />
+                <span>Auto-review MRs</span>
+              </div>
+              <div className="text-muted-foreground flex items-center gap-1 text-[10px]">
+                <IconShieldCheck className="size-3" />
+                <span>OAuth 2.0</span>
+              </div>
+            </div>
+            <div className="mt-auto pt-3">
+              {gitlabConnected ? (
+                <div className="flex h-8 items-center justify-center text-xs font-medium text-emerald-500">
+                  Connected
+                </div>
+              ) : (
+                <Button
+                  size="sm"
+                  variant="cta"
+                  className="h-8 w-full text-xs"
+                  onClick={() => setGlDialogOpen(true)}
+                >
+                  Connect GitLab &rarr;
+                </Button>
+              )}
+            </div>
+          </div>
         </div>
 
         <p className="mt-3 text-[11px] text-muted-foreground">
@@ -222,6 +275,80 @@ export function ProvidersBanner({
               </p>
             </div>
           </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={glDialogOpen} onOpenChange={setGlDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <IconBrandGitlab className="size-5 text-[#FC6D26]" />
+              Connect GitLab
+            </DialogTitle>
+            <DialogDescription>
+              Connect a GitLab group or your self-hosted instance.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form action={startGitlabOAuth} className="space-y-3 pt-2">
+            <div className="space-y-1.5">
+              <Label htmlFor="gl-banner-host">GitLab host</Label>
+              <Input
+                id="gl-banner-host"
+                name="host"
+                placeholder={DEFAULT_GITLAB_HOST}
+                value={glHost}
+                onChange={(e) => setGlHost(e.target.value)}
+                onBlur={(e) => setGlHost(e.target.value.trim() || DEFAULT_GITLAB_HOST)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="gl-banner-namespace">Namespace (group, subgroup or username)</Label>
+              <Input
+                id="gl-banner-namespace"
+                name="namespace"
+                placeholder="my-group or my-group/team"
+                required
+              />
+            </div>
+
+            {isGlSelfHosted && (
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950">
+                <p className="text-amber-800 dark:text-amber-200 text-xs font-medium mb-2">
+                  Self-hosted instance — paste your GitLab OAuth application credentials
+                </p>
+                <p className="text-amber-700 dark:text-amber-300 text-xs mb-3">
+                  Create one at <span className="font-mono">{glHost.replace(/\/+$/, "")}/admin/applications</span>{" "}
+                  (or User Settings → Applications). Redirect URI must match this app&apos;s callback URL.
+                </p>
+                <div className="space-y-2">
+                  <Input
+                    name="clientId"
+                    placeholder="Application ID (Client ID)"
+                    autoComplete="off"
+                    required
+                  />
+                  <Input
+                    name="clientSecret"
+                    type="password"
+                    placeholder="Secret (Client Secret)"
+                    autoComplete="off"
+                    required
+                  />
+                </div>
+              </div>
+            )}
+
+            <Button className="w-full" size="lg" type="submit">
+              <IconBrandGitlab className="mr-2 size-4" />
+              Connect GitLab
+              <IconArrowRight className="ml-2 size-4" />
+            </Button>
+
+            <p className="text-muted-foreground text-center text-xs">
+              Secure access only - we never store your code.
+            </p>
+          </form>
         </DialogContent>
       </Dialog>
     </>

--- a/apps/web/lib/gitlab.ts
+++ b/apps/web/lib/gitlab.ts
@@ -1,0 +1,533 @@
+import { prisma } from "@octopus/db";
+import { decryptString } from "@/lib/crypto";
+
+// ── Token Management ──
+
+async function getIntegration(organizationId: string) {
+  const integration = await prisma.gitlabIntegration.findUnique({
+    where: { organizationId },
+  });
+  if (!integration) {
+    throw new Error("No GitLab integration found for this organization");
+  }
+  return integration;
+}
+
+function apiBase(host: string): string {
+  return `${host.replace(/\/+$/, "")}/api/v4`;
+}
+
+/**
+ * Resolve OAuth app credentials. Per-integration creds (used by self-hosted
+ * orgs) take precedence; fall back to env vars for gitlab.com.
+ */
+export function resolveOAuthCreds(integration: {
+  oauthClientId: string | null;
+  oauthClientSecretEnc: string | null;
+}): { clientId: string; clientSecret: string } {
+  if (integration.oauthClientId && integration.oauthClientSecretEnc) {
+    return {
+      clientId: integration.oauthClientId,
+      clientSecret: decryptString(integration.oauthClientSecretEnc),
+    };
+  }
+  const clientId = process.env.GITLAB_CLIENT_ID;
+  const clientSecret = process.env.GITLAB_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "No GitLab OAuth credentials configured. Set GITLAB_CLIENT_ID/GITLAB_CLIENT_SECRET env vars or attach per-integration credentials.",
+    );
+  }
+  return { clientId, clientSecret };
+}
+
+export async function refreshAccessToken(
+  integrationId: string,
+  refreshToken: string,
+  host: string,
+): Promise<{ accessToken: string; refreshToken: string; expiresAt: Date }> {
+  const integration = await prisma.gitlabIntegration.findUnique({
+    where: { id: integrationId },
+    select: { oauthClientId: true, oauthClientSecretEnc: true },
+  });
+  if (!integration) {
+    throw new Error(`GitLab integration ${integrationId} not found`);
+  }
+  const { clientId, clientSecret } = resolveOAuthCreds(integration);
+
+  const res = await fetch(`${host.replace(/\/+$/, "")}/oauth/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+
+  if (!res.ok) {
+    const errBody = await res.text();
+    throw new Error(`Failed to refresh GitLab token: ${res.status} ${errBody}`);
+  }
+
+  const data = await res.json();
+  const newAccessToken = data.access_token as string | undefined;
+  const expiresIn = data.expires_in as number | undefined;
+
+  if (!newAccessToken || !expiresIn) {
+    throw new Error("Invalid token refresh response: missing access_token or expires_in");
+  }
+
+  const expiresAt = new Date(Date.now() + expiresIn * 1000);
+
+  await prisma.gitlabIntegration.update({
+    where: { id: integrationId },
+    data: {
+      accessToken: newAccessToken,
+      refreshToken: (data.refresh_token as string) ?? refreshToken,
+      tokenExpiresAt: expiresAt,
+    },
+  });
+
+  return {
+    accessToken: newAccessToken,
+    refreshToken: (data.refresh_token as string) ?? refreshToken,
+    expiresAt,
+  };
+}
+
+export async function getAccessToken(organizationId: string): Promise<string> {
+  const integration = await getIntegration(organizationId);
+
+  // Refresh if token expires within 5 minutes
+  const bufferMs = 5 * 60 * 1000;
+  if (integration.tokenExpiresAt.getTime() - Date.now() < bufferMs) {
+    console.log(`[gitlab] Token expiring soon for org ${organizationId}, refreshing...`);
+    const refreshed = await refreshAccessToken(
+      integration.id,
+      integration.refreshToken,
+      integration.gitlabHost,
+    );
+    return refreshed.accessToken;
+  }
+
+  return integration.accessToken;
+}
+
+async function getHost(organizationId: string): Promise<string> {
+  const integration = await getIntegration(organizationId);
+  return integration.gitlabHost;
+}
+
+/** Public host (no trailing slash) used to build git clone URLs. */
+export async function getCloneHost(organizationId: string): Promise<string> {
+  const host = await getHost(organizationId);
+  return host.replace(/\/+$/, "");
+}
+
+// ── Project Operations ──
+
+export interface GitlabProject {
+  id: number;
+  name: string;
+  path_with_namespace: string;
+  default_branch: string | null;
+  visibility: string;
+  web_url: string;
+}
+
+export async function listNamespaceProjects(
+  organizationId: string,
+  namespacePath: string,
+): Promise<GitlabProject[]> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  const projects: GitlabProject[] = [];
+  // groups endpoint covers groups & subgroups; if user enters a username, fall back to /users
+  let url: string | null =
+    `${apiBase(host)}/groups/${encodeURIComponent(namespacePath)}/projects?per_page=100&include_subgroups=true&archived=false`;
+
+  let isFirst = true;
+  while (url) {
+    const pageRes: Response = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    // Fallback to /users on first 404 — namespace might be a personal user, not a group
+    if (isFirst && pageRes.status === 404) {
+      url = `${apiBase(host)}/users/${encodeURIComponent(namespacePath)}/projects?per_page=100&archived=false`;
+      const userRes: Response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!userRes.ok) {
+        throw new Error(`Failed to list GitLab projects: ${userRes.status}`);
+      }
+      const userData = await userRes.json();
+      projects.push(...(userData as GitlabProject[]));
+      url = parseNextLink(userRes.headers.get("link"));
+      isFirst = false;
+      continue;
+    }
+
+    if (!pageRes.ok) {
+      throw new Error(`Failed to list GitLab projects: ${pageRes.status}`);
+    }
+
+    const pageData = (await pageRes.json()) as GitlabProject[];
+    projects.push(...pageData);
+    url = parseNextLink(pageRes.headers.get("link"));
+    isFirst = false;
+  }
+
+  return projects;
+}
+
+function parseNextLink(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+  const match = linkHeader.split(",").find((s) => /rel="next"/.test(s));
+  if (!match) return null;
+  const urlMatch = match.match(/<([^>]+)>/);
+  return urlMatch?.[1] ?? null;
+}
+
+// ── Merge Request Operations ──
+
+export interface MergeRequestDetails {
+  number: number;
+  title: string;
+  url: string;
+  author: string;
+  headSha: string;
+}
+
+export async function getPullRequestDetails(
+  organizationId: string,
+  projectPath: string,
+  mrIid: number,
+): Promise<MergeRequestDetails> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  const res = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/merge_requests/${mrIid}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+
+  if (!res.ok) {
+    throw new Error(`Failed to get GitLab MR details: ${res.status}`);
+  }
+
+  const data = await res.json();
+  return {
+    number: data.iid,
+    title: data.title,
+    url: data.web_url ?? "",
+    author: data.author?.name ?? data.author?.username ?? "unknown",
+    headSha: data.sha ?? data.diff_refs?.head_sha ?? "",
+  };
+}
+
+export async function getPullRequestDiff(
+  organizationId: string,
+  projectPath: string,
+  mrIid: number,
+): Promise<string> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  // GitLab returns diffs as JSON entries — synthesise a unified diff.
+  const res = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/merge_requests/${mrIid}/diffs?per_page=100`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+
+  if (!res.ok) {
+    throw new Error(`Failed to get GitLab MR diff: ${res.status}`);
+  }
+
+  const entries = (await res.json()) as Array<{
+    old_path: string;
+    new_path: string;
+    new_file: boolean;
+    deleted_file: boolean;
+    diff: string;
+  }>;
+
+  const parts: string[] = [];
+  for (const e of entries) {
+    const oldPath = e.deleted_file ? "/dev/null" : `a/${e.old_path}`;
+    const newPath = e.new_file ? "/dev/null" : `b/${e.new_path}`;
+    parts.push(`diff --git a/${e.old_path} b/${e.new_path}`);
+    if (e.new_file) parts.push("new file mode 100644");
+    if (e.deleted_file) parts.push("deleted file mode 100644");
+    parts.push(`--- ${oldPath}`);
+    parts.push(`+++ ${newPath}`);
+    parts.push(e.diff.replace(/\n$/, ""));
+  }
+
+  const diff = parts.join("\n");
+  return diff.length > 30_000
+    ? diff.slice(0, 30_000) + "\n\n[... diff truncated at 30,000 chars]"
+    : diff;
+}
+
+export async function createPullRequestComment(
+  organizationId: string,
+  projectPath: string,
+  mrIid: number,
+  body: string,
+): Promise<number> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  const res = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/merge_requests/${mrIid}/notes`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ body }),
+    },
+  );
+
+  if (!res.ok) {
+    const errBody = await res.text();
+    throw new Error(`Failed to create GitLab MR note: ${res.status} ${errBody}`);
+  }
+
+  const data = await res.json();
+  return data.id as number;
+}
+
+export async function updatePullRequestComment(
+  organizationId: string,
+  projectPath: string,
+  mrIid: number,
+  noteId: number,
+  body: string,
+): Promise<void> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  const res = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/merge_requests/${mrIid}/notes/${noteId}`,
+    {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ body }),
+    },
+  );
+
+  if (!res.ok) {
+    throw new Error(`Failed to update GitLab MR note: ${res.status}`);
+  }
+}
+
+export async function createInlineComment(
+  organizationId: string,
+  projectPath: string,
+  mrIid: number,
+  filePath: string,
+  line: number,
+  body: string,
+): Promise<number> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+
+  // GitLab inline (positional) discussions need diff_refs from the MR.
+  const mrRes = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/merge_requests/${mrIid}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!mrRes.ok) {
+    throw new Error(`Failed to get MR for inline comment: ${mrRes.status}`);
+  }
+  const mrData = await mrRes.json();
+  const refs = mrData.diff_refs as { base_sha: string; head_sha: string; start_sha: string } | undefined;
+  if (!refs) {
+    throw new Error("MR has no diff_refs — cannot create inline comment");
+  }
+
+  const res = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/merge_requests/${mrIid}/discussions`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        body,
+        position: {
+          base_sha: refs.base_sha,
+          head_sha: refs.head_sha,
+          start_sha: refs.start_sha,
+          position_type: "text",
+          new_path: filePath,
+          old_path: filePath,
+          new_line: line,
+        },
+      }),
+    },
+  );
+
+  if (!res.ok) {
+    const errBody = await res.text();
+    throw new Error(`Failed to create GitLab inline comment: ${res.status} ${errBody}`);
+  }
+
+  const data = await res.json();
+  return data.id as number;
+}
+
+// ── Repository Tree & Content ──
+
+export async function getRepositoryTree(
+  organizationId: string,
+  projectPath: string,
+  branch: string,
+): Promise<string[]> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  const paths: string[] = [];
+  const TIMEOUT_MS = 15_000;
+  const MAX_RETRIES = 3;
+
+  async function fetchWithRetry(url: string): Promise<Response | null> {
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+      try {
+        const res = await fetch(url, {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: controller.signal,
+        });
+
+        if (res.status === 429) {
+          const retryAfter = res.headers.get("retry-after");
+          const waitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : 2000 * (attempt + 1);
+          console.warn(`[gitlab] Rate limited, waiting ${waitMs}ms (attempt ${attempt + 1}/${MAX_RETRIES})`);
+          await new Promise((r) => setTimeout(r, waitMs));
+          continue;
+        }
+
+        return res;
+      } catch (err) {
+        if (attempt === MAX_RETRIES - 1) {
+          console.warn(`[gitlab] Failed after ${MAX_RETRIES} attempts: ${url}`, err);
+          return null;
+        }
+        await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+    return null;
+  }
+
+  // GitLab supports recursive tree traversal in a single endpoint with pagination.
+  let url: string | null =
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/repository/tree?ref=${encodeURIComponent(branch)}&recursive=true&per_page=100&pagination=keyset`;
+
+  while (url) {
+    const res = await fetchWithRetry(url);
+    if (!res || !res.ok) {
+      if (res) console.warn(`[gitlab] Failed to fetch tree ${url}: ${res.status}`);
+      break;
+    }
+
+    const items = (await res.json()) as Array<{ type: string; path: string }>;
+    for (const item of items) {
+      if (item.type === "blob") paths.push(item.path);
+    }
+
+    url = parseNextLink(res.headers.get("link"));
+  }
+
+  return paths;
+}
+
+export async function getFileContent(
+  organizationId: string,
+  projectPath: string,
+  branch: string,
+  filePath: string,
+): Promise<string> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  const res = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/repository/files/${encodeURIComponent(filePath)}/raw?ref=${encodeURIComponent(branch)}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+
+  if (!res.ok) {
+    throw new Error(`Failed to get GitLab file content: ${res.status}`);
+  }
+
+  return res.text();
+}
+
+// ── Webhooks ──
+//
+// Group-level hooks are a Premium feature on gitlab.com. To stay on the free tier
+// and remain self-hosted-friendly, we register one project hook per repo at sync
+// time. Each hook carries the same shared secret stored on the integration.
+
+export async function createProjectWebhook(
+  organizationId: string,
+  projectPath: string,
+  callbackUrl: string,
+  secret: string,
+): Promise<number | null> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  const res = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/hooks`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        url: callbackUrl,
+        token: secret,
+        merge_requests_events: true,
+        note_events: true,
+        push_events: false,
+        enable_ssl_verification: true,
+      }),
+    },
+  );
+
+  if (!res.ok) {
+    const errBody = await res.text();
+    console.error(`[gitlab] Failed to create webhook on ${projectPath}: ${res.status} ${errBody}`);
+    return null;
+  }
+
+  const data = await res.json();
+  return (data.id as number) ?? null;
+}
+
+export async function deleteProjectWebhook(
+  organizationId: string,
+  projectPath: string,
+  hookId: number,
+): Promise<void> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  const res = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/hooks/${hookId}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+
+  if (!res.ok) {
+    console.error(`[gitlab] Failed to delete webhook: ${res.status}`);
+  }
+}

--- a/apps/web/lib/indexer.ts
+++ b/apps/web/lib/indexer.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { promisify } from "node:util";
 import { getInstallationToken, getFileContent as ghGetFileContent, getRepositoryDetails } from "@/lib/github";
 import * as bitbucketLib from "@/lib/bitbucket";
+import * as gitlabLib from "@/lib/gitlab";
 import { ensureCollection, upsertChunks, deleteRepoChunks, deleteRepoFileChunks } from "@/lib/qdrant";
 import { generateSparseVectors } from "@/lib/sparse-vector";
 import { parseOctopusIgnore, type Ignore } from "@/lib/octopus-ignore";
@@ -168,16 +169,25 @@ export async function indexRepository(
   let contributors: Contributor[] = [];
   let resolvedDefaultBranch: string | undefined;
 
-  if (provider === "bitbucket" && organizationId) {
-    // ── Bitbucket indexing flow (clone-based) ──
-    onLog("Authenticating with Bitbucket...");
-    const [workspace, repoSlug] = fullName.split("/");
-    const token = await bitbucketLib.getAccessToken(organizationId);
-    onLog("Bitbucket authentication successful", "success");
+  if ((provider === "bitbucket" || provider === "gitlab") && organizationId) {
+    // ── Bitbucket / GitLab indexing flow (clone-based) ──
+    const isGl = provider === "gitlab";
+    onLog(`Authenticating with ${isGl ? "GitLab" : "Bitbucket"}...`);
+    const token = isGl
+      ? await gitlabLib.getAccessToken(organizationId)
+      : await bitbucketLib.getAccessToken(organizationId);
+    onLog(`${isGl ? "GitLab" : "Bitbucket"} authentication successful`, "success");
 
     // 1. Shallow clone the repo
-    const cloneDir = join(tmpdir(), `octopus-bb-${repoId}-${Date.now()}`);
-    const cloneUrl = `https://bitbucket.org/${workspace}/${repoSlug}.git`;
+    const cloneDir = join(tmpdir(), `octopus-${isGl ? "gl" : "bb"}-${repoId}-${Date.now()}`);
+    let cloneUrl: string;
+    if (isGl) {
+      const gh = await gitlabLib.getCloneHost(organizationId);
+      cloneUrl = `${gh}/${fullName}.git`;
+    } else {
+      const [workspace, repoSlug] = fullName.split("/");
+      cloneUrl = `https://bitbucket.org/${workspace}/${repoSlug}.git`;
+    }
 
     try {
       onLog(`Cloning ${fullName}@${defaultBranch}...`);
@@ -636,6 +646,19 @@ export async function incrementalIndex(
     for (const filePath of addedOrModified) {
       try {
         const content = await bitbucketLib.getFileContent(organizationId, workspace, repoSlug, defaultBranch, filePath);
+        if (!content || content.includes("\0")) continue;
+        const chunks = chunkText(content, filePath);
+        for (const chunk of chunks) {
+          allChunks.push({ text: chunk.text, filePath, startLine: chunk.startLine, endLine: chunk.endLine });
+        }
+      } catch {
+        console.warn(`[indexer:incremental] Failed to fetch ${filePath}, skipping`);
+      }
+    }
+  } else if (provider === "gitlab" && organizationId) {
+    for (const filePath of addedOrModified) {
+      try {
+        const content = await gitlabLib.getFileContent(organizationId, fullName, defaultBranch, filePath);
         if (!content || content.includes("\0")) continue;
         const chunks = chunkText(content, filePath);
         for (const chunk of chunks) {

--- a/apps/web/lib/provider.ts
+++ b/apps/web/lib/provider.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@octopus/db";
 import * as github from "@/lib/github";
 import * as bitbucket from "@/lib/bitbucket";
+import * as gitlab from "@/lib/gitlab";
 import type { ReviewComment } from "@/lib/github";
 
 export interface ProviderClient {
@@ -169,9 +170,82 @@ class BitbucketProviderClient implements ProviderClient {
   }
 }
 
+class GitlabProviderClient implements ProviderClient {
+  constructor(
+    private organizationId: string,
+    private projectPath: string,
+  ) {}
+
+  async getPullRequestDiff(prNumber: number) {
+    return gitlab.getPullRequestDiff(this.organizationId, this.projectPath, prNumber);
+  }
+
+  async createPullRequestComment(prNumber: number, body: string) {
+    return gitlab.createPullRequestComment(this.organizationId, this.projectPath, prNumber, body);
+  }
+
+  async updatePullRequestComment(commentId: number, body: string, prNumber?: number) {
+    if (!prNumber) {
+      throw new Error("GitLab requires prNumber to update a note");
+    }
+    return gitlab.updatePullRequestComment(
+      this.organizationId, this.projectPath, prNumber, commentId, body,
+    );
+  }
+
+  async createPullRequestReview(
+    prNumber: number,
+    body: string,
+    _event: "COMMENT" | "REQUEST_CHANGES" | "APPROVE",
+    comments: ReviewComment[],
+  ) {
+    for (const comment of comments) {
+      try {
+        await gitlab.createInlineComment(
+          this.organizationId,
+          this.projectPath,
+          prNumber,
+          comment.path,
+          comment.line,
+          comment.body,
+        );
+      } catch (err) {
+        console.error(`[gitlab] Failed to post inline comment on ${comment.path}:${comment.line}:`, err);
+      }
+    }
+
+    if (body) {
+      const commentId = await gitlab.createPullRequestComment(
+        this.organizationId,
+        this.projectPath,
+        prNumber,
+        body,
+      );
+      return commentId;
+    }
+    return 0;
+  }
+
+  async createCheckRun(): Promise<number | null> {
+    return null;
+  }
+
+  async updateCheckRun(): Promise<void> {
+    // No-op for GitLab
+  }
+
+  async getRepositoryTree(branch: string) {
+    return gitlab.getRepositoryTree(this.organizationId, this.projectPath, branch);
+  }
+
+  async getFileContent(branch: string, filePath: string) {
+    return gitlab.getFileContent(this.organizationId, this.projectPath, branch, filePath);
+  }
+}
+
 /**
  * Create a provider client for a given repository.
- * Resolves the correct provider (GitHub or Bitbucket) and returns a unified interface.
+ * Resolves the correct provider (GitHub, Bitbucket, GitLab) and returns a unified interface.
  */
 export async function getProviderClient(repoId: string): Promise<ProviderClient> {
   const repo = await prisma.repository.findUniqueOrThrow({
@@ -190,6 +264,10 @@ export async function getProviderClient(repoId: string): Promise<ProviderClient>
   if (repo.provider === "bitbucket") {
     const [workspace, repoSlug] = repo.fullName.split("/");
     return new BitbucketProviderClient(repo.organizationId, workspace, repoSlug);
+  }
+
+  if (repo.provider === "gitlab") {
+    return new GitlabProviderClient(repo.organizationId, repo.fullName);
   }
 
   // Default: GitHub

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -44,6 +44,7 @@ import {
   getCommentReactions as ghGetCommentReactions,
 } from "@/lib/github";
 import * as bitbucket from "@/lib/bitbucket";
+import * as gitlab from "@/lib/gitlab";
 import { parseOctopusIgnore, filterDiff, detectBadCommits } from "@/lib/octopus-ignore";
 import type { ReviewComment } from "@/lib/github";
 import { eventBus } from "@/lib/events";
@@ -665,6 +666,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
 
   const isGitHub = repo.provider === "github";
   const isBitbucket = repo.provider === "bitbucket";
+  const isGitlab = repo.provider === "gitlab";
   const installationId = repo.installationId ?? org.githubInstallationId;
 
   if (isGitHub && !installationId) {
@@ -672,23 +674,32 @@ export async function processReview(pullRequestId: string): Promise<void> {
     return;
   }
 
+  // For GitHub & Bitbucket: workspace/repo. For GitLab: full path with namespace
+  // (which can contain subgroups, so the simple split is only used by github/bitbucket).
   const [owner, repoName] = repo.fullName.split("/");
+  const projectPath = repo.fullName;
 
   // Provider-aware helper functions
   const providerGetDiff = (prNumber: number) =>
     isGitHub
       ? ghGetPullRequestDiff(installationId!, owner, repoName, prNumber)
-      : bitbucket.getPullRequestDiff(org.id, owner, repoName, prNumber);
+      : isGitlab
+        ? gitlab.getPullRequestDiff(org.id, projectPath, prNumber)
+        : bitbucket.getPullRequestDiff(org.id, owner, repoName, prNumber);
 
   const providerCreateComment = (prNumber: number, body: string) =>
     isGitHub
       ? ghCreatePullRequestComment(installationId!, owner, repoName, prNumber, body)
-      : bitbucket.createPullRequestComment(org.id, owner, repoName, prNumber, body);
+      : isGitlab
+        ? gitlab.createPullRequestComment(org.id, projectPath, prNumber, body)
+        : bitbucket.createPullRequestComment(org.id, owner, repoName, prNumber, body);
 
   const providerUpdateComment = async (commentId: number, body: string) => {
     try {
       if (isGitHub) {
         await ghUpdatePullRequestComment(installationId!, owner, repoName, commentId, body);
+      } else if (isGitlab) {
+        await gitlab.updatePullRequestComment(org.id, projectPath, pr.number, commentId, body);
       } else {
         await bitbucket.updatePullRequestComment(org.id, owner, repoName, pr.number, commentId, body);
       }
@@ -711,7 +722,9 @@ export async function processReview(pullRequestId: string): Promise<void> {
   const providerGetTree = (branch: string) =>
     isGitHub
       ? ghGetRepositoryTree(installationId!, owner, repoName, branch)
-      : bitbucket.getRepositoryTree(org.id, owner, repoName, branch);
+      : isGitlab
+        ? gitlab.getRepositoryTree(org.id, projectPath, branch)
+        : bitbucket.getRepositoryTree(org.id, owner, repoName, branch);
   let reviewCommentId = pr.reviewCommentId ? Number(pr.reviewCommentId) : null;
   const baseEvent = {
     repoId: repo.id,
@@ -1099,7 +1112,9 @@ export async function processReview(pullRequestId: string): Promise<void> {
           ? await ghGetFileContent(installationId, owner, repoName, repo.defaultBranch, ".octopusignore")
           : isBitbucket
             ? await bitbucket.getFileContent(org.id, owner, repoName, repo.defaultBranch, ".octopusignore")
-            : null;
+            : isGitlab
+              ? await gitlab.getFileContent(org.id, projectPath, repo.defaultBranch, ".octopusignore")
+              : null;
 
         if (ignoreContent) {
           octopusIg = parseOctopusIgnore(ignoreContent);
@@ -1511,7 +1526,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
       .replace("{{KNOWLEDGE_CONTEXT}}", knowledgeContext)
       .replace("{{PR_NUMBER}}", String(pr.number))
       .replace("{{USER_INSTRUCTION}}", userInstruction)
-      .replace("{{PROVIDER}}", isGitHub ? "GitHub" : isBitbucket ? "Bitbucket" : repo.provider)
+      .replace("{{PROVIDER}}", isGitHub ? "GitHub" : isBitbucket ? "Bitbucket" : isGitlab ? "GitLab" : repo.provider)
       .replace("{{FALSE_POSITIVE_CONTEXT}}", falsePositiveContext)
       .replace("{{RE_REVIEW_CONTEXT}}", priorReviewContext)
       .replace("{{CONFLICT_DETECTION}}", conflictPrompt)
@@ -1809,7 +1824,9 @@ Rules:
             ? async (path) => (await ghGetFileContent(installationId!, owner, repoName, pr.headSha!, path)) ?? ""
             : isBitbucket
               ? (path) => bitbucket.getFileContent(org.id, owner, repoName, pr.headSha ?? repo.defaultBranch ?? "main", path)
-              : undefined;
+              : isGitlab
+                ? (path) => gitlab.getFileContent(org.id, projectPath, pr.headSha ?? repo.defaultBranch ?? "main", path)
+                : undefined;
 
         // Phase 1: Cross-file context (existing — function signatures, types, APIs)
         let crossFileContext = "";
@@ -2084,53 +2101,61 @@ Rules:
           await ghCreatePullRequestComment(installationId, owner, repoName, pr.number, summaryBody);
         }
       }
-    } else if (isBitbucket) {
-      // Bitbucket: post inline comments individually, then a summary comment
-      const bbFailedInlineComments: ReviewComment[] = [];
+    } else if (isBitbucket || isGitlab) {
+      // Bitbucket / GitLab: post inline comments individually, then a summary comment
+      const failedInlineComments: ReviewComment[] = [];
       for (const comment of inlineComments) {
         try {
-          await bitbucket.createInlineComment(
-            org.id, owner, repoName, pr.number,
-            comment.path, comment.line, comment.body,
-          );
+          if (isGitlab) {
+            await gitlab.createInlineComment(
+              org.id, projectPath, pr.number,
+              comment.path, comment.line, comment.body,
+            );
+          } else {
+            await bitbucket.createInlineComment(
+              org.id, owner, repoName, pr.number,
+              comment.path, comment.line, comment.body,
+            );
+          }
         } catch (err) {
-          console.error(`[reviewer] Failed to post Bitbucket inline comment on ${comment.path}:${comment.line}:`, err);
-          bbFailedInlineComments.push(comment);
+          console.error(`[reviewer] Failed to post inline comment on ${comment.path}:${comment.line}:`, err);
+          failedInlineComments.push(comment);
         }
       }
-      const bbInlinePaths = new Set(inlineComments.map((c) => `${c.path}:${c.line}`));
-      const bbNonInlineFindings = allParsedFindings.filter((f) => {
+      const inlinePaths = new Set(inlineComments.map((c) => `${c.path}:${c.line}`));
+      const nonInlineFindings = allParsedFindings.filter((f) => {
         for (let l = f.startLine; l <= f.endLine; l++) {
-          if (bbInlinePaths.has(`${f.filePath}:${l}`)) return false;
+          if (inlinePaths.has(`${f.filePath}:${l}`)) return false;
         }
         return true;
       });
       // Add unmappable findings to summary (inline-severity but couldn't map to diff lines)
       // Also add findings whose inline comments failed to post
-      const bbFailedInlinePaths = new Set(bbFailedInlineComments.map((c) => `${c.path}:${c.line}`));
-      const bbFailedInlineFindings = bbFailedInlineComments.length > 0
+      const failedInlinePaths = new Set(failedInlineComments.map((c) => `${c.path}:${c.line}`));
+      const failedInlineFindings = failedInlineComments.length > 0
         ? inlineFindings.filter((f) => {
             for (let l = f.startLine; l <= f.endLine; l++) {
-              if (bbFailedInlinePaths.has(`${f.filePath}:${l}`)) return true;
+              if (failedInlinePaths.has(`${f.filePath}:${l}`)) return true;
             }
             return false;
           })
         : [];
-      const bbNonInlineWithUnmappable = [
-        ...bbNonInlineFindings,
+      const nonInlineWithUnmappable = [
+        ...nonInlineFindings,
         ...unmappableFindings.filter((uf) =>
-          !bbNonInlineFindings.some((nf) => nf.filePath === uf.filePath && nf.startLine === uf.startLine && nf.title === uf.title),
+          !nonInlineFindings.some((nf) => nf.filePath === uf.filePath && nf.startLine === uf.startLine && nf.title === uf.title),
         ),
-        ...bbFailedInlineFindings,
+        ...failedInlineFindings,
       ];
       // Count only actually-posted inline comments + summary table findings
-      const bbSuccessfulInline = inlineComments.length - bbFailedInlineComments.length;
-      const bbVisibleCount = bbSuccessfulInline + bbNonInlineWithUnmappable.length;
-      effectiveFindingsCount = bbVisibleCount;
-      const findingsBlock = buildLowSeveritySummary(bbNonInlineWithUnmappable);
-      const summaryBody = `${filesChanged} file${filesChanged !== 1 ? "s" : ""} reviewed, ${bbVisibleCount} finding${bbVisibleCount !== 1 ? "s" : ""}${findingsBlock ? "\n\n" + findingsBlock : ""}`;
+      const successfulInline = inlineComments.length - failedInlineComments.length;
+      const visibleCount = successfulInline + nonInlineWithUnmappable.length;
+      effectiveFindingsCount = visibleCount;
+      const findingsBlock = buildLowSeveritySummary(nonInlineWithUnmappable);
+      const summaryBody = `${filesChanged} file${filesChanged !== 1 ? "s" : ""} reviewed, ${visibleCount} finding${visibleCount !== 1 ? "s" : ""}${findingsBlock ? "\n\n" + findingsBlock : ""}`;
       await providerCreateComment(pr.number, summaryBody);
-      console.log(`[reviewer] Bitbucket review posted with ${inlineComments.length} inline comments, ${bbNonInlineWithUnmappable.length} in summary`);
+      const providerLabel = isGitlab ? "GitLab" : "Bitbucket";
+      console.log(`[reviewer] ${providerLabel} review posted with ${inlineComments.length} inline comments, ${nonInlineWithUnmappable.length} in summary`);
     }
 
     // Step 6: Persist parsed findings as ReviewIssue records (ALL findings, not just capped/inline)

--- a/apps/web/lib/webhook-shared.ts
+++ b/apps/web/lib/webhook-shared.ts
@@ -4,13 +4,14 @@ import { enqueue } from "@/lib/queue";
 import { eventBus } from "@/lib/events";
 import * as github from "@/lib/github";
 import * as bitbucket from "@/lib/bitbucket";
+import * as gitlab from "@/lib/gitlab";
 
 /**
  * Post a neutral "skipped" check run so the PR isn't blocked forever.
- * GitHub only — Bitbucket has no checks API.
+ * GitHub only — Bitbucket and GitLab have no equivalent checks API in this integration.
  */
 async function postSkippedCheckRun(
-  provider: "github" | "bitbucket",
+  provider: "github" | "bitbucket" | "gitlab",
   installationId: number | undefined,
   repoFullName: string,
   headSha: string,
@@ -32,13 +33,13 @@ async function postSkippedCheckRun(
 
 /**
  * Shared flow: upsert PR -> post placeholder comment -> notify dashboard -> start review.
- * Works for both GitHub and Bitbucket.
+ * Works for GitHub, Bitbucket, and GitLab.
  */
 export async function startReviewFlow(params: {
-  provider: "github" | "bitbucket";
+  provider: "github" | "bitbucket" | "gitlab";
   // GitHub-specific
   installationId?: number;
-  // Bitbucket-specific
+  // Bitbucket / GitLab-specific
   organizationId?: string;
   // Common
   repoFullName: string;
@@ -171,6 +172,8 @@ export async function startReviewFlow(params: {
         await github.updatePullRequestComment(installationId, owner, repoName, existingCommentId, placeholderBody);
       } else if (provider === "bitbucket" && organizationId) {
         await bitbucket.updatePullRequestComment(organizationId, owner, repoName, prNumber, existingCommentId, placeholderBody);
+      } else if (provider === "gitlab" && organizationId) {
+        await gitlab.updatePullRequestComment(organizationId, repoFullName, prNumber, existingCommentId, placeholderBody);
       }
     } else {
       console.log(`[webhook] Posting new placeholder comment to PR #${prNumber}`);
@@ -179,6 +182,8 @@ export async function startReviewFlow(params: {
         newCommentId = await github.createPullRequestComment(installationId, owner, repoName, prNumber, placeholderBody);
       } else if (provider === "bitbucket" && organizationId) {
         newCommentId = await bitbucket.createPullRequestComment(organizationId, owner, repoName, prNumber, placeholderBody);
+      } else if (provider === "gitlab" && organizationId) {
+        newCommentId = await gitlab.createPullRequestComment(organizationId, repoFullName, prNumber, placeholderBody);
       } else {
         throw new Error("Invalid provider configuration");
       }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -134,6 +134,7 @@ model Organization {
   slackIntegration      SlackIntegration?
   collabIntegration     CollabIntegration?
   bitbucketIntegration  BitbucketIntegration?
+  gitlabIntegration     GitlabIntegration?
   linearIntegration     LinearIntegration?
   jiraIntegration       JiraIntegration?
   aiUsages           AiUsage[]
@@ -478,6 +479,32 @@ model BitbucketIntegration {
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@map("bitbucket_integrations")
+}
+
+model GitlabIntegration {
+  id             String   @id @default(cuid())
+  // "https://gitlab.com" for cloud, or self-hosted host like "https://gitlab.example.com"
+  gitlabHost     String   @default("https://gitlab.com")
+  // Numeric group/namespace id or username; user-supplied, used to scope project listing & webhook setup
+  namespacePath  String
+  namespaceName  String
+  // Per-org OAuth application credentials (used for self-hosted instances).
+  // When null, fall back to GITLAB_CLIENT_ID/GITLAB_CLIENT_SECRET env vars.
+  // The secret is stored encrypted via lib/crypto.ts.
+  oauthClientId        String?
+  oauthClientSecretEnc String?
+  accessToken    String
+  refreshToken   String
+  tokenExpiresAt DateTime
+  scopes         String?
+  webhookSecret  String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  organizationId String       @unique
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@map("gitlab_integrations")
 }
 
 model CollabIntegration {


### PR DESCRIPTION
## Summary

Adds GitLab as a third provider alongside GitHub and Bitbucket. \`gitlab.com\` and self-hosted instances are both supported. Per-org OAuth credentials for self-hosted; cloud default falls back to env vars.

- Prisma \`GitlabIntegration\` model + Organization relation.
- OAuth flow: \`startGitlabOAuth\` server action stashes credentials in an encrypted short-lived cookie (secret never enters the OAuth state URL); \`/api/gitlab/callback\` exchanges code → tokens, persists integration, registers webhooks.
- Webhook (\`/api/gitlab/webhook\`) handles MR open/sync/reopen + comment events with HMAC verification against per-org \`webhookSecret\`.
- GitLab API client (\`lib/gitlab.ts\`): repo tree, file content, MR diff, comments + inline (discussion) notes, refresh-token handling.
- Indexer: clone-based path mirroring Bitbucket, using the OAuth bearer.
- Provider client + reviewer: \`GitlabProviderClient\` and \`isGitlab\` branches in \`processReview\` so MRs get the same inline + summary review treatment.
- Settings UI: \`GitlabIntegrationCard\` + reusable debug banner (\`BitbucketDebugBanner\` accepts a \`title\` prop, used for \`gl_debug\`).
- Dashboard providers banner: third card + connect dialog (host, namespace, optional self-hosted client id/secret); grid widened to 3 columns.
- Repositories page: \`gitlab\` + \`bitbucket\` icon/url entries; package-analyzer link gated to GitHub-only (was previously \`!= bitbucket\`).

Closes #359

## Required env

- \`GITLAB_CLIENT_ID\` / \`GITLAB_CLIENT_SECRET\` (cloud default app)
- \`GITLAB_REDIRECT_URI\` (must match the OAuth app's redirect URL)

## Test plan

- [ ] DB migration applies cleanly (\`bun run db:migrate\`).
- [ ] \`/settings/integrations\` shows the GitLab card; connect flow on \`gitlab.com\` (env credentials) lands back with \`?gl_debug=...\` and persists a \`GitlabIntegration\` row.
- [ ] Self-hosted connect flow (custom client id/secret) round-trips OAuth and stores the encrypted secret.
- [ ] \`/api/gitlab/webhook\` rejects requests with bad HMAC; accepts MR open and posts a placeholder comment.
- [ ] MR review pipeline produces inline + summary notes on the MR (visible in GitLab UI).
- [ ] Repositories page renders the GitLab provider icon and \`gitlab.com\` repo links; package-analyzer link only shows for GitHub repos.
- [ ] Dashboard banner shows the GitLab card when not connected; hides once connected.
- [ ] Disconnect deletes the integration row and deactivates GitLab repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)