### PR TITLE
feat(blog): add RSS feed at /blog/feed.xml

### DIFF
--- a/apps/web/app/(landing)/blog/feed.xml/route.ts
+++ b/apps/web/app/(landing)/blog/feed.xml/route.ts
@@ -1,0 +1,40 @@
+import { prisma } from "@octopus/db";
+import { buildRssFeed } from "@/lib/blog-rss";
+
+export const dynamic = "force-dynamic";
+
+const MAX_ITEMS = 20;
+
+function fetchPublishedPosts() {
+  return prisma.blogPost.findMany({
+    where: { status: "published", deletedAt: null },
+    orderBy: { publishedAt: "desc" },
+    take: MAX_ITEMS,
+    select: {
+      title: true,
+      slug: true,
+      excerpt: true,
+      authorName: true,
+      publishedAt: true,
+      updatedAt: true,
+    },
+  });
+}
+
+export async function GET() {
+  let posts: Awaited<ReturnType<typeof fetchPublishedPosts>> = [];
+  try {
+    posts = await fetchPublishedPosts();
+  } catch {
+    posts = [];
+  }
+
+  const xml = buildRssFeed(posts);
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/apps/web/app/(landing)/blog/feed.xml/route.ts
+++ b/apps/web/app/(landing)/blog/feed.xml/route.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@octopus/db";
 import { buildRssFeed } from "@/lib/blog-rss";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 const MAX_ITEMS = 20;
 
@@ -22,11 +22,15 @@ function fetchPublishedPosts() {
 }
 
 export async function GET() {
-  let posts: Awaited<ReturnType<typeof fetchPublishedPosts>> = [];
+  let posts: Awaited<ReturnType<typeof fetchPublishedPosts>>;
   try {
     posts = await fetchPublishedPosts();
-  } catch {
-    posts = [];
+  } catch (err) {
+    console.error("[feed.xml] Failed to fetch posts:", err);
+    return new Response("Service Unavailable", { 
+      status: 503, 
+      headers: { "Retry-After": "60" },
+    });
   }
 
   const xml = buildRssFeed(posts);

--- a/apps/web/app/(landing)/blog/page.tsx
+++ b/apps/web/app/(landing)/blog/page.tsx
@@ -18,6 +18,14 @@ export const metadata: Metadata = {
     "Engineering insights, product updates, and lessons learned building AI-powered code review tools.",
   alternates: {
     canonical: "https://octopus-review.ai/blog",
+    types: {
+      "application/rss+xml": [
+        {
+          url: "https://octopus-review.ai/blog/feed.xml",
+          title: "Octopus Blog RSS Feed",
+        },
+      ],
+    },
   },
 };
 
@@ -30,7 +38,9 @@ export default async function BlogPage({
   const page = Math.max(1, parseInt(pageParam ?? "1", 10) || 1);
   const query = searchQuery?.trim() || "";
 
-  const session = await auth.api.getSession({ headers: await headers() }).catch(() => null);
+  const session = await auth.api
+    .getSession({ headers: await headers() })
+    .catch(() => null);
   const isLoggedIn = !!session;
 
   const where = {
@@ -85,12 +95,15 @@ export default async function BlogPage({
 
         {query && (
           <p className="mb-6 text-sm text-[#555]">
-            {totalCount} result{totalCount !== 1 ? "s" : ""} for &ldquo;{query}&rdquo;
+            {totalCount} result{totalCount !== 1 ? "s" : ""} for &ldquo;{query}
+            &rdquo;
           </p>
         )}
 
         {posts.length === 0 ? (
-          <p className="text-[#555]">{query ? "No posts found." : "No posts yet. Check back soon."}</p>
+          <p className="text-[#555]">
+            {query ? "No posts found." : "No posts yet. Check back soon."}
+          </p>
         ) : (
           <div>
             {/* Featured post (first one) */}
@@ -119,18 +132,23 @@ export default async function BlogPage({
                       {featured.title}
                     </h2>
                     {featured.excerpt && (
-                      <p className="mb-3 text-[#888] line-clamp-2">{featured.excerpt}</p>
+                      <p className="mb-3 text-[#888] line-clamp-2">
+                        {featured.excerpt}
+                      </p>
                     )}
                     <div className="flex items-center gap-3 text-sm text-[#555]">
                       <span>{featured.authorName}</span>
                       <span>·</span>
                       <time>
                         {featured.publishedAt
-                          ? new Date(featured.publishedAt).toLocaleDateString("en-US", {
-                              year: "numeric",
-                              month: "long",
-                              day: "numeric",
-                            })
+                          ? new Date(featured.publishedAt).toLocaleDateString(
+                              "en-US",
+                              {
+                                year: "numeric",
+                                month: "long",
+                                day: "numeric",
+                              },
+                            )
                           : ""}
                       </time>
                     </div>
@@ -161,17 +179,22 @@ export default async function BlogPage({
                               {post.title}
                             </h2>
                             {post.excerpt && (
-                              <p className="mt-1 text-sm text-[#888] line-clamp-1">{post.excerpt}</p>
+                              <p className="mt-1 text-sm text-[#888] line-clamp-1">
+                                {post.excerpt}
+                              </p>
                             )}
                           </div>
                           <div className="hidden shrink-0 text-right text-sm text-[#555] sm:block">
                             <div>{post.authorName}</div>
                             <time>
                               {post.publishedAt
-                                ? new Date(post.publishedAt).toLocaleDateString("en-US", {
-                                    month: "short",
-                                    day: "numeric",
-                                  })
+                                ? new Date(post.publishedAt).toLocaleDateString(
+                                    "en-US",
+                                    {
+                                      month: "short",
+                                      day: "numeric",
+                                    },
+                                  )
                                 : ""}
                             </time>
                           </div>
@@ -186,52 +209,53 @@ export default async function BlogPage({
         )}
 
         {/* Pagination */}
-        {totalPages > 1 && (() => {
-          const qs = (p: number) => {
-            const params = new URLSearchParams();
-            if (p > 1) params.set("page", String(p));
-            if (query) params.set("q", query);
-            const str = params.toString();
-            return str ? `/blog?${str}` : "/blog";
-          };
-          return (
-          <div className="mt-12 flex items-center justify-center gap-2">
-            {page > 1 ? (
-              <Link
-                href={qs(page - 1)}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-[#888] transition-colors hover:border-white/[0.15] hover:text-white"
-              >
-                <IconChevronLeft className="size-4" />
-                Previous
-              </Link>
-            ) : (
-              <span className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.04] px-4 py-2 text-sm text-[#333] cursor-not-allowed">
-                <IconChevronLeft className="size-4" />
-                Previous
-              </span>
-            )}
+        {totalPages > 1 &&
+          (() => {
+            const qs = (p: number) => {
+              const params = new URLSearchParams();
+              if (p > 1) params.set("page", String(p));
+              if (query) params.set("q", query);
+              const str = params.toString();
+              return str ? `/blog?${str}` : "/blog";
+            };
+            return (
+              <div className="mt-12 flex items-center justify-center gap-2">
+                {page > 1 ? (
+                  <Link
+                    href={qs(page - 1)}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-[#888] transition-colors hover:border-white/[0.15] hover:text-white"
+                  >
+                    <IconChevronLeft className="size-4" />
+                    Previous
+                  </Link>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.04] px-4 py-2 text-sm text-[#333] cursor-not-allowed">
+                    <IconChevronLeft className="size-4" />
+                    Previous
+                  </span>
+                )}
 
-            <span className="px-4 py-2 text-sm text-[#555]">
-              {page} / {totalPages}
-            </span>
+                <span className="px-4 py-2 text-sm text-[#555]">
+                  {page} / {totalPages}
+                </span>
 
-            {page < totalPages ? (
-              <Link
-                href={qs(page + 1)}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-[#888] transition-colors hover:border-white/[0.15] hover:text-white"
-              >
-                Next
-                <IconChevronRight className="size-4" />
-              </Link>
-            ) : (
-              <span className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.04] px-4 py-2 text-sm text-[#333] cursor-not-allowed">
-                Next
-                <IconChevronRight className="size-4" />
-              </span>
-            )}
-          </div>
-          );
-        })()}
+                {page < totalPages ? (
+                  <Link
+                    href={qs(page + 1)}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-[#888] transition-colors hover:border-white/[0.15] hover:text-white"
+                  >
+                    Next
+                    <IconChevronRight className="size-4" />
+                  </Link>
+                ) : (
+                  <span className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.04] px-4 py-2 text-sm text-[#333] cursor-not-allowed">
+                    Next
+                    <IconChevronRight className="size-4" />
+                  </span>
+                )}
+              </div>
+            );
+          })()}
       </main>
 
       <LandingFooter />

--- a/apps/web/lib/__tests__/blog-rss.test.ts
+++ b/apps/web/lib/__tests__/blog-rss.test.ts
@@ -47,9 +47,17 @@ describe("buildRssFeed", () => {
     expect(xml).toContain("<pubDate>Wed, 10 Jun 2026 12:00:00 GMT</pubDate>");
   });
 
-  it("omits dc:creator when authorName is null", () => {
-    const xml = buildRssFeed([{ ...basePost, authorName: null }]);
-    expect(xml).not.toContain("<dc:creator>");
+  it("includes dc:creator with the author name", () => {
+    const xml = buildRssFeed([basePost]);
+    expect(xml).toContain("<dc:creator>Ada Lovelace</dc:creator>");
+  });
+
+  it("escapes special characters in the slug used for link and guid", () => {
+    const xml = buildRssFeed([{ ...basePost, slug: "a&b<c" }]);
+    expect(xml).toContain(
+      '<guid isPermaLink="true">https://octopus-review.ai/blog/a&amp;b&lt;c</guid>',
+    );
+    expect(/&(?!amp;|lt;|gt;|quot;|apos;)/.test(xml)).toBe(false);
   });
 
   it("falls back to updatedAt when publishedAt is null", () => {

--- a/apps/web/lib/__tests__/blog-rss.test.ts
+++ b/apps/web/lib/__tests__/blog-rss.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "bun:test";
+import { buildRssFeed, escapeXml, type RssFeedPost } from "../blog-rss";
+
+const basePost: RssFeedPost = {
+  title: "Hello World",
+  slug: "hello-world",
+  excerpt: "A first post",
+  authorName: "Ada Lovelace",
+  publishedAt: new Date("2026-06-10T12:00:00Z"),
+  updatedAt: new Date("2026-06-11T12:00:00Z"),
+};
+
+describe("escapeXml", () => {
+  it("escapes all five XML entities", () => {
+    expect(escapeXml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&apos;");
+  });
+});
+
+describe("buildRssFeed", () => {
+  it("produces a well-formed RSS 2.0 document with a self link", () => {
+    const xml = buildRssFeed([basePost]);
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(xml).toContain('<rss version="2.0"');
+    expect(xml).toContain(
+      '<atom:link href="https://octopus-review.ai/blog/feed.xml" rel="self"',
+    );
+  });
+
+  it("escapes special characters in title and excerpt", () => {
+    const xml = buildRssFeed([
+      {
+        ...basePost,
+        title: `Why "AI" review & <you> matter`,
+        excerpt: `Tom & Jerry's <script> take`,
+      },
+    ]);
+    expect(xml).toContain("Why &quot;AI&quot; review &amp; &lt;you&gt; matter");
+    expect(xml).toContain("&lt;script&gt;");
+    expect(/&(?!amp;|lt;|gt;|quot;|apos;)/.test(xml)).toBe(false);
+  });
+
+  it("emits a permalink guid and RFC-822 pubDate", () => {
+    const xml = buildRssFeed([basePost]);
+    expect(xml).toContain(
+      '<guid isPermaLink="true">https://octopus-review.ai/blog/hello-world</guid>',
+    );
+    expect(xml).toContain("<pubDate>Wed, 10 Jun 2026 12:00:00 GMT</pubDate>");
+  });
+
+  it("omits dc:creator when authorName is null", () => {
+    const xml = buildRssFeed([{ ...basePost, authorName: null }]);
+    expect(xml).not.toContain("<dc:creator>");
+  });
+
+  it("falls back to updatedAt when publishedAt is null", () => {
+    const xml = buildRssFeed([
+      {
+        ...basePost,
+        publishedAt: null,
+        updatedAt: new Date("2026-05-01T00:00:00Z"),
+      },
+    ]);
+    expect(xml).toContain("<pubDate>Fri, 01 May 2026 00:00:00 GMT</pubDate>");
+  });
+
+  it("renders an empty description for a null excerpt", () => {
+    const xml = buildRssFeed([{ ...basePost, excerpt: null }]);
+    expect(xml).toContain("<description></description>");
+  });
+});

--- a/apps/web/lib/blog-rss.ts
+++ b/apps/web/lib/blog-rss.ts
@@ -1,0 +1,61 @@
+const SITE_URL = "https://octopus-review.ai";
+const FEED_TITLE = "Octopus Blog";
+const FEED_DESCRIPTION =
+  "Engineering insights, product updates, and lessons learned building AI-powered code review tools.";
+
+export type RssFeedPost = {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  authorName: string | null;
+  publishedAt: Date | null;
+  updatedAt: Date | null;
+};
+
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export function buildRssFeed(posts: RssFeedPost[]): string {
+  const lastBuildDate = (posts[0]?.publishedAt ?? new Date()).toUTCString();
+
+  const items = posts
+    .map((post) => {
+      const link = `${SITE_URL}/blog/${post.slug}`;
+      const pubDate = (
+        post.publishedAt ??
+        post.updatedAt ??
+        new Date()
+      ).toUTCString();
+      const description = post.excerpt ? escapeXml(post.excerpt) : "";
+      const creator = post.authorName
+        ? `\n      <dc:creator>${escapeXml(post.authorName)}</dc:creator>`
+        : "";
+      return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${link}</link>
+      <guid isPermaLink="true">${link}</guid>
+      <pubDate>${pubDate}</pubDate>${creator}
+      <description>${description}</description>
+    </item>`;
+    })
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>${escapeXml(FEED_TITLE)}</title>
+    <link>${SITE_URL}/blog</link>
+    <description>${escapeXml(FEED_DESCRIPTION)}</description>
+    <language>en-us</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${SITE_URL}/blog/feed.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>`;
+}

--- a/apps/web/lib/blog-rss.ts
+++ b/apps/web/lib/blog-rss.ts
@@ -1,13 +1,14 @@
 const SITE_URL = "https://octopus-review.ai";
 const FEED_TITLE = "Octopus Blog";
-const FEED_DESCRIPTION =
-  "Engineering insights, product updates, and lessons learned building AI-powered code review tools.";
+const FEED_DESCRIPTION = "Engineering insights, product updates, and lessons learned building AI-powered code review tools.";
+
+const BUILD_TIME = new Date();
 
 export type RssFeedPost = {
   title: string;
   slug: string;
   excerpt: string | null;
-  authorName: string | null;
+  authorName: string;
   publishedAt: Date | null;
   updatedAt: Date | null;
 };
@@ -22,21 +23,19 @@ export function escapeXml(value: string): string {
 }
 
 export function buildRssFeed(posts: RssFeedPost[]): string {
-  const lastBuildDate = (posts[0]?.publishedAt ?? new Date()).toUTCString();
+  const lastBuildDate = (posts[0]?.publishedAt ?? BUILD_TIME).toUTCString();
 
   const items = posts
     .map((post) => {
-      const link = `${SITE_URL}/blog/${post.slug}`;
+      const link = `${SITE_URL}/blog/${escapeXml(post.slug)}`;
       const pubDate = (
         post.publishedAt ??
         post.updatedAt ??
         new Date()
       ).toUTCString();
       const description = post.excerpt ? escapeXml(post.excerpt) : "";
-      const creator = post.authorName
-        ? `\n      <dc:creator>${escapeXml(post.authorName)}</dc:creator>`
-        : "";
-      return `    <item>
+      const creator = `\n      <dc:creator>${escapeXml(post.authorName)}</dc:creator>`;
+      return `<item>
       <title>${escapeXml(post.title)}</title>
       <link>${link}</link>
       <guid isPermaLink="true">${link}</guid>


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

fixes #496 

## Changes

<!-- List the key changes -->

- Adds an RSS 2.0 feed for the blog (#496).
- New /blog/feed.xml route that lists the most recent published posts.
- Discovery <link rel="alternate" type="application/rss+xml"> added to the blog page <head> via metadata.alternates.types.
- Mirrors sitemap.ts: same status: "published", deletedAt: null query.
- Unit tests for the feed builder included.

## Test plan

<!-- How was this tested? -->

- [x] Linting passes (`bun run lint`)
- [x] Type check passes (`bun run typecheck`)
- [x] Tested locally
