### PR TITLE
fix(qdrant): skip upsert for points with empty embedding vectors

### DIFF
--- a/apps/web/lib/qdrant.ts
+++ b/apps/web/lib/qdrant.ts
@@ -147,8 +147,12 @@ export async function upsertChunks(
 ) {
   // createEmbeddings returns [] for points whose org is over its spend limit;
   // qdrant rejects dim=0 dense vectors, so drop those points before sending.
+  const originalCount = points.length;
   points = points.filter((p) => p.vector.length > 0);
-  if (points.length === 0) return;
+  if (points.length === 0) {
+    if (originalCount > 0) console.warn(`[qdrant] upsertChunks: all ${originalCount} points had empty vectors, skipping upsert (org may be over spend limit)`);
+    return;
+  }
   const qdrant = getQdrantClient();
   // Qdrant accepts max 100 points per request
   for (let i = 0; i < points.length; i += 100) {
@@ -374,8 +378,14 @@ export async function upsertKnowledgeChunks(
     sparseVector?: { indices: number[]; values: number[] };
   }[],
 ) {
+  // createEmbeddings returns [] for points whose org is over its spend limit;
+  // qdrant rejects dim=0 dense vectors, so drop those points before sending.
+  const originalCount = points.length;
   points = points.filter((p) => p.vector.length > 0);
-  if (points.length === 0) return;
+  if (points.length === 0) {
+    if (originalCount > 0) console.warn(`[qdrant] upsertKnowledgeChunks: all ${originalCount} points had empty vectors, skipping upsert (org may be over spend limit)`);
+    return;
+  }
   const qdrant = getQdrantClient();
   for (let i = 0; i < points.length; i += 100) {
     const slice = points.slice(i, i + 100).map((p) => ({ ...applyQdrantId(p.id, p.payload), vector: p.vector, sparseVector: p.sparseVector }));
@@ -534,8 +544,14 @@ export async function upsertReviewChunks(
     sparseVector?: { indices: number[]; values: number[] };
   }[],
 ) {
+  // createEmbeddings returns [] for points whose org is over its spend limit;
+  // qdrant rejects dim=0 dense vectors, so drop those points before sending.
+  const originalCount = points.length;
   points = points.filter((p) => p.vector.length > 0);
-  if (points.length === 0) return;
+  if (points.length === 0) {
+    if (originalCount > 0) console.warn(`[qdrant] upsertReviewChunks: all ${originalCount} points had empty vectors, skipping upsert (org may be over spend limit)`);
+    return;
+  }
   const qdrant = getQdrantClient();
   for (let i = 0; i < points.length; i += 100) {
     const slice = points.slice(i, i + 100).map((p) => ({ ...applyQdrantId(p.id, p.payload), vector: p.vector, sparseVector: p.sparseVector }));
@@ -672,7 +688,10 @@ export async function upsertChatChunk(point: {
   payload: Record<string, unknown>;
   sparseVector?: { indices: number[]; values: number[] };
 }) {
-  if (point.vector.length === 0) return;
+  if (point.vector.length === 0) {
+    console.warn(`[qdrant] upsertChatChunk: point ${point.id} had empty vector, skipping upsert (org may be over spend limit)`);
+    return;
+  }
   const qdrant = getQdrantClient();
   const { id, payload } = applyQdrantId(point.id, point.payload);
   const qdrantPoint = {
@@ -822,7 +841,10 @@ export async function upsertDiagramChunk(point: {
   payload: Record<string, unknown>;
   sparseVector?: { indices: number[]; values: number[] };
 }) {
-  if (point.vector.length === 0) return;
+  if (point.vector.length === 0) {
+    console.warn(`[qdrant] upsertDiagramChunk: point ${point.id} had empty vector, skipping upsert (org may be over spend limit)`);
+    return;
+  }
   const qdrant = getQdrantClient();
   const { id, payload } = applyQdrantId(point.id, point.payload);
   const qdrantPoint = {
@@ -957,7 +979,10 @@ export async function upsertFeedbackPattern(point: {
   payload: Record<string, unknown>;
   sparseVector?: { indices: number[]; values: number[] };
 }) {
-  if (point.vector.length === 0) return;
+  if (point.vector.length === 0) {
+    console.warn(`[qdrant] upsertFeedbackPattern: point ${point.id} had empty vector, skipping upsert (org may be over spend limit)`);
+    return;
+  }
   const qdrant = getQdrantClient();
   // Feedback also stores `issueId` explicitly because it's the semantic name
   // callers expect for this collection; applyQdrantId additionally writes
@@ -1092,8 +1117,14 @@ export async function upsertDocsChunks(
     sparseVector?: { indices: number[]; values: number[] };
   }[],
 ) {
+  // createEmbeddings returns [] for points whose org is over its spend limit;
+  // qdrant rejects dim=0 dense vectors, so drop those points before sending.
+  const originalCount = points.length;
   points = points.filter((p) => p.vector.length > 0);
-  if (points.length === 0) return;
+  if (points.length === 0) {
+    if (originalCount > 0) console.warn(`[qdrant] upsertDocsChunks: all ${originalCount} points had empty vectors, skipping upsert (org may be over spend limit)`);
+    return;
+  }
   const qdrant = getQdrantClient();
   for (let i = 0; i < points.length; i += 100) {
     const slice = points.slice(i, i + 100).map((p) => ({ ...applyQdrantId(p.id, p.payload), vector: p.vector, sparseVector: p.sparseVector }));

--- a/apps/web/lib/qdrant.ts
+++ b/apps/web/lib/qdrant.ts
@@ -145,6 +145,10 @@ export async function upsertChunks(
     sparseVector?: { indices: number[]; values: number[] };
   }[],
 ) {
+  // createEmbeddings returns [] for points whose org is over its spend limit;
+  // qdrant rejects dim=0 dense vectors, so drop those points before sending.
+  points = points.filter((p) => p.vector.length > 0);
+  if (points.length === 0) return;
   const qdrant = getQdrantClient();
   // Qdrant accepts max 100 points per request
   for (let i = 0; i < points.length; i += 100) {
@@ -370,6 +374,8 @@ export async function upsertKnowledgeChunks(
     sparseVector?: { indices: number[]; values: number[] };
   }[],
 ) {
+  points = points.filter((p) => p.vector.length > 0);
+  if (points.length === 0) return;
   const qdrant = getQdrantClient();
   for (let i = 0; i < points.length; i += 100) {
     const slice = points.slice(i, i + 100).map((p) => ({ ...applyQdrantId(p.id, p.payload), vector: p.vector, sparseVector: p.sparseVector }));
@@ -528,6 +534,8 @@ export async function upsertReviewChunks(
     sparseVector?: { indices: number[]; values: number[] };
   }[],
 ) {
+  points = points.filter((p) => p.vector.length > 0);
+  if (points.length === 0) return;
   const qdrant = getQdrantClient();
   for (let i = 0; i < points.length; i += 100) {
     const slice = points.slice(i, i + 100).map((p) => ({ ...applyQdrantId(p.id, p.payload), vector: p.vector, sparseVector: p.sparseVector }));
@@ -664,6 +672,7 @@ export async function upsertChatChunk(point: {
   payload: Record<string, unknown>;
   sparseVector?: { indices: number[]; values: number[] };
 }) {
+  if (point.vector.length === 0) return;
   const qdrant = getQdrantClient();
   const { id, payload } = applyQdrantId(point.id, point.payload);
   const qdrantPoint = {
@@ -813,6 +822,7 @@ export async function upsertDiagramChunk(point: {
   payload: Record<string, unknown>;
   sparseVector?: { indices: number[]; values: number[] };
 }) {
+  if (point.vector.length === 0) return;
   const qdrant = getQdrantClient();
   const { id, payload } = applyQdrantId(point.id, point.payload);
   const qdrantPoint = {
@@ -947,6 +957,7 @@ export async function upsertFeedbackPattern(point: {
   payload: Record<string, unknown>;
   sparseVector?: { indices: number[]; values: number[] };
 }) {
+  if (point.vector.length === 0) return;
   const qdrant = getQdrantClient();
   // Feedback also stores `issueId` explicitly because it's the semantic name
   // callers expect for this collection; applyQdrantId additionally writes
@@ -1081,6 +1092,8 @@ export async function upsertDocsChunks(
     sparseVector?: { indices: number[]; values: number[] };
   }[],
 ) {
+  points = points.filter((p) => p.vector.length > 0);
+  if (points.length === 0) return;
   const qdrant = getQdrantClient();
   for (let i = 0; i < points.length; i += 100) {
     const slice = points.slice(i, i + 100).map((p) => ({ ...applyQdrantId(p.id, p.payload), vector: p.vector, sparseVector: p.sparseVector }));


### PR DESCRIPTION
## Summary
- When an org is over its spend limit, `createEmbeddings` returns `[]` for each input. Upsert paths still POST these to Qdrant, which rejects with `Wrong input: Vector dimension error: expected dim: 3072, got 0`.
- The catch block then mistakes this for a sparse-vector schema mismatch and re-tries via the "dense-only" fallback — also with the empty vector. Net result: useless fallback path exercised + log noise.
- Fix: drop points with empty vectors at the top of every upsert. Singular upserts return early; batch upserts filter and bail if nothing remains.

## Affected functions
`upsertChunks`, `upsertKnowledgeChunks`, `upsertReviewChunks`, `upsertChatChunk`, `upsertDiagramChunk`, `upsertFeedbackPattern`, `upsertDocsChunks`.

## Context
Surfaced in prod monitoring as a 12× spike in Qdrant WARN logs over 10min on `chat_chunks`. Trace: a single org `cmp7pqdsd008501m94ilt1ew3` (Tegalsari) is over its embedding spend limit; embeddings layer correctly skips, but upsert call sites didn't honour that. No user-facing 5xx — chat completions still ran, but retrieval and indexing for that org degraded silently.

This PR is the cleanup. The user/billing side is a separate operational thread.

## Test plan
- [ ] Call `upsertChatChunk` with `vector: []` — verify no Qdrant request is made
- [ ] Call `upsertChunks` with a mix of empty and non-empty vectors — only non-empty are sent
- [ ] Call any upsert with all-empty input — returns without error and without warn log
- [ ] Confirm `[qdrant] Falling back to dense-only upsert` log volume drops in prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)