### PR TITLE
fix(review): normalize score table denominators to always be /5

### DIFF
--- a/apps/web/lib/__tests__/score-normalize.test.ts
+++ b/apps/web/lib/__tests__/score-normalize.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "bun:test";
+import { normalizeScoreDenominators } from "@/lib/review-helpers";
+
+const scoreSection = (rows: string) => `## 🐙 Octopus Review — PR #42
+
+### Summary
+Adds a turn picker component.
+
+### Score
+| Category | Score | Notes |
+|----------|-------|-------|
+${rows}
+
+### Risk Assessment
+| Metric | Value |
+|--------|-------|
+| Overall Risk | 🟢 Low |
+`;
+
+describe("normalizeScoreDenominators", () => {
+  it("rewrites a wrong denominator to /5", () => {
+    const body = scoreSection(
+      `| Security | 5/5 | Pure local UI state |
+| Performance | 4/4 | Clamp + slice fine for ≤50 turns |`,
+    );
+    const result = normalizeScoreDenominators(body);
+    expect(result).toContain("| Performance | 4/5 |");
+    expect(result).not.toContain("4/4");
+  });
+
+  it("keeps correct /5 scores untouched", () => {
+    const body = scoreSection(
+      `| Security | 5/5 | Fine |
+| Code Quality | 3/5 | Medium concerns |`,
+    );
+    expect(normalizeScoreDenominators(body)).toBe(body);
+  });
+
+  it("normalizes the bold Overall row", () => {
+    const body = scoreSection(`| **Overall** | **4/4** | Lowest individual score |`);
+    const result = normalizeScoreDenominators(body);
+    expect(result).toContain("| **Overall** | **4/5** |");
+  });
+
+  it("leaves N/A rows untouched", () => {
+    const body = scoreSection(`| Security | N/A | No security-relevant changes |`);
+    expect(normalizeScoreDenominators(body)).toBe(body);
+  });
+
+  it("does not touch fractions outside the Score section", () => {
+    const body = `${scoreSection(`| Security | 5/5 | Fine |`)}
+### Checklist
+- [x] 4/4 tests passed
+`;
+    const result = normalizeScoreDenominators(body);
+    expect(result).toContain("4/4 tests passed");
+  });
+
+  it("does not touch numerators above the 1-5 rubric range", () => {
+    const body = scoreSection(`| Security | 8/10 | Out-of-rubric output |`);
+    expect(normalizeScoreDenominators(body)).toBe(body);
+  });
+
+  it("handles a Score section at the end of the body", () => {
+    const body = `### Score
+| Category | Score | Notes |
+|----------|-------|-------|
+| Security | 4/4 | Minor nits |`;
+    const result = normalizeScoreDenominators(body);
+    expect(result).toContain("| Security | 4/5 |");
+  });
+});

--- a/apps/web/lib/review-core.ts
+++ b/apps/web/lib/review-core.ts
@@ -25,7 +25,7 @@ import {
   parseFindingsFromJson,
   parseFindingsFromMarkdown,
 } from "@/lib/review-dedup";
-import { extractCrossFileQueries, generateVerificationQueries } from "@/lib/review-helpers";
+import { extractCrossFileQueries, generateVerificationQueries, normalizeScoreDenominators } from "@/lib/review-helpers";
 import { gatherCrossFileContext, gatherVerificationContext, validateFindings } from "@/lib/review-validation";
 import { logAiUsage } from "@/lib/ai-usage";
 import { getReviewModel } from "@/lib/ai-client";
@@ -367,6 +367,9 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
   // Step 5: Parse and clean review body
   let reviewBody = response.text.replace(/([^\n])```(\n|$)/g, "$1\n```$2");
   reviewBody = reviewBody.replace(/```([^`\n\sa-z])/g, "```\n\n$1");
