### PR TITLE
feat(api): add health and readiness probes

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,0 +1,5 @@
+export function GET() {
+  return Response.json({
+    status: "ok",
+  });
+}

--- a/apps/web/app/api/ready/route.ts
+++ b/apps/web/app/api/ready/route.ts
@@ -1,0 +1,26 @@
+import { prisma } from "@octopus/db";
+
+export async function GET() {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+
+    return Response.json({
+      status: "ready",
+      checks: {
+        database: "ok",
+      },
+    });
+  } catch (error) {
+    console.error("Readiness check failed", error);
+
+    return Response.json(
+      {
+        status: "not_ready",
+        checks: {
+          database: "error",
+        },
+      },
+      { status: 503 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/health` liveness probe returning `{ status: "ok" }` when the process is up.
- Adds `GET /api/ready` readiness probe that runs a lightweight Prisma `SELECT 1` DB check.
- Returns 503 from `/api/ready` when the DB check fails.

Closes #455

## Validation
- `DATABASE_URL='postgresql://user:***@localhost:5432/octopus' npx -y bun --filter @octopus/db db:generate` ✅
- `DATABASE_URL='postgresql://user:***@localhost:5432/octopus' npx -y bun --filter @octopus/web typecheck` ✅
- `cd apps/web && npx -y bun run eslint app/api/health/route.ts app/api/ready/route.ts` ✅