### PR TITLE
fix(slack): bind OAuth state to initiating session (account-linking CSRF)

### DIFF
--- a/apps/web/app/api/slack/callback/route.ts
+++ b/apps/web/app/api/slack/callback/route.ts
@@ -1,8 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { headers, cookies } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
-import { encryptString } from "@/lib/crypto";
+import { encryptString, decryptJson } from "@/lib/crypto";
+import { SLACK_OAUTH_STATE_COOKIE } from "@/lib/slack-oauth";
+
+type SlackOAuthState = {
+  orgId: string;
+  userId: string;
+  nonce: string;
+  exp: number;
+};
+
+// The state cookie is single-use: clear it on every callback response so a
+// captured code+state pair cannot be replayed against a stale cookie.
+function redirectClearingState(url: URL): NextResponse {
+  const response = NextResponse.redirect(url);
+  response.cookies.delete(SLACK_OAUTH_STATE_COOKIE);
+  return response;
+}
 
 const SLACK_EVENT_TYPES = [
   "review-requested",
@@ -32,30 +48,53 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  let orgId: string;
+  // State is authenticated (AES-GCM): decryption fails if it was forged or
+  // tampered with, so orgId/userId/nonce here are exactly what we issued.
+  let state: SlackOAuthState;
   try {
-    const parsed = JSON.parse(
-      Buffer.from(stateParam, "base64url").toString("utf-8"),
-    );
-    orgId = parsed.orgId;
+    state = decryptJson<SlackOAuthState>(stateParam);
   } catch {
-    return NextResponse.redirect(
+    return redirectClearingState(
       new URL("/settings/integrations?error=invalid_state", baseUrl),
     );
   }
+  const orgId = state.orgId;
 
-  // Verify the authenticated user is an admin of the org referenced in state
-  // to prevent a crafted callback from binding attacker tokens to a victim org.
+  // CSRF binding: the nonce in the (server-issued) state must match the
+  // HttpOnly cookie set in the browser that initiated this exact OAuth
+  // transaction. An attacker cannot plant this cookie in a victim's browser,
+  // so a crafted callback (attacker code + forged/replayed state) has no
+  // matching cookie and is rejected here.
+  const cookieStore = await cookies();
+  const cookieNonce = cookieStore.get(SLACK_OAUTH_STATE_COOKIE)?.value;
+  if (!cookieNonce || cookieNonce !== state.nonce) {
+    return redirectClearingState(
+      new URL("/settings/integrations?error=invalid_state", baseUrl),
+    );
+  }
+  if (typeof state.exp !== "number" || Date.now() > state.exp) {
+    return redirectClearingState(
+      new URL("/settings/integrations?error=state_expired", baseUrl),
+    );
+  }
+
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) {
-    return NextResponse.redirect(new URL("/login", baseUrl));
+    return redirectClearingState(new URL("/login", baseUrl));
   }
+  // The session completing the callback must be the same user that started it.
+  if (session.user.id !== state.userId) {
+    return redirectClearingState(
+      new URL("/settings/integrations?error=forbidden", baseUrl),
+    );
+  }
+  // Defense in depth: that user must still be an admin of the target org.
   const member = await prisma.organizationMember.findFirst({
     where: { userId: session.user.id, organizationId: orgId, deletedAt: null },
     select: { role: true },
   });
   if (!member || (member.role !== "owner" && member.role !== "admin")) {
-    return NextResponse.redirect(
+    return redirectClearingState(
       new URL("/settings/integrations?error=forbidden", baseUrl),
     );
   }
@@ -80,7 +119,7 @@ export async function GET(request: NextRequest) {
 
   if (!tokenData.ok) {
     console.error("[slack-callback] Token exchange failed:", tokenData.error);
-    return NextResponse.redirect(
+    return redirectClearingState(
       new URL("/settings/integrations?error=token_exchange", baseUrl),
     );
   }
@@ -127,7 +166,7 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  return NextResponse.redirect(
+  return redirectClearingState(
     new URL("/settings/integrations?success=slack", baseUrl),
   );
 }

--- a/apps/web/app/api/slack/callback/route.ts
+++ b/apps/web/app/api/slack/callback/route.ts
@@ -3,14 +3,10 @@ import { headers, cookies } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { encryptString, decryptJson } from "@/lib/crypto";
-import { SLACK_OAUTH_STATE_COOKIE } from "@/lib/slack-oauth";
-
-type SlackOAuthState = {
-  orgId: string;
-  userId: string;
-  nonce: string;
-  exp: number;
-};
+import {
+  SLACK_OAUTH_STATE_COOKIE,
+  type SlackOAuthState,
+} from "@/lib/slack-oauth";
 
 // The state cookie is single-use: clear it on every callback response so a
 // captured code+state pair cannot be replayed against a stale cookie.
@@ -60,6 +56,14 @@ export async function GET(request: NextRequest) {
   }
   const orgId = state.orgId;
 
+  // Expiry is the cheapest structural check, so reject stale/replayed-after-
+  // expiry state up front, before any I/O (cookie read, session fetch, DB).
+  if (typeof state.exp !== "number" || Date.now() > state.exp) {
+    return redirectClearingState(
+      new URL("/settings/integrations?error=state_expired", baseUrl),
+    );
+  }
+
   // CSRF binding: the nonce in the (server-issued) state must match the
   // HttpOnly cookie set in the browser that initiated this exact OAuth
   // transaction. An attacker cannot plant this cookie in a victim's browser,
@@ -70,11 +74,6 @@ export async function GET(request: NextRequest) {
   if (!cookieNonce || cookieNonce !== state.nonce) {
     return redirectClearingState(
       new URL("/settings/integrations?error=invalid_state", baseUrl),
-    );
-  }
-  if (typeof state.exp !== "number" || Date.now() > state.exp) {
-    return redirectClearingState(
-      new URL("/settings/integrations?error=state_expired", baseUrl),
     );
   }
 

--- a/apps/web/app/api/slack/oauth/route.ts
+++ b/apps/web/app/api/slack/oauth/route.ts
@@ -1,7 +1,13 @@
 import { NextResponse } from "next/server";
 import { headers, cookies } from "next/headers";
+import { randomBytes } from "node:crypto";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
+import { encryptJson } from "@/lib/crypto";
+import {
+  SLACK_OAUTH_STATE_COOKIE,
+  SLACK_OAUTH_STATE_TTL_MS,
+} from "@/lib/slack-oauth";
 
 export async function GET() {
   const session = await auth.api.getSession({
@@ -36,7 +42,20 @@ export async function GET() {
     );
   }
 
-  const state = Buffer.from(JSON.stringify({ orgId })).toString("base64url");
+  // High-entropy nonce that ties this OAuth transaction to the browser that
+  // started it. The nonce is both embedded in the (encrypted, tamper-proof)
+  // state and stored in an HttpOnly cookie; the callback only proceeds when the
+  // two match. An attacker cannot set this cookie in a victim's browser, so a
+  // crafted callback URL (forged state + attacker code) is rejected. The state
+  // also carries the initiating userId and orgId so the callback can re-check
+  // both against the live session instead of trusting attacker-controlled input.
+  const nonce = randomBytes(32).toString("base64url");
+  const state = encryptJson({
+    orgId,
+    userId: session.user.id,
+    nonce,
+    exp: Date.now() + SLACK_OAUTH_STATE_TTL_MS,
+  });
 
   const params = new URLSearchParams({
     client_id: clientId,
@@ -45,7 +64,15 @@ export async function GET() {
     state,
   });
 
-  return NextResponse.redirect(
+  const response = NextResponse.redirect(
     `https://slack.com/oauth/v2/authorize?${params.toString()}`,
   );
+  response.cookies.set(SLACK_OAUTH_STATE_COOKIE, nonce, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: Math.floor(SLACK_OAUTH_STATE_TTL_MS / 1000),
+  });
+  return response;
 }

--- a/apps/web/lib/__tests__/slack-oauth-state.test.ts
+++ b/apps/web/lib/__tests__/slack-oauth-state.test.ts
@@ -1,0 +1,161 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Real crypto is used (not mocked) so the test exercises actual state
+// encryption/decryption and the cookie<->state nonce binding. crypto.ts reads
+// the key from env at call time, so setting it here is enough.
+process.env.BETTER_AUTH_SECRET ??= "test-secret-for-slack-oauth-state-binding";
+process.env.SLACK_CLIENT_ID ??= "client-id";
+process.env.SLACK_CLIENT_SECRET ??= "client-secret";
+process.env.SLACK_REDIRECT_URI ??= "https://app.test/api/slack/callback";
+process.env.BETTER_AUTH_URL ??= "https://app.test";
+
+// ── Controllable test state ──────────────────────────────────────────────────
+type Session = { user: { id: string } } | null;
+let currentSession: Session;
+let memberRole: string | null; // role returned by organizationMember.findFirst
+let requestCookies: Map<string, string>; // cookies the "browser" sends back
+let upsertedIntegration: { teamId: string; organizationId: string } | null;
+
+const mockGetSession = mock(() => Promise.resolve(currentSession));
+const mockMemberFindFirst = mock(() =>
+  Promise.resolve(memberRole ? { role: memberRole } : null),
+);
+const mockIntegrationUpsert = mock(
+  ({ where, create }: { where: { organizationId: string }; create: { teamId: string } }) => {
+    upsertedIntegration = {
+      teamId: create.teamId,
+      organizationId: where.organizationId,
+    };
+    return Promise.resolve({ id: "integration_1" });
+  },
+);
+const mockEventConfigUpsert = mock(() => Promise.resolve({}));
+
+// `next/headers` cookies()/headers() — backed by the controllable map.
+mock.module("next/headers", () => ({
+  headers: () => Promise.resolve(new Headers()),
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) =>
+        requestCookies.has(name) ? { name, value: requestCookies.get(name)! } : undefined,
+      set: (name: string, value: string) => requestCookies.set(name, value),
+      delete: (name: string) => requestCookies.delete(name),
+    }),
+}));
+
+mock.module("@/lib/auth", () => ({
+  auth: { api: { getSession: (...a: unknown[]) => mockGetSession(...(a as [])) } },
+}));
+
+mock.module("@octopus/db", () => ({
+  prisma: {
+    organizationMember: { findFirst: (...a: unknown[]) => mockMemberFindFirst(...(a as [])) },
+    slackIntegration: { upsert: (...a: unknown[]) => mockIntegrationUpsert(...(a as [{ where: { organizationId: string }; create: { teamId: string } }])) },
+    slackEventConfig: { upsert: (...a: unknown[]) => mockEventConfigUpsert(...(a as [])) },
+  },
+}));
+
+// Token exchange with Slack — return an attacker-controlled team.
+const originalFetch = globalThis.fetch;
+
+const { GET: oauthStart } = await import("@/app/api/slack/oauth/route");
+const { GET: oauthCallback } = await import("@/app/api/slack/callback/route");
+
+const VICTIM_ORG = "org_victim_owned_test";
+const VICTIM_ADMIN = "user_victim_admin";
+const ATTACKER_TEAM = "T_ATTACKER_OWNED_TEST";
+
+function callbackRequest(params: Record<string, string>) {
+  const url = new URL("https://app.test/api/slack/callback");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  // NextRequest is what the route types expect; a plain Request with nextUrl works
+  // for these handlers since they only read `nextUrl.searchParams`.
+  return Object.assign(new Request(url), { nextUrl: url }) as never;
+}
+
+function locationOf(res: Response) {
+  return new URL(res.headers.get("location")!);
+}
+
+beforeEach(() => {
+  currentSession = { user: { id: VICTIM_ADMIN } };
+  memberRole = "owner";
+  requestCookies = new Map([["current_org_id", VICTIM_ORG]]);
+  upsertedIntegration = null;
+  mockIntegrationUpsert.mockClear();
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          team: { id: ATTACKER_TEAM, name: "Attacker Workspace" },
+          access_token: "xoxb-attacker",
+          bot_user_id: "B_ATTACKER",
+        }),
+      ),
+    ),
+  ) as typeof fetch;
+});
+
+describe("slack oauth state CSRF binding", () => {
+  it("rejects a forged plaintext state (old attack: base64url({orgId}))", async () => {
+    const forgedState = Buffer.from(JSON.stringify({ orgId: VICTIM_ORG })).toString(
+      "base64url",
+    );
+    const res = await oauthCallback(
+      callbackRequest({ code: "attacker_code", state: forgedState }),
+    );
+    expect(locationOf(res).searchParams.get("error")).toBe("invalid_state");
+    expect(upsertedIntegration).toBeNull();
+  });
+
+  it("rejects a valid server-issued state when the initiating cookie is absent (CSRF)", async () => {
+    // Attacker completes their own OAuth start to obtain a genuine encrypted state...
+    requestCookies = new Map([["current_org_id", VICTIM_ORG]]);
+    const startRes = await oauthStart();
+    const state = locationOf(startRes).searchParams.get("state")!;
+
+    // ...then replays it through a VICTIM browser that never initiated OAuth,
+    // so it carries no slack_oauth_state cookie.
+    requestCookies = new Map(); // victim has no state cookie
+    const res = await oauthCallback(callbackRequest({ code: "attacker_code", state }));
+
+    expect(locationOf(res).searchParams.get("error")).toBe("invalid_state");
+    expect(upsertedIntegration).toBeNull();
+  });
+
+  it("rejects when a different user completes the flow than started it", async () => {
+    const startRes = await oauthStart(); // started by VICTIM_ADMIN
+    const state = locationOf(startRes).searchParams.get("state")!;
+    const nonce = startRes.cookies.get("slack_oauth_state")!.value;
+
+    // A different logged-in user replays the same state + cookie.
+    currentSession = { user: { id: "user_someone_else" } };
+    requestCookies = new Map([["slack_oauth_state", nonce]]);
+    const res = await oauthCallback(callbackRequest({ code: "code", state }));
+
+    expect(locationOf(res).searchParams.get("error")).toBe("forbidden");
+    expect(upsertedIntegration).toBeNull();
+  });
+
+  it("accepts the genuine flow: same browser, same user, admin role", async () => {
+    const startRes = await oauthStart();
+    const state = locationOf(startRes).searchParams.get("state")!;
+    const nonce = startRes.cookies.get("slack_oauth_state")!.value;
+
+    // Browser sends the state cookie back on the callback navigation.
+    requestCookies = new Map([["slack_oauth_state", nonce]]);
+    const res = await oauthCallback(callbackRequest({ code: "code", state }));
+
+    expect(locationOf(res).searchParams.get("success")).toBe("slack");
+    expect(upsertedIntegration).toEqual({
+      teamId: ATTACKER_TEAM,
+      organizationId: VICTIM_ORG,
+    });
+  });
+});
+
+// restore fetch for any later test files in the same process
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});

