### PR TITLE
feat(lib): robust JSON extraction with three-tier recovery

### DIFF
--- a/apps/web/lib/__tests__/extract-json.test.ts
+++ b/apps/web/lib/__tests__/extract-json.test.ts
@@ -72,6 +72,15 @@ describe("extractJson — tier 3 (balanced scan)", () => {
   it("returns null when no candidate parses", () => {
     expect(extractJson("definitely not json {nope nope}")).toBeNull();
   });
+
+  it("recovers a valid candidate after an unterminated string desyncs an earlier one", () => {
+    // A lone `"` inside the first candidate flips inString=true and is never
+    // toggled back, so the matching close-brace is treated as in-string and
+    // the candidate never balances. Scanner must advance to a later open
+    // delimiter rather than bailing entirely.
+    const input = 'first {"a": "unterminated string here ok ok ok    later {"b":1}';
+    expect(extractJson(input)).toEqual({ b: 1 });
+  });
 });
 
 describe("extractJsonObject", () => {

--- a/apps/web/lib/__tests__/extract-json.test.ts
+++ b/apps/web/lib/__tests__/extract-json.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "bun:test";
+import { extractJson, extractJsonObject } from "@/lib/extract-json";
+
+describe("extractJson — tier 1 (strict)", () => {
+  it("parses a clean JSON object", () => {
+    expect(extractJson('{"a":1,"b":"x"}')).toEqual({ a: 1, b: "x" });
+  });
+
+  it("parses a clean JSON array", () => {
+    expect(extractJson("[1,2,3]")).toEqual([1, 2, 3]);
+  });
+
+  it("returns null for non-JSON input", () => {
+    expect(extractJson("this is not json at all")).toBeNull();
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(extractJson('   {"a":1}\n')).toEqual({ a: 1 });
+  });
+});
+
+describe("extractJson — tier 2 (fenced code block)", () => {
+  it("strips a ```json fence and parses the inner content", () => {
+    const input = "preface\n```json\n{\"a\":1}\n```\nepilogue";
+    expect(extractJson(input)).toEqual({ a: 1 });
+  });
+
+  it("strips a fence with no language hint", () => {
+    const input = "```\n[1,2,3]\n```";
+    expect(extractJson(input)).toEqual([1, 2, 3]);
+  });
+
+  it("falls through tier 2 when the fenced content is unparseable", () => {
+    // No tier-1 hit (the whole input isn't JSON), tier 2 sees garbage,
+    // tier 3 has no candidates — should return null.
+    const input = "```json\nnot really json\n```";
+    expect(extractJson(input)).toBeNull();
+  });
+});
+
+describe("extractJson — tier 3 (balanced scan)", () => {
+  it("recovers an unfenced object embedded in prose", () => {
+    const input = 'Here is the response: {"purpose":"x","summary":"y"} hope that helps.';
+    expect(extractJson(input)).toEqual({ purpose: "x", summary: "y" });
+  });
+
+  it("recovers an unfenced ARRAY embedded in prose", () => {
+    // The regression case: an unfenced array would have been dropped
+    // by an object-first scan, since the first `{` matches the inner
+    // object and returns it standalone.
+    const input = 'Findings: [{"sev":"high"},{"sev":"low"}] — over.';
+    expect(extractJson(input)).toEqual([{ sev: "high" }, { sev: "low" }]);
+  });
+
+  it("ignores braces inside string literals", () => {
+    const input = 'noise {"msg":"has } in it","count":2} tail';
+    expect(extractJson(input)).toEqual({ msg: "has } in it", count: 2 });
+  });
+
+  it("handles escaped quotes inside string literals", () => {
+    const input = 'lead {"k":"he said \\"hi\\""} tail';
+    expect(extractJson(input)).toEqual({ k: 'he said "hi"' });
+  });
+
+  it("skips a malformed first object and recovers the second", () => {
+    // First candidate parses to a balanced block but its content is
+    // invalid JSON; we should advance past it and try the next `{`.
+    const input = "leading {bad json here} ok {\"a\":1}";
+    expect(extractJson(input)).toEqual({ a: 1 });
+  });
+
+  it("returns null when no candidate parses", () => {
+    expect(extractJson("definitely not json {nope nope}")).toBeNull();
+  });
+});
+
+describe("extractJsonObject", () => {
+  it("returns the object when the root is an object", () => {
+    expect(extractJsonObject('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("returns null when the root is an array", () => {
+    expect(extractJsonObject('[{"a":1}]')).toBeNull();
+  });
+
+  it("returns null when the root is a primitive", () => {
+    expect(extractJsonObject('"just a string"')).toBeNull();
+    expect(extractJsonObject("42")).toBeNull();
+    expect(extractJsonObject("true")).toBeNull();
+  });
+
+  it("returns null when extraction fails", () => {
+    expect(extractJsonObject("no json here")).toBeNull();
+  });
+
+  it("recovers an object embedded in prose", () => {
+    expect(extractJsonObject('reply: {"purpose":"x"}')).toEqual({ purpose: "x" });
+  });
+});

--- a/apps/web/lib/extract-json.ts
+++ b/apps/web/lib/extract-json.ts
@@ -88,8 +88,19 @@ function scanForRoot(text: string, open: string, close: string): unknown | null 
       }
     }
 
-    if (consumedTo === -1) return null;
-    firstOpen = text.indexOf(open, consumedTo);
+    // Three exit paths from the for-loop above:
+    //   (a) parse succeeded → early-returned the candidate
+    //   (b) parse failed at depth=0 → break with consumedTo set, advance past it
+    //   (c) loop exited via i === text.length without depth reaching 0 again
+    //       — happens on an unterminated string literal inside the candidate
+    //       (the toggling `"` count desyncs and the close delimiter is then
+    //       treated as in-string and ignored). Advance firstOpen by ONE so a
+    //       later valid candidate elsewhere in the text still has a chance.
+    if (consumedTo === -1) {
+      firstOpen = text.indexOf(open, firstOpen + 1);
+    } else {
+      firstOpen = text.indexOf(open, consumedTo);
+    }
   }
 
   return null;
@@ -101,7 +112,12 @@ function scanForRoot(text: string, open: string, close: string): unknown | null 
  */
 export function extractJsonObject(text: string): Record<string, unknown> | null {
   const parsed = extractJson(text);
-  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+  // `typeof null === "object"` and `Array.isArray(null) === false`, so without
+  // the explicit `!== null` check, a null root would slip through and get
+  // cast to Record. The `!== null` form is also clearer about intent than
+  // the previous truthy-check (`parsed &&`), since in JS every non-null
+  // object is truthy by definition.
+  if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
     return parsed as Record<string, unknown>;
   }
   return null;

--- a/apps/web/lib/extract-json.ts
+++ b/apps/web/lib/extract-json.ts
@@ -1,0 +1,108 @@
+/**
+ * Best-effort JSON extraction from LLM text output.
+ *
+ * Three-tier recovery, returning the first that parses successfully:
+ *   1. Strict `JSON.parse` on the whole input.
+ *   2. Strip a single triple-backtick code fence (` ```json ` or ` ``` `) and parse the inner content.
+ *   3. Walk the input looking for balanced `{...}` or `[...]` blocks and parse each candidate.
+ *
+ * Returns `null` if nothing parses. Both object AND array roots are
+ * supported in tier 3 — an unfenced top-level findings array
+ * (`[{...}, {...}]`) is recovered as well as a single object literal.
+ */
+export function extractJson(text: string): unknown | null {
+  const trimmed = text.trim();
+
+  // Tier 1: strict
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // fall through
+  }
+
+  // Tier 2: code-fence
+  const fenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/u);
+  if (fenceMatch && fenceMatch[1]) {
+    try {
+      return JSON.parse(fenceMatch[1].trim());
+    } catch {
+      // fall through
+    }
+  }
+
+  // Tier 3: balanced scan. Try ARRAY roots FIRST — an unfenced findings
+  // array (`[{...}, {...}]`) always starts with `[` containing inner
+  // objects, so scanning for `{` first would match the first inner object
+  // and return it standalone, losing the rest of the array. Object roots
+  // are tried second for the case where the model emitted a single object
+  // literal (no surrounding array).
+  const arrayResult = scanForRoot(trimmed, "[", "]");
+  if (arrayResult !== null) return arrayResult;
+  const objectResult = scanForRoot(trimmed, "{", "}");
+  if (objectResult !== null) return objectResult;
+
+  return null;
+}
+
+/**
+ * Walk the input looking for balanced `open`/`close` delimited blocks
+ * and return the first that parses as JSON. String literals (and their
+ * escape sequences) are tracked so braces / brackets inside strings
+ * don't throw off the depth counter.
+ */
+function scanForRoot(text: string, open: string, close: string): unknown | null {
+  let firstOpen = text.indexOf(open);
+  while (firstOpen !== -1) {
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    let consumedTo = -1;
+
+    for (let i = firstOpen; i < text.length; i += 1) {
+      const ch = text[i];
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = !inString;
+        continue;
+      }
+      if (inString) continue;
+      if (ch === open) depth += 1;
+      else if (ch === close) {
+        depth -= 1;
+        if (depth === 0) {
+          const candidate = text.slice(firstOpen, i + 1);
+          try {
+            return JSON.parse(candidate);
+          } catch {
+            consumedTo = i + 1;
+            break;
+          }
+        }
+      }
+    }
+
+    if (consumedTo === -1) return null;
+    firstOpen = text.indexOf(open, consumedTo);
+  }
+
+  return null;
+}
+
+/**
+ * Convenience: extract and assert the result is a JSON object (not array, not primitive).
+ * Returns `null` if extraction fails or the root is not an object.
+ */
+export function extractJsonObject(text: string): Record<string, unknown> | null {
+  const parsed = extractJson(text);
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
+  }
+  return null;
+}

