### PR TITLE
feat(credits): adaptive low-credit warning threshold based on burn rate

### DIFF
--- a/apps/web/lib/__tests__/credit-low-pace.test.ts
+++ b/apps/web/lib/__tests__/credit-low-pace.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "bun:test";
+import { buildPaceLine } from "@/lib/events/observers/email.observer";
+
+const base = { type: "credit-low" as const, orgId: "org_1", remainingBalance: 5 };
+
+describe("buildPaceLine", () => {
+  it("returns an empty string when there is no measurable burn", () => {
+    expect(buildPaceLine(base)).toBe("");
+    expect(buildPaceLine({ ...base, burnRatePerHour: 0, runwayMinutes: undefined })).toBe("");
+  });
+
+  it("reports minutes for short runways", () => {
+    // $5 left at $10/hour => 30 minutes
+    expect(buildPaceLine({ ...base, burnRatePerHour: 10, runwayMinutes: 30 })).toBe(
+      "At your current pace (~$10.00/hour), this will run out in about 30 minutes.",
+    );
+  });
+
+  it("uses singular minute at exactly one minute", () => {
+    expect(buildPaceLine({ ...base, burnRatePerHour: 60, runwayMinutes: 1 })).toContain(
+      "about 1 minute.",
+    );
+  });
+
+  it("switches to hours once runway reaches 90 minutes", () => {
+    expect(buildPaceLine({ ...base, burnRatePerHour: 4, runwayMinutes: 120 })).toBe(
+      "At your current pace (~$4.00/hour), this will run out in about 2 hours.",
+    );
+  });
+});

--- a/apps/web/lib/__tests__/credit-low-pace.test.ts
+++ b/apps/web/lib/__tests__/credit-low-pace.test.ts
@@ -22,9 +22,25 @@ describe("buildPaceLine", () => {
     );
   });
 
+  it("still reports minutes at the 60-minute boundary", () => {
+    expect(buildPaceLine({ ...base, burnRatePerHour: 5, runwayMinutes: 60 })).toBe(
+      "At your current pace (~$5.00/hour), this will run out in about 60 minutes.",
+    );
+  });
+
+  it("switches to hours at the 90-minute boundary", () => {
+    expect(buildPaceLine({ ...base, burnRatePerHour: 4, runwayMinutes: 90 })).toBe(
+      "At your current pace (~$4.00/hour), this will run out in about 2 hours.",
+    );
+  });
+
   it("switches to hours once runway reaches 90 minutes", () => {
     expect(buildPaceLine({ ...base, burnRatePerHour: 4, runwayMinutes: 120 })).toBe(
       "At your current pace (~$4.00/hour), this will run out in about 2 hours.",
     );
+  });
+
+  it("returns empty string for a non-finite burn rate", () => {
+    expect(buildPaceLine({ ...base, burnRatePerHour: Infinity, runwayMinutes: 0 })).toBe("");
   });
 });

--- a/apps/web/lib/credits.ts
+++ b/apps/web/lib/credits.ts
@@ -122,19 +122,60 @@ export async function deductCredits(
     });
   });
 
-  const CREDIT_LOW_THRESHOLD = 10; // dollars
-  if (totalAfter > 0 && totalAfter < CREDIT_LOW_THRESHOLD) {
-    eventBus.emit({
-      type: "credit-low",
-      orgId,
-      remainingBalance: totalAfter,
-    });
-  }
+  await maybeNotifyCreditLow(orgId, totalAfter);
 
   // Check auto-reload after deduction (fire-and-forget)
   triggerAutoReloadIfNeeded(orgId, totalAfter).catch((err) =>
     console.error("[credits] Auto-reload failed:", err),
   );
