### PR TITLE
fix(review): show full finding description in summary table (#515)

### DIFF
--- a/apps/web/lib/__tests__/reviewer.test.ts
+++ b/apps/web/lib/__tests__/reviewer.test.ts
@@ -340,6 +340,21 @@ describe("buildLowSeveritySummary", () => {
     expect(result).toContain("Findings that could not be mapped");
     expect(result).toContain("<details>");
   });
+
+  it("keeps the full description (no 120-char truncation) — issue #515", () => {
+    const longDescription = "x".repeat(400);
+    const result = buildLowSeveritySummary([makeFinding({ description: longDescription })]);
+    expect(result).toContain(longDescription);
+    expect(result).not.toContain("…");
+  });
+
+  it("escapes pipes and newlines so long text cannot break the table row", () => {
+    const result = buildLowSeveritySummary([
+      makeFinding({ description: "line one | with pipe\nline two" }),
+    ]);
+    expect(result).toContain("line one \\| with pipe<br>line two");
+    expect(result).not.toMatch(/\| with pipe\n/);
+  });
 });
 
 // ─── stripDetailedFindings ──────────────────────────────────────────────────

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -212,8 +212,15 @@ export function buildLowSeveritySummary(findings: InlineFinding[]): string {
     ...rows,
   ].join("\n");
 
+  // Escape a value so it is safe inside a Markdown table cell: literal pipes
+  // would otherwise close the cell, and newlines would break the row. We keep
+  // the FULL text — truncating here (issue #515) leaves no way to read the
+  // complete finding, since these findings have no inline comment to expand.
+  const tableCell = (text: string) =>
+    text.replace(/\|/g, "\\|").replace(/\r?\n+/g, "<br>").trim();
+
   const toRow = (f: InlineFinding) =>
-    `| ${f.severity} | \`${f.filePath}:L${f.startLine}\` | ${f.title} | ${f.description.slice(0, 120)}${f.description.length > 120 ? "…" : ""} |`;
+    `| ${f.severity} | \`${f.filePath}:L${f.startLine}\` | ${tableCell(f.title)} | ${tableCell(f.description)} |`;
 
   const parts: string[] = [];
 


### PR DESCRIPTION
## Problem

Closes #515.

When findings can't be mapped to a diff line, they're listed in the "Additional findings" Markdown table (`buildLowSeveritySummary`). The description cell was hard-truncated to 120 chars with an ellipsis:

```ts
`... | ${f.description.slice(0, 120)}${f.description.length > 120 ? "…" : ""} |`
```

Because these findings have **no inline comment to expand**, there was no way for the user to read the complete description. The reporter (self-hosted GitLab) saw findings cut off after ~119 chars with no way to view the rest.

## Fix

- Drop the 120-char cap — render the **full** description.
- Add a `tableCell()` sanitizer that escapes `|` (would close the cell) and converts newlines to `<br>` (would break the row), applied to both title and description, so long/multi-line text can't corrupt the table. Renders correctly on both GitHub and GitLab.

## Tests

Added cases to `buildLowSeveritySummary`:
- A 400-char description is preserved in full, no ellipsis.
- Pipes and newlines are escaped so the row stays intact.

`bun run --cwd apps/web test` → 343 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)