### PR TITLE
feat(providers): add Ollama provider (env-configured)

### DIFF
--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -21,6 +21,7 @@ const PROVIDER_FALLBACK: Record<string, AiProvider> = {
   // Native OpenRouter ids are vendor/model (e.g. "openai/gpt-4o") and resolve
   // via the AvailableModel DB cache above, not this prefix.
   "openrouter/": "openrouter",
+  "ollama:": "ollama", // namespaced local models, e.g. "ollama:qwen2.5-coder:32b"
 };
 
 let providerCache: Map<string, AiProvider> | null = null;
@@ -98,6 +99,8 @@ function getOrgKeyForProvider(keys: OrgKeys, provider: AiProvider): string | nul
     case "google": return keys.googleApiKey;
     case "grok": return keys.grokApiKey;
     case "openrouter": return keys.openrouterApiKey;
+    // Ollama runs on the operator's own infra — env-configured, no per-org key.
+    case "ollama": return null;
   }
 }
 

--- a/apps/web/lib/ai-usage.ts
+++ b/apps/web/lib/ai-usage.ts
@@ -3,7 +3,7 @@ import { calcCost, getModelPricing } from "./cost";
 import { deductCredits } from "./credits";
 
 type LogAiUsageParams = {
-  provider: "anthropic" | "openai" | "google" | "cohere" | "grok" | "openrouter";
+  provider: "anthropic" | "openai" | "google" | "cohere" | "grok" | "openrouter" | "ollama";
   model: string;
   operation: string;
   inputTokens: number;
@@ -39,7 +39,9 @@ export async function logAiUsage(params: LogAiUsageParams): Promise<void> {
       (params.provider === "google" && !!org.googleApiKey) ||
       (params.provider === "cohere" && !!org.cohereApiKey) ||
       (params.provider === "grok" && !!org.grokApiKey) ||
-      (params.provider === "openrouter" && !!org.openrouterApiKey);
+      (params.provider === "openrouter" && !!org.openrouterApiKey) ||
+      // Ollama runs on the org's own infra — never bills the platform.
+      params.provider === "ollama";
 
     await prisma.aiUsage.create({
       data: {

--- a/apps/web/lib/providers/index.ts
+++ b/apps/web/lib/providers/index.ts
@@ -4,8 +4,9 @@ import { openaiProvider } from "./openai";
 import { googleProvider } from "./google";
 import { grokProvider } from "./grok";
 import { openrouterProvider } from "./openrouter";
+import { ollamaProvider } from "./ollama";
 
-export type AiProvider = "anthropic" | "openai" | "google" | "grok" | "openrouter";
+export type AiProvider = "anthropic" | "openai" | "google" | "grok" | "openrouter" | "ollama";
 
 export type AiMessage = {
   role: "user" | "assistant";
@@ -58,6 +59,7 @@ const PROVIDERS: Record<AiProvider, Provider> = {
   google: googleProvider,
   grok: grokProvider,
   openrouter: openrouterProvider,
+  ollama: ollamaProvider,
 };
 
 export function getProvider(name: AiProvider): Provider {

--- a/apps/web/lib/providers/ollama.ts
+++ b/apps/web/lib/providers/ollama.ts
@@ -18,12 +18,37 @@ import type { Provider, AiCreateParams, AiResponse } from "./index";
 
 const DEFAULT_BASE_URL = "http://localhost:11434";
 
+/**
+ * Parse + sanitize the operator-supplied base URL: require http(s) and reduce
+ * to a clean origin (drops any path/query so the SDK doesn't build `/v1/v1`).
+ * Throws on a malformed value so a typo'd OLLAMA_SERVER_URL fails loudly at
+ * first use instead of producing confusing request errors. Private/loopback
+ * hosts are intentionally allowed — this is a deployment-operator env var and
+ * Ollama is normally reached at localhost or an internal host (no SSRF surface:
+ * the value is not user-supplied).
+ */
+function normalizeServerUrl(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`OLLAMA_SERVER_URL is not a valid URL: ${raw.slice(0, 80)}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`OLLAMA_SERVER_URL must use http(s); got ${parsed.protocol}`);
+  }
+  return parsed.origin;
+}
+
+// Cached for the process lifetime: env vars are read once at first use, so a
+// changed OLLAMA_SERVER_URL / credentials take effect on restart — same as the
+// platform-key singletons in the other providers (anthropic/openai/grok/...).
 let platformClient: OpenAI | null = null;
 
 function getClient(): OpenAI {
   if (platformClient) return platformClient;
 
-  const base = (process.env.OLLAMA_SERVER_URL?.trim() || DEFAULT_BASE_URL).replace(/\/+$/, "");
+  const base = normalizeServerUrl(process.env.OLLAMA_SERVER_URL?.trim() || DEFAULT_BASE_URL);
   const username = process.env.OLLAMA_USERNAME;
   const password = process.env.OLLAMA_PASSWORD ?? "";
   const defaultHeaders = username

--- a/apps/web/lib/providers/ollama.ts
+++ b/apps/web/lib/providers/ollama.ts
@@ -1,0 +1,74 @@
+import "server-only";
+import OpenAI from "openai";
+import type { Provider, AiCreateParams, AiResponse } from "./index";
+
+/**
+ * Ollama exposes an OpenAI-compatible Chat Completions endpoint at
+ * `<base>/v1/chat/completions`, so we reuse the OpenAI SDK with a custom
+ * baseURL. Ollama ignores the API key but the SDK requires a non-empty value.
+ *
+ * Configured per deployment (operator-trusted) via env, matching the existing
+ * `.env.example` keys:
+ *   - OLLAMA_SERVER_URL            base URL (default http://localhost:11434)
+ *   - OLLAMA_USERNAME / _PASSWORD  optional HTTP Basic auth for a proxied host
+ *
+ * Pricing is zero — Ollama runs on the operator's own infra; `ai-usage.ts`
+ * treats `ollama` as a free provider (never bills the platform).
+ */
+
+const DEFAULT_BASE_URL = "http://localhost:11434";
+
+let platformClient: OpenAI | null = null;
+
+function getClient(): OpenAI {
+  if (platformClient) return platformClient;
+
+  const base = (process.env.OLLAMA_SERVER_URL?.trim() || DEFAULT_BASE_URL).replace(/\/+$/, "");
+  const username = process.env.OLLAMA_USERNAME;
+  const password = process.env.OLLAMA_PASSWORD ?? "";
+  const defaultHeaders = username
+    ? { Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}` }
+    : undefined;
+
+  platformClient = new OpenAI({
+    apiKey: "ollama", // ignored by Ollama; the SDK just requires a non-empty value
+    baseURL: `${base}/v1`,
+    defaultHeaders,
+  });
+  return platformClient;
+}
+
+export const ollamaProvider: Provider = {
+  name: "ollama",
+  supportsJsonSchema: false, // Ollama can be asked for JSON but doesn't enforce a schema yet
+  async create(params: AiCreateParams): Promise<AiResponse> {
+    const client = getClient();
+
+    const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+    if (params.system) messages.push({ role: "system", content: params.system });
+    for (const m of params.messages) messages.push({ role: m.role, content: m.content });
+
+    // Octopus namespaces local models as "ollama:<model>"; strip the prefix.
+    const model = params.model.startsWith("ollama:") ? params.model.slice(7) : params.model;
+
+    const response = await client.chat.completions.create({
+      model,
+      max_completion_tokens: params.maxTokens,
+      messages,
+    });
+
+    const text = response.choices[0]?.message?.content ?? "";
+
+    return {
+      text,
+      provider: "ollama",
+      model: params.model,
+      usage: {
+        inputTokens: response.usage?.prompt_tokens ?? 0,
+        outputTokens: response.usage?.completion_tokens ?? 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      },
+    };
+  },
+};


### PR DESCRIPTION
## What
Implement the **Ollama** provider that the repo's `.env.example` already anticipated (`OLLAMA_SERVER_URL` / `OLLAMA_USERNAME` / `OLLAMA_PASSWORD`) but had no code for. Ollama exposes an OpenAI-compatible Chat Completions API, so it reuses the OpenAI SDK with a custom `baseURL`.

- `providers/ollama.ts`: base URL from `OLLAMA_SERVER_URL` (default `http://localhost:11434`), optional HTTP Basic auth (`OLLAMA_USERNAME`/`OLLAMA_PASSWORD`) for a proxied host, strips the `ollama:` model-id namespace prefix
- registered in `providers/index.ts`; `AiProvider` union + `"ollama:"` `PROVIDER_FALLBACK` prefix; `getOrgKeyForProvider` returns `null` (Ollama is env-configured, no per-org key)
- `ai-usage`: `ollama` is free — it runs on the operator's own infra and never bills the platform (`usedOwnKey` true → no credit deduction)

## Why
Continues upstreaming the provider set unblocked by the registry (#540). Ollama is configured per **deployment** via the env vars the repo already documents, so this PR aligns code with those existing keys.

## Scope notes
- **Env-configured / operator-trusted** — there is intentionally **no per-org base-URL column** and therefore **no SSRF surface** in this PR. The `orgId` registry widening and the SSRF URL guard (`url-validation.ts`) arrive with the **ACPX / OpenCode** providers, which take genuinely *org-supplied* gateway endpoints (and will ship a settings writer for them).
- `supportsJsonSchema: false` — Ollama can be asked for JSON but doesn't enforce a schema, so the (currently unwired) `responseSchema` is ignored for it.
- No models are seeded; admins add Ollama models to `AvailableModel` (priced; Ollama is free so credits aren't deducted regardless).

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `cd apps/web && bun test` — 0 fail (400 tests)
- [x] `bun run build` OK
- [x] no schema/migration change (env-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
