### PR TITLE
feat(models): seed GPT-5 Codex and GPT-5 Codex Mini

### DIFF
--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -725,7 +725,9 @@ async function main() {
     { modelId: "o3", displayName: "OpenAI o3", provider: "openai", category: "llm", inputPrice: 10, outputPrice: 40, sortOrder: 9 },
     { modelId: "o3-mini", displayName: "OpenAI o3 Mini", provider: "openai", category: "llm", inputPrice: 1.1, outputPrice: 4.4, sortOrder: 10 },
     { modelId: "o4-mini", displayName: "OpenAI o4 Mini", provider: "openai", category: "llm", inputPrice: 1.1, outputPrice: 4.4, sortOrder: 11 },
-    { modelId: "codex-mini-latest", displayName: "Codex Mini", provider: "openai", category: "llm", inputPrice: 1.5, outputPrice: 6, sortOrder: 12 },
+    { modelId: "gpt-5-codex", displayName: "GPT-5 Codex", provider: "openai", category: "llm", inputPrice: 1.25, outputPrice: 10, sortOrder: 12 },
+    { modelId: "gpt-5-codex-mini", displayName: "GPT-5 Codex Mini", provider: "openai", category: "llm", inputPrice: 0.25, outputPrice: 2, sortOrder: 13 },
+    { modelId: "codex-mini-latest", displayName: "Codex Mini", provider: "openai", category: "llm", inputPrice: 1.5, outputPrice: 6, sortOrder: 14 },
     // Embeddings
     { modelId: "text-embedding-3-large", displayName: "Embedding 3 Large", provider: "openai", category: "embedding", inputPrice: 0.13, outputPrice: 0, sortOrder: 0 },
     { modelId: "text-embedding-3-small", displayName: "Embedding 3 Small", provider: "openai", category: "embedding", inputPrice: 0.02, outputPrice: 0, sortOrder: 1 },

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -725,8 +725,8 @@ async function main() {
     { modelId: "o3", displayName: "OpenAI o3", provider: "openai", category: "llm", inputPrice: 10, outputPrice: 40, sortOrder: 9 },
     { modelId: "o3-mini", displayName: "OpenAI o3 Mini", provider: "openai", category: "llm", inputPrice: 1.1, outputPrice: 4.4, sortOrder: 10 },
     { modelId: "o4-mini", displayName: "OpenAI o4 Mini", provider: "openai", category: "llm", inputPrice: 1.1, outputPrice: 4.4, sortOrder: 11 },
-    { modelId: "gpt-5-codex", displayName: "GPT-5 Codex", provider: "openai", category: "llm", inputPrice: 1.25, outputPrice: 10, sortOrder: 12 },
-    { modelId: "gpt-5-codex-mini", displayName: "GPT-5 Codex Mini", provider: "openai", category: "llm", inputPrice: 0.25, outputPrice: 2, sortOrder: 13 },
+    { modelId: "gpt-5.3-codex", displayName: "GPT-5.3 Codex", provider: "openai", category: "llm", inputPrice: 1.25, outputPrice: 10, sortOrder: 12 },
+    { modelId: "gpt-5.3-codex-mini", displayName: "GPT-5.3 Codex Mini", provider: "openai", category: "llm", inputPrice: 0.25, outputPrice: 2, sortOrder: 13 },
     { modelId: "codex-mini-latest", displayName: "Codex Mini", provider: "openai", category: "llm", inputPrice: 1.5, outputPrice: 6, sortOrder: 14 },
     // Embeddings
     { modelId: "text-embedding-3-large", displayName: "Embedding 3 Large", provider: "openai", category: "embedding", inputPrice: 0.13, outputPrice: 0, sortOrder: 0 },


### PR DESCRIPTION
Adds the new OpenAI Codex flagship and mini models to the seeded
AvailableModel list so they show up in the org/repo model picker.
Provider resolution already routes gpt-* / codex-* prefixes to
OpenAI, so no router or schema changes are needed.