### PR TITLE
feat(ai): support OpenAI Codex (gpt-5.3-codex) via Responses API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,9 @@ BETTER_AUTH_URL=http://localhost:3000
 # If unset, falls back to sha256(BETTER_AUTH_SECRET) for backward compatibility.
 # For an existing deployment, see `apps/web/scripts/print-data-key.ts` to keep
 # all existing ciphertext readable.
-# Generate with: openssl rand -hex 32  (64 hex chars; example value below)
-OCTOPUS_DATA_KEY=0000000000000000000000000000000000000000000000000000000000000000
+# Generate with: openssl rand -hex 32  (64 hex chars). Leave as-is to fall back
+# to sha256(BETTER_AUTH_SECRET); the placeholder below is intentionally invalid.
+OCTOPUS_DATA_KEY=<run: openssl rand -hex 32>
 
 # Google OAuth
 GOOGLE_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ BETTER_AUTH_URL=http://localhost:3000
 # If unset, falls back to sha256(BETTER_AUTH_SECRET) for backward compatibility.
 # For an existing deployment, see `apps/web/scripts/print-data-key.ts` to keep
 # all existing ciphertext readable.
-OCTOPUS_DATA_KEY=
+# Generate with: openssl rand -hex 32  (64 hex chars; example value below)
+OCTOPUS_DATA_KEY=0000000000000000000000000000000000000000000000000000000000000000
 
 # Google OAuth
 GOOGLE_CLIENT_ID=

--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -185,11 +185,21 @@ async function callAnthropic(
   };
 }
 
+// Codex / agentic coding models (e.g. gpt-5.3-codex) are served only via the
+// Responses API; chat.completions returns 404 "not a chat model".
+function usesResponsesApi(model: string): boolean {
+  return model.includes("codex");
+}
+
 async function callOpenAI(
   params: AiCreateParams,
   apiKey?: string | null,
 ): Promise<AiResponse> {
   const client = getOpenAI(apiKey);
+
+  if (usesResponsesApi(params.model)) {
+    return callOpenAIResponses(client, params);
+  }
 
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
   if (params.system) {
@@ -215,6 +225,30 @@ async function callOpenAI(
       inputTokens: response.usage?.prompt_tokens ?? 0,
       outputTokens: response.usage?.completion_tokens ?? 0,
       cacheReadTokens: response.usage?.prompt_tokens_details?.cached_tokens ?? 0,
+      cacheWriteTokens: 0,
+    },
+  };
+}
+
+async function callOpenAIResponses(
+  client: OpenAI,
+  params: AiCreateParams,
+): Promise<AiResponse> {
+  const response = await client.responses.create({
+    model: params.model,
+    instructions: params.system,
+    input: params.messages.map((m) => ({ role: m.role, content: m.content })),
+    max_output_tokens: params.maxTokens,
+  });
+
+  return {
+    text: response.output_text ?? "",
+    provider: "openai",
+    model: params.model,
+    usage: {
+      inputTokens: response.usage?.input_tokens ?? 0,
+      outputTokens: response.usage?.output_tokens ?? 0,
+      cacheReadTokens: response.usage?.input_tokens_details?.cached_tokens ?? 0,
       cacheWriteTokens: 0,
     },
   };

--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -241,8 +241,19 @@ async function callOpenAIResponses(
     max_output_tokens: params.maxTokens,
   });
 
