### PR TITLE
fix(middleware): allow GitLab webhook route through auth

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -15,6 +15,7 @@ const publicPrefixes = [
   "/api/auth",
   "/api/github",
   "/api/bitbucket/webhook",
+  "/api/gitlab/webhook",
   "/api/pubby",
   "/api/version",
   "/api/invitations",


### PR DESCRIPTION
## Summary

GitLab webhook deliveries hit `/api/gitlab/webhook` without an authenticated session. That prefix was missing from the middleware public allowlist, so the auth middleware blocked incoming GitLab webhooks.

## Changes

- Add `/api/gitlab/webhook` to `publicPrefixes` in `apps/web/middleware.ts`, alongside the existing `/api/bitbucket/webhook` entry.

## Test plan

- [x] Type check passes (`bun run typecheck`)
- [ ] GitLab webhook delivery reaches the handler instead of being redirected/blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)