### PR TITLE
feat(chat): use org-selected model and surface defaults in settings

### DIFF
--- a/apps/web/app/(app)/settings/models/models-settings.tsx
+++ b/apps/web/app/(app)/settings/models/models-settings.tsx
@@ -25,8 +25,12 @@ type AvailableModel = {
   category: string;
 };
 
-function getModelDisplayName(modelId: string | null, models: AvailableModel[]): string {
-  if (!modelId) return "Org Default";
+function getModelDisplayName(
+  modelId: string | null,
+  models: AvailableModel[],
+  orgDefaultLabel: string = "Org Default",
+): string {
+  if (!modelId) return orgDefaultLabel;
   const model = models.find((m) => m.modelId === modelId);
   return model ? model.displayName : modelId;
 }
@@ -35,10 +39,14 @@ function RepoModelRow({
   repo,
   availableModels,
   isOwner,
+  orgDefaultLlmName,
+  orgDefaultEmbedName,
 }: {
   repo: RepoModelItem;
   availableModels: AvailableModel[];
   isOwner: boolean;
+  orgDefaultLlmName: string | null;
+  orgDefaultEmbedName: string | null;
 }) {
   const [editing, setEditing] = useState(false);
   const [reviewModelId, setReviewModelId] = useState(repo.reviewModelId ?? "");
@@ -103,7 +111,9 @@ function RepoModelRow({
               onChange={(e) => setReviewModelId(e.target.value)}
               className="flex h-8 w-full rounded-md border border-input bg-background px-2 py-1 text-xs shadow-sm transition-colors"
             >
-              <option value="">(Org Default)</option>
+              <option value="">
+                {orgDefaultLlmName ? `(Org Default — ${orgDefaultLlmName})` : "(Org Default)"}
+              </option>
               {llmModels.map((m) => (
                 <option key={m.modelId} value={m.modelId}>
                   {m.displayName} ({m.provider})
@@ -118,7 +128,9 @@ function RepoModelRow({
               onChange={(e) => setEmbedModelId(e.target.value)}
               className="flex h-8 w-full rounded-md border border-input bg-background px-2 py-1 text-xs shadow-sm transition-colors"
             >
-              <option value="">(Org Default)</option>
+              <option value="">
+                {orgDefaultEmbedName ? `(Org Default — ${orgDefaultEmbedName})` : "(Org Default)"}
+              </option>
               {embedModels.map((m) => (
                 <option key={m.modelId} value={m.modelId}>
                   {m.displayName} ({m.provider})
@@ -142,7 +154,11 @@ function RepoModelRow({
               variant={savedReviewModelId ? "default" : "secondary"}
               className="text-[10px] font-normal h-5"
             >
-              {getModelDisplayName(savedReviewModelId, availableModels)}
+              {getModelDisplayName(
+                savedReviewModelId,
+                availableModels,
+                orgDefaultLlmName ? `Org Default — ${orgDefaultLlmName}` : "Org Default",
+              )}
             </Badge>
           </div>
           <div className="flex items-center gap-1.5">
@@ -151,7 +167,11 @@ function RepoModelRow({
               variant={savedEmbedModelId ? "default" : "secondary"}
               className="text-[10px] font-normal h-5"
             >
-              {getModelDisplayName(savedEmbedModelId, availableModels)}
+              {getModelDisplayName(
+                savedEmbedModelId,
+                availableModels,
+                orgDefaultEmbedName ? `Org Default — ${orgDefaultEmbedName}` : "Org Default",
+              )}
             </Badge>
           </div>
         </div>
@@ -182,11 +202,15 @@ function RepositoryModelsSection({
   totalRepoCount,
   availableModels,
   isOwner,
+  orgDefaultLlmName,
+  orgDefaultEmbedName,
 }: {
   initialRepos: RepoModelItem[];
   totalRepoCount: number;
   availableModels: AvailableModel[];
   isOwner: boolean;
+  orgDefaultLlmName: string | null;
+  orgDefaultEmbedName: string | null;
 }) {
   const [repos, setRepos] = useState<RepoModelItem[]>(initialRepos);
   const [total, setTotal] = useState(totalRepoCount);
@@ -275,6 +299,8 @@ function RepositoryModelsSection({
                     repo={repo}
                     availableModels={availableModels}
                     isOwner={isOwner}
+                    orgDefaultLlmName={orgDefaultLlmName}
+                    orgDefaultEmbedName={orgDefaultEmbedName}
                   />
                 ))}
               </div>
@@ -306,6 +332,8 @@ export function ModelsSettings({
   availableModels,
   currentModelId,
   currentEmbedModelId,
+  platformDefaultLlmName,
+  platformDefaultEmbedName,
   initialRepos,
   totalRepoCount,
 }: {
@@ -313,6 +341,8 @@ export function ModelsSettings({
   availableModels: AvailableModel[];
   currentModelId: string | null;
   currentEmbedModelId: string | null;
+  platformDefaultLlmName: string | null;
+  platformDefaultEmbedName: string | null;
   initialRepos: RepoModelItem[];
   totalRepoCount: number;
 }) {
@@ -320,6 +350,15 @@ export function ModelsSettings({
   const [selectedEmbedModelId, setSelectedEmbedModelId] = useState(currentEmbedModelId ?? "");
   const [saving, startTransition] = useTransition();
   const [saveResult, setSaveResult] = useState<{ error?: string; success?: boolean }>({});
+
+  const orgLlmModel = currentModelId
+    ? availableModels.find((m) => m.modelId === currentModelId)
+    : null;
+  const orgEmbedModel = currentEmbedModelId
+    ? availableModels.find((m) => m.modelId === currentEmbedModelId)
+    : null;
+  const orgDefaultLlmName = orgLlmModel?.displayName ?? platformDefaultLlmName;
+  const orgDefaultEmbedName = orgEmbedModel?.displayName ?? platformDefaultEmbedName;
 
   const llmModels = availableModels.filter((m) => m.category === "llm");
   const embedModels = availableModels.filter((m) => m.category === "embedding");
@@ -355,7 +394,11 @@ export function ModelsSettings({
                 disabled={!isOwner}
                 className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50"
               >
-                <option value="">(Platform Default)</option>
+                <option value="">
+                  {platformDefaultLlmName
+                    ? `(Platform Default — ${platformDefaultLlmName})`
+                    : "(Platform Default)"}
+                </option>
                 {llmModels.map((m) => (
                   <option key={m.modelId} value={m.modelId}>
                     {m.displayName} ({m.provider})
@@ -379,7 +422,11 @@ export function ModelsSettings({
                 disabled={!isOwner}
                 className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50"
               >
-                <option value="">(Platform Default)</option>
+                <option value="">
+                  {platformDefaultEmbedName
+                    ? `(Platform Default — ${platformDefaultEmbedName})`
+                    : "(Platform Default)"}
+                </option>
                 {embedModels.map((m) => (
                   <option key={m.modelId} value={m.modelId}>
                     {m.displayName} ({m.provider})
@@ -422,6 +469,8 @@ export function ModelsSettings({
         totalRepoCount={totalRepoCount}
         availableModels={availableModels}
         isOwner={isOwner}
+        orgDefaultLlmName={orgDefaultLlmName}
+        orgDefaultEmbedName={orgDefaultEmbedName}
       />
     </div>
   );

--- a/apps/web/app/(app)/settings/models/page.tsx
+++ b/apps/web/app/(app)/settings/models/page.tsx
@@ -72,6 +72,22 @@ export default async function ModelsPage() {
 
   const isOwner = member.role === "owner";
 
+  const HARDCODED_LLM_FALLBACK = "claude-sonnet-4-6";
+  const HARDCODED_EMBED_FALLBACK = "text-embedding-3-large";
+
+  const platformDefaults = await prisma.availableModel.findMany({
+    where: { isPlatformDefault: true, isActive: true },
+    select: { modelId: true, displayName: true, category: true },
+  });
+  const platformDefaultLlm =
+    platformDefaults.find((m) => m.category === "llm") ??
+    availableModels.find((m) => m.modelId === HARDCODED_LLM_FALLBACK) ??
+    null;
+  const platformDefaultEmbed =
+    platformDefaults.find((m) => m.category === "embedding") ??
+    availableModels.find((m) => m.modelId === HARDCODED_EMBED_FALLBACK) ??
+    null;
+
   return (
     <ModelsSettings
       key={orgId}
@@ -79,6 +95,8 @@ export default async function ModelsPage() {
       availableModels={availableModels}
       currentModelId={member.organization.defaultModelId}
       currentEmbedModelId={member.organization.defaultEmbedModelId}
+      platformDefaultLlmName={platformDefaultLlm?.displayName ?? null}
+      platformDefaultEmbedName={platformDefaultEmbed?.displayName ?? null}
       initialRepos={repos}
       totalRepoCount={totalCount}
     />

--- a/apps/web/app/(app)/settings/models/page.tsx
+++ b/apps/web/app/(app)/settings/models/page.tsx
@@ -2,6 +2,7 @@ import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
+import { HARDCODED_REVIEW_MODEL, HARDCODED_EMBED_MODEL } from "@/lib/ai-client";
 import { ModelsSettings } from "./models-settings";
 
 const INITIAL_REPO_COUNT = 10;
@@ -72,20 +73,17 @@ export default async function ModelsPage() {
 
   const isOwner = member.role === "owner";
 
-  const HARDCODED_LLM_FALLBACK = "claude-sonnet-4-6";
-  const HARDCODED_EMBED_FALLBACK = "text-embedding-3-large";
-
   const platformDefaults = await prisma.availableModel.findMany({
     where: { isPlatformDefault: true, isActive: true },
     select: { modelId: true, displayName: true, category: true },
   });
   const platformDefaultLlm =
     platformDefaults.find((m) => m.category === "llm") ??
-    availableModels.find((m) => m.modelId === HARDCODED_LLM_FALLBACK) ??
+    availableModels.find((m) => m.modelId === HARDCODED_REVIEW_MODEL) ??
     null;
   const platformDefaultEmbed =
     platformDefaults.find((m) => m.category === "embedding") ??
-    availableModels.find((m) => m.modelId === HARDCODED_EMBED_FALLBACK) ??
+    availableModels.find((m) => m.modelId === HARDCODED_EMBED_MODEL) ??
     null;
 
   return (

--- a/apps/web/app/api/blog/route.ts
+++ b/apps/web/app/api/blog/route.ts
@@ -143,7 +143,7 @@ export async function POST(request: NextRequest) {
       try {
         const client = new Anthropic();
         const response = await client.messages.create({
-          model: "claude-sonnet-4-20250514",
+          model: "claude-sonnet-4-6",
           max_tokens: 200,
           messages: [
             {

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -19,6 +19,7 @@ import { pubby } from "@/lib/pubby";
 import { processNextInQueue } from "@/lib/chat-queue-processor";
 import { generateSparseVector } from "@/lib/sparse-vector";
 import { requestAgentSearch, findClaudeAgent, requestAgentAnswer } from "@/lib/agent-search";
+import { getReviewModel } from "@/lib/ai-client";
 
 let anthropicClient: Anthropic | null = null;
 
@@ -613,8 +614,10 @@ ${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent run
         let deltaBatch = "";
         let lastBroadcast = Date.now();
 
+        const chatModel = await getReviewModel(orgId);
+
         const anthropicStream = client.messages.stream({
-          model: "claude-sonnet-4-20250514",
+          model: chatModel,
           max_tokens: 4096,
           system: [
             {
@@ -676,7 +679,7 @@ ${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent run
 
         await logAiUsage({
           provider: "anthropic",
-          model: "claude-sonnet-4-20250514",
+          model: chatModel,
           operation: "chat",
           inputTokens,
           outputTokens,

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -614,7 +614,15 @@ ${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent run
         let deltaBatch = "";
         let lastBroadcast = Date.now();
 
-        const chatModel = await getReviewModel(orgId);
+        let chatRepoId: string | undefined;
+        if (repoContext) {
+          const repo = await prisma.repository.findFirst({
+            where: { fullName: repoContext, organizationId: orgId },
+            select: { id: true },
+          });
+          chatRepoId = repo?.id;
+        }
+        const chatModel = await getReviewModel(orgId, chatRepoId);
 
         const anthropicStream = client.messages.stream({
           model: chatModel,

--- a/apps/web/app/api/cli/chat/route.ts
+++ b/apps/web/app/api/cli/chat/route.ts
@@ -10,6 +10,7 @@ import { logAiUsage } from "@/lib/ai-usage";
 import { rerankDocuments } from "@/lib/reranker";
 import Anthropic from "@anthropic-ai/sdk";
 import { requestAgentSearch } from "@/lib/agent-search";
+import { getReviewModel } from "@/lib/ai-client";
 
 let anthropicClient: Anthropic | null = null;
 
@@ -172,8 +173,10 @@ ${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent ("$
         const client = getAnthropicClient();
         let fullResponse = "";
 
+        const chatModel = await getReviewModel(orgId, repoId);
+
         const anthropicStream = client.messages.stream({
-          model: "claude-sonnet-4-20250514",
+          model: chatModel,
           max_tokens: 4096,
           system: systemPrompt,
           messages: historyMessages,
@@ -192,7 +195,7 @@ ${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent ("$
         const finalMessage = await anthropicStream.finalMessage();
         await logAiUsage({
           provider: "anthropic",
-          model: "claude-sonnet-4-20250514",
+          model: chatModel,
           operation: "chat",
           inputTokens: finalMessage.usage.input_tokens,
           outputTokens: finalMessage.usage.output_tokens,

--- a/apps/web/lib/ai-client.ts
+++ b/apps/web/lib/ai-client.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@octopus/db";
 
-const HARDCODED_REVIEW_MODEL = "claude-sonnet-4-20250514";
+const HARDCODED_REVIEW_MODEL = "claude-sonnet-4-6";
 const HARDCODED_EMBED_MODEL = "text-embedding-3-large";
 
 async function getPlatformDefault(category: "llm" | "embedding"): Promise<string | null> {

--- a/apps/web/lib/ai-client.ts
+++ b/apps/web/lib/ai-client.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@octopus/db";
 
-const HARDCODED_REVIEW_MODEL = "claude-sonnet-4-6";
-const HARDCODED_EMBED_MODEL = "text-embedding-3-large";
+export const HARDCODED_REVIEW_MODEL = "claude-sonnet-4-6";
+export const HARDCODED_EMBED_MODEL = "text-embedding-3-large";
 
 async function getPlatformDefault(category: "llm" | "embedding"): Promise<string | null> {
   try {


### PR DESCRIPTION
## Summary
- Chat and CLI chat routes were hardcoded to `claude-sonnet-4-20250514` (now deprecated). Route them through `getReviewModel(orgId, repoId?)` so chat respects the org's "Review & Chat Model" setting (and repo-level override on CLI).
- Updated the hardcoded fallback in `lib/ai-client.ts` and the blog SEO excerpt model to `claude-sonnet-4-6`.
- Surfaced the resolved default in the settings dropdowns:
  - Org Defaults: `(Platform Default — Claude Sonnet 4.6)`
  - Repository rows: `(Org Default — <model name>)`, plus matching badges on the saved row.

## Test plan
- [ ] Open `/settings/models` and confirm the "(Platform Default — …)" label shows the resolved model name in both LLM and embedding dropdowns.
- [ ] Edit a repository row and confirm "(Org Default — …)" shows the org-selected model (or platform default when the org has none).
- [ ] Send a chat message and verify the model used in `[ai-usage] chat …` logs matches the org's selected model (no more `claude-sonnet-4-20250514`).
- [ ] CLI chat with `--repo` honors the repo's `reviewModelId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)