### PR TITLE
fix(github): truncate PR comment bodies to avoid 422 on long reviews

### DIFF
--- a/apps/web/lib/__tests__/github-comment-truncate.test.ts
+++ b/apps/web/lib/__tests__/github-comment-truncate.test.ts
@@ -41,4 +41,17 @@ describe("truncateForGithubComment", () => {
     expect(out.length).toBeLessThanOrEqual(MAX_GITHUB_COMMENT_BODY);
     expect(out).toContain("Comment truncated");
   });
+
+  it("does not end on a lone surrogate (would break JSON encode)", () => {
+    // 🔴 is a surrogate pair in UTF-16. A body of contiguous 🔴 with no
+    // newlines lands in the hard-cut path; without the guard, slice may
+    // cut between the high and low surrogate and emit a malformed string.
+    // String.prototype.isWellFormed() (ES2024) reports unpaired surrogates.
+    const body = "🔴".repeat(MAX_GITHUB_COMMENT_BODY);
+    const out = truncateForGithubComment(body);
+    expect(out.length).toBeLessThanOrEqual(MAX_GITHUB_COMMENT_BODY);
+    expect(out.isWellFormed()).toBe(true);
+    // Sanity: re-encoding through JSON preserves all code points.
+    expect(() => JSON.parse(JSON.stringify({ body: out }))).not.toThrow();
+  });
 });

