### PR TITLE
fix(bitbucket): cache repo file tree by branch HEAD SHA to stop rate limits

### DIFF
--- a/apps/web/lib/bitbucket.ts
+++ b/apps/web/lib/bitbucket.ts
@@ -275,6 +275,31 @@ export async function createInlineComment(
 
 // ── Repository Tree & Content ──
 
+/**
+ * Fetch the HEAD commit SHA of a branch in a single cheap request. Used to
+ * decide whether a cached file tree is still valid before walking the whole
+ * tree (which costs one request per directory). Returns null on failure so
+ * callers can fall back to walking the tree.
+ */
+export async function getBranchHead(
+  organizationId: string,
+  workspace: string,
+  repoSlug: string,
+  branch: string,
+): Promise<string | null> {
+  const token = await getAccessToken(organizationId);
+  const res = await fetch(
+    `${BITBUCKET_API}/repositories/${workspace}/${repoSlug}/refs/branches/${encodeURIComponent(branch)}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) {
+    console.warn(`[bitbucket] Failed to get branch head for ${branch}: ${res.status}`);
+    return null;
+  }
+  const data = await res.json();
+  return data.target?.hash ?? null;
+}
+
 export async function getRepositoryTree(
   organizationId: string,
   workspace: string,

--- a/apps/web/lib/gitlab.ts
+++ b/apps/web/lib/gitlab.ts
@@ -385,6 +385,30 @@ export async function createInlineComment(
 
 // ── Repository Tree & Content ──
 
+/**
+ * Fetch the HEAD commit SHA of a branch in a single cheap request, used to
+ * validate a cached file tree before re-walking it. Returns null on failure
+ * so callers can fall back to walking the tree.
+ */
+export async function getBranchHead(
+  organizationId: string,
+  projectPath: string,
+  branch: string,
+): Promise<string | null> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  const res = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/repository/branches/${encodeURIComponent(branch)}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) {
+    console.warn(`[gitlab] Failed to get branch head for ${branch}: ${res.status}`);
+    return null;
+  }
+  const data = await res.json();
+  return data.commit?.id ?? null;
+}
+
 export async function getRepositoryTree(
   organizationId: string,
   projectPath: string,

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -750,7 +750,12 @@ export async function processReview(pullRequestId: string): Promise<void> {
       console.warn("[reviewer] Failed to fetch branch head, skipping tree cache:", err);
     }
 
-    if (headSha && repo.treeSha === headSha && Array.isArray(repo.treePaths)) {
+    if (
+      headSha &&
+      repo.treeSha === headSha &&
+      Array.isArray(repo.treePaths) &&
+      repo.treePaths.every((p) => typeof p === "string")
+    ) {
       const cached = repo.treePaths as string[];
       console.log(`[reviewer] Tree cache hit for ${repo.fullName}@${headSha.slice(0, 8)} (${cached.length} files)`);
       return cached;

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -725,6 +725,54 @@ export async function processReview(pullRequestId: string): Promise<void> {
       : isGitlab
         ? gitlab.getRepositoryTree(org.id, projectPath, branch)
         : bitbucket.getRepositoryTree(org.id, owner, repoName, branch);
+
+  // Cheap HEAD-SHA lookup used to validate the cached file tree. GitHub returns
+  // the whole tree in one request, so caching it saves nothing — only Bitbucket
+  // (one request per directory) and GitLab (paginated walk) benefit.
+  const providerGetBranchHead = (branch: string): Promise<string | null> =>
+    isBitbucket
+      ? bitbucket.getBranchHead(org.id, owner, repoName, branch)
+      : isGitlab
+        ? gitlab.getBranchHead(org.id, projectPath, branch)
+        : Promise.resolve(null);
+
+  // Walk the repo tree, but reuse a cached copy when the branch HEAD hasn't
+  // moved since we last walked it. The full walk floods provider rate limits
+  // (see [bitbucket] getRepositoryTree), so we trade it for a single HEAD-SHA
+  // request on every review where the tree is unchanged.
+  const getRepoTreeCached = async (branch: string): Promise<string[]> => {
+    if (isGitHub) return providerGetTree(branch);
+
+    let headSha: string | null = null;
+    try {
+      headSha = await providerGetBranchHead(branch);
+    } catch (err) {
+      console.warn("[reviewer] Failed to fetch branch head, skipping tree cache:", err);
+    }
+
+    if (headSha && repo.treeSha === headSha && Array.isArray(repo.treePaths)) {
+      const cached = repo.treePaths as string[];
+      console.log(`[reviewer] Tree cache hit for ${repo.fullName}@${headSha.slice(0, 8)} (${cached.length} files)`);
+      return cached;
+    }
+
+    const paths = await providerGetTree(branch);
+
+    // Only persist when we know which commit the tree belongs to — otherwise a
+    // future HEAD-SHA lookup could match a stale cache it never validated.
+    if (headSha) {
+      try {
+        await prisma.repository.update({
+          where: { id: repo.id },
+          data: { treeSha: headSha, treePaths: paths },
+        });
+        console.log(`[reviewer] Tree cache stored for ${repo.fullName}@${headSha.slice(0, 8)} (${paths.length} files)`);
+      } catch (err) {
+        console.warn("[reviewer] Failed to persist tree cache:", err);
+      }
+    }
+    return paths;
+  };
   let reviewCommentId = pr.reviewCommentId ? Number(pr.reviewCommentId) : null;
   const baseEvent = {
     repoId: repo.id,
@@ -1095,7 +1143,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
       }
       throw err;
     }
-    const repoTree = await providerGetTree(repo.defaultBranch);
+    const repoTree = await getRepoTreeCached(repo.defaultBranch);
 
     // Detect committed build artifacts / dependency folders
     const badFiles = detectBadCommits(rawDiff);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -212,6 +212,8 @@ model Repository {
   totalChunks    Int      @default(0)
   totalVectors   Int      @default(0)
   indexDurationMs    Int?
+  treeSha        String?  // default-branch HEAD commit SHA that treePaths was cached at
+  treePaths      Json?    // cached repo file tree (string[]) valid for treeSha; avoids re-walking the tree on every review
   contributorCount   Int      @default(0)
   contributors       Json     @default("[]")
   summary        String?


### PR DESCRIPTION
## Problem

Every review re-walked the entire repo tree. Bitbucket has no single-request tree API like GitHub, so `getRepositoryTree` does a BFS over the `/src` endpoint, making **one request per directory**. On large repos, and with concurrent reviews sharing one org-scoped token, this floods Bitbucket's hourly rate limit:

```
[bitbucket] Rate limited, waiting 2000ms (attempt 1/3)
```

That log line's only source was `getRepositoryTree`.

## Fix

Cache the walked tree on `Repository`, keyed by the **default-branch HEAD commit SHA**:

1. Before walking, fetch the branch HEAD SHA in a **single cheap request**.
2. If it matches `repo.treeSha`, reuse the cached `treePaths` and skip the walk entirely.
3. If not, walk the tree and persist it with the new SHA.

The cache is **self-correcting**: when the branch moves, the SHA differs, the cache misses, and we re-walk. No explicit invalidation needed. GitHub is unchanged (its tree is already one request).

## Changes

- **schema**: add `Repository.treeSha` + `treePaths`
- **bitbucket / gitlab**: add `getBranchHead` (cheap HEAD-SHA lookup)
- **reviewer**: `getRepoTreeCached` validates the cache by SHA, falls back to walking on any error

## Note

The migration SQL (`20260602130000_add_repository_tree_cache`) is gitignored per repo convention and applied manually. Before deploy, add `treeSha` (TEXT) + `treePaths` (JSONB) columns to `Repository`.

## Tests

`bun run --cwd apps/web test` → 288 pass, 0 fail. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)