### PR TITLE
fix(gitlab): clone fails — git smart-http rejects Bearer, use Basic auth

### DIFF
--- a/apps/web/lib/indexer.ts
+++ b/apps/web/lib/indexer.ts
@@ -188,6 +188,12 @@ export async function indexRepository(
       const [workspace, repoSlug] = fullName.split("/");
       cloneUrl = `https://bitbucket.org/${workspace}/${repoSlug}.git`;
     }
+    // GitLab's git smart-http server requires Basic auth (Bearer is rejected);
+    // Bitbucket accepts a Bearer header. Build the auth header per provider —
+    // never embed the token in the URL, since git surfaces the cmd in error logs.
+    const gitAuthHeader = isGl
+      ? `Basic ${Buffer.from(`oauth2:${token}`).toString("base64")}`
+      : `Bearer ${token}`;
 
     try {
       onLog(`Cloning ${fullName}@${defaultBranch}...`);
@@ -209,7 +215,7 @@ export async function indexRepository(
           ...process.env,
           GIT_CONFIG_COUNT: "1",
           GIT_CONFIG_KEY_0: "http.extraHeader",
-          GIT_CONFIG_VALUE_0: `Authorization: Bearer ${token}`,
+          GIT_CONFIG_VALUE_0: `Authorization: ${gitAuthHeader}`,
         },
       });
       onLog("Repository cloned successfully", "success");


### PR DESCRIPTION
## Summary

After connecting GitLab via OAuth, every clone-based index attempt failed with:
\`\`\`
fatal: could not read Username for 'https://gitlab.com': No such device or address
\`\`\`

**Root cause**: \`lib/indexer.ts\` set \`http.extraHeader: Authorization: Bearer <token>\`. GitHub and Bitbucket accept that; **GitLab's git smart-http server requires Basic auth** (\`oauth2:<token>\`). With the Bearer header, GitLab ignored it and fell back to interactive prompting — the worker has no TTY, so git died.

**Fix**: build the auth header per provider in \`indexer.ts\`:
- GitLab → \`Basic base64(oauth2:<token>)\`
- Bitbucket → \`Bearer <token>\` (unchanged)

Token is not embedded in the URL — git surfaces the full \`cmd\` in error logs and process listings.

Closes #365

## Reproduction (before this fix)

1. Connect GitLab namespace via OAuth (repo rows get created).
2. Manually trigger indexing on one repo.
3. Logs show: \`fatal: could not read Username\`; \`indexStatus = failed\`.

## Test plan

- [ ] Re-trigger indexing on a previously failed GitLab repo → expect \`indexed\`, chunks > 0.
- [ ] Bitbucket indexing still passes (regression).
- [ ] Token does not appear in any error log on failed clone (negative test: revoke token, retry, confirm log shows the plain URL only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)