### PR TITLE
fix(security): encrypt per-org AI provider keys at rest and decouple data key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@ DATABASE_URL=postgresql://octopus:octopus@localhost:43332/octopus
 BETTER_AUTH_SECRET=
 BETTER_AUTH_URL=http://localhost:3000
 
+# Data encryption key (32 bytes hex, e.g. `openssl rand -hex 32`).
+# Encrypts OAuth tokens and per-org AI provider keys at rest. Decoupled from
+# BETTER_AUTH_SECRET so the auth secret can rotate without invalidating data.
+# If unset, falls back to sha256(BETTER_AUTH_SECRET) for backward compatibility.
+# For an existing deployment, see `apps/web/scripts/print-data-key.ts` to keep
+# all existing ciphertext readable.
+OCTOPUS_DATA_KEY=
+
 # Google OAuth
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -15,6 +15,7 @@ import { runIndexingInBackground } from "@/lib/indexing-runner";
 import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
 import { canUserCreateOrg } from "@/lib/org-limits";
 import { MAX_OWNED_ORGS_PER_USER } from "@/lib/constants";
+import { encryptString } from "@/lib/crypto";
 
 export async function clearOrgCookie() {
   const cookieStore = await cookies();
@@ -256,12 +257,13 @@ export async function updateApiKeys(
     return { error: "Invalid Google AI API key format." };
   }
 
-  // Only update keys that have new values — empty fields keep the existing key
+  // Only update keys that have new values — empty fields keep the existing key.
+  // Keys are encrypted at rest with the same helper used for OAuth tokens.
   const data: Record<string, string | null> = {};
-  if (openaiApiKey) data.openaiApiKey = openaiApiKey;
-  if (anthropicApiKey) data.anthropicApiKey = anthropicApiKey;
-  if (googleApiKey) data.googleApiKey = googleApiKey;
-  if (cohereApiKey) data.cohereApiKey = cohereApiKey;
+  if (openaiApiKey) data.openaiApiKey = encryptString(openaiApiKey);
+  if (anthropicApiKey) data.anthropicApiKey = encryptString(anthropicApiKey);
+  if (googleApiKey) data.googleApiKey = encryptString(googleApiKey);
+  if (cohereApiKey) data.cohereApiKey = encryptString(cohereApiKey);
 
   if (Object.keys(data).length === 0) {
     return { error: "Enter at least one API key to save." };

--- a/apps/web/app/(app)/knowledge/actions.ts
+++ b/apps/web/app/(app)/knowledge/actions.ts
@@ -11,6 +11,7 @@ import { deleteKnowledgeDocumentChunks } from "@/lib/qdrant";
 import Anthropic from "@anthropic-ai/sdk";
 import { logAiUsage } from "@/lib/ai-usage";
 import { knowledgeTemplates } from "@/lib/knowledge-templates";
+import { decryptStringMaybeLegacy } from "@/lib/crypto";
 
 export async function createKnowledgeDocument(
   _prevState: { error?: string },
@@ -526,7 +527,9 @@ export async function enhanceKnowledgeContent(
     });
 
     const client = new Anthropic({
-      apiKey: org?.anthropicApiKey || process.env.ANTHROPIC_API_KEY!,
+      apiKey: org?.anthropicApiKey
+        ? decryptStringMaybeLegacy(org.anthropicApiKey)
+        : process.env.ANTHROPIC_API_KEY!,
     });
 
     const response = await client.messages.create({

--- a/apps/web/app/(app)/settings/api-keys-form.tsx
+++ b/apps/web/app/(app)/settings/api-keys-form.tsx
@@ -16,12 +16,6 @@ import { Separator } from "@/components/ui/separator";
 import { IconX } from "@tabler/icons-react";
 import { updateApiKeys, removeApiKey } from "../actions";
 
-function maskKey(key: string | null): string {
-  if (!key) return "";
-  if (key.length <= 8) return "••••••••";
-  return key.slice(0, 7) + "••••••••" + key.slice(-4);
-}
-
 export function ApiKeysForm({
   openaiApiKey,
   anthropicApiKey,
@@ -29,6 +23,8 @@ export function ApiKeysForm({
   cohereApiKey,
   isOwner,
 }: {
+  // Masked previews (e.g. "sk-abc••••••••wxyz"), not full keys. The server masks
+  // the decrypted key so plaintext never reaches the browser.
   openaiApiKey: string | null;
   anthropicApiKey: string | null;
   googleApiKey: string | null;
@@ -68,7 +64,7 @@ export function ApiKeysForm({
               <Label htmlFor="openaiApiKey">OpenAI</Label>
               {openaiApiKey ? (
                 <Badge variant="outline" className="gap-1 text-[10px] font-normal">
-                  {maskKey(openaiApiKey)}
+                  {openaiApiKey}
                   {isOwner && (
                     <button
                       type="button"
@@ -103,7 +99,7 @@ export function ApiKeysForm({
               <Label htmlFor="anthropicApiKey">Anthropic</Label>
               {anthropicApiKey ? (
                 <Badge variant="outline" className="gap-1 text-[10px] font-normal">
-                  {maskKey(anthropicApiKey)}
+                  {anthropicApiKey}
                   {isOwner && (
                     <button
                       type="button"
@@ -138,7 +134,7 @@ export function ApiKeysForm({
               <Label htmlFor="googleApiKey">Google AI</Label>
               {googleApiKey ? (
                 <Badge variant="outline" className="gap-1 text-[10px] font-normal">
-                  {maskKey(googleApiKey)}
+                  {googleApiKey}
                   {isOwner && (
                     <button
                       type="button"
@@ -176,7 +172,7 @@ export function ApiKeysForm({
               <Label htmlFor="cohereApiKey">Cohere Rerank</Label>
               {cohereApiKey ? (
                 <Badge variant="outline" className="gap-1 text-[10px] font-normal">
-                  {maskKey(cohereApiKey)}
+                  {cohereApiKey}
                   {isOwner && (
                     <button
                       type="button"

--- a/apps/web/app/(app)/settings/api-keys/page.tsx
+++ b/apps/web/app/(app)/settings/api-keys/page.tsx
@@ -2,7 +2,17 @@ import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
+import { decryptStringMaybeLegacy } from "@/lib/crypto";
 import { ApiKeysForm } from "../api-keys-form";
+
+// Decrypt the stored key (ciphertext at rest) and return a masked preview so the
+// full plaintext key never reaches the browser.
+function maskStoredKey(stored: string | null): string | null {
+  if (!stored) return null;
+  const key = decryptStringMaybeLegacy(stored);
+  if (key.length <= 8) return "••••••••";
+  return key.slice(0, 7) + "••••••••" + key.slice(-4);
+}
 
 export default async function ApiKeysPage() {
   const session = await auth.api.getSession({
@@ -40,10 +50,10 @@ export default async function ApiKeysPage() {
   return (
     <ApiKeysForm
       key={member.organization.id}
-      openaiApiKey={member.organization.openaiApiKey}
-      anthropicApiKey={member.organization.anthropicApiKey}
-      googleApiKey={member.organization.googleApiKey}
-      cohereApiKey={member.organization.cohereApiKey}
+      openaiApiKey={maskStoredKey(member.organization.openaiApiKey)}
+      anthropicApiKey={maskStoredKey(member.organization.anthropicApiKey)}
+      googleApiKey={maskStoredKey(member.organization.googleApiKey)}
+      cohereApiKey={maskStoredKey(member.organization.cohereApiKey)}
       isOwner={isOwner}
     />
   );

--- a/apps/web/app/(landing)/docs/self-hosting/env-generator.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/env-generator.tsx
@@ -17,6 +17,7 @@ const DEFAULT_ENV = {
 
 export function EnvGenerator() {
   const [secret, setSecret] = useState(() => generateSecret());
+  const [dataKey, setDataKey] = useState(() => generateSecret());
   const [copied, setCopied] = useState(false);
 
   const envContent = `# Database (overridden by docker-compose when using Docker)
@@ -29,6 +30,11 @@ QDRANT_API_KEY=
 # Auth
 BETTER_AUTH_SECRET=${secret}
 BETTER_AUTH_URL=${DEFAULT_ENV.BETTER_AUTH_URL}
+
+# Data encryption key (32 bytes hex). Encrypts OAuth tokens and per-org AI
+# provider keys at rest. Decoupled from BETTER_AUTH_SECRET so the auth secret
+# can rotate without invalidating encrypted data.
+OCTOPUS_DATA_KEY=${dataKey}
 
 # AI Providers
 OPENAI_API_KEY=
@@ -50,6 +56,7 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=`;
 
   const regenerate = useCallback(() => {
     setSecret(generateSecret());
+    setDataKey(generateSecret());
     setCopied(false);
   }, []);
 

--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -3,6 +3,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { prisma } from "@octopus/db";
+import { decryptStringMaybeLegacy } from "@/lib/crypto";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -127,9 +128,9 @@ async function getOrgKeys(orgId: string): Promise<OrgKeys> {
     select: { anthropicApiKey: true, openaiApiKey: true, googleApiKey: true },
   });
   return {
-    anthropicApiKey: org?.anthropicApiKey ?? null,
-    openaiApiKey: org?.openaiApiKey ?? null,
-    googleApiKey: org?.googleApiKey ?? null,
+    anthropicApiKey: org?.anthropicApiKey ? decryptStringMaybeLegacy(org.anthropicApiKey) : null,
+    openaiApiKey: org?.openaiApiKey ? decryptStringMaybeLegacy(org.openaiApiKey) : null,
+    googleApiKey: org?.googleApiKey ? decryptStringMaybeLegacy(org.googleApiKey) : null,
   };
 }
 

--- a/apps/web/lib/crypto.ts
+++ b/apps/web/lib/crypto.ts
@@ -9,66 +9,110 @@ const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
 
-function getKey(): Buffer {
+// ── Key resolution ───────────────────────────────────────────────────────────
+//
+// Data encryption uses OCTOPUS_DATA_KEY when set, otherwise falls back to the
+// legacy `sha256(BETTER_AUTH_SECRET)` derivation. Splitting the data key off
+// the auth secret means BETTER_AUTH_SECRET can be rotated (for session/CSRF
+// reasons) without invalidating every encrypted row in the database.
+//
+// Bootstrap paths for an existing deployment:
+//
+//   1. Zero-migration: set OCTOPUS_DATA_KEY to the hex-encoded current key
+//      (i.e. hex(sha256(BETTER_AUTH_SECRET)) of the value already in use).
+//      All existing ciphertext stays readable with bit-identical bytes, and
+//      BETTER_AUTH_SECRET can then rotate freely. Use `scripts/print-data-key.ts`
+//      to compute this value.
+//
+//   2. Fresh key: set OCTOPUS_DATA_KEY=$(openssl rand -hex 32). Existing
+//      ciphertext is still readable because decryption falls back to the legacy
+//      key when the primary key fails. New writes use the new key. Run a
+//      re-encrypt migration to flip remaining rows over the new key.
+//
+// OCTOPUS_DATA_KEY is hex-encoded 32 bytes (64 lowercase hex characters).
+
+function parseDataKey(raw: string): Buffer {
+  const trimmed = raw.trim();
+  if (!/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+    throw new Error(
+      "OCTOPUS_DATA_KEY must be 64 hex characters (32 bytes). Generate with: openssl rand -hex 32",
+    );
+  }
+  return Buffer.from(trimmed, "hex");
+}
+
+function getPrimaryKey(): Buffer {
+  const dataKey = process.env.OCTOPUS_DATA_KEY;
+  if (dataKey) return parseDataKey(dataKey);
   const secret = process.env.BETTER_AUTH_SECRET;
   if (!secret) {
-    throw new Error("BETTER_AUTH_SECRET is not set");
+    throw new Error("OCTOPUS_DATA_KEY or BETTER_AUTH_SECRET must be set");
   }
   return createHash("sha256").update(secret).digest();
 }
 
-export function encryptJson(value: unknown): string {
-  const key = getKey();
+// Returns the legacy BETTER_AUTH_SECRET-derived key only when it differs from
+// the primary key (i.e. OCTOPUS_DATA_KEY is set). Used as a decryption fallback
+// during the transition; returns null when no fallback is needed or available.
+function getLegacyKey(): Buffer | null {
+  if (!process.env.OCTOPUS_DATA_KEY) return null;
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (!secret) return null;
+  return createHash("sha256").update(secret).digest();
+}
+
+function aeadEncrypt(key: Buffer, plaintext: Buffer): string {
   const iv = randomBytes(IV_LENGTH);
   const cipher = createCipheriv(ALGORITHM, key, iv);
-  const plaintext = Buffer.from(JSON.stringify(value), "utf8");
   const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
   const tag = cipher.getAuthTag();
   return Buffer.concat([iv, tag, ciphertext]).toString("base64url");
+}
+
+function aeadDecrypt(key: Buffer, token: string): Buffer {
+  const buf = Buffer.from(token, "base64url");
+  if (buf.length < IV_LENGTH + AUTH_TAG_LENGTH) {
+    throw new Error("Ciphertext too short");
+  }
+  const iv = buf.subarray(0, IV_LENGTH);
+  const tag = buf.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = buf.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+// Try the primary key; on AEAD failure (wrong tag, wrong key), try the legacy
+// key if available. Any other failure (truncated payload, etc.) surfaces from
+// the primary attempt.
+function decryptWithFallback(token: string): Buffer {
+  try {
+    return aeadDecrypt(getPrimaryKey(), token);
+  } catch (primaryErr) {
+    const legacy = getLegacyKey();
+    if (!legacy) throw primaryErr;
+    try {
+      return aeadDecrypt(legacy, token);
+    } catch {
+      throw primaryErr;
+    }
+  }
+}
+
+export function encryptJson(value: unknown): string {
+  return aeadEncrypt(getPrimaryKey(), Buffer.from(JSON.stringify(value), "utf8"));
 }
 
 export function decryptJson<T>(token: string): T {
-  const key = getKey();
-  const buf = Buffer.from(token, "base64url");
-  if (buf.length < IV_LENGTH + AUTH_TAG_LENGTH) {
-    throw new Error("Ciphertext too short");
-  }
-  const iv = buf.subarray(0, IV_LENGTH);
-  const tag = buf.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
-  const ciphertext = buf.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
-  const decipher = createDecipheriv(ALGORITHM, key, iv);
-  decipher.setAuthTag(tag);
-  const plaintext = Buffer.concat([
-    decipher.update(ciphertext),
-    decipher.final(),
-  ]);
-  return JSON.parse(plaintext.toString("utf8")) as T;
+  return JSON.parse(decryptWithFallback(token).toString("utf8")) as T;
 }
 
 export function encryptString(value: string): string {
-  const key = getKey();
-  const iv = randomBytes(IV_LENGTH);
-  const cipher = createCipheriv(ALGORITHM, key, iv);
-  const plaintext = Buffer.from(value, "utf8");
-  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
-  const tag = cipher.getAuthTag();
-  return Buffer.concat([iv, tag, ciphertext]).toString("base64url");
+  return aeadEncrypt(getPrimaryKey(), Buffer.from(value, "utf8"));
 }
 
 export function decryptString(token: string): string {
-  const key = getKey();
-  const buf = Buffer.from(token, "base64url");
-  if (buf.length < IV_LENGTH + AUTH_TAG_LENGTH) {
-    throw new Error("Ciphertext too short");
-  }
-  const iv = buf.subarray(0, IV_LENGTH);
-  const tag = buf.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
-  const ciphertext = buf.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
-  const decipher = createDecipheriv(ALGORITHM, key, iv);
-  decipher.setAuthTag(tag);
-  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString(
-    "utf8",
-  );
+  return decryptWithFallback(token).toString("utf8");
 }
 
 // Tries decryptString; on any failure (legacy plaintext row, truncated payload,

--- a/apps/web/scripts/encrypt-ai-keys.ts
+++ b/apps/web/scripts/encrypt-ai-keys.ts
@@ -1,0 +1,99 @@
+/**
+ * One-shot backfill: encrypt legacy plaintext AI provider keys at rest.
+ *
+ * Organizations store per-org AI provider keys (OpenAI, Anthropic, Google,
+ * Cohere). The runtime now writes ciphertext and reads via
+ * `decryptStringMaybeLegacy`, so existing plaintext rows keep working. This
+ * script flips remaining plaintext values over to ciphertext so all rows are
+ * uniform and a future commit can drop the "maybe-legacy" fallback.
+ *
+ * Strategy per field:
+ *   1. Try decrypt: if it succeeds, value is already ciphertext → skip.
+ *   2. Otherwise treat as plaintext, encrypt, and update.
+ *
+ * Usage:
+ *   Dry run (default):  bun run --cwd apps/web scripts/encrypt-ai-keys.ts
+ *   Apply changes:      bun run --cwd apps/web scripts/encrypt-ai-keys.ts --apply
+ */
+
+import { prisma } from "@octopus/db";
+import { decryptString, encryptString } from "@/lib/crypto";
+
+const APPLY = process.argv.includes("--apply");
+
+const KEY_FIELDS = [
+  "openaiApiKey",
+  "anthropicApiKey",
+  "googleApiKey",
+  "cohereApiKey",
+] as const;
+
+function isCiphertext(value: string): boolean {
+  try {
+    decryptString(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function main() {
+  if (!process.env.BETTER_AUTH_SECRET) {
+    console.error("BETTER_AUTH_SECRET is required to encrypt keys.");
+    process.exit(1);
+  }
+
+  console.log(
+    APPLY
+      ? "[encrypt-ai-keys] APPLY mode\n"
+      : "[encrypt-ai-keys] DRY RUN (use --apply to persist)\n",
+  );
+
+  const rows = await prisma.organization.findMany({
+    select: {
+      id: true,
+      openaiApiKey: true,
+      anthropicApiKey: true,
+      googleApiKey: true,
+      cohereApiKey: true,
+    },
+  });
+
+  const perField: Record<string, number> = {
+    openaiApiKey: 0,
+    anthropicApiKey: 0,
+    googleApiKey: 0,
+    cohereApiKey: 0,
+  };
+  let orgsUpdated = 0;
+
+  for (const row of rows) {
+    const data: Record<string, string> = {};
+    for (const field of KEY_FIELDS) {
+      const value = row[field];
+      if (!value || isCiphertext(value)) continue;
+      perField[field]++;
+      data[field] = encryptString(value);
+    }
+    if (Object.keys(data).length === 0) continue;
+    orgsUpdated++;
+    if (!APPLY) continue;
+    await prisma.organization.update({ where: { id: row.id }, data });
+  }
+
+  console.log(`Organizations scanned:  ${rows.length}`);
+  console.log(`Organizations to update: ${orgsUpdated}\n`);
+  console.log("Field             To encrypt");
+  console.log("----------------- ----------");
+  for (const field of KEY_FIELDS) {
+    console.log(`${field.padEnd(17)} ${String(perField[field]).padStart(10)}`);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error(err);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/apps/web/scripts/encrypt-ai-keys.ts
+++ b/apps/web/scripts/encrypt-ai-keys.ts
@@ -38,9 +38,22 @@ function isCiphertext(value: string): boolean {
 }
 
 async function main() {
-  if (!process.env.BETTER_AUTH_SECRET) {
-    console.error("BETTER_AUTH_SECRET is required to encrypt keys.");
+  // Encryption uses OCTOPUS_DATA_KEY when set, otherwise the legacy
+  // BETTER_AUTH_SECRET-derived key — either one is enough to encrypt.
+  if (!process.env.OCTOPUS_DATA_KEY && !process.env.BETTER_AUTH_SECRET) {
+    console.error("Set OCTOPUS_DATA_KEY or BETTER_AUTH_SECRET to encrypt keys.");
     process.exit(1);
+  }
+
+  // Without BETTER_AUTH_SECRET the legacy decryption fallback is unavailable, so
+  // ciphertext written under the old BETTER_AUTH_SECRET-derived key would not be
+  // recognized by isCiphertext() and would get re-encrypted (double-encrypted).
+  // Only safe when every row is already under OCTOPUS_DATA_KEY.
+  if (process.env.OCTOPUS_DATA_KEY && !process.env.BETTER_AUTH_SECRET) {
+    console.warn(
+      "[encrypt-ai-keys] BETTER_AUTH_SECRET is not set: legacy ciphertext cannot be detected. " +
+        "Only run this if all existing keys are already encrypted under OCTOPUS_DATA_KEY.\n",
+    );
   }
 
   console.log(

--- a/apps/web/scripts/print-data-key.ts
+++ b/apps/web/scripts/print-data-key.ts
@@ -1,0 +1,36 @@
+/**
+ * Prints the value to set OCTOPUS_DATA_KEY to.
+ *
+ * Default (zero-migration upgrade): prints hex(sha256(BETTER_AUTH_SECRET)),
+ * which is bit-identical to the key currently used by lib/crypto.ts. Setting
+ * OCTOPUS_DATA_KEY to this value lets you decouple data encryption from
+ * BETTER_AUTH_SECRET without re-encrypting any existing row, so BETTER_AUTH_SECRET
+ * can then rotate freely.
+ *
+ *   bun run --cwd apps/web scripts/print-data-key.ts
+ *
+ * --new: prints a fresh random 32-byte key (hex). Use when you want a key that
+ * was never derived from the auth secret; existing rows stay readable via the
+ * legacy decrypt fallback, and new writes use the fresh key.
+ *
+ *   bun run --cwd apps/web scripts/print-data-key.ts --new
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+
+const NEW = process.argv.includes("--new");
+
+if (NEW) {
+  process.stdout.write(randomBytes(32).toString("hex") + "\n");
+  process.exit(0);
+}
+
+const secret = process.env.BETTER_AUTH_SECRET;
+if (!secret) {
+  console.error(
+    "BETTER_AUTH_SECRET is not set in this environment, so the legacy-equivalent key cannot be computed. Use --new for a fresh random key instead.",
+  );
+  process.exit(1);
+}
+
+process.stdout.write(createHash("sha256").update(secret).digest("hex") + "\n");


### PR DESCRIPTION
## Why

Two security gaps in `lib/crypto`-adjacent code:

1. **Per-org AI provider keys (OpenAI, Anthropic, Google, Cohere) were stored in plaintext.** OAuth tokens have used `encryptString` for a while, but the AI keys — the ones directly tied to billing and most attractive to an attacker — sat in the clear. A single `SELECT` on `organizations` leaked every customer-billable key. The settings page also shipped the full plaintext key to the browser and masked client-side.
2. **The encryption key was `sha256(BETTER_AUTH_SECRET)`.** Rotating the auth secret (for session/CSRF reasons) would silently invalidate decryption of every stored token. One secret protected both auth and every encrypted integration credential.

## What

### 1. Encrypt AI provider keys at rest

- `actions.ts` `updateApiKeys` now wraps each key in `encryptString` before writing. Validation still runs on plaintext.
- `ai-router.ts` `getOrgKeys` and `knowledge/actions.ts` (Anthropic client) decrypt via `decryptStringMaybeLegacy` so unmigrated plaintext rows keep working.
- `settings/api-keys/page.tsx` decrypts and **masks on the server**; the form now receives an already-masked preview, so the full plaintext key never reaches the browser.
- `ai-usage.ts` / `cost.ts` only do truthiness checks; ciphertext is still truthy, no change needed.
- `scripts/encrypt-ai-keys.ts` is the backfill: dry-run by default, `--apply` to persist. Idempotent (`isCiphertext` skips already-encrypted values).

### 2. Decouple data encryption from `BETTER_AUTH_SECRET`

- New `OCTOPUS_DATA_KEY` env var: 32 bytes hex (e.g. `openssl rand -hex 32`).
- `lib/crypto.ts`: primary key reads from `OCTOPUS_DATA_KEY`; if unset, falls back to the legacy `sha256(BETTER_AUTH_SECRET)` so nothing breaks on upgrade.
- Decryption tries the primary key first; on AEAD failure it tries the legacy key (when `OCTOPUS_DATA_KEY` is set and `BETTER_AUTH_SECRET` is also present). This makes the transition seamless whichever path an operator takes.
- `scripts/print-data-key.ts` helps existing deployments adopt:
  - default → prints `hex(sha256(BETTER_AUTH_SECRET))`, the legacy-equivalent value. Setting `OCTOPUS_DATA_KEY` to this means **zero existing rows need re-encryption**; `BETTER_AUTH_SECRET` can then rotate freely.
  - `--new` → fresh random 32-byte hex. Existing rows stay readable via the legacy fallback; new writes use the new key.
- `.env.example` and the self-hosting `env-generator.tsx` include the new variable.

## Deploy & migration order

Designed for a rolling deploy with no downtime:

1. **Deploy this PR.** Reads handle both plaintext AI keys and ciphertext; writes encrypt going forward.
2. (Optional but recommended) **Adopt `OCTOPUS_DATA_KEY`** by running `bun run --cwd apps/web scripts/print-data-key.ts` against prod env and pasting the output into `OCTOPUS_DATA_KEY`. Zero data migration needed.
3. **Backfill AI keys** when convenient:
   ```bash
   bun run --cwd apps/web scripts/encrypt-ai-keys.ts          # dry-run
   bun run --cwd apps/web scripts/encrypt-ai-keys.ts --apply  # persist
   ```
   Idempotent; safe to re-run.

## Verification

- `bun run --cwd apps/web typecheck` ✓
- `bun run --cwd apps/web lint` ✓ (no new warnings; 2 pre-existing unrelated ones)
- `bun run --cwd apps/web test` → 281/281 pass
- Synthetic crypto roundtrip covers 6 scenarios: legacy-only env, `OCTOPUS_DATA_KEY` introduction, legacy ciphertext under new key (fallback), legacy-only env correctly rejecting new ciphertext, zero-migration bootstrap, invalid key format error. All pass.
- Synthetic AI-key migration on a throwaway org: plaintext detected → encrypted, ciphertext skipped, `decryptStringMaybeLegacy` roundtrip returns the exact original, second run reports 0 fields to encrypt. Cleaned up after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)