### PR TITLE
fix(ai-router): raise max_tokens floor and stream for always-thinking models

### DIFF
--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -157,6 +157,17 @@ function getOrgKeyForProvider(keys: OrgKeys, provider: AiProvider): string | nul
 const ALWAYS_THINKING_MODEL_RX = /^claude-(fable|mythos)-/;
 const ALWAYS_THINKING_MAX_TOKENS_FLOOR = 64000;
 
+/**
+ * Hard deadline for one Anthropic call, thinking time included. The SDK's
+ * built-in timeout only covers time-to-response-headers (its clearTimeout
+ * runs as soon as fetch resolves), so once the SSE stream is open a stalled
+ * connection would hang finalMessage() forever. A caller-supplied abort
+ * signal, by contrast, stays attached for the whole body read. Keep this
+ * below the review queue's 900s job timeout so the call fails with a clear,
+ * retryable error instead of the job silently expiring.
+ */
+const ANTHROPIC_CALL_TIMEOUT_MS = 14 * 60 * 1000;
+
 async function callAnthropic(
   params: AiCreateParams,
   apiKey?: string | null,
@@ -190,8 +201,24 @@ async function callAnthropic(
       role: m.role,
       content: m.content,
     })),
-  });
-  const response = await stream.finalMessage();
+  }, { signal: AbortSignal.timeout(ANTHROPIC_CALL_TIMEOUT_MS) });
+
+  let response: Anthropic.Message;
+  try {
+    response = await stream.finalMessage();
+  } catch (err) {
+    // Map the abort (only our timeout signal can trigger it here) to an
+    // actionable error instead of the SDK's generic "Request was aborted".
+    if (
+      err instanceof Anthropic.APIUserAbortError ||
+      (err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError"))
+    ) {
+      throw new Error(
+        `Anthropic call timed out after ${ANTHROPIC_CALL_TIMEOUT_MS / 1000}s (model: ${params.model})`,
+      );
+    }
+    throw err;
+  }
 
   // Models with extended thinking (e.g. claude-fable-5) prepend a thinking
   // block, so the text block is not necessarily content[0] — collect every

--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -144,15 +144,37 @@ function getOrgKeyForProvider(keys: OrgKeys, provider: AiProvider): string | nul
 
 // ── Provider-specific call implementations ───────────────────────────────────
 
+/**
+ * Claude Fable/Mythos models have always-on extended thinking that spends
+ * from the max_tokens budget BEFORE any text is produced, and a tokenizer
+ * that uses ~30% more tokens than Opus-tier models. Budgets tuned for other
+ * models (8192 for reviews, 256 for titles) get fully consumed by the
+ * thinking block on hard inputs, the response ends with
+ * stop_reason "max_tokens" and zero text blocks, and the whole review fails.
+ * Raise the cap to a floor that leaves room for thinking + text; max_tokens
+ * is a ceiling, not a spend, so the floor costs nothing on easy inputs.
+ */
+const ALWAYS_THINKING_MODEL_RX = /^claude-(fable|mythos)-/;
+const ALWAYS_THINKING_MAX_TOKENS_FLOOR = 64000;
+
 async function callAnthropic(
   params: AiCreateParams,
   apiKey?: string | null,
 ): Promise<AiResponse> {
   const client = getAnthropic(apiKey);
 
-  const response = await client.messages.create({
+  const maxTokens = ALWAYS_THINKING_MODEL_RX.test(params.model)
+    ? Math.max(params.maxTokens, ALWAYS_THINKING_MAX_TOKENS_FLOOR)
+    : params.maxTokens;
+
+  // Streaming here is purely between this process and the Anthropic API —
+  // finalMessage() buffers the SSE chunks and returns the same complete
+  // Message object messages.create() would. It's required because thinking
+  // models can take minutes before the first byte, and the SDK enforces
+  // streaming for large max_tokens to avoid HTTP timeouts.
+  const stream = client.messages.stream({
     model: params.model,
-    max_tokens: params.maxTokens,
+    max_tokens: maxTokens,
     system: params.system
       ? [
           {
@@ -169,6 +191,7 @@ async function callAnthropic(
       content: m.content,
     })),
   });
+  const response = await stream.finalMessage();
 
   // Models with extended thinking (e.g. claude-fable-5) prepend a thinking
   // block, so the text block is not necessarily content[0] — collect every


### PR DESCRIPTION
## The bug

Production reviews on `claude-fable-5` intermittently fail with:

```
[ai-router] anthropic API error for model claude-fable-5: Anthropic returned no text (stop_reason: max_tokens, blocks: thinking)
[reviewer] Review failed for PR #145: Error: AI provider anthropic failed: ...
```

`claude-fable-5` has always-on extended thinking that spends from the `max_tokens` budget before any text is produced, and its tokenizer uses roughly 30% more tokens than Opus-tier models for the same content. The review call passes `maxTokens: 8192` (`reviewer.ts:1600`). On large or complex diffs the model consumes the entire budget inside the thinking block, the API returns `stop_reason: "max_tokens"` with no text block, and the empty-response guard in `ai-router.ts` (correctly) turns that into a failed review. Small PRs slip through because the thinking stays short, which is why the failure looked intermittent.

The smaller call sites were also at risk: `maxTokens: 256` (title generation, `reviewer.ts:209`) and `maxTokens: 4096` (`reviewer.ts:1724`, `review-core.ts:404`) would die the same way on Fable, since thinking alone exceeds those budgets.

## The fix

Both changes are inside `callAnthropic`, so every Anthropic call site is covered from one place:

1. **64k `max_tokens` floor for always-thinking models** (`claude-fable-*` / `claude-mythos-*`). Other providers and Opus-tier models keep the caller's value. `max_tokens` is a ceiling, not a spend, so easy inputs cost exactly what they did before.
2. **`messages.create()` -> `messages.stream()` + `finalMessage()`.** The SSE stream is consumed in-process and `finalMessage()` returns the same complete `Message` object, so the function signature, the empty-response guard, and all callers are unchanged. This removes the SDK HTTP timeout risk on minutes-long thinking turns and satisfies the SDK requirement to stream at large `max_tokens` values. No change for the multi-node engine: each pg-boss worker still claims a job, makes the call, and posts the finished review.

## Test plan
- [x] `bun run typecheck` clean
- [x] Full web suite passes: 337/337
- [ ] Production: re-trigger the failed review on a large PR with `claude-fable-5`, confirm it completes and the comment posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
