### PR TITLE
feat(repositories): add remove/restore with sync-safe dismissal

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -514,13 +514,15 @@ export async function syncRepos(): Promise<{ synced: number; removed: number; er
       }
     }
 
-    // Deactivate GitHub repos no longer in any installation
+    // Deactivate GitHub repos no longer in any installation.
+    // Skip dismissed repos so we don't churn rows the user has already removed.
     const ghRemoved = await prisma.repository.updateMany({
       where: {
         organizationId: orgId,
         provider: "github",
         externalId: { notIn: allGhRepoIds },
         isActive: true,
+        dismissedAt: null,
       },
       data: { isActive: false },
     });
@@ -572,13 +574,15 @@ export async function syncRepos(): Promise<{ synced: number; removed: number; er
         synced++;
       }
 
-      // Deactivate Bitbucket repos no longer in workspace
+      // Deactivate Bitbucket repos no longer in workspace.
+      // Skip dismissed repos so we don't churn rows the user has already removed.
       const bbRemoved = await prisma.repository.updateMany({
         where: {
           organizationId: orgId,
           provider: "bitbucket",
           externalId: { notIn: allBbRepoIds },
           isActive: true,
+          dismissedAt: null,
         },
         data: { isActive: false },
       });

--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -470,12 +470,22 @@ export async function syncRepos(): Promise<{ synced: number; removed: number; er
   const allGhRepoIds: string[] = [];
 
   if (installationIds.size > 0) {
+    const dismissedGh = new Set(
+      (
+        await prisma.repository.findMany({
+          where: { organizationId: orgId, provider: "github", dismissedAt: { not: null } },
+          select: { externalId: true },
+        })
+      ).map((r) => r.externalId),
+    );
+
     for (const instId of installationIds) {
       try {
         const ghRepos = await listInstallationRepos(instId);
         for (const repo of ghRepos) {
           const externalId = String(repo.id);
           allGhRepoIds.push(externalId);
+          if (dismissedGh.has(externalId)) continue;
           await prisma.repository.upsert({
             where: {
               provider_externalId_organizationId: { provider: "github", externalId, organizationId: orgId },
@@ -528,8 +538,18 @@ export async function syncRepos(): Promise<{ synced: number; removed: number; er
       const bbRepos = await listWorkspaceRepos(orgId, bbIntegration.workspaceSlug);
       const allBbRepoIds: string[] = [];
 
+      const dismissedBb = new Set(
+        (
+          await prisma.repository.findMany({
+            where: { organizationId: orgId, provider: "bitbucket", dismissedAt: { not: null } },
+            select: { externalId: true },
+          })
+        ).map((r) => r.externalId),
+      );
+
       for (const repo of bbRepos) {
         allBbRepoIds.push(repo.uuid);
+        if (dismissedBb.has(repo.uuid)) continue;
         await prisma.repository.upsert({
           where: {
             provider_externalId_organizationId: { provider: "bitbucket", externalId: repo.uuid, organizationId: orgId },

--- a/apps/web/app/(app)/repositories/actions.ts
+++ b/apps/web/app/(app)/repositories/actions.ts
@@ -7,6 +7,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { pubby } from "@/lib/pubby";
 import { createAnalysisAbortController, abortAnalysis, clearAnalysisAbortController } from "@/lib/analysis-abort";
+import { abortIndexing } from "@/lib/indexing-abort";
 import { eventBus } from "@/lib/events/bus";
 
 export type RepoDetailData = {
@@ -657,6 +658,7 @@ export async function removeRepository(
       id: true,
       fullName: true,
       organizationId: true,
+      indexStatus: true,
       organization: {
         select: {
           members: {
@@ -677,6 +679,7 @@ export async function removeRepository(
   }
 
   abortAnalysis(repoId);
+  abortIndexing(repoId);
 
   await prisma.repository.update({
     where: { id: repoId },
@@ -684,6 +687,7 @@ export async function removeRepository(
       isActive: false,
       autoReview: false,
       dismissedAt: new Date(),
+      indexStatus: repo.indexStatus === "indexing" ? "cancelled" : repo.indexStatus,
     },
   });
 

--- a/apps/web/app/(app)/repositories/actions.ts
+++ b/apps/web/app/(app)/repositories/actions.ts
@@ -643,6 +643,114 @@ export async function transferRepository(
   return { success: true };
 }
 
+export async function removeRepository(
+  repoId: string,
+): Promise<{ error?: string; success?: boolean }> {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+  if (!session) redirect("/login");
+
+  const repo = await prisma.repository.findUnique({
+    where: { id: repoId },
+    select: {
+      id: true,
+      fullName: true,
+      organizationId: true,
+      organization: {
+        select: {
+          members: {
+            where: { userId: session.user.id, deletedAt: null },
+            select: { role: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!repo || repo.organization.members.length === 0) {
+    return { error: "Repository not found." };
+  }
+
+  if (repo.organization.members[0].role !== "owner") {
+    return { error: "Only organization owners can remove repositories." };
+  }
+
+  abortAnalysis(repoId);
+
+  await prisma.repository.update({
+    where: { id: repoId },
+    data: {
+      isActive: false,
+      autoReview: false,
+      dismissedAt: new Date(),
+    },
+  });
+
+  pubby.trigger(`presence-org-${repo.organizationId}`, "repo-removed", {
+    repoId: repo.id,
+    repoName: repo.fullName,
+  });
+
+  revalidatePath("/repositories");
+  return { success: true };
+}
+
+export async function restoreRepository(
+  repoId: string,
+): Promise<{ error?: string; success?: boolean }> {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+  if (!session) redirect("/login");
+
+  const repo = await prisma.repository.findUnique({
+    where: { id: repoId },
+    select: {
+      id: true,
+      fullName: true,
+      dismissedAt: true,
+      organizationId: true,
+      organization: {
+        select: {
+          members: {
+            where: { userId: session.user.id, deletedAt: null },
+            select: { role: true },
+          },
+        },
+      },
+    },
+  });
+
+  if (!repo || repo.organization.members.length === 0) {
+    return { error: "Repository not found." };
+  }
+
+  if (repo.organization.members[0].role !== "owner") {
+    return { error: "Only organization owners can restore repositories." };
+  }
+
+  if (!repo.dismissedAt) {
+    return { error: "Repository is not removed." };
+  }
+
+  await prisma.repository.update({
+    where: { id: repoId },
+    data: {
+      isActive: true,
+      dismissedAt: null,
+    },
+  });
+
+  pubby.trigger(`presence-org-${repo.organizationId}`, "repo-restored", {
+    repoId: repo.id,
+    repoName: repo.fullName,
+  });
+
+  revalidatePath("/repositories");
+  return { success: true };
+}
+
 export async function toggleAutoReview(
   repoId: string,
   enabled: boolean,

--- a/apps/web/app/(app)/repositories/page.tsx
+++ b/apps/web/app/(app)/repositories/page.tsx
@@ -43,8 +43,14 @@ export default async function RepositoriesPage({
   // Build where clause for repository query
   const baseWhere: Record<string, unknown> = {
     organizationId: orgId,
-    isActive: true,
   };
+
+  if (filter === "removed") {
+    baseWhere.dismissedAt = { not: null };
+    baseWhere.isActive = false;
+  } else {
+    baseWhere.isActive = true;
+  }
 
   if (search) {
     baseWhere.OR = [
@@ -75,6 +81,7 @@ export default async function RepositoriesPage({
     defaultBranch: true,
     isActive: true,
     autoReview: true,
+    dismissedAt: true,
     indexStatus: true,
     indexedAt: true,
     indexedFiles: true,
@@ -198,6 +205,7 @@ export default async function RepositoriesPage({
     defaultBranch: r.defaultBranch,
     isActive: r.isActive,
     autoReview: r.autoReview,
+    dismissedAt: r.dismissedAt?.toISOString() ?? null,
     indexStatus: r.indexStatus,
     indexedAt: r.indexedAt?.toISOString() ?? null,
     indexedFiles: r.indexedFiles,

--- a/apps/web/app/(app)/repositories/repositories-content.tsx
+++ b/apps/web/app/(app)/repositories/repositories-content.tsx
@@ -65,7 +65,7 @@ import {
 } from "@/components/ui/dialog";
 import { MermaidDiagram } from "@/components/mermaid-diagram";
 import { extractAllMermaidBlocks, DIAGRAM_TYPE_LABELS, type DiagramType, type MermaidBlock } from "@/lib/mermaid-utils";
-import { analyzeRepository, cancelAnalysis, toggleAutoReview, toggleFavoriteRepository, deletePullRequestReview, cancelPullRequestReview, updateRepoModels, transferRepository, getRepoDetail, updateReviewConfig, type RepoDetailData } from "./actions";
+import { analyzeRepository, cancelAnalysis, toggleAutoReview, toggleFavoriteRepository, deletePullRequestReview, cancelPullRequestReview, updateRepoModels, transferRepository, removeRepository, restoreRepository, getRepoDetail, updateReviewConfig, type RepoDetailData } from "./actions";
 import { indexRepository, cancelIndexing, syncRepos } from "../actions";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -113,6 +113,7 @@ type Repo = {
   defaultBranch: string;
   isActive: boolean;
   autoReview: boolean;
+  dismissedAt: string | null;
   indexStatus: string;
   indexedAt: string | null;
   indexedFiles: number;
@@ -1020,6 +1021,11 @@ function RepoDetail({
   const [transferTargetOrgId, setTransferTargetOrgId] = useState("");
   const [transferPending, startTransferTransition] = useTransition();
   const [transferError, setTransferError] = useState("");
+  const [removeOpen, setRemoveOpen] = useState(false);
+  const [removeConfirmText, setRemoveConfirmText] = useState("");
+  const [removePending, startRemoveTransition] = useTransition();
+  const [removeError, setRemoveError] = useState("");
+  const [restorePending, startRestoreTransition] = useTransition();
   const [reviewConfigOpen, setReviewConfigOpen] = useState(false);
   const [reviewConfigPending, startReviewConfigTransition] = useTransition();
   const [reviewConfigSaved, setReviewConfigSaved] = useState(false);
@@ -1610,6 +1616,136 @@ function RepoDetail({
           </Dialog>
         </>
       )}
+
+      {/* Remove or Restore Repository */}
+      {repo.dismissedAt ? (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 px-4 py-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="text-sm font-medium">Repository Removed</div>
+              <div className="text-xs text-muted-foreground">
+                Removed on {new Date(repo.dismissedAt).toLocaleString()}. Restore to make it active again. Indexed code and pull request history are preserved.
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-fit shrink-0 border-emerald-500/50 text-emerald-700 hover:bg-emerald-500/10 dark:text-emerald-400"
+              disabled={restorePending}
+              onClick={() => {
+                startRestoreTransition(async () => {
+                  const result = await restoreRepository(repo.id);
+                  if (result.error) {
+                    toast.error(result.error);
+                    return;
+                  }
+                  toast.success(`${repo.fullName} restored`);
+                  router.push(`/repositories?repo=${repo.id}`);
+                  router.refresh();
+                });
+              }}
+            >
+              <IconRouteSquare2 className="mr-1 size-3" />
+              {restorePending ? "Restoring..." : "Restore"}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 px-4 py-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="text-sm font-medium">Remove Repository</div>
+              <div className="text-xs text-muted-foreground">
+                Detach this repository from the organization. A future sync will not bring it back.
+              </div>
+            </div>
+            <Button
+              variant="destructive"
+              size="sm"
+              className="w-fit shrink-0"
+              onClick={() => setRemoveOpen(true)}
+            >
+              <IconTrash className="mr-1 size-3" />
+              Remove
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <Dialog
+        open={removeOpen}
+        onOpenChange={(v) => {
+          setRemoveOpen(v);
+          if (!v) {
+            setRemoveConfirmText("");
+            setRemoveError("");
+          }
+        }}
+      >
+        <DialogContent showCloseButton={false} className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Remove Repository</DialogTitle>
+            <DialogDescription>
+              Remove <span className="font-semibold">{repo.fullName}</span> from this organization.
+              Pull request history and the indexed code are preserved so you can restore it later. Auto-review is turned off.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            <div className="flex items-start gap-2 rounded-md bg-destructive/10 border border-destructive/30 px-3 py-2.5">
+              <IconAlertTriangle className="size-4 text-destructive shrink-0 mt-0.5" />
+              <div className="text-sm text-destructive space-y-1">
+                <p>This repository will be hidden and a future provider sync will not restore it.</p>
+                <p className="text-xs opacity-90">
+                  The same repository can still be connected from a different organization you belong to.
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="remove-confirm" className="text-xs">
+                Type <span className="font-mono font-semibold">{repo.name}</span> to confirm
+              </Label>
+              <input
+                id="remove-confirm"
+                value={removeConfirmText}
+                onChange={(e) => setRemoveConfirmText(e.target.value)}
+                placeholder={repo.name}
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors"
+                autoComplete="off"
+              />
+            </div>
+
+            {removeError && <p className="text-sm text-destructive">{removeError}</p>}
+          </div>
+
+          <DialogFooter className="gap-2">
+            <Button variant="outline" onClick={() => setRemoveOpen(false)} disabled={removePending}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={removeConfirmText !== repo.name || removePending}
+              onClick={() => {
+                setRemoveError("");
+                startRemoveTransition(async () => {
+                  const result = await removeRepository(repo.id);
+                  if (result.error) {
+                    setRemoveError(result.error);
+                    return;
+                  }
+                  setRemoveOpen(false);
+                  toast.success(`${repo.fullName} removed from organization`);
+                  router.push("/repositories");
+                  router.refresh();
+                });
+              }}
+            >
+              {removePending ? "Removing..." : "Remove Repository"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
@@ -2015,6 +2151,7 @@ export function RepositoriesContent({
                 <SelectItem value="stale">Stale</SelectItem>
                 <SelectItem value="not-indexed">Not indexed</SelectItem>
                 <SelectItem value="failed">Failed</SelectItem>
+                <SelectItem value="removed">Removed</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/apps/web/app/api/bitbucket/callback/route.ts
+++ b/apps/web/app/api/bitbucket/callback/route.ts
@@ -192,7 +192,16 @@ export async function GET(request: NextRequest) {
   // Sync repos from workspace
   try {
     const bbRepos = await listWorkspaceRepos(orgId, workspaceSlug);
+    const dismissedBb = new Set(
+      (
+        await prisma.repository.findMany({
+          where: { organizationId: orgId, provider: "bitbucket", dismissedAt: { not: null } },
+          select: { externalId: true },
+        })
+      ).map((r) => r.externalId),
+    );
     for (const repo of bbRepos) {
+      if (dismissedBb.has(repo.uuid)) continue;
       await prisma.repository.upsert({
         where: {
           provider_externalId_organizationId: {

--- a/apps/web/app/api/github/callback/route.ts
+++ b/apps/web/app/api/github/callback/route.ts
@@ -88,7 +88,20 @@ export async function GET(request: NextRequest) {
     console.log(
       `[github/callback] listInstallationRepos returned ${ghRepos.length} repos for installation=${installationIdNum}`,
     );
+    const dismissedGh = new Set(
+      (
+        await prisma.repository.findMany({
+          where: {
+            organizationId: membership.organizationId,
+            provider: "github",
+            dismissedAt: { not: null },
+          },
+          select: { externalId: true },
+        })
+      ).map((r) => r.externalId),
+    );
     for (const repo of ghRepos) {
+      if (dismissedGh.has(String(repo.id))) continue;
       await prisma.repository.upsert({
         where: {
           provider_externalId_organizationId: {

--- a/apps/web/app/api/github/webhook/route.ts
+++ b/apps/web/app/api/github/webhook/route.ts
@@ -57,6 +57,15 @@ export async function POST(request: NextRequest) {
 
     // Sync repos from GitHub
     try {
+      const dismissedGh = new Set(
+        (
+          await prisma.repository.findMany({
+            where: { organizationId: org.id, provider: "github", dismissedAt: { not: null } },
+            select: { externalId: true },
+          })
+        ).map((r) => r.externalId),
+      );
+
       if (event === "installation_repositories") {
         // Incremental sync: only add/remove repos that changed.
         // The webhook payload omits `default_branch` for added repos, so we
@@ -79,6 +88,7 @@ export async function POST(request: NextRequest) {
         );
 
         for (const { repo, defaultBranch } of detailed) {
+          if (dismissedGh.has(String(repo.id))) continue;
           const branch = defaultBranch ?? "main";
           await prisma.repository.upsert({
             where: {
@@ -124,6 +134,7 @@ export async function POST(request: NextRequest) {
         const ghRepos = await listInstallationRepos(installationId);
 
         for (const repo of ghRepos) {
+          if (dismissedGh.has(String(repo.id))) continue;
           await prisma.repository.upsert({
             where: {
               provider_externalId_organizationId: {

--- a/apps/web/app/api/gitlab/callback/route.ts
+++ b/apps/web/app/api/gitlab/callback/route.ts
@@ -221,7 +221,16 @@ export async function GET(request: NextRequest) {
   try {
     const projects = await listNamespaceProjects(orgId, namespacePath);
     projectCount = projects.length;
+    const dismissedGl = new Set(
+      (
+        await prisma.repository.findMany({
+          where: { organizationId: orgId, provider: "gitlab", dismissedAt: { not: null } },
+          select: { externalId: true },
+        })
+      ).map((r) => r.externalId),
+    );
     for (const project of projects) {
+      if (dismissedGl.has(String(project.id))) continue;
       await prisma.repository.upsert({
         where: {
           provider_externalId_organizationId: {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -224,6 +224,7 @@ model Repository {
   reviewConfig   Json     @default("{}")
   useRepoConfig    Boolean  @default(false) // read repo-level config files from this repo
   repoConfigFiles  Json     @default("[\".octopus.md\", \"AGENTS.md\", \"CLAUDE.md\"]") // ordered candidate filenames at repo root
+  dismissedAt    DateTime? // set when a member removes the repo from the org; sync must not resurrect it
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 


### PR DESCRIPTION
## Summary

- Org owners can remove a repository from the organization. A dismissed repo is hidden from the active list, auto-review is paused, and indexed code + PR history are preserved so it can be restored later.
- All provider sync paths (GitHub callback/webhook/manual, GitLab callback, Bitbucket callback/manual) now skip repos with \`dismissedAt\` set so a re-sync cannot resurrect them.
- New \"Removed\" filter on the repositories page surfaces dismissed repos with a Restore action.
- Emits \`repo-removed\` / \`repo-restored\` on the org presence channel for realtime UI updates.

## Schema

Adds \`Repository.dismissedAt: DateTime?\` — set when removed, cleared on restore.

## Test plan

- [ ] Run \`bun run db:migrate\` to apply the new \`dismissedAt\` column
- [ ] As an owner, remove a repo, confirm it disappears from the active list and shows under the \"Removed\" filter
- [ ] Trigger a manual sync (and a webhook \`installation_repositories\` event if possible) and confirm the dismissed repo is not re-added
- [ ] Restore the repo and verify it returns to the active list with auto-review still off until re-enabled
- [ ] Non-owner attempt to remove/restore returns a permission error

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)