### PR TITLE
docs(self-hosting): document new provider env vars + fix integrations webhook var

### DIFF
--- a/apps/web/app/(landing)/docs/integrations/page.tsx
+++ b/apps/web/app/(landing)/docs/integrations/page.tsx
@@ -76,7 +76,7 @@ export default function IntegrationsPage() {
           vars={[
             { name: "GITHUB_APP_ID", description: "Your GitHub App ID" },
             { name: "GITHUB_APP_PRIVATE_KEY", description: "RSA private key (PEM or base64-encoded)" },
-            { name: "GITHUB_APP_WEBHOOK_SECRET", description: "Webhook secret for event verification" },
+            { name: "GITHUB_WEBHOOK_SECRET", description: "Webhook secret for event verification" },
           ]}
         />
       </IntegrationSection>

--- a/apps/web/app/(landing)/docs/self-hosting/page.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/page.tsx
@@ -158,6 +158,12 @@ volumes:
         </EnvGroup>
 
         <EnvGroup title="Optional">
+          <EnvVar name="GOOGLE_API_KEY" example="AIza..." description="Gemini models" />
+          <EnvVar name="GROK_API_KEY" example="xai-..." description="xAI Grok models" />
+          <EnvVar name="OPENROUTER_API_KEY" example="sk-or-..." description="OpenRouter — many model vendors via one key" />
+          <EnvVar name="OLLAMA_SERVER_URL" example="http://localhost:11434" description="Self-hosted Ollama (ollama: model ids); optional OLLAMA_USERNAME / OLLAMA_PASSWORD for a proxied host" />
+          <EnvVar name="ACP_BASE_URL" example="https://acpx.example.com" description="ACPX gateway (acp: model ids); set together with ACP_API_KEY" />
+          <EnvVar name="OPENCODE_BASE_URL" example="https://opencode.example.com" description="OpenCode gateway (opencode: model ids); set together with OPENCODE_API_KEY" />
           <EnvVar name="QDRANT_API_KEY" example="your-qdrant-api-key" description="If Qdrant auth is enabled" />
           <EnvVar name="COHERE_API_KEY" example="..." description="For reranking search results" />
           <EnvVar name="STRIPE_SECRET_KEY" example="sk_..." description="For billing" />


### PR DESCRIPTION
## What
- Self-hosting page: add **Optional** env-var rows for the providers upstreamed in Theme 2 — `GOOGLE_API_KEY`, `GROK_API_KEY`, `OPENROUTER_API_KEY`, `OLLAMA_SERVER_URL`, `ACP_BASE_URL`, `OPENCODE_BASE_URL` — so operators know how to enable them.
- Fix `docs/integrations/page.tsx`: it documented `GITHUB_APP_WEBHOOK_SECRET`, which **no code reads**. The webhook handler reads `GITHUB_WEBHOOK_SECRET` (matching `.env.example` + the rest of the docs). A self-hoster following that page would get broken webhooks.

## Scope
This is a **focused** self-hosting-docs refresh — it documents only providers/features that actually exist in origin. The fork's broader page rewrite also describes not-yet-upstreamed features (claude-code subscription, Ollama embeddings, `octp agent serve`, the updates page); those are intentionally deferred until the features land (per the #548 precedent).

## Test plan
- [x] typecheck / lint / build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)