### PR TITLE
fix(bitbucket): resolve webhook integration by X-Hook-UUID to fix multi-tenant 401

### DIFF
--- a/apps/web/app/api/bitbucket/webhook/route.ts
+++ b/apps/web/app/api/bitbucket/webhook/route.ts
@@ -33,6 +33,7 @@ export async function POST(request: NextRequest) {
   const body = await request.text();
   const event = request.headers.get("x-event-key");
   const signature = request.headers.get("x-hub-signature");
+  const hookUuidHeader = request.headers.get("x-hook-uuid");
 
   if (!event) {
     return NextResponse.json({ error: "Missing event header" }, { status: 400 });
@@ -55,18 +56,29 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Missing repository workspace" }, { status: 400 });
   }
 
-  // Find integration by workspace slug
-  const integration = await prisma.bitbucketIntegration.findFirst({
-    where: { workspaceSlug: workspace },
-    select: {
-      id: true,
-      organizationId: true,
-      webhookSecret: true,
-    },
-  });
+  // Bitbucket sends X-Hook-UUID identifying the exact webhook config. Multiple
+  // orgs can share the same workspaceSlug, so match by UUID first to avoid
+  // verifying the signature with the wrong tenant's secret.
+  const hookUuid = hookUuidHeader
+    ? hookUuidHeader.startsWith("{")
+      ? hookUuidHeader
+      : `{${hookUuidHeader}}`
+    : null;
+
+  const integration = hookUuid
+    ? await prisma.bitbucketIntegration.findFirst({
+        where: { webhookUuid: hookUuid },
+        select: { id: true, organizationId: true, webhookSecret: true },
+      })
+    : await prisma.bitbucketIntegration.findFirst({
+        where: { workspaceSlug: workspace },
+        select: { id: true, organizationId: true, webhookSecret: true },
+      });
 
   if (!integration) {
-    console.warn(`[bitbucket-webhook] No integration found for workspace: ${workspace}`);
+    console.warn(
+      `[bitbucket-webhook] No integration found — workspace: ${workspace}, hookUuid: ${hookUuid ?? "(none)"}`,
+    );
     return NextResponse.json({ error: "Unknown workspace" }, { status: 404 });
   }
 


### PR DESCRIPTION
## Summary
- Bitbucket webhooks for repos in shared workspaces (e.g. `teamnavy` used by 4 Octopus orgs) were returning **401** at the route handler because `findFirst({ workspaceSlug })` returned the wrong tenant's integration and its secret failed HMAC verification.
- Match on the `X-Hook-UUID` header Bitbucket sends with every delivery so the right integration (and secret) is used. Fall back to slug lookup if header is missing.

## Context
Found during investigation of why review wasn't starting for PRs against `teamnavy/navywebsite` (recently moved from `aot` org). nginx logged `POST /api/bitbucket/webhook 401` repeatedly. DB inspection showed 4 `bitbucket_integrations` rows with `workspaceSlug='teamnavy'`; Prisma's `findFirst` returned the oldest (CN org), whose `webhookSecret` did not match the signature.

## Immediate operational fix (already applied)
Two stale `teamnavy` integrations (CN, Erkan — no `webhookUuid` set, never wired to a Bitbucket webhook) were deleted from prod DB so the current code path resolves correctly until this PR ships. This PR is the durable fix.

## Test plan
- [ ] Trigger a PR event (`pullrequest:created` / `:updated`) on `teamnavy/navywebsite` and confirm 200 + auto-review starts
- [ ] Confirm a webhook from a different org sharing the same workspaceSlug also resolves to its correct integration
- [ ] Verify back-compat path: if `X-Hook-UUID` is absent, slug lookup still works
- [ ] Unit-test signature verification against the matched integration's secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)