### PR TITLE
fix(review-dedup): null-item crash + non-Latin keyword loss

### DIFF
--- a/apps/web/lib/__tests__/review-dedup.test.ts
+++ b/apps/web/lib/__tests__/review-dedup.test.ts
@@ -366,3 +366,79 @@ describe("parseFindingsFromSummaryTable", () => {
     expect(findings[0].keywords.has("user")).toBe(true);
   });
 });
+
+// ─── parseFindingsFromJson null-guard ──────────────────────────────────────
+
+describe("parseFindingsFromJson — null / non-object items", () => {
+  const wrap = (arr: string) =>
+    `${FINDINGS_START_MARKER}\n\`\`\`json\n${arr}\n\`\`\`\n${FINDINGS_END_MARKER}`;
+
+  it("skips a null item and keeps the rest", () => {
+    // Models occasionally emit a trailing `null` when their output runs past
+    // the schema. Pre-fix, this threw at `typeof item.severity` because the
+    // outer try/catch dropped the entire findings array.
+    const body = wrap(
+      '[null,{"severity":"🔴","title":"t","filePath":"a.ts","startLine":1,"description":"d"}]',
+    );
+    const findings = parseFindingsFromJson(body);
+    expect(findings).not.toBeNull();
+    expect(findings!.length).toBe(1);
+    expect(findings![0].title).toBe("t");
+  });
+
+  it("skips non-object items (strings, numbers)", () => {
+    const body = wrap(
+      '["bad",42,{"severity":"🔴","title":"ok","filePath":"a.ts","startLine":1,"description":"d"}]',
+    );
+    const findings = parseFindingsFromJson(body);
+    expect(findings).not.toBeNull();
+    expect(findings!.length).toBe(1);
+    expect(findings![0].title).toBe("ok");
+  });
+
+  it("returns null when the only item is null (no valid findings)", () => {
+    // Pre-fix this threw because of the null deref; now it just yields
+    // zero valid findings, which the helper returns as null per existing
+    // contract (callers treat null === no JSON block / no findings).
+    const body = wrap("[null]");
+    const findings = parseFindingsFromJson(body);
+    expect(findings).toBeNull();
+  });
+});
+
+// ─── extractKeywords — non-Latin scripts ───────────────────────────────────
+
+describe("extractKeywords — non-Latin scripts", () => {
+  it("preserves Japanese tokens (was stripped by /[^a-z0-9\\s]/g)", () => {
+    const out = extractKeywords("SQL インジェクション バグ報告");
+    expect(out.has("sql")).toBe(true);
+    expect(out.has("インジェクション")).toBe(true);
+    expect(out.has("バグ報告")).toBe(true);
+  });
+
+  it("preserves Cyrillic tokens", () => {
+    const out = extractKeywords("Ошибка переполнения буфера");
+    expect(out.has("ошибка")).toBe(true);
+    expect(out.has("переполнения")).toBe(true);
+    expect(out.has("буфера")).toBe(true);
+  });
+
+  it("preserves Arabic tokens", () => {
+    const out = extractKeywords("خطأ في الذاكرة");
+    expect(out.has("خطأ")).toBe(true);
+    expect(out.has("الذاكرة")).toBe(true);
+  });
+
+  it("still strips punctuation and code symbols", () => {
+    const out = extractKeywords("user.input(arg)/code-path");
+    // The punctuation becomes whitespace and tokens split apart cleanly.
+    expect(out.has("user")).toBe(true);
+    expect(out.has("input")).toBe(true);
+    expect(out.has("arg")).toBe(true);
+    expect(out.has("code")).toBe(true);
+    expect(out.has("path")).toBe(true);
+    // Compound symbol-laden tokens don't survive.
+    expect(out.has("user.input")).toBe(false);
+    expect(out.has("user.input(arg)/code-path")).toBe(false);
+  });
+});

