### PR TITLE
feat(repositories): show resolved model in repo AI Models dropdowns

### DIFF
--- a/apps/web/app/(app)/repositories/page.tsx
+++ b/apps/web/app/(app)/repositories/page.tsx
@@ -94,7 +94,7 @@ export default async function RepositoriesPage({
   } as const;
 
   // Step 2: All queries in parallel
-  const [repos, totalCount, allRepoNames, favoriteRepos, otherOrgMemberships, availableModels, bitbucketIntegration] = await Promise.all([
+  const [repos, totalCount, allRepoNames, favoriteRepos, otherOrgMemberships, availableModels, bitbucketIntegration, platformDefaults] = await Promise.all([
     // Paginated repos — light select, no heavy fields
     prisma.repository.findMany({
       where: baseWhere,
@@ -144,12 +144,14 @@ export default async function RepositoriesPage({
       where: { organizationId: orgId },
       select: { workspaceSlug: true },
     }),
+
+    // Platform-default models (fallback when org hasn't picked an LLM/embedding)
+    prisma.availableModel.findMany({
+      where: { isPlatformDefault: true, isActive: true },
+      select: { modelId: true, displayName: true, category: true },
+    }),
   ]);
 
-  const platformDefaults = await prisma.availableModel.findMany({
-    where: { isPlatformDefault: true, isActive: true },
-    select: { modelId: true, displayName: true, category: true },
-  });
   const orgLlmModelId = member.organization.defaultModelId;
   const orgEmbedModelId = member.organization.defaultEmbedModelId;
   const orgDefaultLlmName =

--- a/apps/web/app/(app)/repositories/page.tsx
+++ b/apps/web/app/(app)/repositories/page.tsx
@@ -2,6 +2,7 @@ import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
+import { HARDCODED_REVIEW_MODEL, HARDCODED_EMBED_MODEL } from "@/lib/ai-client";
 import { RepositoriesContent } from "./repositories-content";
 
 const PAGE_SIZE = 50;
@@ -27,7 +28,9 @@ export default async function RepositoriesPage({
       deletedAt: null,
     },
     select: {
-      organization: { select: { id: true } },
+      organization: {
+        select: { id: true, defaultModelId: true, defaultEmbedModelId: true },
+      },
     },
   });
 
@@ -143,6 +146,23 @@ export default async function RepositoriesPage({
     }),
   ]);
 
+  const platformDefaults = await prisma.availableModel.findMany({
+    where: { isPlatformDefault: true, isActive: true },
+    select: { modelId: true, displayName: true, category: true },
+  });
+  const orgLlmModelId = member.organization.defaultModelId;
+  const orgEmbedModelId = member.organization.defaultEmbedModelId;
+  const orgDefaultLlmName =
+    (orgLlmModelId && availableModels.find((m) => m.modelId === orgLlmModelId)?.displayName) ??
+    platformDefaults.find((m) => m.category === "llm")?.displayName ??
+    availableModels.find((m) => m.modelId === HARDCODED_REVIEW_MODEL)?.displayName ??
+    null;
+  const orgDefaultEmbedName =
+    (orgEmbedModelId && availableModels.find((m) => m.modelId === orgEmbedModelId)?.displayName) ??
+    platformDefaults.find((m) => m.category === "embedding")?.displayName ??
+    availableModels.find((m) => m.modelId === HARDCODED_EMBED_MODEL)?.displayName ??
+    null;
+
   const favoriteRepoIds = favoriteRepos.map((f) => f.repositoryId);
   const paginatedRepoIds = new Set(repos.map((r) => r.id));
 
@@ -200,6 +220,8 @@ export default async function RepositoriesPage({
       githubAppSlug={process.env.NEXT_PUBLIC_GITHUB_APP_SLUG ?? null}
       favoriteRepoIds={favoriteRepoIds}
       availableModels={availableModels}
+      orgDefaultLlmName={orgDefaultLlmName}
+      orgDefaultEmbedName={orgDefaultEmbedName}
       otherOrgs={otherOrgs}
       owners={owners}
       currentSearch={search}

--- a/apps/web/app/(app)/repositories/repositories-content.tsx
+++ b/apps/web/app/(app)/repositories/repositories-content.tsx
@@ -988,6 +988,8 @@ function RepoDetail({
   detail,
   detailLoading,
   availableModels,
+  orgDefaultLlmName,
+  orgDefaultEmbedName,
   otherOrgs = [],
   onDetailRefresh,
 }: {
@@ -997,6 +999,8 @@ function RepoDetail({
   detail: RepoDetailData | null;
   detailLoading: boolean;
   availableModels: AvailableModel[];
+  orgDefaultLlmName: string | null;
+  orgDefaultEmbedName: string | null;
   otherOrgs?: OtherOrg[];
   onDetailRefresh: () => void;
 }) {
@@ -1201,7 +1205,9 @@ function RepoDetail({
                 onChange={(e) => setRepoReviewModelId(e.target.value)}
                 className="flex h-8 w-full rounded-md border border-input bg-background px-2 py-1 text-xs shadow-sm transition-colors"
               >
-                <option value="">(Org Default)</option>
+                <option value="">
+                  {orgDefaultLlmName ? `(Org Default — ${orgDefaultLlmName})` : "(Org Default)"}
+                </option>
                 {availableModels
                   .filter((m) => m.category === "llm")
                   .map((m) => (
@@ -1218,7 +1224,9 @@ function RepoDetail({
                 onChange={(e) => setRepoEmbedModelId(e.target.value)}
                 className="flex h-8 w-full rounded-md border border-input bg-background px-2 py-1 text-xs shadow-sm transition-colors"
               >
-                <option value="">(Org Default)</option>
+                <option value="">
+                  {orgDefaultEmbedName ? `(Org Default — ${orgDefaultEmbedName})` : "(Org Default)"}
+                </option>
                 {availableModels
                   .filter((m) => m.category === "embedding")
                   .map((m) => (
@@ -1757,6 +1765,8 @@ export function RepositoriesContent({
   githubAppSlug,
   favoriteRepoIds,
   availableModels = [],
+  orgDefaultLlmName = null,
+  orgDefaultEmbedName = null,
   otherOrgs = [],
   owners = [],
   currentSearch = "",
@@ -1773,6 +1783,8 @@ export function RepositoriesContent({
   githubAppSlug: string | null;
   favoriteRepoIds: string[];
   availableModels?: AvailableModel[];
+  orgDefaultLlmName?: string | null;
+  orgDefaultEmbedName?: string | null;
   otherOrgs?: OtherOrg[];
   owners?: string[];
   currentSearch?: string;
@@ -2142,6 +2154,8 @@ export function RepositoriesContent({
               detail={repoDetail}
               detailLoading={detailLoading}
               availableModels={availableModels}
+              orgDefaultLlmName={orgDefaultLlmName}
+              orgDefaultEmbedName={orgDefaultEmbedName}
               otherOrgs={otherOrgs}
               onDetailRefresh={() => setDetailRefreshKey((k) => k + 1)}
             />


### PR DESCRIPTION
## Summary
- Repository detail page's "AI Models" section now surfaces the resolved fallback in the dropdowns: `(Org Default — <model name>)` instead of a generic `(Org Default)`.
- Resolution order: repo override → org `defaultModelId` → `AvailableModel.isPlatformDefault` → hardcoded `claude-sonnet-4-6` / `text-embedding-3-large` (imported from `lib/ai-client`, matching the settings page).
- Same treatment for both Review & Chat Model and Embedding Model dropdowns.

## Test plan
- [ ] Visit `/repositories?repo=<id>` for a repo that has no per-repo override → dropdowns should show "(Org Default — <name>)" matching whatever the org's defaultModelId resolves to.
- [ ] Set a repo override → dropdown shows the selected model.
- [ ] If the org has no defaultModelId, label should reflect the platform default (or the hardcoded fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)