+}
+
+// Minimum low-credit threshold for slow/steady usage; preserves the original
+// $10 warning floor so nothing regresses for low-volume orgs.
+const CREDIT_LOW_FLOOR = 10; // dollars
+// Window used to estimate the org's recent burn rate.
+const BURN_LOOKBACK_MS = 60 * 60 * 1000; // 1 hour
+// Skip the burn-rate query entirely for well-funded orgs to keep the
+// deduction hot path cheap. Orgs above this balance never need a warning;
+// the next deduction that drops them below it will re-evaluate.
+const BURN_QUERY_CEILING = 100; // dollars
+
+/**
+ * Emit a `credit-low` event when the balance can no longer cover the org's
+ * projected next hour of usage. The threshold adapts to burn rate: a fast
+ * burner is warned with roughly an hour of runway left, while a slow/steady
+ * org keeps the original $10 floor.
+ */
+async function maybeNotifyCreditLow(
+  orgId: string,
+  totalAfter: number,
+): Promise<void> {
+  if (totalAfter <= 0 || totalAfter >= BURN_QUERY_CEILING) return;
+
+  // Sum of usage over the last hour. Usage amounts are stored negative, so the
+  // absolute value is dollars-per-hour at the recent pace.
+  const recent = await prisma.creditTransaction.aggregate({
+    where: {
+      organizationId: orgId,
+      type: "usage",
+      createdAt: { gte: new Date(Date.now() - BURN_LOOKBACK_MS) },
+    },
+    _sum: { amount: true },
+  });
+
+  const burnPerHour = Math.abs(Number(recent._sum.amount ?? 0));
+  // Warn once the balance can't fund the next projected hour, never below the floor.
+  const threshold = Math.max(CREDIT_LOW_FLOOR, burnPerHour);
+
+  if (totalAfter >= threshold) return;
+
+  eventBus.emit({
+    type: "credit-low",
+    orgId,
+    remainingBalance: totalAfter,
+    burnRatePerHour: burnPerHour,
+    runwayMinutes: burnPerHour > 0 ? (totalAfter / burnPerHour) * 60 : undefined,
+  });
 }
 
 async function triggerAutoReloadIfNeeded(

--- a/apps/web/lib/email-template-seeds.ts
+++ b/apps/web/lib/email-template-seeds.ts
@@ -187,10 +187,12 @@ If this was you, you can ignore this email. If you don't recognize this activity
     subject: "Credit Balance Low: {{balance}} remaining",
     body: `Your organization's credit balance has dropped to **{{balance}}**.
 
+{{paceLine}}
+
 When credits run out, PR reviews and other AI-powered features will stop working.`,
     buttonText: "Add Credits",
     buttonUrl: "{{appUrl}}/settings/billing",
-    variables: ["balance", "appUrl"],
+    variables: ["balance", "paceLine", "appUrl"],
   },
 
   // ── Marketing templates (for Send Email) ──────────────────────────────

