### PR TITLE
feat(web): grant admins the same org permissions as owners

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -193,8 +193,8 @@ export async function updateOrganizationName(
     select: { role: true },
   });
 
-  if (!member || member.role !== "owner") {
-    return { error: "Only organization owners can change the name." };
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can change the name." };
   }
 
   const name = (formData.get("name") as string)?.trim();
@@ -236,8 +236,8 @@ export async function updateApiKeys(
     select: { role: true },
   });
 
-  if (!member || member.role !== "owner") {
-    return { error: "Only organization owners can update API keys." };
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can update API keys." };
   }
 
   const openaiApiKey = (formData.get("openaiApiKey") as string)?.trim() || null;
@@ -302,8 +302,8 @@ export async function removeApiKey(
     select: { role: true },
   });
 
-  if (!member || member.role !== "owner") {
-    return { error: "Only organization owners can manage API keys." };
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can manage API keys." };
   }
 
   await prisma.organization.update({
@@ -334,8 +334,8 @@ export async function updateDefaultModels(
     select: { role: true },
   });
 
-  if (!member || member.role !== "owner") {
-    return { error: "Only organization owners can change default models." };
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can change default models." };
   }
 
   const defaultModelId = (formData.get("defaultModelId") as string)?.trim() || null;
@@ -796,8 +796,8 @@ export async function updateCheckFailureThreshold(
     select: { role: true },
   });
 
-  if (!member || member.role !== "owner") {
-    return { error: "Only organization owners can change review settings." };
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can change review settings." };
   }
 
   const threshold = formData.get("threshold") as string;
@@ -833,8 +833,8 @@ export async function toggleReviewsPaused(
     select: { role: true },
   });
 
-  if (!member || member.role !== "owner") {
-    return { error: "Only organization owners can pause reviews." };
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can pause reviews." };
   }
 
   const paused = formData.get("paused") === "true";
@@ -866,8 +866,8 @@ export async function updateOrgDefaultReviewConfig(
     select: { role: true },
   });
 