+  const text = response.output_text ?? "";
+  // Surface non-text or truncated responses as errors instead of silently
+  // returning an empty review (e.g. status "incomplete" when max_output_tokens
+  // is hit, or a refusal/non-text output item).
+  if (!text) {
+    const reason = response.incomplete_details?.reason;
+    throw new Error(
+      `OpenAI Responses returned no text (status: ${response.status}${reason ? `, reason: ${reason}` : ""})`,
+    );
+  }
+
   return {
-    text: response.output_text ?? "",
+    text,
     provider: "openai",
     model: params.model,
     usage: {

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -17,6 +17,7 @@ const FALLBACK_PRICING: Record<string, ModelPricing> = {
   "claude-haiku-4-5-20251001": { input: 1, output: 5 },
   "gemini-2.5-pro": { input: 1.25, output: 10 },
   "gemini-2.5-flash": { input: 0.15, output: 0.6 },
+  "gpt-5.3-codex": { input: 1.75, output: 14 },
   "text-embedding-3-large": { input: 0.13, output: 0 },
   "rerank-v3.5": { input: 2000.0, output: 0 },
 };

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -719,15 +719,8 @@ async function main() {
     // Google
     { modelId: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro", provider: "google", category: "llm", inputPrice: 1.25, outputPrice: 10, sortOrder: 5 },
     { modelId: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash", provider: "google", category: "llm", inputPrice: 0.15, outputPrice: 0.6, sortOrder: 6 },
-    // OpenAI
-    { modelId: "gpt-4o", displayName: "GPT-4o", provider: "openai", category: "llm", inputPrice: 2.5, outputPrice: 10, sortOrder: 7 },
-    { modelId: "gpt-4o-mini", displayName: "GPT-4o Mini", provider: "openai", category: "llm", inputPrice: 0.15, outputPrice: 0.6, sortOrder: 8 },
-    { modelId: "o3", displayName: "OpenAI o3", provider: "openai", category: "llm", inputPrice: 10, outputPrice: 40, sortOrder: 9 },
-    { modelId: "o3-mini", displayName: "OpenAI o3 Mini", provider: "openai", category: "llm", inputPrice: 1.1, outputPrice: 4.4, sortOrder: 10 },
-    { modelId: "o4-mini", displayName: "OpenAI o4 Mini", provider: "openai", category: "llm", inputPrice: 1.1, outputPrice: 4.4, sortOrder: 11 },
-    { modelId: "gpt-5.3-codex", displayName: "GPT-5.3 Codex", provider: "openai", category: "llm", inputPrice: 1.25, outputPrice: 10, sortOrder: 12 },
-    { modelId: "gpt-5.3-codex-mini", displayName: "GPT-5.3 Codex Mini", provider: "openai", category: "llm", inputPrice: 0.25, outputPrice: 2, sortOrder: 13 },
-    { modelId: "codex-mini-latest", displayName: "Codex Mini", provider: "openai", category: "llm", inputPrice: 1.5, outputPrice: 6, sortOrder: 14 },
+    // OpenAI — Codex is the only OpenAI LLM we offer; served via the Responses API.
+    { modelId: "gpt-5.3-codex", displayName: "GPT-5.3 Codex", provider: "openai", category: "llm", inputPrice: 1.75, outputPrice: 14, sortOrder: 7 },
     // Embeddings
     { modelId: "text-embedding-3-large", displayName: "Embedding 3 Large", provider: "openai", category: "embedding", inputPrice: 0.13, outputPrice: 0, sortOrder: 0 },
     { modelId: "text-embedding-3-small", displayName: "Embedding 3 Small", provider: "openai", category: "embedding", inputPrice: 0.02, outputPrice: 0, sortOrder: 1 },


### PR DESCRIPTION
> Stacked on #395 (shares `.env.example` and `ai-router.ts` changes). Retarget to `master` once #395 merges.

## What
Add OpenAI Codex support and make `gpt-5.3-codex` the only OpenAI LLM we offer.

## Why
`gpt-5.3-codex` is served **only via the OpenAI Responses API**. Calling it on `chat.completions` returns `404 "This is not a chat model and thus not supported in the v1/chat/completions endpoint."` — verified with a live call. So the model could not be enabled until `callOpenAI` learned the Responses API.

## Changes
- **`apps/web/lib/ai-router.ts`** — `callOpenAI` routes codex models (`model.includes("codex")`) to `client.responses.create`: `system → instructions`, `messages → input`, `maxTokens → max_output_tokens`, and maps `input_tokens`/`output_tokens`/`cached_tokens` back to our `AiResponse`. Non-codex OpenAI models are unchanged.
- **`apps/web/lib/cost.ts`** — add `gpt-5.3-codex` fallback pricing ($1.75 in / $14 out per 1M).
- **`packages/db/prisma/seed.ts`** — Codex is now the only OpenAI LLM seeded; dropped the dormant `gpt-4o`/`gpt-4o-mini`/`o3`/`o3-mini`/`o4-mini`/`codex-mini-latest` rows (all `isActive=false`, zero usage in prod). Embeddings untouched.
- **`.env.example`** — example value + `openssl rand -hex 32` hint for `OCTOPUS_DATA_KEY`.

> Mirror change in the engine repo: `octopus-engine/src/engine/ai-router.ts` + `cost.ts` get the same Responses-API branch and pricing.

## Verification
Ran PR #395's diff through `gpt-5.3-codex` using the engine's own system prompt and the exact integrated call shape (`responses.create` with `input: [{role, content}]`): `status=completed`, ~21s, 14k in / 1.5k out tokens, produced a full review. chat.completions 404'd, confirming the routing is required.

## Post-deploy step (manual, prod DB)
`packages/db/prisma/migrations/manual_server_sync_20260602_models.sql` (gitignored dir, run after deploy): deletes the dropped OpenAI LLM rows and upserts `gpt-5.3-codex` with `isActive=true`. Run only after this code is deployed, otherwise reviews picking the model would 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)