### PR TITLE
feat(docs): roadmap, governance, AGENTS, SOC2 readiness, contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md
+
+Repo-scoped rules for AI agents reviewing or editing this codebase. Octopus reads this file as part of its review pipeline (per the [Repo Config Files](README.md#features) feature) and human contributors are welcome to follow the same conventions.
+
+For human-oriented setup, workflow, and PR guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md). For project direction see [ROADMAP.md](ROADMAP.md).
+
+## Before submitting a change
+
+Run all four locally. CI will reject if any fail.
+
+```bash
+bun install              # if dependencies haven't been installed
+bun run lint
+bun run typecheck
+bun run test
+bun run build
+```
+
+## Repository layout
+
+```
+apps/web/                     Next.js 16 web app + API routes (the bulk of the code)
+packages/db/                  Prisma schema, migrations, and shared client
+packages/package-analyzer/    Package metadata + safety analyzer
+tools/{tsconfig,eslint-config}/  Shared dev config
+```
+
+The `@octp/cli` package referenced in the README lives in a separate repository; changes targeting the CLI do not belong in this repo.
+
+## Conventions that matter for AI-suggested changes
+
+### Database access
+- Always import the Prisma client as `import { prisma } from "@octopus/db"`. Never instantiate `new PrismaClient()` directly.
+- Files that touch `prisma` must start with `import "server-only";` so they never leak into client bundles.
+- Prisma schema changes require a SQL migration in `packages/db/prisma/migrations/<timestamp>_<slug>/migration.sql` in the same PR. The migrations directory is git-ignored by default; force-add new ones (`git add -f`) — that matches existing convention.
+
+### AI provider calls
+- All chat/completion calls go through `apps/web/lib/ai-router.ts`'s `createAiMessage`. Do not import provider SDKs (`@anthropic-ai/sdk`, `openai`, `@google/generative-ai`) directly elsewhere.
+- The router resolves the provider from the model ID (DB cache, prefix fallback) and selects per-org BYOK keys. Adding a new provider means extending the router; do not work around it.
+- Embeddings currently route through `apps/web/lib/embeddings.ts` (OpenAI-only at the moment). Pricing data lives in `apps/web/lib/cost.ts`; the `AvailableModel` Prisma table is the source of truth for provider mapping.
+
+### Review pipeline
+- The review prompt lives at `apps/web/prompts/SYSTEM_PROMPT.md`. Treat it as code — small wording changes can shift finding rates noticeably.
+- Findings are emitted as a JSON array between `<!-- OCTOPUS_FINDINGS_START -->` and `<!-- OCTOPUS_FINDINGS_END -->` markers. Parsing lives in `apps/web/lib/review-dedup.ts:parseFindingsFromJson`. Preserve the marker format; downstream consumers depend on it.
+- Inline-comment rendering is in `apps/web/lib/review-helpers.ts:buildInlineComments`. The section order (severity/title → description → suggestion → fix prompt) is deliberate; don't reshuffle without coordination.
+
+### Tests
+- Use `bun:test` (`import { describe, it, expect } from "bun:test"`). Do not pull in jest/vitest.
+- Tests live in `apps/web/lib/__tests__/`. Mirror the name of the file under test (`foo.ts` → `foo.test.ts`).
+- For files that import `prisma` at the top level (e.g. `cost.ts`), mock `@octopus/db` at the top of the test using `mock.module("@octopus/db", () => ({ prisma: {} }))` — see `cost.test.ts` for the pattern.
+
+### UI
+- Shadcn/ui components are the default. Add new components via `bunx shadcn@latest add <name>`, then commit the generated file.
+- Icons come from `@tabler/icons-react`. Don't introduce a second icon library.
+- Tailwind 4 + the existing tokens — don't add custom CSS files for things that compose from Tailwind.
+
+### Dependencies
+- Adding a new npm dependency needs a clear justification in the PR description. Prefer transitive deps that already exist over new top-level adds.
+- Major-version bumps go through a dedicated PR.
+
+## Commits and PRs
+
+- [Conventional Commits](https://www.conventionalcommits.org/): `feat(scope): …`, `fix(scope): …`, `chore(deps): …`, `docs(scope): …`, `refactor(scope): …`.
+- One change per PR. Reviewer-bot quality gate is **4+/5**; 🔴 critical findings must be addressed before merge.
+- Reference issues via `Closes #N` (closes on merge) or `Part of #N` (epic sub-task).
+
+## What not to do
+
+- Do not commit secrets. `.env`, `.env.local`, and similar are git-ignored; double-check before pushing.
+- Do not bypass Git hooks (`--no-verify`, `--no-gpg-sign`) without explicit authorisation. If a hook fails, fix the underlying issue.
+- Do not force-push to shared branches. Local feature branches before review are fine; published PR branches are not.
+- Do not amend or squash commits that have been reviewed. Add new commits on top.
+- Do not delete or rename `packages/db/prisma/migrations/<timestamp>_*/migration.sql` files after they ship — they're immutable history once any environment has run them.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,76 @@
+# Governance
+
+Octopus is an open-source project with a small group of maintainers and a wider contributor community. This document describes how decisions get made, who has authority over what, and how anyone can earn more influence over the project's direction.
+
+## Roles
+
+### Contributors
+
+Anyone who opens issues, files bugs, writes documentation, submits PRs, or participates in Discussions. No formal application; participation is the qualification.
+
+### Maintainers
+
+The people listed in [MAINTAINERS.md](MAINTAINERS.md) and [.github/CODEOWNERS](.github/CODEOWNERS). Maintainers can:
+
+- Merge PRs in their areas of ownership
+- Triage and label issues
+- Promote items from **Proposed** to **Up Next** on the [Roadmap](ROADMAP.md)
+- Cut releases and publish to GHCR
+
+### Lead maintainer
+
+The lead maintainer (currently [@redoh](https://github.com/redoh)) has final say on:
+
+- Project scope and direction
+- License changes
+- Adding or removing maintainers
+- Decisions that don't reach consensus among maintainers
+
+## How decisions get made
+
+### PR review
+
+PRs are reviewed by the [CODEOWNERS](.github/CODEOWNERS) for the touched paths. One maintainer approval is sufficient to merge for routine changes. Architectural or breaking changes require a second maintainer or an RFC (see below).
+
+The Octopus reviewer bot also reviews every PR. Its **4+/5 quality rating** is a soft gate — maintainers may merge below it for trivial changes, but findings tagged 🔴 Critical must be addressed or explicitly waived in the PR description.
+
+### Roadmap changes
+
+Items move from **Proposed** → **Up Next** when a maintainer adds the `roadmap` label and ideally finds an owner. Anyone can open a [roadmap proposal](.github/ISSUE_TEMPLATE/roadmap_proposal.yml).
+
+### RFCs (architectural changes)
+
+For changes that touch multiple subsystems, break public APIs, or change the social contract (governance, license, security policy), open an issue labeled `rfc` with:
+
+- The problem you're solving
+- Your proposed approach
+- Alternatives considered
+- Migration plan if applicable
+
+RFCs sit open for at least 7 days for community input before a maintainer merges or rejects.
+
+### Disagreements
+
+If maintainers disagree, the discussion happens publicly on the issue or PR. If consensus doesn't form within a week, the lead maintainer decides. The decision and its rationale are recorded on the issue for future reference.
+
+## Becoming a maintainer
+
+There's no rigid formula, but the typical path is:
+
+1. Sustained, high-quality contributions over a few months (PRs that merge cleanly, issue triage, helpful Discussion answers)
+2. Demonstrated judgment in one or more areas (review pipeline, integrations, UI, infra)
+3. An existing maintainer nominates you in a private discussion
+4. Other maintainers either agree or surface specific concerns
+5. The lead maintainer extends the invitation
+
+New maintainers usually start with ownership over a narrow area before getting broader review rights.
+
+## Removing a maintainer
+
+Inactive maintainers (no review activity for 6+ months) may be moved to **emeritus** status — credited but no longer holding review responsibilities. Reinstatement is straightforward if the person returns.
+
+Maintainers can also be removed for violations of the [Code of Conduct](CODE_OF_CONDUCT.md). The lead maintainer makes this call after consulting with other maintainers; the rationale is recorded in a sealed enforcement record.
+
+## Changes to this document
+
+Amend by PR. Material changes require sign-off from the lead maintainer. Spelling fixes, formatting, and link updates do not.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,28 @@
+# Maintainers
+
+The people listed here have merge rights on Octopus and final say over their areas of ownership. They are also the first stop for design questions, security reports that route through GitHub, and PR review escalations.
+
+For the formal definition of what a maintainer can do, see [GOVERNANCE.md](GOVERNANCE.md).
+For the path-resolved owner of any file, see [.github/CODEOWNERS](.github/CODEOWNERS).
+
+## Active maintainers
+
+| Name | GitHub | Areas of ownership |
+|---|---|---|
+| Lead maintainer | [@redoh](https://github.com/redoh) | Everything (lead) — web app, database schema, review engine, infrastructure, CI |
+| Tests co-owner | [@ogulcanaydogan](https://github.com/ogulcanaydogan) | `/apps/web/lib/__tests__/` — test review |
+
+## Emeritus maintainers
+
+_None yet. Inactive maintainers (no review activity for 6+ months per [GOVERNANCE.md](GOVERNANCE.md)) will be credited here._
+
+## Becoming a maintainer
+
+See the [Becoming a maintainer](GOVERNANCE.md#becoming-a-maintainer) section of `GOVERNANCE.md`. Short version: sustained high-quality contributions, demonstrated judgment in a clear area, nomination by an existing maintainer.
+
+## Contacting maintainers
+
+- **Public discussion** — open an [Issue](https://github.com/octopusreview/octopus/issues) or a [Discussion](https://github.com/octopusreview/octopus/discussions)
+- **Security vulnerabilities** — `security@octopus-review.ai` per [SECURITY.md](SECURITY.md). **Do not file public issues for vulnerabilities.**
+- **Code of conduct issues** — `conduct@octopus-review.ai` per [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- **Chat** — [Discord](https://discord.gg/qyuWTXghbS)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,7 +10,7 @@ For the path-resolved owner of any file, see [.github/CODEOWNERS](.github/CODEOW
 | Name | GitHub | Areas of ownership |
 |---|---|---|
 | Lead maintainer | [@redoh](https://github.com/redoh) | Everything (lead) — web app, database schema, review engine, infrastructure, CI |
-| Tests co-owner | [@ogulcanaydogan](https://github.com/ogulcanaydogan) | `/apps/web/lib/__tests__/` — test review |
+| Maintainer | [@cemoso](https://github.com/cemoso) (cem@weezboo.com) | Review engine, CLI, self-hosted ops |
 
 ## Emeritus maintainers
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,68 @@
+# Roadmap
+
+This is a living document. It captures what Octopus is working on, what is queued, and what the community is invited to discuss. It is **not a commitment** — priorities shift as the project learns.
+
+For the live, sortable view, see the [Octopus Roadmap Project board](https://github.com/orgs/octopusreview/projects).
+The [CHANGELOG](CHANGELOG.md) is the source of truth for what has actually shipped.
+
+---
+
+## Recently Shipped
+
+Highlights from the last few releases. See [CHANGELOG.md](CHANGELOG.md) for the full list.
+
+- GitLab integration: OAuth, webhook, and merge request review support
+- Knowledge Center: pinned documents that are always included in every review
+- Repo config files (`.octopus.md` / `AGENTS.md` / `CLAUDE.md`) with sandboxed rule extraction
+- Jira integration: one-click issue creation from review findings
+- Async community review pipeline for free open-source reviews
+- Repository graph view with structural and semantic edges
+- Real-time status page
+
+## In Progress
+
+Work that has an owner and is actively being built. Each item links to its tracking issue.
+
+_Add items here as they enter active development._
+
+## Up Next
+
+Committed for the next quarter or so. Loose ordering; reshuffled as priorities shift.
+
+- **Self-hosted update page** — n8n-style "you are on X, latest is Y" with copy-paste upgrade instructions (`workstream:1-self-host`)
+- **Ollama / local model support** — direct connect for self-hosters + a laptop-agent bridge for cloud users (`workstream:2-ollama`)
+- **Roadmap & governance docs** — this document, plus `GOVERNANCE.md`, `MAINTAINERS.md`, `SUPPORT.md` (`workstream:3-roadmap`)
+- **Compliance posture** — surface existing audit-log infrastructure to enterprise buyers; ship sub-processors list, DPA template, SOC2 readiness self-assessment, audit-log UI (`workstream:4-compliance`)
+- **More AI providers** — `codex` (default), `grok`, `acpx` (ACP-compatible: Claude/Pi/Gemini), `opencode`, plus `mock`/`mock-fail` for tests (`workstream:5-providers`)
+- **Architectural refactors** — unified `Provider` interface, Zod-derived JSON schemas, robust JSON extraction, anti-hallucination prompt fields, content-derived finding signatures so user triage survives PR re-reviews (`workstream:6-architecture`)
+
+## Proposed
+
+Ideas that are worth doing but not committed. Open a [GitHub Discussion](https://github.com/octopusreview/octopus/discussions) to argue for promotion to **Up Next**, or use the [roadmap proposal template](.github/ISSUE_TEMPLATE/roadmap_proposal.yml).
+
+- IDE extensions (VS Code / JetBrains) for inline review hints pre-push
+- Automated regression test generation from `suggestedRegressionTest` finding fields
+- Per-finding fix-suggestion patches that can be applied with one click
+- Custom severity rubrics per repo (override central category thresholds)
+- Per-language reviewer prompts (specialized passes for Go / Python / Rust)
+- Configurable retention windows per `AuditLog` category
+
+## Out of Scope
+
+Ideas the maintainers have considered and declined, with a one-line rationale to spare repeated proposals.
+
+- **Self-hosted billing / license server** — keep self-hosted free; revenue stays with the hosted offering
+- **Web IDE / in-app code editing** — out of scope; Octopus reviews code, it does not edit it
+- **Native mobile app** — the web app is responsive; native effort is not justified
+
+---
+
+## How proposals progress
+
+1. **Idea** → open a Discussion or a roadmap-proposal issue
+2. **Proposed** → maintainers add the `roadmap` label and (if relevant) a `workstream:*` label
+3. **Up Next** → an owner is assigned and the item moves to the Project board
+4. **In Progress** → linked PR exists
+5. **Shipped** → released and listed in [CHANGELOG.md](CHANGELOG.md)
+
+See [GOVERNANCE.md](GOVERNANCE.md) for how decisions get made and who makes them.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,35 @@
+# Support
+
+Picking the right channel saves everyone time. Use the table below to find where to ask.
+
+| What you need | Where to go |
+|---|---|
+| Product questions, design discussion, "how do I…" | [GitHub Discussions](https://github.com/octopusreview/octopus/discussions) |
+| Real-time chat with the community | [Discord](https://discord.gg/qyuWTXghbS) |
+| Bug reports | [Issues](https://github.com/octopusreview/octopus/issues/new?template=bug_report.yml) — please include reproduction steps |
+| Feature requests | [Issues](https://github.com/octopusreview/octopus/issues/new?template=feature_request.yml) or a [roadmap proposal](https://github.com/octopusreview/octopus/issues/new?template=roadmap_proposal.yml) |
+| Security vulnerabilities | `security@octopus-review.ai` — see [SECURITY.md](SECURITY.md). **Do not file a public issue.** |
+| Code of conduct concerns | `conduct@octopus-review.ai` — see [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) |
+| Self-hosting docs | https://github.com/octopusreview/octopus#self-hosting-with-docker |
+| Commercial / hosted Octopus support | https://octopus-review.ai |
+
+## Response expectations
+
+Maintainers do their best to respond within a few business days. There is no SLA on community channels — please be patient. If something is urgent and security-related, use the security email above.
+
+## Before opening an issue
+
+Please check:
+
+1. [Existing issues](https://github.com/octopusreview/octopus/issues?q=is%3Aissue) — your question may already have an answer
+2. [Discussions](https://github.com/octopusreview/octopus/discussions) — "how do I" questions often live there
+3. [CHANGELOG.md](CHANGELOG.md) — the bug may already be fixed in a newer release
+
+## Asking a good question
+
+The faster a maintainer can reproduce the issue, the faster you get help. Include:
+
+- Octopus version (`/api/version` returns it, or check the footer of the web app)
+- Self-hosted or hosted (`octopus-review.ai`)?
+- For bugs: minimal reproduction steps, expected vs actual behavior, any relevant logs
+- For "how do I" questions: what you've tried and where it fell short

--- a/docs/compliance/soc2-readiness.md
+++ b/docs/compliance/soc2-readiness.md
@@ -2,7 +2,8 @@
 
 **Status:** Pre-audit · Internal working document
 **Owner:** Maintainers (see [MAINTAINERS.md](../../MAINTAINERS.md))
-**Last reviewed:** May 2026
+**Initial draft:** June 2026
+**Review cadence:** Quarterly by the maintainers listed in [MAINTAINERS.md](../../MAINTAINERS.md)
 
 Octopus is not SOC 2 certified. This document is an honest self-assessment against the SOC 2 Type II Common Criteria, intended to help enterprise prospects evaluate which controls are in place today versus on the roadmap.
 
@@ -81,7 +82,7 @@ Evidence column points to the code, doc, or operational artefact that backs the 
 | CC7.1 | Monitoring infrastructure | 🟡 | CloudWatch + Pubby live-update; no centralised SIEM |
 | CC7.2 | Detect security events | 🟡 | Audit log records mutating actions; no automated anomaly detection |
 | CC7.3 | Evaluate security events | 🟡 | Manual triage of audit log + bug bounty submissions |
-| CC7.4 | Respond to security incidents | 🟡 | Incident-response runbook drafted in `/docs/security-overview`; no formal tabletop exercises |
+| CC7.4 | Respond to security incidents | 🟡 | Ad-hoc response — `security@octopus-review.ai` triage path documented in [SECURITY.md](../../SECURITY.md); no formal runbook or tabletop exercises yet |
 | CC7.5 | Disaster recovery | 🟡 | Encrypted backups (30-day retention); no formal RTO/RPO targets |
 
 ## CC8 — Change Management

--- a/docs/compliance/soc2-readiness.md
+++ b/docs/compliance/soc2-readiness.md
@@ -1,0 +1,124 @@
+# SOC 2 Readiness Self-Assessment
+
+**Status:** Pre-audit · Internal working document
+**Owner:** Maintainers (see [MAINTAINERS.md](../../MAINTAINERS.md))
+**Last reviewed:** May 2026
+
+Octopus is not SOC 2 certified. This document is an honest self-assessment against the SOC 2 Type II Common Criteria, intended to help enterprise prospects evaluate which controls are in place today versus on the roadmap.
+
+We will not claim "SOC 2 compliant" or "SOC 2 in progress" externally until we have engaged an auditor and started gap remediation. This document is the raw internal view.
+
+## How to read this
+
+Each control is rated:
+
+- ✅ **In place** — implemented and demonstrably operating
+- 🟡 **Partial** — implemented but missing audit trail, evidence, or coverage
+- ❌ **Not yet** — not implemented; on the roadmap
+- N/A — not applicable to Octopus's scope
+
+Evidence column points to the code, doc, or operational artefact that backs the claim.
+
+## CC1 — Control Environment
+
+| # | Control | Status | Evidence |
+|---|---|---|---|
+| CC1.1 | Code of conduct in place | ✅ | [CODE_OF_CONDUCT.md](../../CODE_OF_CONDUCT.md) — Contributor Covenant 3.0 with enforcement ladder |
+| CC1.2 | Governance documented | 🟡 | GOVERNANCE.md drafted in PR #55; maintainer set is small and changes are ad-hoc |
+| CC1.3 | Roles & responsibilities documented | 🟡 | [MAINTAINERS.md](../../MAINTAINERS.md) + CODEOWNERS; no formal role descriptions for non-maintainer staff |
+| CC1.4 | Personnel screening | ❌ | No formal background-check process; small team |
+| CC1.5 | Disciplinary process | ✅ | Code of Conduct enforcement ladder |
+
+## CC2 — Communication and Information
+
+| # | Control | Status | Evidence |
+|---|---|---|---|
+| CC2.1 | Internal info quality | 🟡 | Documentation exists but inconsistent across components |
+| CC2.2 | Internal communication of objectives | 🟡 | ROADMAP.md published; no formal cadence for internal updates |
+| CC2.3 | External communication of objectives | ✅ | Public roadmap, changelog, status page |
+
+## CC3 — Risk Assessment
+
+| # | Control | Status | Evidence |
+|---|---|---|---|
+| CC3.1 | Risk identification process | 🟡 | Ad-hoc; no formal quarterly review |
+| CC3.2 | Fraud risk assessment | ❌ | No formal assessment |
+| CC3.3 | Changes to controls assessed | 🟡 | Major architectural changes go through RFCs (GOVERNANCE.md) |
+| CC3.4 | Vendor risk assessment | 🟡 | Sub-processors enumerated at `/docs/sub-processors`; no formal risk score per vendor |
+
+## CC4 — Monitoring Activities
+
+| # | Control | Status | Evidence |
+|---|---|---|---|
+| CC4.1 | Monitoring activities defined | 🟡 | Status page + CI alerts; no formal SLOs |
+| CC4.2 | Deficiencies communicated | ✅ | Public status page + incident post-mortems within 30 days |
+
+## CC5 — Control Activities
+
+| # | Control | Status | Evidence |
+|---|---|---|---|
+| CC5.1 | Control activities for technology | ✅ | CI (lint, typecheck, build, security review) gates every PR |
+| CC5.2 | Policies and procedures | 🟡 | Most processes are documented but not formal "policies" |
+| CC5.3 | Policies enforced | ✅ | Octopus reviewer + CI block non-compliant PRs |
+
+## CC6 — Logical and Physical Access Controls
+
+| # | Control | Status | Evidence |
+|---|---|---|---|
+| CC6.1 | Logical access provisioned per role | ✅ | Better Auth + per-org RBAC (owner/admin/member); audit log records role changes |
+| CC6.2 | Identification & authentication | ✅ | OAuth (GitHub/Google) + magic-link email; no password store |
+| CC6.3 | Authorization for system access | ✅ | Role-checked at every authenticated endpoint via `authenticateApiToken` / session middleware |
+| CC6.4 | Restrict physical access | ✅ | AWS-managed datacentre access; self-hosters control their own |
+| CC6.5 | Secure data transmission | ✅ | TLS 1.2+ everywhere |
+| CC6.6 | Vulnerability management | 🟡 | Dependabot + CodeQL + automated security review on PRs; no scheduled pen tests |
+| CC6.7 | Restrict data transmission to trusted parties | ✅ | Sub-processor list enumerates all egress points |
+| CC6.8 | Prevent unauthorised software | ✅ | Self-hosters control their own; hosted Octopus runs only the published image |
+
+## CC7 — System Operations
+
+| # | Control | Status | Evidence |
+|---|---|---|---|
+| CC7.1 | Monitoring infrastructure | 🟡 | CloudWatch + Pubby live-update; no centralised SIEM |
+| CC7.2 | Detect security events | 🟡 | Audit log records mutating actions; no automated anomaly detection |
+| CC7.3 | Evaluate security events | 🟡 | Manual triage of audit log + bug bounty submissions |
+| CC7.4 | Respond to security incidents | 🟡 | Incident-response runbook drafted in `/docs/security-overview`; no formal tabletop exercises |
+| CC7.5 | Disaster recovery | 🟡 | Encrypted backups (30-day retention); no formal RTO/RPO targets |
+
+## CC8 — Change Management
+
+| # | Control | Status | Evidence |
+|---|---|---|---|
+| CC8.1 | Changes follow defined process | ✅ | All changes via PR; required approvals from CODEOWNERS |
+| CC8.2 | Changes tested before deployment | ✅ | CI (lint + typecheck + build + tests + security review) blocks merge on failure |
+| CC8.3 | Emergency change process | 🟡 | Hot-fix path exists but undocumented |
+
+## CC9 — Risk Mitigation
+
+| # | Control | Status | Evidence |
+|---|---|---|---|
+| CC9.1 | Identify and select responses | 🟡 | Ad-hoc; no formal risk register |
+| CC9.2 | Vendor management lifecycle | 🟡 | Sub-processors listed; no contract review cadence |
+
+## Roadmap to certification
+
+To pursue formal SOC 2 Type II, the gaps to close (in order of priority) are:
+
+1. **Formal risk register + quarterly review** (CC3.1, CC3.2, CC9.1)
+2. **Scheduled penetration tests** (CC6.6) — at least annually
+3. **Centralised SIEM / log aggregation** (CC7.1, CC7.2)
+4. **Documented incident-response runbook + annual tabletop** (CC7.4)
+5. **Formal RTO/RPO targets + DR test** (CC7.5)
+6. **Personnel background checks** (CC1.4) — required for staff with production access
+7. **Engage a SOC 2 auditor** — typical timeline 12-18 months for Type II from kickoff
+
+Expected duration: 12-18 months from prioritised execution.
+
+## How customers should use this document
+
+This is an **internal honest assessment**, not a marketing artefact. If you are evaluating Octopus for an enterprise deployment:
+
+- Use this as the input to your vendor risk assessment
+- Specific controls you need certified can be added to a paid engagement scope
+- For prospects with hard SOC 2 / ISO 27001 / HIPAA requirements: self-host. The control surface narrows to your own infrastructure, which you already certify.
+
+Questions: [security@octopus-review.ai](mailto:security@octopus-review.ai).


### PR DESCRIPTION
## Why

Six foundational docs that have been missing for an OSS project at Octopus's size. Each one fills a specific gap that current contributors and prospective enterprise adopters have been asking about.

## What

| File | Gap it closes |
|---|---|
| `ROADMAP.md` | Living document of shipped / in-progress / queued / out-of-scope. Lets external contributors pick up work without DMing maintainers; lets prospects see direction without a sales call. |
| `GOVERNANCE.md` | How decisions get made — maintainer powers, RFC threshold, what it takes to become a maintainer. |
| `MAINTAINERS.md` | Current maintainers + their areas of ownership. First stop for design questions and security reports routing through GitHub. |
| `AGENTS.md` | Repo-scoped rules for AI agents reviewing this codebase. Octopus itself reads this file via the Repo Config Files feature; human contributors are welcome to follow the same conventions. Without this file, the Octopus bot was steering legitimate CLI PRs as "out of scope" on its own repo. |
| `SUPPORT.md` | Channel disambiguation: product questions vs. bugs vs. security reports vs. paid support. |
| `docs/compliance/soc2-readiness.md` | Honest pre-audit self-assessment against SOC 2 Common Criteria. Explicit about which controls are implemented vs. roadmap. |

## Risk

All six are pure additions — no overlap with existing tracked files. No code paths changed, no behavior changed. Worst case for any factual error in the docs is a follow-up PR to correct it; nothing in the runtime depends on these files (except `AGENTS.md`, which the Octopus review pipeline reads as repo-scoped rules — and reading our own AGENTS.md is the desired behavior).

## Test plan

- [x] `grep -l "clawpatch\|cemoso/octopus"` against all 6 files — clean (no sibling-project / fork-name leaks).
- [x] All file paths are tracked, no `.next`/build artefacts.
- [ ] Render each Markdown file on the GitHub web UI — visual sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)