-  if (!member || member.role !== "owner") {
-    return { error: "Only organization owners can change review defaults." };
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can change review defaults." };
   }
 
   await prisma.organization.update({
@@ -894,8 +894,8 @@ export async function updateOrgReviewLanguage(
     select: { role: true },
   });
 
-  if (!member || member.role !== "owner") {
-    return { error: "Only organization owners can change the review language." };
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can change the review language." };
   }
 
   if (!isSupportedReviewLanguage(language)) {
@@ -929,8 +929,8 @@ export async function updateOrgBlockedAuthors(
     select: { role: true },
   });
 
-  if (!member || member.role !== "owner") {
-    return { error: "Only organization owners can change blocked authors." };
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can change blocked authors." };
   }
 
   if (authors.length > 50) {

--- a/apps/web/app/(app)/repositories/[id]/settings/page.tsx
+++ b/apps/web/app/(app)/repositories/[id]/settings/page.tsx
@@ -39,7 +39,7 @@ export default async function RepoSettingsPage({
 
   if (!repo || repo.organization.members.length === 0) notFound();
 
-  const isOwner =
+  const canManage =
     repo.organization.members[0].role === "owner" ||
     repo.organization.members[0].role === "admin";
   const reviewConfig = (repo.reviewConfig as Record<string, unknown>) ?? {};
@@ -54,12 +54,12 @@ export default async function RepoSettingsPage({
       </div>
       <ReviewConfigForm
         repoId={repo.id}
-        isOwner={isOwner}
+        isOwner={canManage}
         initialConfig={reviewConfig}
       />
       <RepoConfigForm
         repoId={repo.id}
-        isOwner={isOwner}
+        isOwner={canManage}
         initialEnabled={repo.useRepoConfig}
         initialFiles={initialFilesOrDefault}
       />

--- a/apps/web/app/(app)/repositories/[id]/settings/page.tsx
+++ b/apps/web/app/(app)/repositories/[id]/settings/page.tsx
@@ -39,7 +39,9 @@ export default async function RepoSettingsPage({
 
   if (!repo || repo.organization.members.length === 0) notFound();
 
-  const isOwner = repo.organization.members[0].role === "owner";
+  const isOwner =
+    repo.organization.members[0].role === "owner" ||
+    repo.organization.members[0].role === "admin";
   const reviewConfig = (repo.reviewConfig as Record<string, unknown>) ?? {};
   const initialFiles = normalizeRepoConfigFiles(repo.repoConfigFiles);
   const initialFilesOrDefault = initialFiles.length > 0 ? initialFiles : [...DEFAULT_REPO_CONFIG_FILES];

--- a/apps/web/app/(app)/repositories/[id]/settings/repo-config-form.tsx
+++ b/apps/web/app/(app)/repositories/[id]/settings/repo-config-form.tsx
@@ -172,7 +172,7 @@ export function RepoConfigForm({
 
           {!isOwner && (
             <p className="text-muted-foreground text-center text-xs">
-              Only owners can change repository config settings.
+              Only owners and admins can change repository config settings.
             </p>
           )}
         </fieldset>

--- a/apps/web/app/(app)/repositories/[id]/settings/review-config-form.tsx
+++ b/apps/web/app/(app)/repositories/[id]/settings/review-config-form.tsx
@@ -247,7 +247,7 @@ export function ReviewConfigForm({
 
           {!isOwner && (
             <p className="text-muted-foreground text-center text-xs">
-              Only owners can change review configuration.
+              Only owners and admins can change review configuration.
             </p>
           )}
         </form>

--- a/apps/web/app/(app)/repositories/actions.ts
+++ b/apps/web/app/(app)/repositories/actions.ts
@@ -537,8 +537,11 @@ export async function updateRepoModels(
     return { error: "Repository not found." };
   }
 
-  if (repo.organization.members[0].role !== "owner") {
-    return { error: "Only organization owners can change model settings." };
+  if (
+    repo.organization.members[0].role !== "owner" &&
+    repo.organization.members[0].role !== "admin"
+  ) {
+    return { error: "Only organization owners and admins can change model settings." };
   }
 
   await prisma.repository.update({
@@ -589,8 +592,11 @@ export async function transferRepository(
     return { error: "Repository not found." };
   }
 
-  if (repo.organization.members[0].role !== "owner") {
-    return { error: "Only organization owners can transfer repositories." };
+  if (
+    repo.organization.members[0].role !== "owner" &&
+    repo.organization.members[0].role !== "admin"
+  ) {
+    return { error: "Only organization owners and admins can transfer repositories." };
   }
 
   if (repo.organizationId === targetOrgId) {
@@ -674,8 +680,11 @@ export async function removeRepository(
     return { error: "Repository not found." };
   }
 
-  if (repo.organization.members[0].role !== "owner") {
-    return { error: "Only organization owners can remove repositories." };
+  if (
+    repo.organization.members[0].role !== "owner" &&
+    repo.organization.members[0].role !== "admin"
+  ) {
+    return { error: "Only organization owners and admins can remove repositories." };
   }
 
   abortAnalysis(repoId);
@@ -730,8 +739,11 @@ export async function restoreRepository(
     return { error: "Repository not found." };
   }
 
-  if (repo.organization.members[0].role !== "owner") {
-    return { error: "Only organization owners can restore repositories." };
+  if (
+    repo.organization.members[0].role !== "owner" &&
+    repo.organization.members[0].role !== "admin"
+  ) {
+    return { error: "Only organization owners and admins can restore repositories." };
   }
 
   if (!repo.dismissedAt) {
@@ -825,8 +837,11 @@ export async function updateReviewConfig(
     return { error: "Repository not found." };
   }
 
-  if (repo.organization.members[0].role !== "owner") {
-    return { error: "Only organization owners can change review config." };
+  if (
+    repo.organization.members[0].role !== "owner" &&
+    repo.organization.members[0].role !== "admin"
+  ) {
+    return { error: "Only organization owners and admins can change review config." };
   }
 
   // Validate config values
@@ -885,8 +900,11 @@ export async function updateRepoConfigSettings(
   if (!repo || repo.organization.members.length === 0) {
     return { error: "Repository not found." };
   }
-  if (repo.organization.members[0].role !== "owner") {
-    return { error: "Only organization owners can change repo config settings." };
+  if (
+    repo.organization.members[0].role !== "owner" &&
+    repo.organization.members[0].role !== "admin"
+  ) {
+    return { error: "Only organization owners and admins can change repo config settings." };
   }
 
   if (input.useRepoConfig && input.repoConfigFiles.length === 0) {

--- a/apps/web/app/(app)/settings/api-keys-form.tsx
+++ b/apps/web/app/(app)/settings/api-keys-form.tsx
@@ -221,7 +221,7 @@ export function ApiKeysForm({
 
           {!isOwner && (
             <p className="text-muted-foreground text-center text-xs">
-              Only owners can manage API keys.
+              Only owners and admins can manage API keys.
             </p>
           )}
         </form>

--- a/apps/web/app/(app)/settings/api-keys/page.tsx
+++ b/apps/web/app/(app)/settings/api-keys/page.tsx
@@ -45,7 +45,7 @@ export default async function ApiKeysPage() {
 
   if (!member) redirect("/dashboard");
 
-  const isOwner = member.role === "owner";
+  const isOwner = member.role === "owner" || member.role === "admin";
 
   return (
     <ApiKeysForm

--- a/apps/web/app/(app)/settings/api-keys/page.tsx
+++ b/apps/web/app/(app)/settings/api-keys/page.tsx
@@ -45,7 +45,7 @@ export default async function ApiKeysPage() {
 
   if (!member) redirect("/dashboard");
 
-  const isOwner = member.role === "owner" || member.role === "admin";
+  const canManage = member.role === "owner" || member.role === "admin";
 
   return (
     <ApiKeysForm
@@ -54,7 +54,7 @@ export default async function ApiKeysPage() {
       anthropicApiKey={maskStoredKey(member.organization.anthropicApiKey)}
       googleApiKey={maskStoredKey(member.organization.googleApiKey)}
       cohereApiKey={maskStoredKey(member.organization.cohereApiKey)}
-      isOwner={isOwner}
+      isOwner={canManage}
     />
   );
 }

--- a/apps/web/app/(app)/settings/api-tokens/api-tokens-client.tsx
+++ b/apps/web/app/(app)/settings/api-tokens/api-tokens-client.tsx
@@ -21,13 +21,7 @@ interface Token {
   createdBy: { name: string; email: string };
 }
 
-export function ApiTokensClient({
-  tokens,
-  isOwner,
-}: {
-  tokens: Token[];
-  isOwner: boolean;
-}) {
+export function ApiTokensClient({ tokens }: { tokens: Token[] }) {
   const [newToken, setNewToken] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [showForm, setShowForm] = useState(false);
@@ -98,7 +92,7 @@ export function ApiTokensClient({
         </div>
       )}
 
-      {isOwner && (showForm ? (
+      {showForm ? (
         <form action={handleCreate} className="flex items-end gap-3">
           <div className="flex-1">
             <label htmlFor="token-name" className="text-sm font-medium">
@@ -136,7 +130,7 @@ export function ApiTokensClient({
           <IconPlus className="size-4" />
           Create Token
         </button>
-      ))}
+      )}
 
       {tokens.length > 0 ? (
         <div className="overflow-hidden rounded-lg border dark:border-stone-700">

--- a/apps/web/app/(app)/settings/api-tokens/page.tsx
+++ b/apps/web/app/(app)/settings/api-tokens/page.tsx
@@ -47,7 +47,6 @@ export default async function ApiTokensPage() {
         expiresAt: t.expiresAt?.toISOString() ?? null,
         createdAt: t.createdAt.toISOString(),
       }))}
-      isOwner={member.role === "owner"}
     />
   );
 }

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -648,7 +648,7 @@ export function BillingSettings({
 
           {!isOwner && (
             <p className="text-muted-foreground text-center text-xs">
-              Only owners can manage billing settings.
+              Only owners and admins can manage billing settings.
             </p>
           )}
         </CardContent>

--- a/apps/web/app/(app)/settings/invitations/invitations-panel.tsx
+++ b/apps/web/app/(app)/settings/invitations/invitations-panel.tsx
@@ -81,7 +81,6 @@ interface InvitationsPanelProps {
 export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [members, setMembers] = useState<Member[]>([]);
-  const [callerRole, setCallerRole] = useState<string>("member");
   const [callerUserId, setCallerUserId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [membersLoading, setMembersLoading] = useState(true);
@@ -98,7 +97,6 @@ export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
       if (!res.ok) return;
       const data = await res.json();
       setMembers(data.members);
-      setCallerRole(data.callerRole);
       setCallerUserId(data.callerUserId);
     } finally {
       setMembersLoading(false);
@@ -193,23 +191,17 @@ export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
     if (!isAdmin) return false;
     if (target.user.id === callerUserId) return false;
     if (target.role === "owner") return false;
-    if (callerRole !== "owner" && target.role === "admin") return false;
     return true;
   }
 
   function canChangeRole(target: Member): boolean {
     if (!isAdmin) return false;
     if (target.role === "owner") return false;
-    // Only owner can manage admin roles
-    if (callerRole !== "owner" && target.role === "admin") return false;
     return true;
   }
 
-  function getAvailableRoles(target: Member): string[] {
-    if (callerRole === "owner") return ["admin", "member"];
-    // Admin can only toggle member role (not admin)
-    if (target.role === "member") return ["admin", "member"];
-    return [];
+  function getAvailableRoles(): string[] {
+    return ["admin", "member"];
   }
 
   function formatDate(d: string) {
@@ -274,7 +266,7 @@ export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {getAvailableRoles(m).map((role) => (
+                {getAvailableRoles().map((role) => (
                   <SelectItem key={role} value={role} className="text-xs capitalize">
                     {role}
                   </SelectItem>

--- a/apps/web/app/(app)/settings/models/models-settings.tsx
+++ b/apps/web/app/(app)/settings/models/models-settings.tsx
@@ -456,7 +456,7 @@ export function ModelsSettings({
 
             {!isOwner && (
               <p className="text-muted-foreground text-center text-xs">
-                Only owners can change default models.
+                Only owners and admins can change default models.
               </p>
             )}
           </form>

--- a/apps/web/app/(app)/settings/models/page.tsx
+++ b/apps/web/app/(app)/settings/models/page.tsx
@@ -71,7 +71,7 @@ export default async function ModelsPage() {
     return 0;
   });
 
-  const isOwner = member.role === "owner" || member.role === "admin";
+  const canManage = member.role === "owner" || member.role === "admin";
 
   const platformDefaults = await prisma.availableModel.findMany({
     where: { isPlatformDefault: true, isActive: true },
@@ -89,7 +89,7 @@ export default async function ModelsPage() {
   return (
     <ModelsSettings
       key={orgId}
-      isOwner={isOwner}
+      isOwner={canManage}
       availableModels={availableModels}
       currentModelId={member.organization.defaultModelId}
       currentEmbedModelId={member.organization.defaultEmbedModelId}

--- a/apps/web/app/(app)/settings/models/page.tsx
+++ b/apps/web/app/(app)/settings/models/page.tsx
@@ -71,7 +71,7 @@ export default async function ModelsPage() {
     return 0;
   });
 
-  const isOwner = member.role === "owner";
+  const isOwner = member.role === "owner" || member.role === "admin";
 
   const platformDefaults = await prisma.availableModel.findMany({
     where: { isPlatformDefault: true, isActive: true },

--- a/apps/web/app/(app)/settings/org-name-form.tsx
+++ b/apps/web/app/(app)/settings/org-name-form.tsx
@@ -224,7 +224,7 @@ export function OrgNameForm({
             )}
             {!isOwner && (
               <p className="text-muted-foreground text-xs">
-                Only owners can change the organization details.
+                Only owners and admins can change the organization details.
               </p>
             )}
           </form>

--- a/apps/web/app/(app)/settings/page.tsx
+++ b/apps/web/app/(app)/settings/page.tsx
@@ -32,6 +32,7 @@ export default async function SettingsPage() {
   if (!member) redirect("/dashboard");
 
   const isOwner = member.role === "owner";
+  const canManage = member.role === "owner" || member.role === "admin";
 
   let isLastOrg = false;
   if (isOwner) {
@@ -51,7 +52,7 @@ export default async function SettingsPage() {
       <OrgNameForm
         currentName={member.organization.name}
         avatarUrl={member.organization.avatarUrl}
-        isOwner={isOwner}
+        isOwner={canManage}
       />
       {isOwner && <DangerZoneCard orgSlug={member.organization.slug} isLastOrg={isLastOrg} />}
     </div>

--- a/apps/web/app/(app)/settings/reviews/blocked-authors-form.tsx
+++ b/apps/web/app/(app)/settings/reviews/blocked-authors-form.tsx
@@ -100,7 +100,7 @@ export function BlockedAuthorsForm({
 
           {!isOwner && (
             <p className="text-muted-foreground text-center text-xs">
-              Only owners can change blocked authors.
+              Only owners and admins can change blocked authors.
             </p>
           )}
         </fieldset>

--- a/apps/web/app/(app)/settings/reviews/org-review-config-form.tsx
+++ b/apps/web/app/(app)/settings/reviews/org-review-config-form.tsx
@@ -184,7 +184,7 @@ export function OrgReviewConfigForm({
 
           {!isOwner && (
             <p className="text-muted-foreground text-center text-xs">
-              Only owners can change review defaults.
+              Only owners and admins can change review defaults.
             </p>
           )}
         </fieldset>

--- a/apps/web/app/(app)/settings/reviews/page.tsx
+++ b/apps/web/app/(app)/settings/reviews/page.tsx
@@ -49,26 +49,28 @@ export default async function ReviewsSettingsPage() {
   });
   const globalBlockedAuthors = (globalConfig?.blockedAuthors as string[]) ?? [];
 
+  const canManage = member.role === "owner" || member.role === "admin";
+
   return (
     <div key={member.organization.id} className="space-y-6">
       <ReviewsPausedSwitch
-        isOwner={member.role === "owner"}
+        isOwner={canManage}
         paused={member.organization.reviewsPaused}
       />
       <ReviewSettingsForm
-        isOwner={member.role === "owner"}
+        isOwner={canManage}
         currentThreshold={member.organization.checkFailureThreshold}
       />
       <OrgReviewConfigForm
-        isOwner={member.role === "owner"}
+        isOwner={canManage}
         initialConfig={orgReviewConfig}
       />
       <ReviewLanguageForm
-        isOwner={member.role === "owner"}
+        isOwner={canManage}
         initialLanguage={member.organization.reviewLanguage ?? "en"}
       />
       <BlockedAuthorsForm
-        isOwner={member.role === "owner"}
+        isOwner={canManage}
         initialAuthors={orgBlockedAuthors}
         globalAuthors={globalBlockedAuthors}
       />

--- a/apps/web/app/(app)/settings/reviews/review-language-form.tsx
+++ b/apps/web/app/(app)/settings/reviews/review-language-form.tsx
@@ -84,7 +84,7 @@ export function ReviewLanguageForm({
 
           {!isOwner && (
             <p className="text-muted-foreground text-center text-xs">
-              Only owners can change the review language.
+              Only owners and admins can change the review language.
             </p>
           )}
         </fieldset>

--- a/apps/web/app/(app)/settings/reviews/review-settings-form.tsx
+++ b/apps/web/app/(app)/settings/reviews/review-settings-form.tsx
@@ -104,7 +104,7 @@ export function ReviewSettingsForm({
 
           {!isOwner && (
             <p className="text-muted-foreground text-center text-xs">
-              Only owners can change review settings.
+              Only owners and admins can change review settings.
             </p>
           )}
         </form>

--- a/apps/web/app/(app)/settings/reviews/reviews-paused-switch.tsx
+++ b/apps/web/app/(app)/settings/reviews/reviews-paused-switch.tsx
@@ -60,7 +60,7 @@ export function ReviewsPausedSwitch({
 
           {!isOwner && (
             <p className="text-muted-foreground text-xs mt-3">
-              Only owners can pause or resume reviews.
+              Only owners and admins can pause or resume reviews.
             </p>
           )}
         </form>

--- a/apps/web/app/api/organizations/avatar/route.ts
+++ b/apps/web/app/api/organizations/avatar/route.ts
@@ -24,8 +24,8 @@ async function getOwnerContext() {
     where: { organizationId: orgId, userId: session.user.id, deletedAt: null },
     select: { role: true },
   });
-  if (!member || member.role !== "owner") {
-    return { error: "Only organization owners can change the avatar.", status: 403 as const };
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can change the avatar.", status: 403 as const };
   }
   return { userId: session.user.id, userEmail: session.user.email, orgId };
 }

--- a/apps/web/app/api/orgs/[orgId]/members/[memberId]/route.ts
+++ b/apps/web/app/api/orgs/[orgId]/members/[memberId]/route.ts
@@ -56,11 +56,6 @@ export async function PATCH(
     return NextResponse.json({ error: "Cannot change the owner's role" }, { status: 400 });
   }
 
-  // Only owner can promote to admin or demote admins
-  if (caller.role !== "owner" && (target.role === "admin" || role === "admin")) {
-    return NextResponse.json({ error: "Only the owner can manage admin roles" }, { status: 403 });
-  }
-
   if (target.role === role) {
     return NextResponse.json({ error: "Member already has this role" }, { status: 400 });
   }
@@ -118,11 +113,6 @@ export async function DELETE(
   // Cannot remove the owner
   if (target.role === "owner") {
     return NextResponse.json({ error: "Cannot remove the owner" }, { status: 400 });
-  }
-
-  // Only owner can remove admins
-  if (caller.role !== "owner" && target.role === "admin") {
-    return NextResponse.json({ error: "Only the owner can remove admins" }, { status: 403 });
   }
 
   await prisma.organizationMember.update({


### PR DESCRIPTION
## Summary

- Admins now have the same permissions as the organization owner across org settings: organization name and avatar, API keys (add/remove), default models, review settings (threshold, pause, defaults, language, blocked authors).
- Repository management is also opened to admins: model overrides, review config, repo config, transfer, remove, and restore.
- Member management: admins can promote members to admin, demote admins, and remove admin members. The owner remains protected (role cannot be changed, owner cannot be removed).
- API tokens: the create button is now visible to all members. The server actions already allowed any member to create and delete tokens, so this only removes the UI-side owner restriction.
- Disabled-state hint texts updated from "Only owners can..." to "Only owners and admins can...".

## Intentionally unchanged

- Organization deletion (danger zone) stays owner-only.
- Owner role protections (cannot change or remove the owner) are kept.

## Testing

- `bun run --cwd apps/web typecheck` passes
- `bun run --cwd apps/web lint` passes (2 pre-existing warnings in untouched files)
- `bun run --cwd apps/web test` passes (302 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)