### PR TITLE
fix(reviewer): build artifacts in diff no longer gate the check as critical

### DIFF
--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -2032,7 +2032,12 @@ Rules:
 
     console.log(`[reviewer] Parsed ${allParsedFindings.length} total, ${findings.length} after filters, ${inlineComments.length} inline comments`);
 
-    const hasCritical = findings.some((f) => f.severity === "🔴") || badFiles.length > 0;
+    // Build artifacts in the diff are surfaced as an advisory in the review body
+    // (see badFilesSection above), but they are NOT findings and must not gate the
+    // check run: counting them as critical produces a contradictory "0 findings" +
+    // "Critical issues found that must be fixed before merge" failure and blocks
+    // legitimate commits (e.g. a GitHub Action repo committing its dist/ bundle).
+    const hasCritical = findings.some((f) => f.severity === "🔴");
     const hasHigh = findings.some((f) => f.severity === "🟠");
     const hasMedium = findings.some((f) => f.severity === "🟡");
 


### PR DESCRIPTION
## Problem

When a diff contains build-artifact files (e.g. a compiled `dist/` bundle or vendored dependencies), `detectBadCommits` flags them and they were OR'd into `hasCritical`:

```ts
const hasCritical = findings.some((f) => f.severity === "🔴") || badFiles.length > 0;
```

This produced a contradictory, merge-blocking check run:

```
Octopus Review — failure
  title:   "4 files reviewed, 0 findings"
  summary: "Critical issues found that must be fixed before merge."
```

Real example: [octopusreview/action#1](https://github.com/octopusreview/action/pull/1) commits its required `dist/index.js` bundle. Octopus reported **0 findings** yet failed the check as **Critical** and blocked the merge.

## Fix

Build artifacts are **not findings** — they are already surfaced as an advisory section in the review body (`badFilesSection`). Decouple them from `hasCritical` so they stay advisory only and never gate the check:

```ts
const hasCritical = findings.some((f) => f.severity === "🔴");
```

`large-review-result.ts` already used findings-only severity, so this aligns the two review paths. The build-artifact advisory in the review body is unchanged, so users are still informed.

## Validation

- `bun run --cwd apps/web test` — 362 pass, 0 fail.
- `detectBadCommits` and its tests are untouched (detection behavior unchanged; only the gating coupling is removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)