### PR TITLE
fix(security): move createOrgForUser out of "use server" module

### DIFF
--- a/apps/web/app/(app)/complete-profile/actions.ts
+++ b/apps/web/app/(app)/complete-profile/actions.ts
@@ -4,9 +4,7 @@ import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
-import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
-import { canUserCreateOrg } from "@/lib/org-limits";
-import { MAX_OWNED_ORGS_PER_USER } from "@/lib/constants";
+import { createOrgForUser } from "@/lib/org-create";
 
 export async function completeProfile(
   _prevState: { error?: string },
@@ -45,72 +43,4 @@ export async function completeProfile(
   });
 
   redirect("/dashboard");
-}
-
-/**
- * Creates an organization for a user. Pure DB operation — no cookie setting.
- * Safe to call from Server Components (layout) and Server Actions.
- */
-export async function createOrgForUser(userId: string, userName: string) {
-  const allowed = await canUserCreateOrg(userId);
-  if (!allowed) {
-    throw new Error(`Organization limit reached (max ${MAX_OWNED_ORGS_PER_USER}).`);
-  }
-
-  const firstName = userName.split(" ")[0];
-  const orgName = `${firstName}'s Organization`;
-  const baseSlug = toBaseSlug(orgName);
-
-  // Generate unique slug with random suffix (checks all orgs including soft-deleted)
-  let slug = `${baseSlug}-${randomSlugSuffix()}`;
-  for (let i = 0; i < 10; i++) {
-    const existing = await prisma.organization.findUnique({
-      where: { slug },
-      select: { id: true },
-    });
-    if (!existing) break;
-    slug = `${baseSlug}-${randomSlugSuffix()}`;
-  }
-
-  // Re-check limit and create atomically to prevent TOCTOU race
-  const org = await prisma.$transaction(async (tx) => {
-    const ownedCount = await tx.organizationMember.count({
-      where: { userId, role: "owner", deletedAt: null, organization: { deletedAt: null } },
-    });
-    if (ownedCount >= MAX_OWNED_ORGS_PER_USER) {
-      throw new Error(`Organization limit reached (max ${MAX_OWNED_ORGS_PER_USER}).`);
-    }
-
-    const firstOrg = ownedCount === 0;
-
-    return tx.organization.create({
-      data: {
-        name: orgName,
-        slug,
-        members: {
-          create: {
-            userId,
-            role: "owner",
-          },
-        },
-        ...(firstOrg && {
-          creditTransactions: {
-            create: {
-              amount: 150,
-              type: "free_credit",
-              description: "Welcome bonus — $150 free credits",
-              balanceAfter: 150,
-            },
-          },
-        }),
-      },
-    });
-  });
-
-  await prisma.user.update({
-    where: { id: userId },
-    data: { onboardingCompleted: true },
-  });
-
-  return org;
 }

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -11,7 +11,7 @@ import { getOrgSpendLimitStatus } from "@/lib/cost";
 import { canUserCreateOrg } from "@/lib/org-limits";
 import { OrgCookieSync } from "@/components/org-cookie-sync";
 import { DeviceReporter } from "@/components/device-reporter";