--- a/apps/web/lib/review-dedup.ts
+++ b/apps/web/lib/review-dedup.ts
@@ -3,6 +3,8 @@
  * (reviewer.ts) and the review lifecycle simulator.
  */
 
+import { extractJson } from "./extract-json";
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export type InlineFinding = {
@@ -57,71 +59,70 @@ export function parseFindingsFromJson(reviewBody: string): InlineFinding[] | nul
   const endIdx = reviewBody.indexOf(FINDINGS_END_MARKER);
   if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) return null;
 
-  let block = reviewBody.slice(startIdx + FINDINGS_START_MARKER.length, endIdx).trim();
-
-  // Strip markdown code fences if present
-  const fenceMatch = block.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
-  if (fenceMatch) {
-    block = fenceMatch[1].trim();
-  }
-
-  try {
-    const parsed = JSON.parse(block);
-    if (!Array.isArray(parsed)) return null;
-
-    const findings: InlineFinding[] = [];
-    for (const item of parsed) {
-      // The model occasionally emits `null` (or a non-object literal) in the
-      // findings array — often as the last element when its output ran past
-      // the schema. Without this guard `typeof item.severity` reads through
-      // `null` and throws, dropping EVERY finding in the block, not just
-      // the bad item.
-      if (item === null || typeof item !== "object") continue;
-      if (
-        typeof item.severity !== "string" ||
-        typeof item.title !== "string" ||
-        typeof item.filePath !== "string" ||
-        typeof item.startLine !== "number" ||
-        typeof item.description !== "string"
-      ) {
-        continue;
-      }
-
-      findings.push({
-        severity: item.severity,
-        title: item.title,
-        filePath: item.filePath.replace(/^`|`$/g, "").replace(/:L\d+.*$/, ""),
-        startLine: item.startLine,
-        endLine: typeof item.endLine === "number" ? item.endLine : item.startLine,
-        category: item.category ?? "",
-        description: item.description,
-        suggestion: item.suggestion ?? "",
-        confidence:
-          typeof item.confidence === "number"
-            ? item.confidence
-            : item.confidence === "HIGH"
-              ? 90
-              : 70,
-        // Anti-hallucination fields — typed only when the model emitted a
-        // string. Absent fields stay undefined so the existing UI surfaces
-        // continue to render exactly as before for older reviews.
-        ...(typeof item.whyTestsDoNotAlreadyCoverThis === "string"
-          ? { whyTestsDoNotAlreadyCoverThis: item.whyTestsDoNotAlreadyCoverThis }
-          : {}),
-        ...(typeof item.suggestedRegressionTest === "string"
-          ? { suggestedRegressionTest: item.suggestedRegressionTest }
-          : {}),
-        ...(typeof item.minimumFixScope === "string"
-          ? { minimumFixScope: item.minimumFixScope }
-          : {}),
-      });
+  // Delegate to extractJson — handles strict, code-fenced, and balanced-scan
+  // recovery in one call. The previous inline implementation only handled
+  // strict + code-fenced; if the model emitted prose around the JSON (a
+  // surprisingly common failure mode under output-token pressure), the
+  // parse silently returned null and every finding dropped. The
+  // balanced-scan path recovers those cases.
+  const block = reviewBody.slice(startIdx + FINDINGS_START_MARKER.length, endIdx);
+  const parsed = extractJson(block);
+  if (!Array.isArray(parsed)) {
+    if (parsed === null && block.trim().length > 0) {
+      console.warn("[review-dedup] JSON findings block found but failed to parse");
     }
-
-    return findings.length > 0 ? findings : null;
-  } catch {
-    console.warn("[review-dedup] JSON findings block found but failed to parse");
     return null;
   }
+
+  const findings: InlineFinding[] = [];
+  for (const item of parsed) {
+    // The model occasionally emits `null` (or a non-object literal) in the
+    // findings array — often as the last element when its output ran past
+    // the schema. Without this guard `typeof item.severity` reads through
+    // `null` and throws, dropping EVERY finding in the block, not just
+    // the bad item.
+    if (item === null || typeof item !== "object") continue;
+    if (
+      typeof item.severity !== "string" ||
+      typeof item.title !== "string" ||
+      typeof item.filePath !== "string" ||
+      typeof item.startLine !== "number" ||
+      typeof item.description !== "string"
+    ) {
+      continue;
+    }
+
+    findings.push({
+      severity: item.severity,
+      title: item.title,
+      filePath: item.filePath.replace(/^`|`$/g, "").replace(/:L\d+.*$/, ""),
+      startLine: item.startLine,
+      endLine: typeof item.endLine === "number" ? item.endLine : item.startLine,
+      category: item.category ?? "",
+      description: item.description,
+      suggestion: item.suggestion ?? "",
+      confidence:
+        typeof item.confidence === "number"
+          ? item.confidence
+          : item.confidence === "HIGH"
+            ? 90
+            : 70,
+      // Anti-hallucination fields — typed only when the model emitted a
+      // string. Absent fields stay undefined so the existing UI surfaces
+      // continue to render exactly as before for older reviews.
+      ...(typeof item.whyTestsDoNotAlreadyCoverThis === "string"
+        ? { whyTestsDoNotAlreadyCoverThis: item.whyTestsDoNotAlreadyCoverThis }
+        : {}),
+      ...(typeof item.suggestedRegressionTest === "string"
+        ? { suggestedRegressionTest: item.suggestedRegressionTest }
+        : {}),
+      ...(typeof item.minimumFixScope === "string"
+        ? { minimumFixScope: item.minimumFixScope }
+        : {}),
+    });
+  }
+
+  return findings.length > 0 ? findings : null;
 }
 
 /** Parse findings from legacy markdown format (#### emoji headings). */

--- a/apps/web/lib/summarizer.ts
+++ b/apps/web/lib/summarizer.ts
@@ -3,6 +3,7 @@ import { logAiUsage } from "@/lib/ai-usage";
 import { getReviewModel } from "@/lib/ai-client";
 import { createAiMessage } from "@/lib/ai-router";
 import { isOrgOverSpendLimit } from "@/lib/cost";
+import { extractJsonObject } from "@/lib/extract-json";
 
 export async function summarizeRepository(
   repoId: string,
@@ -64,26 +65,23 @@ ${codeContext}`,
     });
   }
 
-  let text = response.text;
-
-  // Strip markdown code fences if present (e.g. ```json ... ```)
-  const fenceMatch = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);
-  if (fenceMatch) {
-    text = fenceMatch[1].trim();
-  }
-
-  try {
-    const parsed = JSON.parse(text);
+  const text = response.text;
+  // extractJsonObject handles strict-parse, code-fenced, AND balanced-scan
+  // recovery in one call. The old inline implementation only handled the
+  // first two; an LLM that wrapped its JSON in any prose ("Here's the
+  // summary:") would silently fall through to the text.slice(0, 500)
+  // fallback even though the JSON itself was perfectly valid.
+  const parsed = extractJsonObject(text);
+  if (parsed) {
     return {
-      purpose: parsed.purpose ?? "Unknown",
-      summary: parsed.summary ?? "No summary available.",
-    };
-  } catch {
-    return {
-      purpose: "Unknown",
-      summary: text.slice(0, 500),
+      purpose: (parsed.purpose as string | undefined) ?? "Unknown",
+      summary: (parsed.summary as string | undefined) ?? "No summary available.",
     };
   }
+  return {
+    purpose: "Unknown",
+    summary: text.slice(0, 500),
+  };
 }
 
 export async function summarizeDailyReviews(


### PR DESCRIPTION
## What

Adds `apps/web/lib/extract-json.ts` — best-effort JSON extraction from LLM output, with three-tier recovery:

1. **Strict** — `JSON.parse` on the whole input.
2. **Code-fence** — strip a single triple-backtick block and parse the inner content.
3. **Balanced scan** — walk the input looking for balanced `[...]` or `{...}` blocks; string-literal aware so escaped quotes and braces inside strings don't desync the depth counter.

Array roots are scanned **before** object roots in tier 3. An unfenced findings array `[{...}, {...}]` would otherwise match the first inner `{` standalone and drop the rest of the array.

## Why

Two call sites in the codebase previously rolled their own (incomplete) version of tiers 1 + 2:

| Caller | Failure mode without tier 3 |
|---|---|
| `lib/review-dedup.ts::parseFindingsFromJson` | Inline implementation handled only `JSON.parse(stripped-fence)`. If the model emitted any prose between the `OCTOPUS_FINDINGS_START`/`_END` markers (a common failure mode under output-token pressure), the parse returned null and **every finding dropped silently**. |
| `lib/summarizer.ts::summarizeRepository` | Same shape, same gap. An LLM that wrapped its `{purpose, summary}` in any prose ("Here's the summary:") fell through to the `text.slice(0, 500)` fallback even though the JSON itself was perfectly valid. |

Both now use the shared helper. The balanced-scan path recovers prose-wrapped JSON in both cases.

## Test plan

- [x] 18 new unit tests in `apps/web/lib/__tests__/extract-json.test.ts`: tier-1 strict (object/array/non-JSON/whitespace), tier-2 fence (with/without language hint, unparseable inner), tier-3 balanced scan (unfenced object in prose, unfenced array in prose, braces in string literal, escaped quotes, skip-malformed-and-try-next, no-candidate-parses), `extractJsonObject` (object/array/primitive/null/embedded).
- [x] All 42 existing tests in `apps/web/lib/__tests__/review-dedup.test.ts` pass against the refactored `parseFindingsFromJson` — the new path is strictly a superset of the old one.

## Risk

Three-tier recovery never produces a parse where the old strict path also produced one. It only *adds* recovery paths. The worst plausible regression is the balanced-scan path producing a different (but still valid) JSON candidate from prose that the strict path would have rejected — and that's the entire point. Reverting the adoption (e.g. by going back to `JSON.parse(block)`) restores prior behavior exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)