### PR TITLE
feat(auth): add Microsoft social login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,15 @@ QDRANT_URL=http://localhost:43333
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
+# Microsoft OAuth (Entra ID / Azure AD)
+# Register an app at https://entra.microsoft.com → App registrations.
+# Set redirect URI to {BETTER_AUTH_URL}/api/auth/callback/microsoft
+# MICROSOFT_TENANT_ID defaults to "common" (work + personal accounts).
+# Use a specific tenant GUID to restrict to a single organization.
+MICROSOFT_CLIENT_ID=
+MICROSOFT_CLIENT_SECRET=
+MICROSOFT_TENANT_ID=common
+
 # GitHub App
 GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY=

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -30,6 +30,17 @@ function GoogleIcon({ className }: { className?: string }) {
   );
 }
 
+function MicrosoftIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none">
+      <path d="M2 2h9.5v9.5H2z" fill="#F25022" />
+      <path d="M12.5 2H22v9.5h-9.5z" fill="#7FBA00" />
+      <path d="M2 12.5h9.5V22H2z" fill="#00A4EF" />
+      <path d="M12.5 12.5H22V22h-9.5z" fill="#FFB900" />
+    </svg>
+  );
+}
+
 const LoginOctopus = lazy(() =>
   import("@/components/login-octopus").then((m) => ({ default: m.LoginOctopus }))
 );
@@ -125,6 +136,17 @@ function LoginContent() {
         >
           <IconBrandGithub data-icon="inline-start" className="size-5" />
           Sign in with GitHub
+        </Button>
+        <Button
+          type="button"
+          className="w-full bg-white/[0.06] hover:bg-white/[0.12] text-white border border-white/[0.1] h-11 text-sm font-medium"
+          onClick={() => {
+            trackEvent("login_method_click", { method: "microsoft" });
+            signIn.social({ provider: "microsoft", callbackURL: callbackUrl });
+          }}
+        >
+          <MicrosoftIcon className="size-5 shrink-0" />
+          Sign in with Microsoft
         </Button>
       </div>
 

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -166,11 +166,15 @@ export const auth = betterAuth({
       clientId: process.env.GITHUB_CLIENT_ID!,
       clientSecret: process.env.GITHUB_CLIENT_SECRET!,
     },
-    microsoft: {
-      clientId: process.env.MICROSOFT_CLIENT_ID!,
-      clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
-      tenantId: process.env.MICROSOFT_TENANT_ID ?? "common",
-    },
+    ...(process.env.MICROSOFT_CLIENT_ID && process.env.MICROSOFT_CLIENT_SECRET
+      ? {
+          microsoft: {
+            clientId: process.env.MICROSOFT_CLIENT_ID,
+            clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
+            tenantId: process.env.MICROSOFT_TENANT_ID ?? "common",
+          },
+        }
+      : {}),
   },
 });
 

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -166,6 +166,11 @@ export const auth = betterAuth({
       clientId: process.env.GITHUB_CLIENT_ID!,
       clientSecret: process.env.GITHUB_CLIENT_SECRET!,
     },
+    microsoft: {
+      clientId: process.env.MICROSOFT_CLIENT_ID!,
+      clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
+      tenantId: process.env.MICROSOFT_TENANT_ID ?? "common",
+    },
   },
 });
 


### PR DESCRIPTION
Adds Microsoft Entra ID (Azure AD) as a third social provider alongside
Google and GitHub. Defaults MICROSOFT_TENANT_ID to "common" so both
work and personal Microsoft accounts can sign in; orgs can lock it
down by setting a specific tenant GUID.

https://claude.ai/code/session_01RVcTK82KDJCNLfLJVq1hro