--- a/apps/web/lib/events/observers/email.observer.ts
+++ b/apps/web/lib/events/observers/email.observer.ts
@@ -154,16 +154,23 @@ const CREDIT_LOW_COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24h
  */
 export function buildPaceLine(event: CreditLowEvent): string {
   const { burnRatePerHour, runwayMinutes } = event;
-  if (!burnRatePerHour || burnRatePerHour <= 0 || runwayMinutes === undefined) {
+  if (
+    !burnRatePerHour ||
+    !Number.isFinite(burnRatePerHour) ||
+    burnRatePerHour <= 0 ||
+    runwayMinutes === undefined ||
+    !Number.isFinite(runwayMinutes)
+  ) {
     return "";
   }
 
   const rate = `$${burnRatePerHour.toFixed(2)}`;
   const mins = Math.round(runwayMinutes);
+  const hours = Math.round(mins / 60);
   const when =
     mins < 90
       ? `about ${mins} minute${mins === 1 ? "" : "s"}`
-      : `about ${Math.round(mins / 60)} hours`;
+      : `about ${hours} hour${hours === 1 ? "" : "s"}`;
 
   return `At your current pace (~${rate}/hour), this will run out in ${when}.`;
 }

--- a/apps/web/lib/events/observers/email.observer.ts
+++ b/apps/web/lib/events/observers/email.observer.ts
@@ -147,6 +147,27 @@ async function getAdminRecipients(
 
 const CREDIT_LOW_COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24h
 
+/**
+ * Build the human-readable pace sentence for the credit-low email. Returns an
+ * empty string when there is no measurable recent burn, so the template simply
+ * omits the line (the renderer does no conditional logic).
+ */
+export function buildPaceLine(event: CreditLowEvent): string {
+  const { burnRatePerHour, runwayMinutes } = event;
+  if (!burnRatePerHour || burnRatePerHour <= 0 || runwayMinutes === undefined) {
+    return "";
+  }
+
+  const rate = `$${burnRatePerHour.toFixed(2)}`;
+  const mins = Math.round(runwayMinutes);
+  const when =
+    mins < 90
+      ? `about ${mins} minute${mins === 1 ? "" : "s"}`
+      : `about ${Math.round(mins / 60)} hours`;
+
+  return `At your current pace (~${rate}/hour), this will run out in ${when}.`;
+}
+
 async function onCreditLow(event: CreditLowEvent): Promise<void> {
   // Atomically claim the cooldown slot before sending. Two concurrent
   // `credit-low` events would otherwise both miss the cooldown read and
@@ -205,6 +226,7 @@ async function onCreditLow(event: CreditLowEvent): Promise<void> {
 
   const result = await renderEmailTemplate("credit-low", {
     balance: `$${event.remainingBalance.toFixed(2)}`,
+    paceLine: buildPaceLine(event),
     appUrl,
   });
 

--- a/apps/web/lib/events/types.ts
+++ b/apps/web/lib/events/types.ts
@@ -55,6 +55,10 @@ export type CreditLowEvent = {
   type: "credit-low";
   orgId: string;
   remainingBalance: number;
+  /** Dollars spent over the last hour, used to estimate remaining runway. */
+  burnRatePerHour?: number;
+  /** Estimated minutes until the balance is depleted at the recent burn rate. */
+  runwayMinutes?: number;
 };
 
 export type OrgTypeChangedEvent = {


### PR DESCRIPTION
## Problem

The low-credit email fired on a fixed **\$10** threshold, blind to usage speed.

Observed on a real org : the "credit low" email went out at **05:47** with \$6.22 left, and the balance hit zero (and got blocked) by **05:49** — about 2 minutes later. The warning and the hard stop arrived almost together, leaving no time to top up. Meanwhile a slow org could sit at \$10 for weeks.

## Change

Make the threshold adapt to burn rate:

- Estimate dollars-per-hour from the **last hour** of `usage` transactions.
- Warn once the balance can no longer fund the **projected next hour**, but never below the original **\$10 floor** (`threshold = max(10, burnPerHour)`).
- Fast burners get warned with ~1 hour of runway; slow/steady orgs keep the exact prior behavior.
- The burn query is skipped above a **\$100** balance to keep the deduction hot path cheap.

The email gains a dynamic pace line:

> At your current pace (~\$4.71/hour), this will run out in about 80 minutes.

The 24h send cooldown is unchanged (per product decision).

## Files

- `apps/web/lib/credits.ts` — `maybeNotifyCreditLow()` with burn-rate threshold
- `apps/web/lib/events/types.ts` — `CreditLowEvent` gains `burnRatePerHour` + `runwayMinutes`
- `apps/web/lib/events/observers/email.observer.ts` — `buildPaceLine()`, passes `paceLine` to template
- `apps/web/lib/email-template-seeds.ts` — `{{paceLine}}` placeholder for fresh installs
- `apps/web/lib/__tests__/credit-low-pace.test.ts` — pace-line formatting tests (4 passing)

## Post-deploy step (manual)

`seedEmailTemplates()` only creates missing rows, so the **live** `credit-low` template body must be updated to pick up `{{paceLine}}`. SQL is in `packages/db/prisma/migrations/manual_server_sync_20260602.sql` (that directory is gitignored and managed manually, like the other `manual_server_sync_*` files). Run it after deploy:

\`\`\`
docker exec -i \$(docker ps -q -f name=octopus_octopus-db) \\
  psql -U octopus -d octopus < manual_server_sync_20260602.sql
\`\`\`

Without it, the dynamic threshold still works; only the email's ETA line is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)