--- a/apps/web/lib/__tests__/slack-oauth-state.test.ts
+++ b/apps/web/lib/__tests__/slack-oauth-state.test.ts
@@ -55,7 +55,7 @@ mock.module("@octopus/db", () => ({
   },
 }));
 
-// Token exchange with Slack — return an attacker-controlled team.
+// Token exchange with Slack — return a fixed mock workspace.
 const originalFetch = globalThis.fetch;
 
 const { GET: oauthStart } = await import("@/app/api/slack/oauth/route");
@@ -63,7 +63,11 @@ const { GET: oauthCallback } = await import("@/app/api/slack/callback/route");
 
 const VICTIM_ORG = "org_victim_owned_test";
 const VICTIM_ADMIN = "user_victim_admin";
-const ATTACKER_TEAM = "T_ATTACKER_OWNED_TEST";
+// The Slack workspace returned by the mocked token endpoint in every test.
+// Named neutrally because the happy-path test legitimately connects it; the
+// attack semantics in the other tests come from the cookie/state mismatch, not
+// from this id.
+const MOCK_SLACK_TEAM = "T_MOCK_SLACK_TEAM";
 
 function callbackRequest(params: Record<string, string>) {
   const url = new URL("https://app.test/api/slack/callback");
@@ -88,9 +92,9 @@ beforeEach(() => {
       new Response(
         JSON.stringify({
           ok: true,
-          team: { id: ATTACKER_TEAM, name: "Attacker Workspace" },
-          access_token: "xoxb-attacker",
-          bot_user_id: "B_ATTACKER",
+          team: { id: MOCK_SLACK_TEAM, name: "Mock Slack Workspace" },
+          access_token: "xoxb-mock-token",
+          bot_user_id: "B_MOCK",
         }),
       ),
     ),
@@ -149,7 +153,7 @@ describe("slack oauth state CSRF binding", () => {
 
     expect(locationOf(res).searchParams.get("success")).toBe("slack");
     expect(upsertedIntegration).toEqual({
-      teamId: ATTACKER_TEAM,
+      teamId: MOCK_SLACK_TEAM,
       organizationId: VICTIM_ORG,
     });
   });

--- a/apps/web/lib/slack-oauth.ts
+++ b/apps/web/lib/slack-oauth.ts
@@ -10,3 +10,13 @@ export const SLACK_OAUTH_STATE_COOKIE = "slack_oauth_state";
 // OAuth state lifetime: long enough to complete the Slack consent screen, short
 // enough to bound the window a leaked code+state pair can be replayed.
 export const SLACK_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+// Contract for the encrypted `state` blob issued by the OAuth start route and
+// validated by the callback. Co-located here so both routes (and tests) share
+// one definition.
+export type SlackOAuthState = {
+  orgId: string;
+  userId: string;
+  nonce: string;
+  exp: number;
+};

--- a/apps/web/lib/slack-oauth.ts
+++ b/apps/web/lib/slack-oauth.ts
@@ -1,0 +1,12 @@
+// Shared between the Slack OAuth start and callback routes. Kept out of the
+// route.ts files because Next.js only allows HTTP-method and route-config
+// exports from a route segment.
+
+// HttpOnly cookie holding the per-transaction OAuth state nonce. The callback
+// requires it to match the nonce embedded in the encrypted `state`, binding the
+// flow to the browser that initiated it (CSRF protection).
+export const SLACK_OAUTH_STATE_COOKIE = "slack_oauth_state";
+
+// OAuth state lifetime: long enough to complete the Slack consent screen, short
+// enough to bound the window a leaked code+state pair can be replayed.
+export const SLACK_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;


### PR DESCRIPTION
## Summary

Fixes an OAuth account-linking CSRF in the Slack integration (reported privately under the bug bounty policy).

The Slack OAuth `state` was only base64-encoded JSON containing `orgId` (`apps/web/app/api/slack/oauth/route.ts`). It was not signed, stored, single-use, or bound to the browser that initiated the flow. The callback verified that the current user was an admin of the org named in the (attacker-controllable) state, but never verified that this browser actually started the authorization.

### Attack chain (pre-fix)
1. Attacker obtains a valid short-lived Slack OAuth `code` for a workspace they control.
2. Attacker forges `state = base64url({orgId: <victim_org>})`.
3. A logged-in victim org admin opens the crafted callback URL.
4. The callback's admin check passes (the victim *is* an admin of their own org), so the attacker workspace is upserted onto the victim org, overwriting any existing integration.
5. A correctly Slack-signed `/octopus` command from the attacker workspace then maps to the victim org and exposes its private tenant context (repos, members + emails, knowledge, PRs, code/review/chat/diagram chunks) to the attacker's Slack.

## Changes
- Issue a high-entropy nonce per OAuth transaction; embed it in an **AES-256-GCM encrypted (tamper-proof) state** alongside `orgId`, `userId`, and an expiry, and set it in an **HttpOnly, SameSite=Lax, Secure** cookie.
- In the callback: decrypt the state, **require the nonce to match the cookie** (binds the flow to the initiating browser; an attacker cannot plant this cookie in a victim's browser), enforce expiry, **require the completing session to be the same user that started it**, and keep the existing admin check as defense in depth.
- Consume the state cookie **single-use**: cleared on every callback response.
- Extract shared constants to `apps/web/lib/slack-oauth.ts`.
- Add regression tests: forged plaintext state, valid state with missing initiator cookie (the CSRF case), cross-user completion, and the genuine happy path.

## Test
```
bun test lib/__tests__/slack-oauth-state.test.ts
# 4 pass, 0 fail
```

## Not included (follow-up)
The report also suggested making `teamId` unique. Investigation against production showed this is **not viable**: one Slack workspace legitimately maps to multiple orgs (different people from the same company connect the same workspace to their own orgs). The correct follow-up is **explicit tenant selection** in the slash-command handler (`commands/route.ts` currently uses `findFirst({ where: { teamId } })` with no ordering, so it resolves ambiguously when one workspace maps to several orgs). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)