### PR TITLE
feat(seed): make Codex the platform default review model

### DIFF
--- a/apps/web/lib/ai-client.ts
+++ b/apps/web/lib/ai-client.ts
@@ -1,6 +1,8 @@
 import { prisma } from "@octopus/db";
 
-export const HARDCODED_REVIEW_MODEL = "claude-sonnet-4-6";
+// Last-resort fallbacks when the DB has no platform default (e.g. an unseeded
+// instance). Kept in sync with the seed's isPlatformDefault rows.
+export const HARDCODED_REVIEW_MODEL = "gpt-5.3-codex";
 export const HARDCODED_EMBED_MODEL = "text-embedding-3-large";
 
 async function getPlatformDefault(category: "llm" | "embedding"): Promise<string | null> {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -727,25 +727,27 @@ async function main() {
     // (asserted after the seed loop).
     { modelId: "gpt-5.3-codex", displayName: "GPT-5.3 Codex", provider: "openai", category: "llm", inputPrice: 1.75, outputPrice: 14, sortOrder: 7, isPlatformDefault: true },
     // Embeddings
-    { modelId: "text-embedding-3-large", displayName: "Embedding 3 Large", provider: "openai", category: "embedding", inputPrice: 0.13, outputPrice: 0, sortOrder: 0 },
+    { modelId: "text-embedding-3-large", displayName: "Embedding 3 Large", provider: "openai", category: "embedding", inputPrice: 0.13, outputPrice: 0, sortOrder: 0, isPlatformDefault: true },
     { modelId: "text-embedding-3-small", displayName: "Embedding 3 Small", provider: "openai", category: "embedding", inputPrice: 0.02, outputPrice: 0, sortOrder: 1 },
   ];
   for (const m of models) {
     await prisma.availableModel.create({ data: { id: cuid(), ...m } });
   }
-  // Determinism guard: getPlatformDefault("llm") relies on exactly one row
-  // carrying isPlatformDefault=true — multiple would make the lookup
-  // non-deterministic (whichever the query plan returns first wins). Catch it
-  // here instead of discovering it in production.
-  const llmPlatformDefaults = await prisma.availableModel.count({
-    where: { category: "llm", isPlatformDefault: true },
-  });
-  if (llmPlatformDefaults !== 1) {
-    throw new Error(
-      `Seed integrity: expected exactly one LLM platform default, found ${llmPlatformDefaults}.`,
-    );
+  // Determinism guard: getPlatformDefault(category) relies on exactly one row
+  // per category carrying isPlatformDefault=true — multiple would make the
+  // lookup non-deterministic (whichever the query plan returns first wins).
+  // Catch it here instead of discovering it in production.
+  for (const category of ["llm", "embedding"] as const) {
+    const defaults = await prisma.availableModel.count({
+      where: { category, isPlatformDefault: true },
+    });
+    if (defaults !== 1) {
+      throw new Error(
+        `Seed integrity: expected exactly one ${category} platform default, found ${defaults}.`,
+      );
+    }
   }
-  console.log(`✅ ${models.length} available models seeded (1 platform default)`);
+  console.log(`✅ ${models.length} available models seeded (1 llm + 1 embedding platform default)`);
 
   console.log("\n🎉 Seed completed successfully!");
 }

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -720,7 +720,12 @@ async function main() {
     { modelId: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro", provider: "google", category: "llm", inputPrice: 1.25, outputPrice: 10, sortOrder: 5 },
     { modelId: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash", provider: "google", category: "llm", inputPrice: 0.15, outputPrice: 0.6, sortOrder: 6 },
     // OpenAI — Codex is the only OpenAI LLM we offer; served via the Responses API.
-    { modelId: "gpt-5.3-codex", displayName: "GPT-5.3 Codex", provider: "openai", category: "llm", inputPrice: 1.75, outputPrice: 14, sortOrder: 7 },
+    // Platform default review model: coding-focused and cheaper than Claude
+    // Sonnet ($1.75/$14 vs $3/$15 per 1M tokens). ai-client.ts resolves the
+    // default via getPlatformDefault("llm") (falling back to
+    // HARDCODED_REVIEW_MODEL); exactly one llm row may carry isPlatformDefault
+    // (asserted after the seed loop).
+    { modelId: "gpt-5.3-codex", displayName: "GPT-5.3 Codex", provider: "openai", category: "llm", inputPrice: 1.75, outputPrice: 14, sortOrder: 7, isPlatformDefault: true },
     // Embeddings
     { modelId: "text-embedding-3-large", displayName: "Embedding 3 Large", provider: "openai", category: "embedding", inputPrice: 0.13, outputPrice: 0, sortOrder: 0 },
     { modelId: "text-embedding-3-small", displayName: "Embedding 3 Small", provider: "openai", category: "embedding", inputPrice: 0.02, outputPrice: 0, sortOrder: 1 },
@@ -728,7 +733,19 @@ async function main() {
   for (const m of models) {
     await prisma.availableModel.create({ data: { id: cuid(), ...m } });
   }
-  console.log(`✅ ${models.length} available models seeded`);
+  // Determinism guard: getPlatformDefault("llm") relies on exactly one row
+  // carrying isPlatformDefault=true — multiple would make the lookup
+  // non-deterministic (whichever the query plan returns first wins). Catch it
+  // here instead of discovering it in production.
+  const llmPlatformDefaults = await prisma.availableModel.count({
+    where: { category: "llm", isPlatformDefault: true },
+  });
+  if (llmPlatformDefaults !== 1) {
+    throw new Error(
+      `Seed integrity: expected exactly one LLM platform default, found ${llmPlatformDefaults}.`,
+    );
+  }
+  console.log(`✅ ${models.length} available models seeded (1 platform default)`);
 
   console.log("\n🎉 Seed completed successfully!");
 }


### PR DESCRIPTION
## What
Make **Codex** the platform default review model. Promote the existing `gpt-5.3-codex` seed row to `isPlatformDefault: true`, and add a seed integrity guard asserting exactly one `llm` row carries the flag.

## Why
`ai-client.ts` resolves the review model as `org.defaultModelId ?? getPlatformDefault("llm") ?? HARDCODED_REVIEW_MODEL`. Today no model is marked default, so every org without a custom model falls back to the hardcoded `claude-sonnet-4-6`. This marks `gpt-5.3-codex` as the platform default — coding-focused and cheaper than Sonnet ($1.75/$14 vs $3/$15 per 1M tokens).

## ⚠️ Product change — please confirm
This **changes the default review model for every org that hasn't set its own** (`claude-sonnet-4-6` → `gpt-5.3-codex`). Orgs with an explicit `defaultModelId` are unaffected. Flagging it explicitly since it shifts behavior platform-wide.

- I used origin's existing curated codex model (`gpt-5.3-codex`). If you'd prefer the cheaper **`codex-mini-latest`** ($1.5/$6) as the default, that's a one-line follow-up (it would also add that model row to the catalog).

## Test plan
- [x] `bun run typecheck` clean (incl. `packages/db` `tsc`)
- [x] seed integrity guard: exactly one `llm` `isPlatformDefault` row (gpt-5.3-codex)
- [x] no schema change (`isPlatformDefault` column already exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
