### PR TITLE
feat(gitlab,cli): show OAuth redirect URI + scopes and review unsynced PRs on demand

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -504,6 +504,7 @@ export default async function DashboardPage({
           bitbucketConnected={bitbucketConnected}
           gitlabConnected={gitlabConnected}
           githubAppSlug={githubAppSlug}
+          gitlabRedirectUri={process.env.GITLAB_REDIRECT_URI ?? null}
         />
       )}
 

--- a/apps/web/app/(app)/settings/integrations/gitlab-integration-card.tsx
+++ b/apps/web/app/(app)/settings/integrations/gitlab-integration-card.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { IconBrandGitlab, IconArrowRight } from "@tabler/icons-react";
+import { IconBrandGitlab, IconArrowRight, IconCopy, IconCheck } from "@tabler/icons-react";
 import { disconnectGitlab, startGitlabOAuth } from "./actions";
 
 type GitlabData = {
@@ -22,13 +22,35 @@ type GitlabData = {
 } | null;
 
 const DEFAULT_HOST = "https://gitlab.com";
+const REQUIRED_SCOPES = "api read_api read_user read_repository write_repository";
 
-export function GitlabIntegrationCard({ data }: { data: GitlabData }) {
+export function GitlabIntegrationCard({
+  data,
+  redirectUri,
+}: {
+  data: GitlabData;
+  redirectUri: string | null;
+}) {
   const [isPending, startTransition] = useTransition();
   const [host, setHost] = useState(DEFAULT_HOST);
+  const [copied, setCopied] = useState<string | null>(null);
 
   const isSelfHosted =
     host.trim() !== "" && host.replace(/\/+$/, "") !== DEFAULT_HOST;
+
+  const copy = (value: string, key: string) => {
+    navigator.clipboard.writeText(value);
+    setCopied(key);
+    setTimeout(() => setCopied(null), 1500);
+  };
+
+  // Authoritative value used in the OAuth flow; falls back to the current
+  // origin when the server env isn't exposed to the client.
+  const effectiveRedirectUri =
+    redirectUri ??
+    (typeof window !== "undefined"
+      ? `${window.location.origin}/api/gitlab/callback`
+      : "");
 
   if (!data) {
     return (
@@ -84,8 +106,43 @@ export function GitlabIntegrationCard({ data }: { data: GitlabData }) {
                   </p>
                   <p className="text-amber-700 dark:text-amber-300 text-xs mb-3">
                     Create one at <span className="font-mono">{host.replace(/\/+$/, "")}/admin/applications</span>{" "}
-                    (or User Settings → Applications). Redirect URI must match this app&apos;s callback URL.
+                    (or User Settings → Applications) with the exact Redirect URI and scopes below.
                   </p>
+
+                  <div className="mb-3 space-y-2">
+                    <div>
+                      <p className="text-amber-700 dark:text-amber-300 text-[11px] font-medium mb-1">
+                        Redirect URI
+                      </p>
+                      <div className="flex items-center gap-1.5">
+                        <code className="min-w-0 flex-1 truncate rounded bg-amber-100 dark:bg-amber-900/50 px-2 py-1 text-[11px] text-amber-900 dark:text-amber-100">
+                          {effectiveRedirectUri}
+                        </code>
+                        <button
+                          type="button"
+                          onClick={() => copy(effectiveRedirectUri, "uri")}
+                          className="shrink-0 rounded p-1 text-amber-700 hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-900/50"
+                          aria-label="Copy redirect URI"
+                        >
+                          {copied === "uri" ? (
+                            <IconCheck className="size-3.5" />
+                          ) : (
+                            <IconCopy className="size-3.5" />
+                          )}
+                        </button>
+                      </div>
+                    </div>
+
+                    <div>
+                      <p className="text-amber-700 dark:text-amber-300 text-[11px] font-medium mb-1">
+                        Scopes
+                      </p>
+                      <code className="block rounded bg-amber-100 dark:bg-amber-900/50 px-2 py-1 text-[11px] leading-relaxed text-amber-900 dark:text-amber-100 break-words">
+                        {REQUIRED_SCOPES}
+                      </code>
+                    </div>
+                  </div>
+
                   <div className="space-y-2">
                     <Input
                       name="clientId"

--- a/apps/web/app/(app)/settings/integrations/gitlab-integration-card.tsx
+++ b/apps/web/app/(app)/settings/integrations/gitlab-integration-card.tsx
@@ -39,9 +39,16 @@ export function GitlabIntegrationCard({
     host.trim() !== "" && host.replace(/\/+$/, "") !== DEFAULT_HOST;
 
   const copy = (value: string, key: string) => {
-    navigator.clipboard.writeText(value);
-    setCopied(key);
-    setTimeout(() => setCopied(null), 1500);
+    navigator.clipboard
+      .writeText(value)
+      .then(() => {
+        setCopied(key);
+        setTimeout(() => setCopied(null), 1500);
+      })
+      .catch(() => {
+        // Clipboard unavailable (page not focused, older browser) — skip the
+        // success feedback so the UI doesn't claim a copy that didn't happen.
+      });
   };
 
   // Authoritative value used in the OAuth flow; falls back to the current

--- a/apps/web/app/(app)/settings/integrations/page.tsx
+++ b/apps/web/app/(app)/settings/integrations/page.tsx
@@ -132,7 +132,10 @@ export default async function IntegrationsPage({
         error={githubError}
       />
       <BitbucketIntegrationCard data={bitbucketIntegration} />
-      <GitlabIntegrationCard data={gitlabIntegration} />
+      <GitlabIntegrationCard
+        data={gitlabIntegration}
+        redirectUri={process.env.GITLAB_REDIRECT_URI ?? null}
+      />
       <SlackIntegrationCard data={slackIntegration} />
       <LinearIntegrationCard data={linearIntegration} />
       <JiraIntegrationCard data={jiraIntegration} />

--- a/apps/web/app/api/cli/repos/[id]/review/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/review/route.ts
@@ -42,7 +42,11 @@ export async function POST(
     // On-demand: the PR/MR exists on the provider but isn't synced into our DB yet
     // (e.g. opened before the repo was connected, so no webhook ever fired for it).
     // Fetch it straight from the provider API and kick off the full review flow.
-    const [owner, repoName] = repo.fullName.split("/");
+    const parts = repo.fullName.split("/");
+    if (parts.length < 2) {
+      return Response.json({ error: "Invalid repository name" }, { status: 500 });
+    }
+    const [owner, repoName] = parts;
     try {
       let details;
       if (repo.provider === "github") {

--- a/apps/web/app/api/cli/repos/[id]/review/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/review/route.ts
@@ -1,6 +1,10 @@
 import { authenticateApiToken } from "@/lib/api-auth";
 import { prisma } from "@octopus/db";
 import { processReview } from "@/lib/reviewer";
+import * as github from "@/lib/github";
+import * as gitlab from "@/lib/gitlab";
+import * as bitbucket from "@/lib/bitbucket";
+import { startReviewFlow } from "@/lib/webhook-shared";
 import { NextRequest } from "next/server";
 
 export async function POST(
@@ -27,12 +31,52 @@ export async function POST(
     return Response.json({ error: "Missing prNumber" }, { status: 400 });
   }
 
+  // Provider-aware wording: GitLab calls them "merge requests".
+  const prLabel = repo.provider === "gitlab" ? "Merge request" : "Pull request";
+
   const pr = await prisma.pullRequest.findFirst({
     where: { repositoryId: repo.id, number: prNumber },
   });
 
   if (!pr) {
-    return Response.json({ error: "Pull request not found" }, { status: 404 });
+    // On-demand: the PR/MR exists on the provider but isn't synced into our DB yet
+    // (e.g. opened before the repo was connected, so no webhook ever fired for it).
+    // Fetch it straight from the provider API and kick off the full review flow.
+    const [owner, repoName] = repo.fullName.split("/");
+    try {
+      let details;
+      if (repo.provider === "github") {
+        if (!repo.installationId) throw new Error("Missing installation id");
+        details = await github.getPullRequestDetails(repo.installationId, owner, repoName, prNumber);
+      } else if (repo.provider === "gitlab") {
+        details = await gitlab.getPullRequestDetails(result.org.id, repo.fullName, prNumber);
+      } else if (repo.provider === "bitbucket") {
+        details = await bitbucket.getPullRequestDetails(result.org.id, owner, repoName, prNumber);
+      } else {
+        return Response.json({ error: `${prLabel} not found` }, { status: 404 });
+      }
+
+      await startReviewFlow({
+        provider: repo.provider as "github" | "gitlab" | "bitbucket",
+        installationId: repo.installationId ?? undefined,
+        organizationId: result.org.id,
+        repoFullName: repo.fullName,
+        repoId: repo.id,
+        orgId: result.org.id,
+        prNumber: details.number,
+        prTitle: details.title,
+        prUrl: details.url,
+        prAuthor: details.author,
+        headSha: details.headSha,
+        triggerCommentId: 0,
+        triggerCommentBody: "",
+      });
+
+      return Response.json({ message: "Review started", prNumber: details.number });
+    } catch (err) {
+      console.error(`[cli] Failed to fetch ${repo.provider} ${prLabel} #${prNumber}:`, err);
+      return Response.json({ error: `${prLabel} not found` }, { status: 404 });
+    }
   }
 
   if (pr.status === "reviewing") {

--- a/apps/web/components/dashboard/providers-banner.tsx
+++ b/apps/web/components/dashboard/providers-banner.tsx
@@ -22,10 +22,19 @@ import {
   IconArrowRight,
   IconGitPullRequest,
   IconShieldCheck,
+  IconCopy,
+  IconCheck,
 } from "@tabler/icons-react";
 import { startGitlabOAuth } from "@/app/(app)/settings/integrations/actions";
 
 const DEFAULT_GITLAB_HOST = "https://gitlab.com";
+const GITLAB_REQUIRED_SCOPES =
+  "api read_api read_user read_repository write_repository";
+
+// Bottom sheet on mobile (pinned edge-to-edge so content can't overflow
+// sideways), centered dialog on sm+ screens.
+const SHEET_CONTENT_CLASS =
+  "inset-x-0 bottom-0 top-auto max-h-[85vh] max-w-full translate-x-0 translate-y-0 gap-4 overflow-y-auto overflow-x-hidden rounded-b-none rounded-t-2xl sm:inset-x-auto sm:bottom-auto sm:left-1/2 sm:top-1/2 sm:max-w-md sm:-translate-x-1/2 sm:-translate-y-1/2 sm:rounded-xl";
 
 function setCookie(name: string, value: string, days: number) {
   const expires = new Date(Date.now() + days * 864e5).toUTCString();
@@ -37,23 +46,40 @@ export function ProvidersBanner({
   bitbucketConnected,
   gitlabConnected,
   githubAppSlug,
+  gitlabRedirectUri,
 }: {
   githubConnected: boolean;
   bitbucketConnected: boolean;
   gitlabConnected: boolean;
   githubAppSlug: string | undefined;
+  gitlabRedirectUri: string | null;
 }) {
   const [dismissed, setDismissed] = useState(false);
   const [bbDialogOpen, setBbDialogOpen] = useState(false);
   const [glDialogOpen, setGlDialogOpen] = useState(false);
   const [workspaceSlug, setWorkspaceSlug] = useState("");
   const [glHost, setGlHost] = useState(DEFAULT_GITLAB_HOST);
+  const [glCopied, setGlCopied] = useState<string | null>(null);
 
   if (dismissed) return null;
 
   const githubInstallUrl = githubAppSlug ? "/api/github/install?returnTo=/dashboard" : null;
   const isGlSelfHosted =
     glHost.trim() !== "" && glHost.replace(/\/+$/, "") !== DEFAULT_GITLAB_HOST;
+
+  const copyGl = (value: string, key: string) => {
+    navigator.clipboard.writeText(value);
+    setGlCopied(key);
+    setTimeout(() => setGlCopied(null), 1500);
+  };
+
+  // Authoritative value used in the OAuth flow; falls back to the current
+  // origin when the server env isn't exposed to the client.
+  const glEffectiveRedirectUri =
+    gitlabRedirectUri ??
+    (typeof window !== "undefined"
+      ? `${window.location.origin}/api/gitlab/callback`
+      : "");
 
   return (
     <>
@@ -225,7 +251,7 @@ export function ProvidersBanner({
       </Card>
 
       <Dialog open={bbDialogOpen} onOpenChange={setBbDialogOpen}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className={SHEET_CONTENT_CLASS}>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <IconBrandBitbucket className="size-5 text-[#0052CC] dark:text-[#79B8FF]" />
@@ -236,7 +262,7 @@ export function ProvidersBanner({
             </DialogDescription>
           </DialogHeader>
 
-          <div className="pt-2">
+          <div className="min-w-0 pt-2">
             <p className="text-sm font-medium mb-3">How it works</p>
             <ol className="text-sm text-muted-foreground space-y-1.5 list-decimal list-inside mb-5">
               <li>Enter your workspace slug below</li>
@@ -279,7 +305,7 @@ export function ProvidersBanner({
       </Dialog>
 
       <Dialog open={glDialogOpen} onOpenChange={setGlDialogOpen}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className={SHEET_CONTENT_CLASS}>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               <IconBrandGitlab className="size-5 text-[#FC6D26]" />
@@ -290,7 +316,7 @@ export function ProvidersBanner({
             </DialogDescription>
           </DialogHeader>
 
-          <form action={startGitlabOAuth} className="space-y-3 pt-2">
+          <form action={startGitlabOAuth} className="min-w-0 space-y-3 pt-2">
             <div className="space-y-1.5">
               <Label htmlFor="gl-banner-host">GitLab host</Label>
               <Input
@@ -319,8 +345,43 @@ export function ProvidersBanner({
                 </p>
                 <p className="text-amber-700 dark:text-amber-300 text-xs mb-3">
                   Create one at <span className="font-mono">{glHost.replace(/\/+$/, "")}/admin/applications</span>{" "}
-                  (or User Settings → Applications). Redirect URI must match this app&apos;s callback URL.
+                  (or User Settings → Applications) with the exact Redirect URI and scopes below.
                 </p>
+
+                <div className="mb-3 space-y-2">
+                  <div>
+                    <p className="text-amber-700 dark:text-amber-300 text-[11px] font-medium mb-1">
+                      Redirect URI
+                    </p>
+                    <div className="flex items-center gap-1.5">
+                      <code className="min-w-0 flex-1 truncate rounded bg-amber-100 dark:bg-amber-900/50 px-2 py-1 text-[11px] text-amber-900 dark:text-amber-100">
+                        {glEffectiveRedirectUri}
+                      </code>
+                      <button
+                        type="button"
+                        onClick={() => copyGl(glEffectiveRedirectUri, "uri")}
+                        className="shrink-0 rounded p-1 text-amber-700 hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-900/50"
+                        aria-label="Copy redirect URI"
+                      >
+                        {glCopied === "uri" ? (
+                          <IconCheck className="size-3.5" />
+                        ) : (
+                          <IconCopy className="size-3.5" />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+
+                  <div>
+                    <p className="text-amber-700 dark:text-amber-300 text-[11px] font-medium mb-1">
+                      Scopes
+                    </p>
+                    <code className="block rounded bg-amber-100 dark:bg-amber-900/50 px-2 py-1 text-[11px] leading-relaxed text-amber-900 dark:text-amber-100 break-words">
+                      {GITLAB_REQUIRED_SCOPES}
+                    </code>
+                  </div>
+                </div>
+
                 <div className="space-y-2">
                   <Input
                     name="clientId"

--- a/apps/web/components/dashboard/providers-banner.tsx
+++ b/apps/web/components/dashboard/providers-banner.tsx
@@ -68,9 +68,16 @@ export function ProvidersBanner({
     glHost.trim() !== "" && glHost.replace(/\/+$/, "") !== DEFAULT_GITLAB_HOST;
 
   const copyGl = (value: string, key: string) => {
-    navigator.clipboard.writeText(value);
-    setGlCopied(key);
-    setTimeout(() => setGlCopied(null), 1500);
+    navigator.clipboard
+      .writeText(value)
+      .then(() => {
+        setGlCopied(key);
+        setTimeout(() => setGlCopied(null), 1500);
+      })
+      .catch(() => {
+        // Clipboard unavailable (page not focused, older browser) — skip the
+        // success feedback so the UI doesn't claim a copy that didn't happen.
+      });
   };
 
   // Authoritative value used in the OAuth flow; falls back to the current


### PR DESCRIPTION
## Summary

Two related improvements to the review onboarding flow.

### GitLab OAuth setup helper
Setting up a GitLab OAuth application (especially self-hosted) was error-prone: users had to guess the exact Redirect URI and scopes. Now both the settings integration card and the dashboard providers banner display them explicitly with copy buttons.

- Surface the exact **Redirect URI** and **required scopes** (`api read_api read_user read_repository write_repository`).
- Redirect URI comes from `GITLAB_REDIRECT_URI` on the server, falling back to the current origin's `/api/gitlab/callback` when the env isn't exposed to the client.
- Bitbucket/GitLab dialogs now render as edge-to-edge bottom sheets on mobile (centered dialog on `sm+`) to prevent horizontal overflow.

### CLI: review unsynced PRs on demand
When the CLI requests a review for a PR/MR that isn't in our DB yet (e.g. it was opened before the repo was connected, so no webhook ever fired), the route now fetches the PR/MR straight from the provider API (GitHub / GitLab / Bitbucket) and kicks off the full review flow instead of returning 404.

- Provider-aware wording: GitLab references "merge request".

## Files
- `apps/web/app/(app)/settings/integrations/gitlab-integration-card.tsx` — redirect URI + scopes UI
- `apps/web/components/dashboard/providers-banner.tsx` — same helper UI + mobile bottom-sheet
- `apps/web/app/(app)/settings/integrations/page.tsx`, `dashboard/page.tsx` — pass `GITLAB_REDIRECT_URI`
- `apps/web/app/api/cli/repos/[id]/review/route.ts` — on-demand PR/MR fetch

## Test plan
- [ ] Connect GitLab (gitlab.com and self-hosted) using the displayed redirect URI + scopes
- [ ] Copy buttons work for redirect URI
- [ ] Dialogs render correctly on mobile and desktop
- [ ] CLI review of a PR that was never webhook-synced starts a review across all three providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)