+
+  // Fix wrong score denominators ("4/4" → "4/5") in the Score table
+  reviewBody = normalizeScoreDenominators(reviewBody);
 
   // Strip empty diagram sections
   reviewBody = reviewBody.replace(

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -109,6 +109,24 @@ export function countFindingsFromTable(reviewBody: string): number {
   return total;
 }
 
+/**
+ * Normalize score denominators in the "### Score" table. The rubric is always
+ * x/5, but the model occasionally emits a wrong denominator (e.g. "4/4").
+ * Only the Score section is touched so legitimate fractions elsewhere in the
+ * review body (e.g. "4/4 tests passed") are preserved.
+ */
+export function normalizeScoreDenominators(reviewBody: string): string {
+  return reviewBody.replace(
+    /### Score\s*\n[\s\S]*?(?=\n### |\n## |$)/,
+    (section) =>
+      section.replace(
+        /(\*{0,2})([1-5])\/(\d+)(\*{0,2})/g,
+        (match, open: string, score: string, denom: string, close: string) =>
+          denom === "5" ? match : `${open}${score}/5${close}`,
+      ),
+  );
+}
+
 // ─── Diff Parsing ───────────────────────────────────────────────────────────
 
 /**

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -64,6 +64,7 @@ import {
   extractCrossFileQueries,
   generateVerificationQueries,
   resolveIndexClaimWait,
+  normalizeScoreDenominators,
 } from "@/lib/review-helpers";
 import type { ReviewConfig } from "@/lib/review-helpers";
 import { getCategoryConfidenceThreshold } from "@/lib/review-categories";
@@ -1608,6 +1609,9 @@ export async function processReview(pullRequestId: string): Promise<void> {
     // 2. ``` merged with next line: "```### Checklist" → "```\n\n### Checklist"
     //    Only match ``` followed by non-language-tag chars to preserve ```mermaid etc.
     reviewBody = reviewBody.replace(/```([^`\n\sa-z])/g, "```\n\n$1");
+
+    // Fix wrong score denominators ("4/4" → "4/5") in the Score table
+    reviewBody = normalizeScoreDenominators(reviewBody);
 
     // Strip empty diagram sections: remove "### Diagram" when there's no meaningful mermaid content.
     // Matches from "### Diagram" up to the next ### heading or end of string.

--- a/apps/web/prompts/SYSTEM_PROMPT.md
+++ b/apps/web/prompts/SYSTEM_PROMPT.md
@@ -293,6 +293,7 @@ Each category is scored 1-5 based on the changes in THIS PR only:
 1 — Critical: CRITICAL-severity issues present. Must fix before merge.
 
 SCORING RULES:
+- The denominator is ALWAYS 5. Write scores as "4/5" — never "4/4" or any other denominator.
 - Score based ONLY on what changed in this diff, not the entire codebase
 - If a category is not applicable (e.g., no security-relevant changes), use "N/A"
 - The Overall Score is the LOWEST individual score (not the average)


### PR DESCRIPTION
## Problem

User feedback showed a review where the Score table contained `4/4` for Performance while every other category was scored `x/5`. The rubric is 1-5, but the score table is free-form model output and nothing validated the denominators.

## Changes

- **`normalizeScoreDenominators()`** in `review-helpers.ts`: rewrites any wrong denominator (numerator 1-5, denominator != 5) to `/5`, scoped strictly to the `### Score` section so legitimate fractions elsewhere in the review body (e.g. "4/4 tests passed" in a checklist) are preserved. Handles the bold `**Overall**` row and leaves `N/A` rows untouched.
- Applied in both review paths: `reviewer.ts` (PR reviews) and `review-core.ts` (local reviews).
- Added an explicit rule to the scoring rubric in `SYSTEM_PROMPT.md`: the denominator is always 5. This reduces the frequency at the source; the post-processing guarantees correctness.

## Tests

Added `score-normalize.test.ts` with 7 cases (wrong denominator, correct scores untouched, bold Overall row, N/A rows, fractions outside the Score section, out-of-rubric numerators, Score section at end of body).

Full suite: 295 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)