-import { createOrgForUser } from "./complete-profile/actions";
+import { createOrgForUser } from "@/lib/org-create";
 
 /**
  * Derives a display name from an email address.

--- a/apps/web/app/api/cli/auth/orgs/route.ts
+++ b/apps/web/app/api/cli/auth/orgs/route.ts
@@ -1,7 +1,7 @@
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
-import { createOrgForUser } from "@/app/(app)/complete-profile/actions";
+import { createOrgForUser } from "@/lib/org-create";
 
 export async function GET() {
   const session = await auth.api.getSession({ headers: await headers() });

--- a/apps/web/lib/org-create.ts
+++ b/apps/web/lib/org-create.ts
@@ -1,0 +1,85 @@
+import { prisma } from "@octopus/db";
+import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
+import { canUserCreateOrg } from "@/lib/org-limits";
+import { MAX_OWNED_ORGS_PER_USER } from "@/lib/constants";
+
+/**
+ * Creates an organization for a user. Pure DB operation — no cookie setting,
+ * no auth check (callers are responsible).
+ *
+ * Why this lives in /lib instead of complete-profile/actions.ts:
+ * Next.js treats EVERY export from a `"use server"` module as a publicly
+ * invokable server action — a route reachable from any client that obtains
+ * its action ID, with no session check beyond what the function performs
+ * itself. This function takes `userId` as a parameter, so exporting it from
+ * a "use server" module exposed an unauthenticated endpoint that any caller
+ * could use to create owner-organizations for arbitrary user IDs (e.g. to
+ * grief victims by exhausting their MAX_OWNED_ORGS_PER_USER cap).
+ *
+ * Keeping it in a plain server lib makes it importable from server-side
+ * code (Server Components, server actions, route handlers) without being
+ * routable on its own.
+ */
+export async function createOrgForUser(userId: string, userName: string) {
+  const allowed = await canUserCreateOrg(userId);
+  if (!allowed) {
+    throw new Error(`Organization limit reached (max ${MAX_OWNED_ORGS_PER_USER}).`);
+  }
+
+  const firstName = userName.split(" ")[0];
+  const orgName = `${firstName}'s Organization`;
+  const baseSlug = toBaseSlug(orgName);
+
+  // Generate unique slug with random suffix (checks all orgs including soft-deleted)
+  let slug = `${baseSlug}-${randomSlugSuffix()}`;
+  for (let i = 0; i < 10; i++) {
+    const existing = await prisma.organization.findUnique({
+      where: { slug },
+      select: { id: true },
+    });
+    if (!existing) break;
+    slug = `${baseSlug}-${randomSlugSuffix()}`;
+  }
+
+  // Re-check limit and create atomically to prevent TOCTOU race
+  const org = await prisma.$transaction(async (tx) => {
+    const ownedCount = await tx.organizationMember.count({
+      where: { userId, role: "owner", deletedAt: null, organization: { deletedAt: null } },
+    });
+    if (ownedCount >= MAX_OWNED_ORGS_PER_USER) {
+      throw new Error(`Organization limit reached (max ${MAX_OWNED_ORGS_PER_USER}).`);
+    }
+
+    const firstOrg = ownedCount === 0;
+
+    return tx.organization.create({
+      data: {
+        name: orgName,
+        slug,
+        members: {
+          create: {
+            userId,
+            role: "owner",
+          },
+        },
+        ...(firstOrg && {
+          creditTransactions: {
+            create: {
+              amount: 150,
+              type: "free_credit",
+              description: "Welcome bonus — $150 free credits",
+              balanceAfter: 150,
+            },
+          },
+        }),
+      },
+    });
+  });
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: { onboardingCompleted: true },
+  });
+
+  return org;
+}


### PR DESCRIPTION
## The bug

`apps/web/app/(app)/complete-profile/actions.ts` begins with `"use server";`. Next.js treats every export from such a module as a **publicly invokable server action** — a route reachable from any caller that obtains the action ID, with no session check beyond what the function itself performs.

The file currently exports two functions:

\`\`\`ts
// 1. session-checked, the intended public action
export async function completeProfile(_prevState, formData) {
  const session = await auth.api.getSession(...);
  if (!session) redirect("/login");
  ...
  const org = await createOrgForUser(session.user.id, name);
  ...
}

// 2. ALSO exposed as a publicly invokable server action — but with no auth
export async function createOrgForUser(userId: string, userName: string) {
  // accepts ANY userId; no session check
  const org = await prisma.$transaction(async (tx) => { ... });
}
\`\`\`

`createOrgForUser` takes `userId` as a parameter. Because it's exported from a `"use server"` module, an attacker who scrapes / replays the action ID can call it directly with **any user's ID**.

## Impact

Concrete attack:

1. Attacker discovers the action ID (action IDs leak through the HTML payload of any page that imports the module).
2. Attacker calls `createOrgForUser(victimUserId, "spam")` three times.
3. Victim hits `MAX_OWNED_ORGS_PER_USER = 3`. They can no longer create their own organization.
4. Each spam-org consumes the $150 free-credit grant (`creditTransactions.create` in the function body).

The function also runs `prisma.user.update({ where: { id: userId }, data: { onboardingCompleted: true } })` for the victim — flipping their onboarding state without their consent.

## Fix

Move `createOrgForUser` to a plain server lib at `apps/web/lib/org-create.ts` — no `"use server"` directive, so it's not a routable server action. It's still importable from server-side code (Server Components, server actions, route handlers).

The three legitimate callers all already pass a **session-derived** userId — they're unchanged in behavior, only their import path changes:

| Caller | What it does | userId comes from |
|---|---|---|
| `complete-profile/actions.ts::completeProfile` | The form action | `session.user.id` (after `await auth.api.getSession(...)`) |
| `app/(app)/layout.tsx` | Auto-create on first sign-in | `session.user.id` (same) |
| `app/api/cli/auth/orgs/route.ts::GET` | CLI auth endpoint | `session.user.id` (same) |

The unauthenticated endpoint stops existing.

## Test plan
- [ ] In production: confirm scraped action IDs for the old `createOrgForUser` no longer resolve to a handler (404 from `_actions` endpoint).
- [ ] Confirm the three legitimate flows still work: complete-profile form, first-sign-in auto-create, `/api/cli/auth/orgs`.

No new unit tests — the function body is unchanged, only its routing classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)