### PR TITLE
feat(providers): add ACPX and OpenCode gateway providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,3 +142,11 @@ R2_PUBLIC_URL=
 OLLAMA_SERVER_URL=
 OLLAMA_USERNAME=
 OLLAMA_PASSWORD=
+
+# ACPX / OpenCode (optional, OpenAI-compatible gateway providers)
+# Set base URL + bearer token to enable each. Models are namespaced
+# "acp:<model>" / "opencode:<model>".
+ACP_BASE_URL=
+ACP_API_KEY=
+OPENCODE_BASE_URL=
+OPENCODE_API_KEY=

--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -22,6 +22,8 @@ const PROVIDER_FALLBACK: Record<string, AiProvider> = {
   // via the AvailableModel DB cache above, not this prefix.
   "openrouter/": "openrouter",
   "ollama:": "ollama", // namespaced local models, e.g. "ollama:qwen2.5-coder:32b"
+  "acp:": "acp", // OpenAI-compatible gateway (Agent Communication Protocol)
+  "opencode:": "opencode", // OpenAI-compatible gateway
 };
 
 let providerCache: Map<string, AiProvider> | null = null;
@@ -101,6 +103,11 @@ function getOrgKeyForProvider(keys: OrgKeys, provider: AiProvider): string | nul
     case "openrouter": return keys.openrouterApiKey;
     // Ollama runs on the operator's own infra — env-configured, no per-org key.
     case "ollama": return null;
+    // ACPX / OpenCode are operator-configured gateways (env base URL + token,
+    // resolved inside the provider) — no per-org key here.
+    case "acp":
+    case "opencode":
+      return null;
   }
 }
 

