### PR TITLE
feat(providers): add Grok (xAI) and OpenRouter providers

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -244,6 +244,8 @@ export async function updateApiKeys(
   const anthropicApiKey = (formData.get("anthropicApiKey") as string)?.trim() || null;
   const googleApiKey = (formData.get("googleApiKey") as string)?.trim() || null;
   const cohereApiKey = (formData.get("cohereApiKey") as string)?.trim() || null;
+  const grokApiKey = (formData.get("grokApiKey") as string)?.trim() || null;
+  const openrouterApiKey = (formData.get("openrouterApiKey") as string)?.trim() || null;
 
   if (openaiApiKey && !openaiApiKey.startsWith("sk-")) {
     return { error: "Invalid OpenAI API key format." };
@@ -257,6 +259,14 @@ export async function updateApiKeys(
     return { error: "Invalid Google AI API key format." };
   }
 
+  if (grokApiKey && !grokApiKey.startsWith("xai-")) {
+    return { error: "Invalid Grok (xAI) API key format." };
+  }
+
+  if (openrouterApiKey && !openrouterApiKey.startsWith("sk-or-")) {
+    return { error: "Invalid OpenRouter API key format." };
+  }
+
   // Only update keys that have new values — empty fields keep the existing key.
   // Keys are encrypted at rest with the same helper used for OAuth tokens.
   const data: Record<string, string | null> = {};
@@ -264,6 +274,8 @@ export async function updateApiKeys(
   if (anthropicApiKey) data.anthropicApiKey = encryptString(anthropicApiKey);
   if (googleApiKey) data.googleApiKey = encryptString(googleApiKey);
   if (cohereApiKey) data.cohereApiKey = encryptString(cohereApiKey);
+  if (grokApiKey) data.grokApiKey = encryptString(grokApiKey);
+  if (openrouterApiKey) data.openrouterApiKey = encryptString(openrouterApiKey);
 
   if (Object.keys(data).length === 0) {
     return { error: "Enter at least one API key to save." };
@@ -278,7 +290,7 @@ export async function updateApiKeys(
   return { success: true };
 }
 
-const VALID_KEY_FIELDS = ["openaiApiKey", "anthropicApiKey", "googleApiKey", "cohereApiKey"] as const;
+const VALID_KEY_FIELDS = ["openaiApiKey", "anthropicApiKey", "googleApiKey", "cohereApiKey", "grokApiKey", "openrouterApiKey"] as const;
 
 export async function removeApiKey(
   keyField: (typeof VALID_KEY_FIELDS)[number],

--- a/apps/web/app/(app)/settings/api-keys-form.tsx
+++ b/apps/web/app/(app)/settings/api-keys-form.tsx
@@ -21,6 +21,8 @@ export function ApiKeysForm({
   anthropicApiKey,
   googleApiKey,
   cohereApiKey,
+  grokApiKey,
+  openrouterApiKey,
   isOwner,
 }: {
   // Masked previews (e.g. "sk-abc••••••••wxyz"), not full keys. The server masks
@@ -29,12 +31,14 @@ export function ApiKeysForm({
   anthropicApiKey: string | null;
   googleApiKey: string | null;
   cohereApiKey: string | null;
+  grokApiKey: string | null;
+  openrouterApiKey: string | null;
   isOwner: boolean;
 }) {
   const [state, formAction, pending] = useActionState(updateApiKeys, {});
   const [removing, startTransition] = useTransition();
 
-  function handleRemove(keyField: "openaiApiKey" | "anthropicApiKey" | "googleApiKey" | "cohereApiKey") {
+  function handleRemove(keyField: "openaiApiKey" | "anthropicApiKey" | "googleApiKey" | "cohereApiKey" | "grokApiKey" | "openrouterApiKey") {
     startTransition(async () => {
       try {
         await removeApiKey(keyField);
@@ -200,6 +204,79 @@ export function ApiKeysForm({
             />
             <p className="text-xs text-muted-foreground">
               Used to improve search relevance with Cohere Rerank.
+            </p>
+          </div>
+
+          <Separator />
+
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="grokApiKey">Grok (xAI)</Label>
+              {grokApiKey ? (
+                <Badge variant="outline" className="gap-1 text-[10px] font-normal">
+                  {grokApiKey}
+                  {isOwner && (
+                    <button
+                      type="button"
+                      onClick={() => handleRemove("grokApiKey")}
+                      disabled={removing}
+                      className="text-muted-foreground hover:text-destructive -mr-1 ml-0.5"
+                    >
+                      <IconX size={12} />
+                    </button>
+                  )}
+                </Badge>
+              ) : (
+                <Badge variant="secondary" className="text-[10px] font-normal">
+                  Not set
+                </Badge>
+              )}
+            </div>
+            <Input
+              id="grokApiKey"
+              name="grokApiKey"
+              type="password"
+              placeholder="xai-..."
+              disabled={!isOwner}
+              autoComplete="off"
+            />
+          </div>
+
+          <Separator />
+
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="openrouterApiKey">OpenRouter</Label>
+              {openrouterApiKey ? (
+                <Badge variant="outline" className="gap-1 text-[10px] font-normal">
+                  {openrouterApiKey}
+                  {isOwner && (
+                    <button
+                      type="button"
+                      onClick={() => handleRemove("openrouterApiKey")}
+                      disabled={removing}
+                      className="text-muted-foreground hover:text-destructive -mr-1 ml-0.5"
+                    >
+                      <IconX size={12} />
+                    </button>
+                  )}
+                </Badge>
+              ) : (
+                <Badge variant="secondary" className="text-[10px] font-normal">
+                  Not set
+                </Badge>
+              )}
+            </div>
+            <Input
+              id="openrouterApiKey"
+              name="openrouterApiKey"
+              type="password"
+              placeholder="sk-or-..."
+              disabled={!isOwner}
+              autoComplete="off"
+            />
+            <p className="text-xs text-muted-foreground">
+              One key for many model vendors.
             </p>
           </div>
 

--- a/apps/web/app/(app)/settings/api-keys/page.tsx
+++ b/apps/web/app/(app)/settings/api-keys/page.tsx
@@ -38,6 +38,8 @@ export default async function ApiKeysPage() {
           anthropicApiKey: true,
           googleApiKey: true,
           cohereApiKey: true,
+          grokApiKey: true,
+          openrouterApiKey: true,
         },
       },
     },
@@ -54,6 +56,8 @@ export default async function ApiKeysPage() {
       anthropicApiKey={maskStoredKey(member.organization.anthropicApiKey)}
       googleApiKey={maskStoredKey(member.organization.googleApiKey)}
       cohereApiKey={maskStoredKey(member.organization.cohereApiKey)}
+      grokApiKey={maskStoredKey(member.organization.grokApiKey)}
+      openrouterApiKey={maskStoredKey(member.organization.openrouterApiKey)}
       isOwner={canManage}
     />
   );

--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -17,7 +17,10 @@ const PROVIDER_FALLBACK: Record<string, AiProvider> = {
   codex: "openai",
   gemini: "google",
   "grok-": "grok",
-  "openrouter/": "openrouter", // OpenRouter uses vendor/model IDs (e.g. openai/gpt-4o)
+  // Explicit "openrouter/…"-namespaced model id forces OpenRouter routing.
+  // Native OpenRouter ids are vendor/model (e.g. "openai/gpt-4o") and resolve
+  // via the AvailableModel DB cache above, not this prefix.
+  "openrouter/": "openrouter",
 };
 
 let providerCache: Map<string, AiProvider> | null = null;

--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -16,6 +16,8 @@ const PROVIDER_FALLBACK: Record<string, AiProvider> = {
   o4: "openai",
   codex: "openai",
   gemini: "google",
+  "grok-": "grok",
+  "openrouter/": "openrouter", // OpenRouter uses vendor/model IDs (e.g. openai/gpt-4o)
 };
 
 let providerCache: Map<string, AiProvider> | null = null;
@@ -62,17 +64,27 @@ type OrgKeys = {
   anthropicApiKey: string | null;
   openaiApiKey: string | null;
   googleApiKey: string | null;
+  grokApiKey: string | null;
+  openrouterApiKey: string | null;
 };
 
 async function getOrgKeys(orgId: string): Promise<OrgKeys> {
   const org = await prisma.organization.findUnique({
     where: { id: orgId },
-    select: { anthropicApiKey: true, openaiApiKey: true, googleApiKey: true },
+    select: {
+      anthropicApiKey: true,
+      openaiApiKey: true,
+      googleApiKey: true,
+      grokApiKey: true,
+      openrouterApiKey: true,
+    },
   });
   return {
     anthropicApiKey: org?.anthropicApiKey ? decryptStringMaybeLegacy(org.anthropicApiKey) : null,
     openaiApiKey: org?.openaiApiKey ? decryptStringMaybeLegacy(org.openaiApiKey) : null,
     googleApiKey: org?.googleApiKey ? decryptStringMaybeLegacy(org.googleApiKey) : null,
+    grokApiKey: org?.grokApiKey ? decryptStringMaybeLegacy(org.grokApiKey) : null,
+    openrouterApiKey: org?.openrouterApiKey ? decryptStringMaybeLegacy(org.openrouterApiKey) : null,
   };
 }
 
@@ -81,6 +93,8 @@ function getOrgKeyForProvider(keys: OrgKeys, provider: AiProvider): string | nul
     case "anthropic": return keys.anthropicApiKey;
     case "openai": return keys.openaiApiKey;
     case "google": return keys.googleApiKey;
+    case "grok": return keys.grokApiKey;
+    case "openrouter": return keys.openrouterApiKey;
   }
 }
 

--- a/apps/web/lib/ai-usage.ts
+++ b/apps/web/lib/ai-usage.ts
@@ -3,7 +3,7 @@ import { calcCost, getModelPricing } from "./cost";
 import { deductCredits } from "./credits";
 
 type LogAiUsageParams = {
-  provider: "anthropic" | "openai" | "google" | "cohere";
+  provider: "anthropic" | "openai" | "google" | "cohere" | "grok" | "openrouter";
   model: string;
   operation: string;
   inputTokens: number;
@@ -18,7 +18,14 @@ export async function logAiUsage(params: LogAiUsageParams): Promise<void> {
     // Determine key ownership before recording usage
     const org = await prisma.organization.findUnique({
       where: { id: params.organizationId },
-      select: { anthropicApiKey: true, openaiApiKey: true, cohereApiKey: true, googleApiKey: true },
+      select: {
+        anthropicApiKey: true,
+        openaiApiKey: true,
+        cohereApiKey: true,
+        googleApiKey: true,
+        grokApiKey: true,
+        openrouterApiKey: true,
+      },
     });
 
     if (!org) {
@@ -30,7 +37,9 @@ export async function logAiUsage(params: LogAiUsageParams): Promise<void> {
       (params.provider === "anthropic" && !!org.anthropicApiKey) ||
       (params.provider === "openai" && !!org.openaiApiKey) ||
       (params.provider === "google" && !!org.googleApiKey) ||
-      (params.provider === "cohere" && !!org.cohereApiKey);
+      (params.provider === "cohere" && !!org.cohereApiKey) ||
+      (params.provider === "grok" && !!org.grokApiKey) ||
+      (params.provider === "openrouter" && !!org.openrouterApiKey);
 
     await prisma.aiUsage.create({
       data: {

--- a/apps/web/lib/providers/grok.ts
+++ b/apps/web/lib/providers/grok.ts
@@ -1,0 +1,67 @@
+import "server-only";
+import OpenAI from "openai";
+import type { Provider, AiCreateParams, AiResponse } from "./index";
+
+/**
+ * Grok (xAI). OpenAI-compatible REST at `https://api.x.ai/v1` — reuse the
+ * OpenAI SDK with a custom baseURL. The org BYOK key is resolved + decrypted
+ * by the ai-router facade and passed in as `apiKey`.
+ */
+const BASE_URL = "https://api.x.ai/v1";
+
+let platformClient: OpenAI | null = null;
+
+function getClient(apiKey?: string | null): OpenAI {
+  if (apiKey) return new OpenAI({ apiKey, baseURL: BASE_URL });
+  if (!platformClient) {
+    platformClient = new OpenAI({
+      apiKey: process.env.GROK_API_KEY ?? process.env.XAI_API_KEY ?? "",
+      baseURL: BASE_URL,
+    });
+  }
+  return platformClient;
+}
+
+export const grokProvider: Provider = {
+  name: "grok",
+  supportsJsonSchema: true,
+  async create(params: AiCreateParams, apiKey?: string | null): Promise<AiResponse> {
+    const client = getClient(apiKey);
+
+    const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+    if (params.system) messages.push({ role: "system", content: params.system });
+    for (const m of params.messages) messages.push({ role: m.role, content: m.content });
+
+    const response = await client.chat.completions.create({
+      model: params.model,
+      max_completion_tokens: params.maxTokens,
+      messages,
+      ...(params.responseSchema
+        ? {
+            response_format: {
+              type: "json_schema" as const,
+              json_schema: {
+                name: params.responseSchema.name,
+                schema: params.responseSchema.schema,
+                strict: true,
+              },
+            },
+          }
+        : {}),
+    });
+
+    const text = response.choices[0]?.message?.content ?? "";
+
+    return {
+      text,
+      provider: "grok",
+      model: params.model,
+      usage: {
+        inputTokens: response.usage?.prompt_tokens ?? 0,
+        outputTokens: response.usage?.completion_tokens ?? 0,
+        cacheReadTokens: response.usage?.prompt_tokens_details?.cached_tokens ?? 0,
+        cacheWriteTokens: 0,
+      },
+    };
+  },
+};

--- a/apps/web/lib/providers/index.ts
+++ b/apps/web/lib/providers/index.ts
@@ -2,8 +2,10 @@ import "server-only";
 import { anthropicProvider } from "./anthropic";
 import { openaiProvider } from "./openai";
 import { googleProvider } from "./google";
+import { grokProvider } from "./grok";
+import { openrouterProvider } from "./openrouter";
 
-export type AiProvider = "anthropic" | "openai" | "google";
+export type AiProvider = "anthropic" | "openai" | "google" | "grok" | "openrouter";
 
 export type AiMessage = {
   role: "user" | "assistant";
@@ -54,6 +56,8 @@ const PROVIDERS: Record<AiProvider, Provider> = {
   anthropic: anthropicProvider,
   openai: openaiProvider,
   google: googleProvider,
+  grok: grokProvider,
+  openrouter: openrouterProvider,
 };
 
 export function getProvider(name: AiProvider): Provider {

--- a/apps/web/lib/providers/openrouter.ts
+++ b/apps/web/lib/providers/openrouter.ts
@@ -1,0 +1,76 @@
+import "server-only";
+import OpenAI from "openai";
+import type { Provider, AiCreateParams, AiResponse } from "./index";
+
+/**
+ * OpenRouter. Gateway to many models from many vendors via a single API key.
+ * OpenAI-compatible at `https://openrouter.ai/api/v1`. Model IDs are
+ * namespaced (`openai/gpt-4o`, `anthropic/claude-sonnet-4-6`, …).
+ *
+ * The HTTP-Referer + X-Title headers are recommended by OpenRouter for
+ * attribution / rate-limit fairness; they're not enforced but they're free.
+ * The org BYOK key is resolved + decrypted by the ai-router facade.
+ */
+const BASE_URL = "https://openrouter.ai/api/v1";
+
+let platformClient: OpenAI | null = null;
+
+function getClient(apiKey?: string | null): OpenAI {
+  const headers = {
+    "HTTP-Referer": "https://octopus-review.ai",
+    "X-Title": "Octopus",
+  };
+  if (apiKey) return new OpenAI({ apiKey, baseURL: BASE_URL, defaultHeaders: headers });
+  if (!platformClient) {
+    platformClient = new OpenAI({
+      apiKey: process.env.OPENROUTER_API_KEY ?? "",
+      baseURL: BASE_URL,
+      defaultHeaders: headers,
+    });
+  }
+  return platformClient;
+}
+
+export const openrouterProvider: Provider = {
+  name: "openrouter",
+  supportsJsonSchema: true,
+  async create(params: AiCreateParams, apiKey?: string | null): Promise<AiResponse> {
+    const client = getClient(apiKey);
+
+    const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+    if (params.system) messages.push({ role: "system", content: params.system });
+    for (const m of params.messages) messages.push({ role: m.role, content: m.content });
+
+    const response = await client.chat.completions.create({
+      model: params.model,
+      max_completion_tokens: params.maxTokens,
+      messages,
+      ...(params.responseSchema
+        ? {
+            response_format: {
+              type: "json_schema" as const,
+              json_schema: {
+                name: params.responseSchema.name,
+                schema: params.responseSchema.schema,
+                strict: true,
+              },
+            },
+          }
+        : {}),
+    });
+
+    const text = response.choices[0]?.message?.content ?? "";
+
+    return {
+      text,
+      provider: "openrouter",
+      model: params.model,
+      usage: {
+        inputTokens: response.usage?.prompt_tokens ?? 0,
+        outputTokens: response.usage?.completion_tokens ?? 0,
+        cacheReadTokens: response.usage?.prompt_tokens_details?.cached_tokens ?? 0,
+        cacheWriteTokens: 0,
+      },
+    };
+  },
+};

--- a/packages/db/prisma/migrations/20260626182840_add_grok_openrouter_keys/migration.sql
+++ b/packages/db/prisma/migrations/20260626182840_add_grok_openrouter_keys/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."organizations" ADD COLUMN     "grokApiKey" TEXT,
+ADD COLUMN     "openrouterApiKey" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -100,6 +100,8 @@ model Organization {
   anthropicApiKey      String?
   cohereApiKey         String?
   googleApiKey         String?
+  grokApiKey           String?
+  openrouterApiKey     String?
   defaultModelId       String?
   defaultEmbedModelId  String?
   monthlySpendLimitUsd    Float?


### PR DESCRIPTION
## What
Add two OpenAI-compatible AI providers to the `lib/providers` registry (landed in #540): **Grok (xAI)** and **OpenRouter**. Both reuse the OpenAI SDK with a custom `baseURL` and support the structured-output `response_format` path.

- `providers/grok.ts`, `providers/openrouter.ts`; registered in `providers/index.ts` (the `AiProvider` union is extended to 5 values)
- `PROVIDER_FALLBACK` prefixes `grok-` and `openrouter/` (the latter is an explicit-namespace override; native OpenRouter `vendor/model` ids resolve via the `AvailableModel` DB cache)
- Per-org BYOK: `grokApiKey` / `openrouterApiKey` columns (+ migration), resolved and **decrypted at read** in `ai-router` `getOrgKeys` (encrypted at rest on write, exactly like the existing keys)
- API-keys settings form + server action: enter / validate / remove / mask the two keys
- `logAiUsage`: usage recording + own-key (BYOK) billing detection extended to both providers

## Why
Foundation Theme 1 landed the provider registry (#540); this is the first batch of new providers it unblocks. Grok and OpenRouter are the cleanest (pure API-key, OpenAI-compatible), so they go first; self-hosted/gateway providers (Ollama+SSRF, ACPX, OpenCode) and the test doubles follow in separate PRs.

## Test plan
- [x] `bun run typecheck` clean (`tsc --noEmit`)
- [x] `bun run lint` clean
- [x] `cd apps/web && bun test` — 396 pass / 0 fail
- [x] `bun install --frozen-lockfile` (no dependency change) + `bun run build` succeed
- [x] migration applies (`ALTER TABLE "public"."organizations" ADD COLUMN …`) and Prisma client regenerates

## Risk / notes
- **Metering invariant (no behavior change in this PR):** this adds provider *capability* only — it seeds **no** grok/openrouter models, so nothing routes to them until an `AvailableModel` row is added. Per existing convention any model must be added with pricing: `calcCost` returns `0` for an unpriced model (this is true for every provider today), so a model exposed without a price would run unmetered. Pricing must accompany any future grok/openrouter model addition. No change to `calcCost`/seed is made here.
- Public `createAiMessage(params, orgId)` is unchanged; the two providers stay prisma/crypto-free — key resolution and decryption remain in the `ai-router` facade.
- No new dependencies; no SSRF / `orgId` registry widening (those arrive with the self-hosted/gateway providers).
- The spend-limit fast-path bypass in `cost.ts` still keys off the original three providers; left unchanged deliberately (widening it would over-restrict existing orgs) — to revisit if grok/openrouter BYOK orgs should get the same bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
