### PR TITLE
fix(ai-router): collect all Anthropic text blocks, fail on empty response

### DIFF
--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -170,7 +170,20 @@ async function callAnthropic(
     })),
   });
 
-  const text = response.content[0].type === "text" ? response.content[0].text : "";
+  // Models with extended thinking (e.g. claude-fable-5) prepend a thinking
+  // block, so the text block is not necessarily content[0] — collect every
+  // text block instead of only the first.
+  const text = response.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("");
+  // Surface empty responses as errors instead of silently returning an empty
+  // review that downstream code would PATCH to GitHub as a blank comment (422).
+  if (!text) {
+    throw new Error(
+      `Anthropic returned no text (stop_reason: ${response.stop_reason}, blocks: ${response.content.map((b) => b.type).join(",") || "none"})`,
+    );
+  }
 
   return {
     text,


### PR DESCRIPTION
## Summary
- Join every `text` block from Anthropic responses instead of reading only `content[0]`.
- Throw a descriptive error when the response contains no text, mirroring the existing OpenAI Responses guard.

## Problem
Production reviews on `claude-fable-5` were failing with `Review generated: 0 chars, 0 findings` followed by `Failed to update PR comment: 422` (seen on PRs #135, #136, #138, #142, #144, #145 of an affected org). Extended-thinking models prepend a `thinking` block, so `content[0].type === "text"` was false and the extracted text fell back to `""` even though the model produced a complete review (~$1 of spend per attempt). The empty body was then PATCHed to GitHub, which rejects blank comment bodies with 422.

This is unrelated to the comment-length 422 fixed in #511; that fix is deployed and working.

## Fix
- `callAnthropic` now collects all text blocks: `response.content.filter(b => b.type === "text").map(b => b.text).join("")`.
- Empty extraction now throws `Anthropic returned no text (stop_reason: ..., blocks: ...)` so the failure is visible in logs instead of surfacing as a confusing GitHub 422.

## Testing
- `bunx tsc --noEmit` clean
- `bun test`: 308 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)