--- a/apps/web/lib/__tests__/github-comment-truncate.test.ts
+++ b/apps/web/lib/__tests__/github-comment-truncate.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "bun:test";
+import { MAX_GITHUB_COMMENT_BODY, truncateForGithubComment } from "@/lib/github";
+
+describe("truncateForGithubComment", () => {
+  it("returns short bodies unchanged", () => {
+    expect(truncateForGithubComment("hello")).toBe("hello");
+    expect(truncateForGithubComment("")).toBe("");
+  });
+
+  it("does NOT truncate at the cap boundary", () => {
+    const body = "a".repeat(MAX_GITHUB_COMMENT_BODY);
+    expect(truncateForGithubComment(body)).toBe(body);
+  });
+
+  it("appends a clear truncation marker when over the cap", () => {
+    const body = "a".repeat(MAX_GITHUB_COMMENT_BODY + 1000);
+    const out = truncateForGithubComment(body);
+    expect(out.length).toBeLessThanOrEqual(MAX_GITHUB_COMMENT_BODY);
+    expect(out).toContain("Comment truncated");
+    expect(out).toContain("GitHub's per-comment size cap");
+  });
+
+  it("prefers a paragraph boundary near the cap", () => {
+    // Compose a body where the last `\n\n` lies near the limit; the cut
+    // should land at that boundary, not mid-line.
+    const head = "section one".padEnd(MAX_GITHUB_COMMENT_BODY - 5_000, "x");
+    const tail = "section two that wouldn't fit and goes well past the limit";
+    const body = head + "\n\n" + tail.repeat(200);
+    const out = truncateForGithubComment(body);
+    // The marker is the only `\n\n---\n\n` so split on it to find the body content.
+    const beforeMarker = out.split("\n\n---\n\n")[0];
+    // Body content ends at a \n\n boundary OR is exactly equal to the head.
+    // Assert no half-cut tail content (tail starts with "section two").
+    expect(beforeMarker.endsWith(head)).toBe(true);
+  });
+
+  it("falls back to a hard cut when no recent boundary exists", () => {
+    // No newlines at all — must still produce a body that fits.
+    const body = "a".repeat(MAX_GITHUB_COMMENT_BODY * 2);
+    const out = truncateForGithubComment(body);
+    expect(out.length).toBeLessThanOrEqual(MAX_GITHUB_COMMENT_BODY);
+    expect(out).toContain("Comment truncated");
+  });
+});

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -254,6 +254,10 @@ export async function createPullRequestReview(
   event: "COMMENT" | "REQUEST_CHANGES" | "APPROVE",
   comments: ReviewComment[],
 ): Promise<number> {
+  // The review-record `body` is subject to the same 65,536-char limit as
+  // issue/PR comments; without this the standard-pipeline review path can
+  // 422 even when the issue-comment path is safe.
+  const safeBody = truncateForGithubComment(body);
   const token = await getInstallationToken(installationId);
   const res = await fetchWithRetry(
     `${GITHUB_API}/repos/${owner}/${repo}/pulls/${prNumber}/reviews`,
@@ -264,7 +268,7 @@ export async function createPullRequestReview(
         Accept: "application/vnd.github+json",
       },
       body: JSON.stringify({
-        body,
+        body: safeBody,
         event,
         comments,
       }),
@@ -443,7 +447,11 @@ export function truncateForGithubComment(body: string): string {
   // doesn't land mid-codeblock or mid-finding.
   const hardCut = body.slice(0, room);
   const lastBoundary = Math.max(hardCut.lastIndexOf("\n\n"), hardCut.lastIndexOf("\n## "));
-  let cut = lastBoundary > room * 0.8 ? hardCut.slice(0, lastBoundary) : hardCut;
+  // `lastIndexOf` returns -1 when no boundary exists; the numeric comparison
+  // -1 > 0.8 * room is already false (room is positive), but the explicit
+  // `>= 0` guard documents the intent and makes the fallthrough obvious.
+  const cutAtBoundary = lastBoundary >= 0 && lastBoundary > room * 0.8;
+  let cut = cutAtBoundary ? hardCut.slice(0, lastBoundary) : hardCut;
   // Never end on a lone high surrogate — `String.slice` operates on UTF-16
   // code units and can bisect a surrogate pair (emoji, including the
   // 🔴🟠🟡 severity markers Octopus reviews are full of). The result is a

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -443,7 +443,15 @@ export function truncateForGithubComment(body: string): string {
   // doesn't land mid-codeblock or mid-finding.
   const hardCut = body.slice(0, room);
   const lastBoundary = Math.max(hardCut.lastIndexOf("\n\n"), hardCut.lastIndexOf("\n## "));
-  const cut = lastBoundary > room * 0.8 ? hardCut.slice(0, lastBoundary) : hardCut;
+  let cut = lastBoundary > room * 0.8 ? hardCut.slice(0, lastBoundary) : hardCut;
+  // Never end on a lone high surrogate — `String.slice` operates on UTF-16
+  // code units and can bisect a surrogate pair (emoji, including the
+  // 🔴🟠🟡 severity markers Octopus reviews are full of). The result is a
+  // malformed string that `JSON.stringify` emits as an unpaired \ud83d
+  // escape, which RFC 8259 leaves to the receiver's discretion — GitHub
+  // may reject it, recreating the same silent-after-paid-LLM-call failure
+  // mode this whole function exists to prevent.
+  if (/[\uD800-\uDBFF]$/.test(cut)) cut = cut.slice(0, -1);
   return cut + marker;
 }
 

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -417,6 +417,36 @@ async function getPullRequestDiffViaFiles(
   return truncateDiff(patches.join(""));
 }
 
+// GitHub's issue / PR comment API rejects bodies larger than 65536 chars
+// with HTTP 422 "Validation Failed" (the field is `body` and the reason is
+// "too_long"). The error is opaque from the user side — it just looks like
+// the bot failed to post — and the LLM spend behind the failed call is
+// already paid. So clamp at a value below the limit, leaving room for the
+// truncation marker we append.
+export const MAX_GITHUB_COMMENT_BODY = 64_000;
+
+/**
+ * Truncate a comment body to GitHub's accepted size, appending a clear
+ * marker so reviewers know there's more. The full review is still
+ * available via the PR's review-record path; truncating only affects
+ * what GitHub renders in the comment thread. Idempotent on bodies that
+ * already fit. Exported for unit testing.
+ */
+export function truncateForGithubComment(body: string): string {
+  if (body.length <= MAX_GITHUB_COMMENT_BODY) return body;
+  // Cut to (MAX - marker length) so the final string fits exactly.
+  const marker =
+    "\n\n---\n\n> ⚠️ **Comment truncated** — this review exceeded GitHub's per-comment size cap. " +
+    "Visit the dashboard for the full version.";
+  const room = MAX_GITHUB_COMMENT_BODY - marker.length;
+  // Prefer cutting at a paragraph boundary near the limit so the truncation
+  // doesn't land mid-codeblock or mid-finding.
+  const hardCut = body.slice(0, room);
+  const lastBoundary = Math.max(hardCut.lastIndexOf("\n\n"), hardCut.lastIndexOf("\n## "));
+  const cut = lastBoundary > room * 0.8 ? hardCut.slice(0, lastBoundary) : hardCut;
+  return cut + marker;
+}
+
 export async function createPullRequestComment(
   installationId: number,
   owner: string,
@@ -424,6 +454,7 @@ export async function createPullRequestComment(
   prNumber: number,
   body: string,
 ): Promise<number> {
+  const safeBody = truncateForGithubComment(body);
   const token = await getInstallationToken(installationId);
   const res = await fetchWithRetry(
     `${GITHUB_API}/repos/${owner}/${repo}/issues/${prNumber}/comments`,
@@ -433,7 +464,7 @@ export async function createPullRequestComment(
         Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
       },
-      body: JSON.stringify({ body }),
+      body: JSON.stringify({ body: safeBody }),
     },
   );
 
@@ -452,6 +483,7 @@ export async function updatePullRequestComment(
   commentId: number,
   body: string,
 ): Promise<void> {
+  const safeBody = truncateForGithubComment(body);
   const token = await getInstallationToken(installationId);
   const res = await fetchWithRetry(
     `${GITHUB_API}/repos/${owner}/${repo}/issues/comments/${commentId}`,
@@ -461,7 +493,7 @@ export async function updatePullRequestComment(
         Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
       },
-      body: JSON.stringify({ body }),
+      body: JSON.stringify({ body: safeBody }),
     },
   );
 


### PR DESCRIPTION
## Problem

GitHub's issue / PR comment API rejects bodies > 65,536 chars with `422 Validation Failed (field=body, reason=too_long)`. The Octopus reviewer can produce review bodies above that cap when the model is verbose or the PR is large — the post then fails, and the LLM spend behind the failed call is already paid.

Observed live on a self-hosted deployment using `claude-fable-5`: a tight retry loop where every review costs ~\$1 and lands in `[reviewer] Review failed: Failed to update PR comment: 422`. Twelve in-flight PRs were unable to receive a review for over an hour.

## Fix

Add `truncateForGithubComment(body)` at the `apps/web/lib/github.ts` API boundary. Both `createPullRequestComment` and `updatePullRequestComment` route through it before sending.

- Cap: `MAX_GITHUB_COMMENT_BODY = 64_000` (~1.5k headroom for the marker).
- Prefer cutting at the nearest `\n\n` (or `\n## `) above 80% of the budget so truncation doesn't bisect a code fence or finding section.
- Appends `> ⚠️ Comment truncated — visit the dashboard for the full version.` so reviewers know there's more.
- Guard against ending on a lone high UTF-16 surrogate (the bot's findings are full of 🔴🟠🟡 severity emoji); `JSON.stringify` would otherwise emit an unpaired `\\ud83d` escape that GitHub may reject.

GitHub measures characters (Ruby code points); JS `.length` counts UTF-16 code units (always ≥ code points). So a 64,000-unit JS cap is strictly conservative against the 65,536-char API limit. Sources: [community#27190](https://github.com/orgs/community/discussions/27190), [renovate#14551](https://github.com/renovatebot/renovate/issues/14551).

## Scope

GitHub only — GitLab notes accept 1MB (review path is bounded by `maxTokens: 8192` so they're safe today), Bitbucket comments cap at 32KB but the failure-mode is currently latent (no retry loop). The same pattern can be ported to those providers in a follow-up.

## Test plan

- [x] `bun test apps/web/lib/__tests__/github-comment-truncate.test.ts` — 6 pass / 0 fail.
- [x] `bun run --cwd apps/web typecheck` clean.
- [x] Reviewed by an independent code-review pass (boundary, no-newline fallback, surrogate-pair safety, paragraph-boundary preference, JSON round-trip).
- [ ] Production: deploy fixes the running 422 loop on self-hosted instances.

## Diff size
2 files, +78 lines (1 new helper, 1 new test file).