--- a/apps/web/lib/ai-usage.ts
+++ b/apps/web/lib/ai-usage.ts
@@ -3,7 +3,7 @@ import { calcCost, getModelPricing } from "./cost";
 import { deductCredits } from "./credits";
 
 type LogAiUsageParams = {
-  provider: "anthropic" | "openai" | "google" | "cohere" | "grok" | "openrouter" | "ollama";
+  provider: "anthropic" | "openai" | "google" | "cohere" | "grok" | "openrouter" | "ollama" | "acp" | "opencode";
   model: string;
   operation: string;
   inputTokens: number;
@@ -40,8 +40,11 @@ export async function logAiUsage(params: LogAiUsageParams): Promise<void> {
       (params.provider === "cohere" && !!org.cohereApiKey) ||
       (params.provider === "grok" && !!org.grokApiKey) ||
       (params.provider === "openrouter" && !!org.openrouterApiKey) ||
-      // Ollama runs on the org's own infra — never bills the platform.
-      params.provider === "ollama";
+      // Ollama / ACPX / OpenCode run on operator-configured infra/gateways —
+      // never bill the platform.
+      params.provider === "ollama" ||
+      params.provider === "acp" ||
+      params.provider === "opencode";
 
     await prisma.aiUsage.create({
       data: {

--- a/apps/web/lib/providers/acp.ts
+++ b/apps/web/lib/providers/acp.ts
@@ -1,0 +1,28 @@
+import "server-only";
+import type { Provider, AiCreateParams, AiResponse } from "./index";
+import { callOpenAiGateway } from "./openai-gateway";
+
+/**
+ * ACPX — an OpenAI-compatible multi-vendor gateway (Agent Communication
+ * Protocol). Configured per deployment via env:
+ *   ACP_BASE_URL — gateway origin (e.g. https://acpx.internal.example.com)
+ *   ACP_API_KEY  — bearer token for the gateway
+ * Model ids are namespaced "acp:<model>".
+ */
+export const acpProvider: Provider = {
+  name: "acp",
+  supportsJsonSchema: true,
+  async create(params: AiCreateParams): Promise<AiResponse> {
+    const baseUrl = process.env.ACP_BASE_URL;
+    const apiKey = process.env.ACP_API_KEY;
+    if (!baseUrl || !apiKey) {
+      throw new Error("ACPX is not configured — set ACP_BASE_URL and ACP_API_KEY.");
+    }
+    return callOpenAiGateway(params, {
+      name: "acp",
+      modelPrefix: "acp:",
+      baseUrl,
+      apiKey,
+    });
+  },
+};

--- a/apps/web/lib/providers/index.ts
+++ b/apps/web/lib/providers/index.ts
@@ -5,8 +5,18 @@ import { googleProvider } from "./google";
 import { grokProvider } from "./grok";
 import { openrouterProvider } from "./openrouter";
 import { ollamaProvider } from "./ollama";
+import { acpProvider } from "./acp";
+import { opencodeProvider } from "./opencode";
 
-export type AiProvider = "anthropic" | "openai" | "google" | "grok" | "openrouter" | "ollama";
+export type AiProvider =
+  | "anthropic"
+  | "openai"
+  | "google"
+  | "grok"
+  | "openrouter"
+  | "ollama"
+  | "acp"
+  | "opencode";
 
 export type AiMessage = {
   role: "user" | "assistant";
@@ -60,6 +70,8 @@ const PROVIDERS: Record<AiProvider, Provider> = {
   grok: grokProvider,
   openrouter: openrouterProvider,
   ollama: ollamaProvider,
+  acp: acpProvider,
+  opencode: opencodeProvider,
 };
 
 export function getProvider(name: AiProvider): Provider {

--- a/apps/web/lib/providers/openai-gateway.ts
+++ b/apps/web/lib/providers/openai-gateway.ts
@@ -1,0 +1,82 @@
+import "server-only";
+import OpenAI from "openai";
+import type { AiCreateParams, AiResponse, AiProvider } from "./index";
+
+/**
+ * Shared implementation for OpenAI-compatible gateway providers (acp, opencode,
+ * and future custom-endpoint providers). These point at an operator-supplied
+ * gateway (base URL + bearer token from env), so the endpoint is
+ * deployment-trusted — no SSRF attacker surface. We still parse the URL and
+ * require http(s) so a typo'd env value fails loudly at first use.
+ *
+ * Caller supplies the provider name, the model-id namespace prefix to strip
+ * (e.g. "acp:"), the gateway base URL, and the bearer token.
+ */
+export type GatewayCallOptions = {
+  name: AiProvider;
+  modelPrefix: string;
+  baseUrl: string;
+  apiKey: string;
+};
+
+function normalizeGatewayUrl(raw: string, providerName: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error(`${providerName} base URL is not a valid URL: ${raw.slice(0, 80)}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`${providerName} base URL must use http(s); got ${parsed.protocol}`);
+  }
+  // Reduce to origin so the SDK builds `<origin>/v1/chat/completions` cleanly.
+  return parsed.origin;
+}
+
+export async function callOpenAiGateway(
+  params: AiCreateParams,
+  opts: GatewayCallOptions,
+): Promise<AiResponse> {
+  const baseURL = `${normalizeGatewayUrl(opts.baseUrl, opts.name)}/v1`;
+  const client = new OpenAI({ apiKey: opts.apiKey, baseURL });
+
+  const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+  if (params.system) messages.push({ role: "system", content: params.system });
+  for (const m of params.messages) messages.push({ role: m.role, content: m.content });
+
+  const model = params.model.startsWith(opts.modelPrefix)
+    ? params.model.slice(opts.modelPrefix.length)
+    : params.model;
+
+  const response = await client.chat.completions.create({
+    model,
+    max_completion_tokens: params.maxTokens,
+    messages,
+    ...(params.responseSchema
+      ? {
+          response_format: {
+            type: "json_schema" as const,
+            json_schema: {
+              name: params.responseSchema.name,
+              schema: params.responseSchema.schema,
+              strict: true,
+            },
+          },
+        }
+      : {}),
+  });
+
+  const text = response.choices[0]?.message?.content ?? "";
+
+  return {
+    text,
+    provider: opts.name,
+    model: params.model,
+    usage: {
+      inputTokens: response.usage?.prompt_tokens ?? 0,
+      outputTokens: response.usage?.completion_tokens ?? 0,
+      cacheReadTokens: response.usage?.prompt_tokens_details?.cached_tokens ?? 0,
+      cacheWriteTokens: 0,
+    },
+  };
+}

--- a/apps/web/lib/providers/openai-gateway.ts
+++ b/apps/web/lib/providers/openai-gateway.ts
@@ -33,12 +33,26 @@ function normalizeGatewayUrl(raw: string, providerName: string): string {
   return parsed.origin;
 }
 
+// Cache one OpenAI client per provider. The gateway base URL + token come from
+// env (fixed for the process lifetime), so a single client per provider reuses
+// connections across calls instead of constructing a new one every request —
+// matching the singleton pattern in the other providers.
+const clientCache = new Map<AiProvider, OpenAI>();
+
+function getGatewayClient(opts: GatewayCallOptions): OpenAI {
+  const cached = clientCache.get(opts.name);
+  if (cached) return cached;
+  const baseURL = `${normalizeGatewayUrl(opts.baseUrl, opts.name)}/v1`;
+  const client = new OpenAI({ apiKey: opts.apiKey, baseURL });
+  clientCache.set(opts.name, client);
+  return client;
+}
+
 export async function callOpenAiGateway(
   params: AiCreateParams,
   opts: GatewayCallOptions,
 ): Promise<AiResponse> {
-  const baseURL = `${normalizeGatewayUrl(opts.baseUrl, opts.name)}/v1`;
-  const client = new OpenAI({ apiKey: opts.apiKey, baseURL });
+  const client = getGatewayClient(opts);
 
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
   if (params.system) messages.push({ role: "system", content: params.system });
@@ -67,6 +81,13 @@ export async function callOpenAiGateway(
   });
 
   const text = response.choices[0]?.message?.content ?? "";
+  // Surface an empty completion as an error instead of returning a blank review
+  // that downstream code would post as an empty PR comment.
+  if (!text) {
+    throw new Error(
+      `${opts.name} gateway returned no text (finish_reason: ${response.choices[0]?.finish_reason ?? "unknown"})`,
+    );
+  }
 
   return {
     text,

--- a/apps/web/lib/providers/opencode.ts
+++ b/apps/web/lib/providers/opencode.ts
@@ -1,0 +1,28 @@
+import "server-only";
+import type { Provider, AiCreateParams, AiResponse } from "./index";
+import { callOpenAiGateway } from "./openai-gateway";
+
+/**
+ * OpenCode — an OpenAI-compatible gateway, same shape as ACPX with its own
+ * config. Configured per deployment via env:
+ *   OPENCODE_BASE_URL — gateway origin
+ *   OPENCODE_API_KEY  — bearer token for the gateway
+ * Model ids are namespaced "opencode:<model>".
+ */
+export const opencodeProvider: Provider = {
+  name: "opencode",
+  supportsJsonSchema: true,
+  async create(params: AiCreateParams): Promise<AiResponse> {
+    const baseUrl = process.env.OPENCODE_BASE_URL;
+    const apiKey = process.env.OPENCODE_API_KEY;
+    if (!baseUrl || !apiKey) {
+      throw new Error("OpenCode is not configured — set OPENCODE_BASE_URL and OPENCODE_API_KEY.");
+    }
+    return callOpenAiGateway(params, {
+      name: "opencode",
+      modelPrefix: "opencode:",
+      baseUrl,
+      apiKey,
+    });
+  },
+};


### PR DESCRIPTION
## What
Add two OpenAI-compatible **gateway** providers behind a shared helper:
- `providers/openai-gateway.ts` — `callOpenAiGateway()`: parses + normalizes the operator-supplied base URL (require `http(s)`, reduce to origin so the SDK builds `<origin>/v1/...` cleanly), strips the model-id namespace prefix, calls `chat.completions` with structured-output support
- `providers/acp.ts` — **ACPX** gateway via `ACP_BASE_URL` + `ACP_API_KEY` (`acp:<model>`)
- `providers/opencode.ts` — **OpenCode** gateway via `OPENCODE_BASE_URL` + `OPENCODE_API_KEY` (`opencode:<model>`)
- registered in `providers/index.ts`; `AiProvider` union + `"acp:"`/`"opencode:"` `PROVIDER_FALLBACK` prefixes; `getOrgKeyForProvider` returns `null` (env-configured)
- `ai-usage`: `acp`/`opencode` are operator-configured gateways → never bill the platform
- `.env.example`: documents the four new vars

## Why
Continues the provider set unblocked by the registry (#540). These are OpenAI-compatible gateways configured **per deployment** via env, so they share one helper and align with the env-config approach used for Ollama (#543).

## Scope notes
- **Env-configured / operator-trusted** — the gateway base URL + token come from env (the operator controls the deployment), so there is **no SSRF attacker surface** and **no per-org column**. The provider still parses/validates the URL so a typo fails loudly.
- **Per-org multi-tenant gateway config** (each org its own gateway endpoint) + the SSRF host-blocking guard + a settings writer are a deliberate follow-up — the only place untrusted *org-supplied* URLs would appear. (Shipping that now would be dead code: there is no settings writer yet.)
- `supportsJsonSchema: true` (these gateways proxy OpenAI-compatible structured output); `responseSchema` is currently unwired platform-wide.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `cd apps/web && bun test` — 0 fail (400 tests)
- [x] `bun run build` OK
- [x] no schema/migration change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
