### PR TITLE
feat(chat): gate chat completion on org spend limit

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -17,6 +17,7 @@ import { logAiUsage } from "@/lib/ai-usage";
 import { rerankDocuments } from "@/lib/reranker";
 import { pubby } from "@/lib/pubby";
 import { processNextInQueue } from "@/lib/chat-queue-processor";
+import { getOrgSpendLimitStatus } from "@/lib/cost";
 import { generateSparseVector } from "@/lib/sparse-vector";
 import { requestAgentSearch, findClaudeAgent, requestAgentAnswer } from "@/lib/agent-search";
 import { getReviewModel } from "@/lib/ai-client";
@@ -133,7 +134,39 @@ export async function POST(request: Request) {
         userName: session.user.name,
       });
     } catch {}
+  }
 
+  // Spend-limit gate — reject before any AI calls. The queue processor has the
+  // same check, but it only fires when a follow-up message is dequeued, so the
+  // first request after going over limit would otherwise still run a full chat.
+  const spendStatus = await getOrgSpendLimitStatus(orgId);
+  if (spendStatus.blocked) {
+    const limitMsg =
+      spendStatus.reason === "no_credits"
+        ? "Your organization is out of credits. Top up in Settings or add your own API keys to continue."
+        : "Your organization has reached its monthly AI usage limit. Increase the limit or add your own API keys in Settings to continue.";
+    const savedAssistantMsg = await prisma.chatMessage.create({
+      data: { role: "assistant", content: limitMsg, conversationId: conversation.id },
+    });
+    if (conversation.isShared) {
+      try {
+        await pubby.trigger(`presence-chat-${conversation.id}`, "chat-message-complete", {
+          id: savedAssistantMsg.id,
+          role: "assistant",
+          content: limitMsg,
+        });
+      } catch {}
+    }
+    console.warn(`[chat] Org ${orgId} over spend limit (${spendStatus.reason}) — rejecting chat`);
+    return Response.json({
+      blocked: true,
+      reason: spendStatus.reason,
+      conversationId: conversation.id,
+      message: limitMsg,
+    }, { status: 402 });
+  }
+
+  if (conversation.isShared) {
     // Queue mechanism for shared chats
     const processingEntry = await prisma.chatQueue.findFirst({
       where: { conversationId: conversation.id, status: "processing" },

--- a/apps/web/app/api/cli/chat/route.ts
+++ b/apps/web/app/api/cli/chat/route.ts
@@ -11,6 +11,7 @@ import { rerankDocuments } from "@/lib/reranker";
 import Anthropic from "@anthropic-ai/sdk";
 import { requestAgentSearch } from "@/lib/agent-search";
 import { getReviewModel } from "@/lib/ai-client";
+import { getOrgSpendLimitStatus } from "@/lib/cost";
 
 let anthropicClient: Anthropic | null = null;
 
@@ -33,6 +34,21 @@ export async function POST(request: Request) {
   }
 
   const orgId = result.org.id;
+
+  // Spend-limit gate — reject before any AI calls or conversation state
+  // changes. Mirrors the gate in /api/chat and lib/chat-queue-processor.
+  const spendStatus = await getOrgSpendLimitStatus(orgId);
+  if (spendStatus.blocked) {
+    const limitMsg =
+      spendStatus.reason === "no_credits"
+        ? "Your organization is out of credits. Top up in Settings or add your own API keys to continue."
+        : "Your organization has reached its monthly AI usage limit. Increase the limit or add your own API keys in Settings to continue.";
+    console.warn(`[chat-cli] Org ${orgId} over spend limit (${spendStatus.reason}) — rejecting chat`);
+    return Response.json(
+      { blocked: true, reason: spendStatus.reason, message: limitMsg },
+      { status: 402 },
+    );
+  }
 
   // Get or create conversation
   let conversation;


### PR DESCRIPTION
## Summary
- Block chat completion at the route level when an org is over its spend limit or out of credits.
- Both `/api/chat` and `/api/cli/chat` previously skipped this check — only `createEmbeddings` and `lib/chat-queue-processor.ts` had gates. An org over its limit still received paid LLM responses (degraded retrieval only, because embeddings were the lone gated component).
- On a hit: save an assistant message explaining the limit so the conversation history is coherent (mirrors the queue-processor behaviour), broadcast to shared chats, return HTTP 402 with `{ blocked, reason, message }`.

## Context
Surfaced in prod monitoring while investigating qdrant `Falling back to dense-only upsert` warnings for org `cmp7pqdsd008501m94ilt1ew3` (Tegalsari). Their embeddings were being skipped due to `isOrgOverSpendLimit`, but the chat completions kept running and were charged (`[ai-usage] chat model=claude-sonnet-4-6 cost=...`). The intent of the limit is \"no credits → no AI usage,\" so chat should stop too.

Companion PRs:
- #382 — fix bitbucket webhook multi-tenant resolution
- #384 — skip qdrant upsert for points with empty embedding vectors

## Test plan
- [ ] Org with credits + under spend limit: chat works as before
- [ ] Org out of credits: web chat returns 402, conversation shows assistant limit message
- [ ] Org over `monthlySpendLimitUsd`: web chat returns 402, message clearly says \"reached monthly AI usage limit\"
- [ ] Shared chat: limit message is broadcast to all members on `chat-message-complete`
- [ ] CLI chat: returns 402 JSON with `reason: 'spend_limit' | 'no_credits'`
- [ ] Community-mode orgs and orgs with their own API keys for all providers are NOT blocked (`getOrgSpendLimitStatus` already handles these)

🤖 Generated with [Claude Code](https://claude.com/claude-code)