### PR TITLE
fix(middleware): allow health and ready probes through auth

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -29,6 +29,8 @@ const publicPrefixes = [
   "/api/blog",
   "/api/ask-octopus",
   "/api/status",
+  "/api/health",
+  "/api/ready",
 ];
 const publicExact = ["/"];
 


### PR DESCRIPTION
## Summary
- Add `/api/health` and `/api/ready` to the middleware `publicPrefixes` list so the probes added in #470 are reachable without a session.

## Problem
External requests to `/api/health` and `/api/ready` were redirected to `/login?callbackUrl=...` with a 307, which makes them unusable for external uptime monitoring and load balancer checks. The container healthcheck was unaffected because it probes `/api/version`, which is already public.

## Testing
- Verified locally that the routes match the new prefixes before the session check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)