### PR TITLE
feat(providers): add env-gated mock / mock-fail test providers

### DIFF
--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -24,6 +24,10 @@ const PROVIDER_FALLBACK: Record<string, AiProvider> = {
   "ollama:": "ollama", // namespaced local models, e.g. "ollama:qwen2.5-coder:32b"
   "acp:": "acp", // OpenAI-compatible gateway (Agent Communication Protocol)
   "opencode:": "opencode", // OpenAI-compatible gateway
+  // "mock-fail-" MUST precede "mock-" (both match a "mock-fail-…" id). Test
+  // doubles only — never registered in production (see providers/index.ts).
+  "mock-fail-": "mock-fail",
+  "mock-": "mock",
 };
 
 let providerCache: Map<string, AiProvider> | null = null;
@@ -107,6 +111,10 @@ function getOrgKeyForProvider(keys: OrgKeys, provider: AiProvider): string | nul
     // resolved inside the provider) — no per-org key here.
     case "acp":
     case "opencode":
+      return null;
+    // Test doubles take no key.
+    case "mock":
+    case "mock-fail":
       return null;
   }
 }

--- a/apps/web/lib/ai-usage.ts
+++ b/apps/web/lib/ai-usage.ts
@@ -3,7 +3,7 @@ import { calcCost, getModelPricing } from "./cost";
 import { deductCredits } from "./credits";
 
 type LogAiUsageParams = {
-  provider: "anthropic" | "openai" | "google" | "cohere" | "grok" | "openrouter" | "ollama" | "acp" | "opencode";
+  provider: "anthropic" | "openai" | "google" | "cohere" | "grok" | "openrouter" | "ollama" | "acp" | "opencode" | "mock" | "mock-fail";
   model: string;
   operation: string;
   inputTokens: number;
@@ -44,7 +44,10 @@ export async function logAiUsage(params: LogAiUsageParams): Promise<void> {
       // never bill the platform.
       params.provider === "ollama" ||
       params.provider === "acp" ||
-      params.provider === "opencode";
+      params.provider === "opencode" ||
+      // Test doubles — zero cost.
+      params.provider === "mock" ||
+      params.provider === "mock-fail";
 
     await prisma.aiUsage.create({
       data: {

--- a/apps/web/lib/providers/index.ts
+++ b/apps/web/lib/providers/index.ts
@@ -7,6 +7,8 @@ import { openrouterProvider } from "./openrouter";
 import { ollamaProvider } from "./ollama";
 import { acpProvider } from "./acp";
 import { opencodeProvider } from "./opencode";
+import { mockProvider } from "./mock";
+import { mockFailProvider } from "./mock-fail";
 
 export type AiProvider =
   | "anthropic"
@@ -16,7 +18,9 @@ export type AiProvider =
   | "openrouter"
   | "ollama"
   | "acp"
-  | "opencode";
+  | "opencode"
+  | "mock"
+  | "mock-fail";
 
 export type AiMessage = {
   role: "user" | "assistant";
@@ -63,7 +67,19 @@ export type Provider = {
   create(params: AiCreateParams, apiKey?: string | null): Promise<AiResponse>;
 };
 
-const PROVIDERS: Record<AiProvider, Provider> = {
+/**
+ * Test doubles must NEVER be reachable in production — a canned all-clean
+ * response from `mock` would silently approve a PR with real vulnerabilities.
+ * Gate registration on env: only register in non-prod, or when an operator has
+ * explicitly opted in via ENABLE_MOCK_PROVIDERS=true (e.g. staging smoke tests).
+ * getProvider() throws for any unregistered name, so an unregistered mock can
+ * never be selected.
+ */
+const mockProvidersAllowed =
+  process.env.NODE_ENV !== "production" ||
+  process.env.ENABLE_MOCK_PROVIDERS === "true";
+
+const PROVIDERS: Partial<Record<AiProvider, Provider>> = {
   anthropic: anthropicProvider,
   openai: openaiProvider,
   google: googleProvider,
@@ -72,8 +88,18 @@ const PROVIDERS: Record<AiProvider, Provider> = {
   ollama: ollamaProvider,
   acp: acpProvider,
   opencode: opencodeProvider,
+  ...(mockProvidersAllowed
+    ? { mock: mockProvider, "mock-fail": mockFailProvider }
+    : {}),
 };
 
 export function getProvider(name: AiProvider): Provider {
-  return PROVIDERS[name];
+  const provider = PROVIDERS[name];
+  if (!provider) {
+    throw new Error(
+      `Provider "${name}" is not registered in this environment. ` +
+        `Mock providers require NODE_ENV!=="production" or ENABLE_MOCK_PROVIDERS="true".`,
+    );
+  }
+  return provider;
 }

--- a/apps/web/lib/providers/mock-fail.ts
+++ b/apps/web/lib/providers/mock-fail.ts
@@ -1,0 +1,19 @@
+import "server-only";
+import type { Provider, AiCreateParams, AiResponse } from "./index";
+
+/**
+ * Test-only provider that always throws. Lets tests verify retry / fallback /
+ * error-surfacing logic without needing a fragile real-API failure mode.
+ *
+ * The error message includes the model id and call context so test assertions
+ * can be specific.
+ */
+export const mockFailProvider: Provider = {
+  name: "mock-fail",
+  supportsJsonSchema: false,
+  async create(params: AiCreateParams): Promise<AiResponse> {
+    throw new Error(
+      `mock-fail provider: deliberate failure for model ${params.model} (maxTokens=${params.maxTokens})`,
+    );
+  },
+};

--- a/apps/web/lib/providers/mock.ts
+++ b/apps/web/lib/providers/mock.ts
@@ -1,0 +1,75 @@
+import "server-only";
+import { resolve, sep } from "node:path";
+import type { Provider, AiCreateParams, AiResponse } from "./index";
+
+/**
+ * Test-only provider. Returns a canned response so tests can exercise the
+ * review pipeline end-to-end without an actual LLM call.
+ *
+ * Selecting a response:
+ *   1. If `MOCK_AI_FIXTURE` is set, read it as a *relative path inside
+ *      `<cwd>/test/fixtures/ai`* and return the file's contents as the
+ *      response text. Absolute paths and traversal escapes are rejected.
+ *   2. Otherwise return a generic OK payload that satisfies the review
+ *      output schema (zero findings, all-5 score) so the reviewer treats
+ *      the PR as clean.
+ *
+ * Hardening: even when an operator sets `ENABLE_MOCK_PROVIDERS=true` to
+ * expose this in a hosted environment (e.g. for staging smoke tests),
+ * the fixture-file read refuses to run when `NODE_ENV === "production"`.
+ * Otherwise a misconfigured env var becomes a local-file disclosure
+ * primitive (`/etc/passwd`, mounted secrets, `.env`).
+ *
+ * Zero cost — ai-usage.ts treats mock as zero-priced.
+ */
+const GENERIC_OK_RESPONSE = JSON.stringify({
+  overallScore: 5,
+  categoryScores: {
+    security: 5,
+    codeQuality: 5,
+    performance: 5,
+    errorHandling: 5,
+    consistency: 5,
+  },
+  summary: "Mock provider response — no findings.",
+  findings: [],
+});
+
+const FIXTURE_ROOT = resolve(process.cwd(), "test/fixtures/ai");
+
+async function loadFixture(): Promise<string> {
+  const raw = process.env.MOCK_AI_FIXTURE;
+  if (!raw) return GENERIC_OK_RESPONSE;
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("MOCK_AI_FIXTURE is not honoured in production");
+  }
+  const resolved = resolve(FIXTURE_ROOT, raw);
+  if (resolved !== FIXTURE_ROOT && !resolved.startsWith(FIXTURE_ROOT + sep)) {
+    throw new Error(`MOCK_AI_FIXTURE escapes fixture root: ${raw}`);
+  }
+  const fs = await import("node:fs/promises");
+  return fs.readFile(resolved, "utf8");
+}
+
+export const mockProvider: Provider = {
+  name: "mock",
+  supportsJsonSchema: true, // pretends to honor schemas; the fixture is the user's responsibility
+  async create(params: AiCreateParams): Promise<AiResponse> {
+    const text = await loadFixture();
+    // Approximate input token count: 4 chars/token rule of thumb.
+    const inputChars =
+      (params.system?.length ?? 0) +
+      params.messages.reduce((acc, m) => acc + m.content.length, 0);
+    return {
+      text,
+      provider: "mock",
+      model: params.model,
+      usage: {
+        inputTokens: Math.ceil(inputChars / 4),
+        outputTokens: Math.ceil(text.length / 4),
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      },
+    };
+  },
+};


### PR DESCRIPTION
## What
Add two **test-only** providers so the review pipeline can be exercised end-to-end without real LLM calls — gated so they can never run in production.

- `providers/mock.ts` — returns a canned all-clear review (or a fixture from `test/fixtures/ai` when `MOCK_AI_FIXTURE` is set; the fixture read is path-traversal-guarded and **refused when `NODE_ENV==="production"`**)
- `providers/mock-fail.ts` — always throws, for exercising error / fallback / retry paths
- registered **only** when `NODE_ENV!=="production"` or `ENABLE_MOCK_PROVIDERS==="true"`; `PROVIDERS` is now `Partial` and `getProvider()` **throws for any unregistered name**, so an unregistered mock can never be selected
- `PROVIDER_FALLBACK` `"mock-fail-"`/`"mock-"` prefixes (ordered so `mock-fail-` wins); `getOrgKeyForProvider` returns `null`; `ai-usage` treats both as zero-cost

## Why
Enables deterministic pipeline tests / staging smoke tests. The security-critical bit is that a canned all-clear "review" must **never** approve a real PR — hence the env gate + throw-on-unregistered.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `cd apps/web && bun test` — 0 fail (400 tests)
- [x] `bun run build` OK
- [x] no schema/migration change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