--- a/apps/web/lib/review-dedup.ts
+++ b/apps/web/lib/review-dedup.ts
@@ -62,6 +62,12 @@ export function parseFindingsFromJson(reviewBody: string): InlineFinding[] | nul
 
     const findings: InlineFinding[] = [];
     for (const item of parsed) {
+      // The model occasionally emits `null` (or a non-object literal) in the
+      // findings array — often as the last element when its output ran past
+      // the schema. Without this guard `typeof item.severity` reads through
+      // `null` and throws, dropping EVERY finding in the block, not just
+      // the bad item.
+      if (item === null || typeof item !== "object") continue;
       if (
         typeof item.severity !== "string" ||
         typeof item.title !== "string" ||
@@ -154,10 +160,18 @@ const STOP_WORDS = new Set([
 ]);
 
 export function extractKeywords(text: string): Set<string> {
+  // `[^a-z0-9\s]` strips EVERY non-ASCII codepoint, so non-Latin review
+  // languages (Japanese, Cyrillic, Arabic, …) collapse every finding's
+  // keyword set to empty. jaccardSimilarity returns 1 for two empty sets,
+  // so every finding then looked 100% similar to every prior finding and
+  // was wrongly deduplicated as a "rerun of the same issue". Use Unicode
+  // property classes with the /u flag — `\p{L}` (letter) and `\p{N}`
+  // (number) keep non-Latin words intact while still stripping
+  // punctuation and code symbols.
   return new Set(
     text
       .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, " ")
+      .replace(/[^\p{L}\p{N}\s]/gu, " ")
       .split(/\s+/)
       .filter((w) => w.length > 2 && !STOP_WORDS.has(w)),
   );


### PR DESCRIPTION
Two independent correctness bugs in `apps/web/lib/review-dedup.ts`, both surfaced by an adversarial-verify audit. Each silently breaks the review-dedup pipeline on legitimate model output / configurations.

## Bug 1 — `parseFindingsFromJson` crashes on `null` in the findings array

Models occasionally emit `null` (or another non-object literal) as an element in the findings array, most often as the last element when the output ran past the schema. The loop:

\`\`\`ts
for (const item of parsed) {
  if (typeof item.severity !== "string" || ...) continue;
  ...
}
\`\`\`

reads `typeof item.severity` through that `null` and throws `TypeError: Cannot read properties of null`. The outer `try/catch` swallows it and returns `null` for the *whole* block, dropping every legitimate finding in the review.

**Fix:** an `item === null || typeof item !== "object"` guard at the top of the loop. The bad element is skipped; the rest are kept.

## Bug 2 — `extractKeywords` strips every non-Latin codepoint

\`\`\`ts
text.toLowerCase().replace(/[^a-z0-9\s]/g, " ")
\`\`\`

matches "anything that isn't a lowercase ASCII letter, ASCII digit, or whitespace" — which includes every CJK ideograph, every Cyrillic / Greek / Arabic / Hebrew letter, every Devanagari character, etc.

On a repo configured with a non-English `reviewLanguage`, every finding's keyword set collapses to empty. `jaccardSimilarity({}, {})` returns `1` (intersection / union with union size 0 short-circuits to 1), so every new finding looked 100% similar to every prior finding and got wrongly deduplicated as a "rerun of the same issue." Net effect: re-reviews on non-Latin repos surfaced almost no findings.

**Fix:** `\\p{L}` / `\\p{N}` with the `/u` flag — Unicode "letter" and "number" property classes. Non-Latin scripts pass through; punctuation and code symbols still become whitespace.

## Test plan
- [x] 7 new tests in `apps/web/lib/__tests__/review-dedup.test.ts`:
  - `parseFindingsFromJson` — null-guard: skip null & keep rest / skip non-object items / null-only array
  - `extractKeywords` — Japanese / Cyrillic / Arabic / punctuation-still-stripped
- [x] All 42 tests pass.

## Risk
- Both fixes are tightening behavior of pure helpers. No new failure modes.
- `\\p{L}` / `\\p{N}` is widely supported (V8, JavaScriptCore, SpiderMonkey — all engines targeting modern runtimes). The repo's existing tooling (TypeScript / Node) supports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)