### PR TITLE
feat(cli-backend): local indexing + Ollama embeddings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,17 @@ ELASTICSEARCH_INDEX_PREFIX=octopus
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 
+# Embedding provider — how code/knowledge chunks are vectorised for retrieval.
+#   Default (cloud): openai / text-embedding-3-large (3072 dim) via OPENAI_API_KEY.
+#   All-local self-host: OCTOPUS_EMBED_PROVIDER=ollama, OCTOPUS_EMBED_MODEL=nomic-embed-text,
+#   OCTOPUS_EMBED_DIM=768, OCTOPUS_OLLAMA_BASE_URL=http://localhost:11434, then
+#   `ollama pull nomic-embed-text`. Switching providers after collections exist
+#   requires dropping them (different models produce non-comparable vectors).
+OCTOPUS_EMBED_PROVIDER=openai
+OCTOPUS_EMBED_MODEL=
+OCTOPUS_EMBED_DIM=
+OCTOPUS_OLLAMA_BASE_URL=
+
 # Linear OAuth
 LINEAR_CLIENT_ID=
 LINEAR_CLIENT_SECRET=

--- a/apps/web/app/api/cli/repos/index-local/route.ts
+++ b/apps/web/app/api/cli/repos/index-local/route.ts
@@ -1,0 +1,283 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@octopus/db";
+import { authenticateApiToken } from "@/lib/api-auth";
+import { writeAuditLog } from "@/lib/audit";
+import { isOrgOverSpendLimit } from "@/lib/cost";
+import { normaliseRemoteUrl } from "@/app/api/cli/repos/by-remote/route";
+import {
+  IN_FLIGHT_WINDOW_MS,
+  indexLocalBatch,
+  markLocalIndexFailed,
+  prepareRepoForLocalIndex,
+  recordLocalIndexProgress,
+  type LocalFile,
+} from "@/lib/index-local";
+
+/**
+ * POST /api/cli/repos/index-local
+ *
+ * Server endpoint for `octp review` to index a local working tree against an
+ * org when the repo isn't connected via the GitHub App / GitLab / Bitbucket
+ * webhook flow. The CLI walks `git ls-files`, packs files into byte-budgeted
+ * batches, and posts each batch as a separate request — one batch per HTTP
+ * call so a slow embed API doesn't push the request over typical proxy timeouts
+ * and so the user can see progress.
+ *
+ * Body shape per batch:
+ *   - First batch (batchIndex = 0): { remoteUrl, defaultBranch, totalBatches,
+ *     totalFiles, batchIndex: 0, files }
+ *     → creates the Repository row (or re-uses an existing CLI-uploaded one),
+ *       wipes prior chunks, sets indexStatus=indexing, then processes batch 0.
+ *   - Subsequent batches: { repoId, totalBatches, batchIndex, files }
+ *     → process files against an existing in-progress row.
+ *   - Last batch (batchIndex === totalBatches - 1): also flips indexStatus to
+ *     "indexed" + records indexedAt + indexDurationMs.
+ *
+ * Hard limits to keep request size sane:
+ *   - 5 MB total body (Next.js default proxy limits start to bite past this)
+ *   - 200 files per batch
+ *   - 100 KB per file (matches the existing skip threshold in indexer)
+ *
+ * Errors:
+ *   - 401 unauth
+ *   - 400 bad input (parse, batch-index gaps, file too big, etc.)
+ *   - 409 the repo is managed via platform installation — index it via the
+ *     usual flow instead.
+ *   - 500 on indexing failure — repo row gets indexStatus=failed so the CLI's
+ *     poll sees it.
+ *
+ * Audit log: one row per first-batch (cli.index_local_start) and one per
+ * final-batch (cli.index_local_complete) so admins can see who triggered
+ * indexing for which repo.
+ */
+
+const MAX_BODY_BYTES = 5 * 1024 * 1024;
+const MAX_FILES_PER_BATCH = 200;
+const MAX_FILE_CONTENT_BYTES = 100_000;
+
+type FirstBatchBody = {
+  remoteUrl: string;
+  defaultBranch?: string;
+  totalBatches: number;
+  totalFiles: number;
+  batchIndex: 0;
+  files: LocalFile[];
+};
+
+type SubsequentBatchBody = {
+  repoId: string;
+  totalBatches: number;
+  batchIndex: number;
+  files: LocalFile[];
+};
+
+type Body = FirstBatchBody | SubsequentBatchBody;
+
+export async function POST(request: Request) {
+  const auth = await authenticateApiToken(request);
+  if (!auth) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const rawText = await request.text();
+  if (rawText.length > MAX_BODY_BYTES) {
+    return NextResponse.json(
+      { error: `Batch too large (${rawText.length} bytes). Cap is ${MAX_BODY_BYTES}.` },
+      { status: 413 },
+    );
+  }
+
+  let body: Body;
+  try {
+    body = JSON.parse(rawText) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const validation = validateBatch(body);
+  if (!validation.ok) {
+    return NextResponse.json({ error: validation.error }, { status: 400 });
+  }
+
+  const isFirstBatch = body.batchIndex === 0;
+  const isLastBatch = body.batchIndex === body.totalBatches - 1;
+
+  // Resolve / create repo row (first batch) or look up existing (later batches).
+  let repoId: string;
+  let fullName: string;
+  let startedAt: number;
+  if (isFirstBatch) {
+    const first = body as FirstBatchBody;
+    // Spend pre-check BEFORE prepareRepoForLocalIndex creates the row, so an
+    // over-limit org doesn't materialize a phantom (failed) Repository row.
+    // The post-resolution gate below still covers the mid-upload over-limit case.
+    if (await isOrgOverSpendLimit(auth.org.id)) {
+      return NextResponse.json({ error: "Monthly spend limit reached" }, { status: 402 });
+    }
+    const remote = normaliseRemoteUrl(first.remoteUrl);
+    if (!remote) {
+      return NextResponse.json(
+        { error: "Could not parse remoteUrl into provider/owner/repo" },
+        { status: 400 },
+      );
+    }
+    const prep = await prepareRepoForLocalIndex(
+      auth.org.id,
+      remote.provider,
+      remote.fullName,
+      first.defaultBranch || "main",
+    );
+    if (!prep.ok) {
+      const message =
+        prep.reason === "managed-by-platform"
+          ? "This repo is connected via the platform installation. Use the dashboard to re-index it."
+          : `Another local index for this repo is in-flight. Wait for it to complete or fail (status flips after ${Math.round(IN_FLIGHT_WINDOW_MS / 60_000)}min of no activity), then retry.`;
+      return NextResponse.json(
+        { error: message, repoId: prep.repoId, reason: prep.reason },
+        { status: 409 },
+      );
+    }
+    repoId = prep.repoId;
+    fullName = remote.fullName;
+    startedAt = Date.now();
+    await writeAuditLog({
+      action: "cli.index_local_start",
+      category: "repo",
+      actorId: auth.user?.id ?? null,
+      actorEmail: auth.user?.email ?? null,
+      organizationId: auth.org.id,
+      targetType: "repository",
+      targetId: repoId,
+      metadata: {
+        fullName,
+        provider: remote.provider,
+        totalBatches: first.totalBatches,
+        totalFiles: first.totalFiles,
+        reIndex: prep.reIndex,
+      },
+    }).catch((e) => console.error("[cli.index-local] start audit failed:", e));
+  } else {
+    const sub = body as SubsequentBatchBody;
+    const repo = await prisma.repository.findFirst({
+      where: { id: sub.repoId, organizationId: auth.org.id, isActive: true },
+      select: { id: true, fullName: true, indexStatus: true, updatedAt: true },
+    });
+    if (!repo) {
+      return NextResponse.json({ error: "Repo not found or not in org" }, { status: 404 });
+    }
+    if (repo.indexStatus !== "indexing") {
+      return NextResponse.json(
+        { error: `Cannot continue: repo indexStatus is ${repo.indexStatus}` },
+        { status: 409 },
+      );
+    }
+    repoId = repo.id;
+    fullName = repo.fullName;
+    startedAt = repo.updatedAt.getTime();
+  }
+
+  // Spend-limit gate — same invariant the sibling CLI review endpoints enforce.
+  // Run AFTER repo resolution so that we have a repoId in hand. ALWAYS mark
+  // the repo failed before returning, including on the first batch: by this
+  // point `prepareRepoForLocalIndex` has already created / wiped the row at
+  // indexStatus="indexing" (it runs above as part of the first-batch path),
+  // so a 402 without cleanup would strand the row in the same way a
+  // mid-upload 402 strands it. The CLI's retry loop and the dashboard's
+  // re-index UI both rely on indexStatus="failed" to allow user-driven
+  // recovery; "indexing" is treated as "in flight, do not touch."
+  if (await isOrgOverSpendLimit(auth.org.id)) {
+    await markLocalIndexFailed(repoId).catch((e) =>
+      console.error("[cli.index-local] failed to mark repo failed on 402:", e),
+    );
+    return NextResponse.json({ error: "Monthly spend limit reached" }, { status: 402 });
+  }
+
+  try {
+    const result = await indexLocalBatch(repoId, fullName, auth.org.id, body.files);
+    await recordLocalIndexProgress(
+      repoId,
+      startedAt,
+      {
+        indexedFiles: result.indexedInBatch,
+        totalChunks: result.chunksInBatch,
+        totalVectors: result.chunksInBatch,
+        ...(isFirstBatch ? { totalFiles: (body as FirstBatchBody).totalFiles } : {}),
+      },
+      isLastBatch,
+    );
+
+    if (isLastBatch) {
+      await writeAuditLog({
+        action: "cli.index_local_complete",
+        category: "repo",
+        actorId: auth.user?.id ?? null,
+        actorEmail: auth.user?.email ?? null,
+        organizationId: auth.org.id,
+        targetType: "repository",
+        targetId: repoId,
+        metadata: { fullName, totalBatches: body.totalBatches },
+      }).catch((e) => console.error("[cli.index-local] complete audit failed:", e));
+    }
+
+    return NextResponse.json({
+      repoId,
+      batchIndex: body.batchIndex,
+      indexedInBatch: result.indexedInBatch,
+      skippedInBatch: result.skippedInBatch,
+      chunksInBatch: result.chunksInBatch,
+      done: isLastBatch,
+    });
+  } catch (e) {
+    await markLocalIndexFailed(repoId).catch(() => {});
+    const detail = e instanceof Error ? e.message : String(e);
+    console.error(`[cli.index-local] batch ${body.batchIndex}/${body.totalBatches} for ${fullName} failed:`, detail);
+    const isProd = process.env.NODE_ENV === "production";
+    return NextResponse.json(
+      { error: isProd ? "Indexing batch failed" : `Indexing batch failed: ${detail}` },
+      { status: 500 },
+    );
+  }
+}
+
+function validateBatch(body: Body): { ok: true } | { ok: false; error: string } {
+  if (!body || typeof body !== "object") return { ok: false, error: "Empty body" };
+  if (typeof body.batchIndex !== "number" || body.batchIndex < 0) {
+    return { ok: false, error: "batchIndex must be a non-negative integer" };
+  }
+  if (typeof body.totalBatches !== "number" || body.totalBatches < 1) {
+    return { ok: false, error: "totalBatches must be a positive integer" };
+  }
+  if (body.batchIndex >= body.totalBatches) {
+    return { ok: false, error: "batchIndex must be < totalBatches" };
+  }
+  if (!Array.isArray(body.files) || body.files.length === 0) {
+    return { ok: false, error: "files must be a non-empty array" };
+  }
+  if (body.files.length > MAX_FILES_PER_BATCH) {
+    return { ok: false, error: `Too many files in batch (cap ${MAX_FILES_PER_BATCH})` };
+  }
+  for (const f of body.files) {
+    if (!f || typeof f.path !== "string" || typeof f.content !== "string") {
+      return { ok: false, error: "each file must be { path: string, content: string }" };
+    }
+    if (f.content.length > MAX_FILE_CONTENT_BYTES) {
+      return { ok: false, error: `file ${f.path} exceeds per-file cap of ${MAX_FILE_CONTENT_BYTES}` };
+    }
+  }
+  if (body.batchIndex === 0) {
+    const first = body as FirstBatchBody;
+    if (typeof first.remoteUrl !== "string" || !first.remoteUrl.trim()) {
+      return { ok: false, error: "first batch must include remoteUrl" };
+    }
+    if (typeof first.totalFiles !== "number" || first.totalFiles < 0) {
+      return { ok: false, error: "first batch must include totalFiles" };
+    }
+  } else {
+    const sub = body as SubsequentBatchBody;
+    if (typeof sub.repoId !== "string" || !sub.repoId.trim()) {
+      return { ok: false, error: "subsequent batches must include repoId" };
+    }
+  }
+  return { ok: true };
+}
+

--- a/apps/web/app/api/cli/repos/index-local/route.ts
+++ b/apps/web/app/api/cli/repos/index-local/route.ts
@@ -105,7 +105,7 @@ export async function POST(request: Request) {
   // Resolve / create repo row (first batch) or look up existing (later batches).
   let repoId: string;
   let fullName: string;
-  let startedAt: number;
+  let startedAt: number | null;
   if (isFirstBatch) {
     const first = body as FirstBatchBody;
     // Spend pre-check BEFORE prepareRepoForLocalIndex creates the row, so an
@@ -173,7 +173,9 @@ export async function POST(request: Request) {
     }
     repoId = repo.id;
     fullName = repo.fullName;
-    startedAt = repo.updatedAt.getTime();
+    // Multi-batch: no reliable whole-index start across stateless batch
+    // requests, so don't report a (misleading last-batch-only) duration.
+    startedAt = null;
   }
 
   // Spend-limit gate — same invariant the sibling CLI review endpoints enforce.

--- a/apps/web/lib/__tests__/embed-config.test.ts
+++ b/apps/web/lib/__tests__/embed-config.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { getEmbedConfig } from "@/lib/embed-config";
+
+const KEYS = [
+  "OCTOPUS_EMBED_PROVIDER",
+  "OCTOPUS_EMBED_MODEL",
+  "OCTOPUS_EMBED_DIM",
+  "OCTOPUS_OLLAMA_BASE_URL",
+] as const;
+
+describe("getEmbedConfig", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {};
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("defaults to OpenAI text-embedding-3-large @ 3072", () => {
+    const c = getEmbedConfig();
+    expect(c.provider).toBe("openai");
+    expect(c.model).toBe("text-embedding-3-large");
+    expect(c.dim).toBe(3072);
+    expect(c.ollamaBaseUrl).toBeUndefined();
+  });
+
+  it("switches to Ollama defaults", () => {
+    process.env.OCTOPUS_EMBED_PROVIDER = "ollama";
+    const c = getEmbedConfig();
+    expect(c.provider).toBe("ollama");
+    expect(c.model).toBe("nomic-embed-text");
+    expect(c.dim).toBe(768);
+    expect(c.ollamaBaseUrl).toBe("http://localhost:11434");
+  });
+
+  it("respects per-model OpenAI dim defaults", () => {
+    process.env.OCTOPUS_EMBED_MODEL = "text-embedding-3-small";
+    expect(getEmbedConfig().dim).toBe(1536);
+  });
+
+  it("respects per-model Ollama dim defaults", () => {
+    process.env.OCTOPUS_EMBED_PROVIDER = "ollama";
+    process.env.OCTOPUS_EMBED_MODEL = "mxbai-embed-large";
+    expect(getEmbedConfig().dim).toBe(1024);
+  });
+
+  it("explicit OCTOPUS_EMBED_DIM overrides per-model default", () => {
+    process.env.OCTOPUS_EMBED_PROVIDER = "ollama";
+    process.env.OCTOPUS_EMBED_MODEL = "nomic-embed-text";
+    process.env.OCTOPUS_EMBED_DIM = "1024";
+    expect(getEmbedConfig().dim).toBe(1024);
+  });
+
+  it("treats unknown provider as openai", () => {
+    process.env.OCTOPUS_EMBED_PROVIDER = "huggingface";
+    expect(getEmbedConfig().provider).toBe("openai");
+  });
+
+  it("strips trailing slashes from OCTOPUS_OLLAMA_BASE_URL", () => {
+    process.env.OCTOPUS_EMBED_PROVIDER = "ollama";
+    process.env.OCTOPUS_OLLAMA_BASE_URL = "http://my-box:11434///";
+    expect(getEmbedConfig().ollamaBaseUrl).toBe("http://my-box:11434");
+  });
+
+  it("ignores non-numeric OCTOPUS_EMBED_DIM", () => {
+    process.env.OCTOPUS_EMBED_DIM = "garbage";
+    expect(getEmbedConfig().dim).toBe(3072);
+  });
+});

--- a/apps/web/lib/__tests__/embeddings-dim-check.test.ts
+++ b/apps/web/lib/__tests__/embeddings-dim-check.test.ts
@@ -69,10 +69,10 @@ describe("createEmbeddings — Qdrant dim validation", () => {
     expect(out[1].length).toBe(QDRANT_DENSE_VECTOR_SIZE);
   });
 
-  it("throws an actionable error when returned dim is smaller than collection (e.g. text-embedding-3-small native)", async () => {
+  it("throws an actionable error when returned dim doesn't match the configured dim (e.g. text-embedding-3-small native)", async () => {
     mockReturnedDim = 1536; // text-embedding-3-small / ada-002 native
     await expect(createEmbeddings(["hello"], TRACKING)).rejects.toThrow(
-      /Embedding model "text-embedding-3-small" returned 1536-dim vectors but the Qdrant collection is configured for 3072/,
+      /OpenAI embeddings dim mismatch: model "text-embedding-3-small" returned 1536-dim vectors, but OCTOPUS_EMBED_DIM is 3072/,
     );
   });
 
@@ -87,7 +87,7 @@ describe("createEmbeddings — Qdrant dim validation", () => {
       expect(msg).toContain("1536");
       expect(msg).toContain(String(QDRANT_DENSE_VECTOR_SIZE));
       // Actionable remediation guidance must be in the message.
-      expect(msg).toMatch(/pick a model|re-create the Qdrant collection/);
+      expect(msg).toMatch(/Set OCTOPUS_EMBED_DIM|wipe Qdrant collections/);
     }
   });
 
@@ -99,6 +99,6 @@ describe("createEmbeddings — Qdrant dim validation", () => {
     mockReturnedDim = 1536;
     await expect(
       createEmbeddings(["a", "b", "c", "d"], TRACKING),
-    ).rejects.toThrow(/returned 1536-dim vectors but the Qdrant collection is configured for 3072/);
+    ).rejects.toThrow(/returned 1536-dim vectors, but OCTOPUS_EMBED_DIM is 3072/);
   });
 });

--- a/apps/web/lib/__tests__/url-validation.test.ts
+++ b/apps/web/lib/__tests__/url-validation.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "bun:test";
+import { validateProviderUrl } from "@/lib/providers/url-validation";
+
+describe("validateProviderUrl", () => {
+  describe("syntactic validation", () => {
+    it("rejects empty input", () => {
+      expect(() => validateProviderUrl("", { hosted: false })).toThrow(/empty/);
+      expect(() => validateProviderUrl("   ", { hosted: false })).toThrow(/empty/);
+    });
+
+    it("rejects unparseable URLs", () => {
+      expect(() => validateProviderUrl("not-a-url", { hosted: false })).toThrow(/parseable/);
+      expect(() => validateProviderUrl("http://", { hosted: false })).toThrow(/parseable/);
+    });
+
+    it("rejects non-http(s) schemes", () => {
+      expect(() => validateProviderUrl("ftp://example.com", { hosted: false })).toThrow(/http/);
+      expect(() => validateProviderUrl("file:///etc/passwd", { hosted: false })).toThrow(/http/);
+      expect(() => validateProviderUrl("javascript:alert(1)", { hosted: false })).toThrow(/http/);
+    });
+
+    it("returns the origin (drops path/query/fragment)", () => {
+      expect(validateProviderUrl("https://example.com/some/path?foo=bar#frag", { hosted: true })).toBe(
+        "https://example.com",
+      );
+    });
+
+    it("strips trailing slashes", () => {
+      expect(validateProviderUrl("https://example.com///", { hosted: true })).toBe("https://example.com");
+    });
+
+    it("preserves ports", () => {
+      expect(validateProviderUrl("http://example.com:8080", { hosted: true })).toBe("http://example.com:8080");
+    });
+  });
+
+  describe("hosted-mode SSRF protections", () => {
+    it("blocks loopback in hosted mode", () => {
+      expect(() => validateProviderUrl("http://localhost:11434", { hosted: true })).toThrow(/private\/loopback/);
+      expect(() => validateProviderUrl("http://127.0.0.1", { hosted: true })).toThrow(/private\/loopback/);
+      expect(() => validateProviderUrl("http://[::1]", { hosted: true })).toThrow(/private\/loopback/);
+    });
+
+    it("blocks RFC1918 private ranges in hosted mode", () => {
+      expect(() => validateProviderUrl("http://10.0.0.1", { hosted: true })).toThrow();
+      expect(() => validateProviderUrl("http://192.168.1.1", { hosted: true })).toThrow();
+      expect(() => validateProviderUrl("http://172.16.0.1", { hosted: true })).toThrow();
+      expect(() => validateProviderUrl("http://172.31.255.255", { hosted: true })).toThrow();
+    });
+
+    it("allows 172.15.x and 172.32.x (just outside RFC1918)", () => {
+      expect(validateProviderUrl("http://172.15.0.1", { hosted: true })).toBe("http://172.15.0.1");
+      expect(validateProviderUrl("http://172.32.0.1", { hosted: true })).toBe("http://172.32.0.1");
+    });
+
+    it("blocks cloud metadata link-local in hosted mode", () => {
+      expect(() => validateProviderUrl("http://169.254.169.254/latest/meta-data", { hosted: true })).toThrow();
+    });
+
+    it("blocks IPv6 link-local and unique-local in hosted mode", () => {
+      expect(() => validateProviderUrl("http://[fe80::1]", { hosted: true })).toThrow();
+      expect(() => validateProviderUrl("http://[fc00::1]", { hosted: true })).toThrow();
+      expect(() => validateProviderUrl("http://[fd12::1]", { hosted: true })).toThrow();
+    });
+
+    it("blocks IPv4 wildcard 0.0.0.0 (routes to loopback on Linux/macOS)", () => {
+      expect(() => validateProviderUrl("http://0.0.0.0:11434", { hosted: true })).toThrow();
+    });
+
+    it("blocks IPv6 unspecified `::`", () => {
+      expect(() => validateProviderUrl("http://[::]:11434", { hosted: true })).toThrow();
+    });
+
+    it("blocks IPv4-mapped IPv6 (cloud-metadata bypass)", () => {
+      // ::ffff:127.0.0.1 → loopback, ::ffff:169.254.169.254 → cloud metadata
+      expect(() => validateProviderUrl("http://[::ffff:127.0.0.1]", { hosted: true })).toThrow();
+      expect(() => validateProviderUrl("http://[::ffff:169.254.169.254]", { hosted: true })).toThrow();
+    });
+
+    it("blocks 6to4 (2002::/16) — embeds v4 in next 32 bits", () => {
+      // [2002:7f00:1::] addresses 127.0.0.1 via 6to4
+      expect(() => validateProviderUrl("http://[2002:7f00:1::]", { hosted: true })).toThrow();
+      // [2002:a9fe:a9fe::] addresses 169.254.169.254 via 6to4 (cloud-metadata bypass)
+      expect(() => validateProviderUrl("http://[2002:a9fe:a9fe::]", { hosted: true })).toThrow();
+    });
+
+    it("blocks NAT64 well-known prefix (64:ff9b::/96)", () => {
+      // [64:ff9b::a9fe:a9fe] addresses 169.254.169.254 via NAT64
+      expect(() => validateProviderUrl("http://[64:ff9b::a9fe:a9fe]", { hosted: true })).toThrow();
+      // [64:ff9b::7f00:1] addresses 127.0.0.1 via NAT64
+      expect(() => validateProviderUrl("http://[64:ff9b::7f00:1]", { hosted: true })).toThrow();
+    });
+
+    it("blocks IPv4-compatible IPv6 (`::a.b.c.d` deprecated form)", () => {
+      // [::127.0.0.1] canonicalizes to [::7f00:1] — reaches 127.0.0.1
+      expect(() => validateProviderUrl("http://[::127.0.0.1]", { hosted: true })).toThrow();
+      expect(() => validateProviderUrl("http://[::169.254.169.254]", { hosted: true })).toThrow();
+    });
+
+    it("blocks non-canonical IPv6 forms via WHATWG canonicalization", () => {
+      // [0::1] and [0:0:0:0:0:0:0:1] both canonicalize to [::1]
+      expect(() => validateProviderUrl("http://[0::1]", { hosted: true })).toThrow();
+      expect(() => validateProviderUrl("http://[0:0:0:0:0:0:0:1]", { hosted: true })).toThrow();
+      // [::ffff:0:127.0.0.1] canonicalizes to [::ffff:0:7f00:1] (matches ::ffff:)
+      expect(() => validateProviderUrl("http://[::ffff:0:127.0.0.1]", { hosted: true })).toThrow();
+      // Expanded ::ffff:a9fe:a9fe form
+      expect(() => validateProviderUrl("http://[0:0:0:0:0:ffff:a9fe:a9fe]", { hosted: true })).toThrow();
+    });
+
+    it("allows public hosts in hosted mode", () => {
+      expect(validateProviderUrl("https://api.example.com", { hosted: true })).toBe("https://api.example.com");
+      expect(validateProviderUrl("https://1.1.1.1", { hosted: true })).toBe("https://1.1.1.1");
+    });
+  });
+
+  describe("self-hosted mode permissiveness", () => {
+    it("allows loopback in self-hosted mode", () => {
+      expect(validateProviderUrl("http://localhost:11434", { hosted: false })).toBe(
+        "http://localhost:11434",
+      );
+      expect(validateProviderUrl("http://127.0.0.1", { hosted: false })).toBe("http://127.0.0.1");
+    });
+
+    it("allows RFC1918 in self-hosted mode", () => {
+      expect(validateProviderUrl("http://10.0.0.1", { hosted: false })).toBe("http://10.0.0.1");
+      expect(validateProviderUrl("http://192.168.1.100", { hosted: false })).toBe(
+        "http://192.168.1.100",
+      );
+    });
+  });
+
+  describe("default hosted detection", () => {
+    it("defaults to hosted when SELF_HOSTED env is unset", () => {
+      delete process.env.SELF_HOSTED;
+      expect(() => validateProviderUrl("http://localhost")).toThrow(/private/);
+    });
+
+    it("defaults to self-hosted when SELF_HOSTED=true", () => {
+      process.env.SELF_HOSTED = "true";
+      expect(validateProviderUrl("http://localhost")).toBe("http://localhost");
+      delete process.env.SELF_HOSTED;
+    });
+  });
+});

--- a/apps/web/lib/embed-config.ts
+++ b/apps/web/lib/embed-config.ts
@@ -1,0 +1,82 @@
+/**
+ * Process-wide embedding configuration.
+ *
+ * Octopus's vector store (Qdrant collections, schema in `qdrant.ts`) is
+ * created with a fixed dim, so the embedding provider + model + dim need
+ * to be consistent across the lifetime of a deployment. We resolve them
+ * once at module load time via env so that:
+ *
+ *   - the Qdrant collection's `VECTOR_SIZE` matches the embeddings the
+ *     embedder produces (mismatched dim → 400 from Qdrant on upsert);
+ *   - `createEmbeddings` doesn't have to relitigate the choice per call;
+ *   - self-hosters running all-local (Ollama LLM + Ollama embeddings)
+ *     can opt in with a single env block instead of editing source.
+ *
+ * Switching providers on an existing deployment requires wiping the
+ * Qdrant collections — different models produce vectors that aren't
+ * comparable. The dim-mismatch errors thrown in `embeddings.ts` surface
+ * that with an actionable message instead of a cryptic Qdrant 400.
+ *
+ * `OCTOPUS_EMBED_PROVIDER` (default: openai) — "openai" | "ollama".
+ * `OCTOPUS_EMBED_MODEL`    — model id passed to the provider. Sensible
+ *                            defaults per provider (see `defaultModel`).
+ * `OCTOPUS_EMBED_DIM`      — vector dimension. Defaults match the model.
+ * `OCTOPUS_OLLAMA_BASE_URL`— Ollama HTTP endpoint for embeddings (default
+ *                            `http://localhost:11434`). Kept separate from
+ *                            per-org `Organization.ollamaBaseUrl` because
+ *                            embedding is a system-level concern that runs
+ *                            outside any org context (eg. docs indexing).
+ */
+
+export type EmbedProvider = "openai" | "ollama";
+
+export interface EmbedConfig {
+  provider: EmbedProvider;
+  model: string;
+  dim: number;
+  /** Only populated when provider === "ollama". */
+  ollamaBaseUrl?: string;
+}
+
+function defaultModel(provider: EmbedProvider): string {
+  return provider === "ollama" ? "nomic-embed-text" : "text-embedding-3-large";
+}
+
+function defaultDim(provider: EmbedProvider, model: string): number {
+  if (provider === "openai") {
+    if (model === "text-embedding-3-small") return 1536;
+    if (model === "text-embedding-ada-002") return 1536;
+    return 3072; // text-embedding-3-large
+  }
+  // Ollama
+  if (model === "nomic-embed-text") return 768;
+  if (model === "mxbai-embed-large") return 1024;
+  if (model === "snowflake-arctic-embed2") return 1024;
+  return 768;
+}
+
+function parseProvider(raw: string | undefined): EmbedProvider {
+  const v = raw?.trim().toLowerCase();
+  if (v === "ollama") return "ollama";
+  return "openai";
+}
+
+/**
+ * Resolve the active embedding config from process env. Pure — no side
+ * effects, no validation against running services (that's the validator's
+ * job, called separately at startup). Safe to call on every request.
+ */
+export function getEmbedConfig(): EmbedConfig {
+  const provider = parseProvider(process.env.OCTOPUS_EMBED_PROVIDER);
+  const model = process.env.OCTOPUS_EMBED_MODEL?.trim() || defaultModel(provider);
+  const dimEnv = process.env.OCTOPUS_EMBED_DIM?.trim();
+  const dim = dimEnv && /^\d+$/.test(dimEnv) ? Number(dimEnv) : defaultDim(provider, model);
+
+  const config: EmbedConfig = { provider, model, dim };
+  if (provider === "ollama") {
+    config.ollamaBaseUrl =
+      process.env.OCTOPUS_OLLAMA_BASE_URL?.trim().replace(/\/+$/, "") ||
+      "http://localhost:11434";
+  }
+  return config;
+}

--- a/apps/web/lib/embeddings.ts
+++ b/apps/web/lib/embeddings.ts
@@ -3,27 +3,29 @@ import OpenAI from "openai";
 import { logAiUsage } from "@/lib/ai-usage";
 import { getEmbedModel } from "@/lib/ai-client";
 import { isOrgOverSpendLimit } from "@/lib/cost";
-import { QDRANT_DENSE_VECTOR_SIZE } from "@/lib/qdrant";
+import { getEmbedConfig, type EmbedConfig } from "@/lib/embed-config";
+import { validateProviderUrl } from "@/lib/providers/url-validation";
 
 let openai: OpenAI | null = null;
 
-function getClient(): OpenAI {
+function getOpenAIClient(): OpenAI {
   if (!openai) {
     openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
   }
   return openai;
 }
 
-// text-embedding-3-large max: 8191 tokens per input
-// Conservative limit: ~3 chars/token for code → 24000 chars stays safely under 8191 tokens
+// Provider-agnostic per-input char cap. Picked low enough for both providers'
+// per-input token limits (OpenAI's 8191 for text-embedding-3-large, Ollama's
+// effective ~8k for nomic-embed-text). ~3 chars/token in code stays safely
+// under the smaller of those.
 const MAX_EMBEDDING_CHARS = 24_000;
 
-// OpenAI enforces a 300,000 token total-request cap for embeddings.
-// Keep headroom: target ~200k. Dense content (lock files, .dts, hex blobs, CJK)
-// can tokenize at ~2 chars/token, so ASCII gets chars/2 and non-ASCII counts as
-// 1 token per char (CJK in cl100k/o200k often hits 1+ tokens per char).
-const MAX_BATCH_TOKENS = 200_000;
-const MAX_BATCH_ITEMS = 512;
+// Batching is provider-specific: OpenAI accepts large multi-item requests
+// (constrained by token + item ceilings); Ollama processes synchronously
+// per call, so we send modest fixed-size batches for timeout safety on
+// CPU-only setups. Constants for each path live next to the path that
+// uses them, not at module scope.
 
 function estimateTokens(text: string): number {
   let ascii = 0;
@@ -37,68 +39,131 @@ function estimateTokens(text: string): number {
   return Math.ceil(ascii / 2) + other;
 }
 
+/**
+ * Embed an array of input texts using the configured provider (OpenAI or
+ * Ollama). Provider selection is process-wide via `OCTOPUS_EMBED_PROVIDER`
+ * + friends — see `embed-config.ts`. Returns one vector per input; empty
+ * arrays for inputs that were filtered out (whitespace-only, etc.) so
+ * callers can keep the input → output positional mapping.
+ *
+ * Empty inputs are filtered before the API call because both providers
+ * reject blank strings (OpenAI returns 400, Ollama returns a malformed
+ * response). The mapping back to original positions happens at the bottom.
+ *
+ * `tracking` is for ai_usage rows + the spend-limit gate. When omitted
+ * (system-level embeddings outside any org), the usage row is skipped and
+ * the spend gate doesn't apply.
+ */
 export async function createEmbeddings(
   texts: string[],
   tracking?: { organizationId: string; operation: string; repositoryId?: string },
 ): Promise<number[][]> {
-  if (tracking?.organizationId && await isOrgOverSpendLimit(tracking.organizationId)) {
+  if (tracking?.organizationId && (await isOrgOverSpendLimit(tracking.organizationId))) {
     console.warn(`[embeddings] Org ${tracking.organizationId} over spend limit — skipping embeddings`);
     return texts.map(() => []);
   }
 
-  const client = getClient();
-  const embedModel = tracking?.organizationId
-    ? await getEmbedModel(tracking.organizationId, tracking.repositoryId)
-    : "text-embedding-3-large";
+  const baseConfig = getEmbedConfig();
 
-  // Filter out empty/whitespace-only strings — OpenAI embeddings API rejects them
-  const validTexts: string[] = [];
-  const validIndexes: number[] = [];
-  for (let i = 0; i < texts.length; i++) {
-    const trimmed = texts[i]?.trim();
-    if (trimmed) {
-      validTexts.push(texts[i]);
-      validIndexes.push(i);
-    }
+  // Per-org / per-repo embed-model override beats the env default — but ONLY
+  // for OpenAI. The `getEmbedModel` chain (Repository.embedModelId →
+  // Organization.defaultEmbedModelId → platform default → text-embedding-3-large)
+  // ALWAYS returns a non-empty string, so applying it in Ollama mode would send
+  // an OpenAI model name to Ollama's /api/embed and fail. In Ollama mode the
+  // env-configured model (OCTOPUS_EMBED_MODEL) always wins; system-level
+  // embeddings (no org context) also use the env model.
+  //
+  // Caveat: an OpenAI org-level override must produce vectors with the same dim
+  // as the global Qdrant collection. Mismatched dim is rejected explicitly
+  // below with an actionable message instead of a cryptic Qdrant 400. Hosters
+  // who want per-org dims would need per-org collections — out of scope here.
+  let model = baseConfig.model;
+  if (tracking?.organizationId && baseConfig.provider !== "ollama") {
+    const resolved = await getEmbedModel(tracking.organizationId, tracking.repositoryId);
+    if (resolved) model = resolved;
   }
+  const config: EmbedConfig = { ...baseConfig, model };
 
+  const { validTexts, validIndexes } = filterAndTruncate(texts);
   if (validTexts.length === 0) {
     return texts.map(() => []);
   }
 
-  // Pre-truncate each input to the per-item char cap.
-  const truncated = validTexts.map((t) =>
-    t.length > MAX_EMBEDDING_CHARS ? t.slice(0, MAX_EMBEDDING_CHARS) : t,
-  );
+  const { vectors: validVectors, promptTokens } =
+    config.provider === "ollama"
+      ? await embedWithOllama(validTexts, config)
+      : await embedWithOpenAI(validTexts, config);
 
-  const validVectors: number[][] = [];
-  let totalPromptTokens = 0;
+  // Map valid vectors back to original positions; empty array for filtered-out.
+  const out: number[][] = texts.map(() => []);
+  for (let i = 0; i < validIndexes.length; i++) {
+    out[validIndexes[i]] = validVectors[i];
+  }
 
-  // Send a batch, splitting in half on the 300k-token 400 error. Token estimates
-  // can underestimate for dense content; this lets us recover without failing
-  // the whole repo index over one bad batch.
+  if (tracking) {
+    await logAiUsage({
+      provider: config.provider,
+      model: config.model,
+      operation: tracking.operation,
+      inputTokens: promptTokens,
+      outputTokens: 0,
+      organizationId: tracking.organizationId,
+    });
+  }
+
+  return out;
+}
+
+function filterAndTruncate(texts: string[]): { validTexts: string[]; validIndexes: number[] } {
+  const validTexts: string[] = [];
+  const validIndexes: number[] = [];
+  for (let i = 0; i < texts.length; i++) {
+    const trimmed = texts[i]?.trim();
+    if (!trimmed) continue;
+    validTexts.push(
+      texts[i].length > MAX_EMBEDDING_CHARS ? texts[i].slice(0, MAX_EMBEDDING_CHARS) : texts[i],
+    );
+    validIndexes.push(i);
+  }
+  return { validTexts, validIndexes };
+}
+
+// OpenAI batching ceilings — 300k total tokens per request, 512 items per
+// call. Conservative target leaves headroom for tokenization variance
+// (dense content like lockfiles or CJK tokenize at ~2 chars/token in
+// cl100k/o200k tokenizers).
+const OPENAI_MAX_BATCH_TOKENS = 200_000;
+const OPENAI_MAX_BATCH_ITEMS = 512;
+
+async function embedWithOpenAI(
+  texts: string[],
+  config: EmbedConfig,
+): Promise<{ vectors: number[][]; promptTokens: number }> {
+  const client = getOpenAIClient();
+  const vectors: number[][] = [];
+  let promptTokens = 0;
+
   async function embedBatch(batch: string[]): Promise<void> {
+    // For text-embedding-3-* models OpenAI accepts an explicit
+    // `dimensions` arg and returns vectors at that length. Pass
+    // config.dim through so an org override (eg. 1536 for compact
+    // storage) actually takes effect instead of defaulting to the
+    // model's native dim and producing a Qdrant 400 at upsert time.
+    // Older embedding models reject the field, so only opt in for
+    // the v3 family.
+    const supportsDimensionsArg = config.model.startsWith("text-embedding-3-");
+    let res;
     try {
-      const res = await client.embeddings.create({ model: embedModel, input: batch });
-      // Validate the entire batch BEFORE pushing any item, so a mid-batch
-      // failure doesn't leave validVectors with partial entries (which
-      // could still get upserted by an outer catcher and produce a
-      // half-indexed repo on retry). The assertion catches misconfigured
-      // `embedModelId` overrides — e.g. text-embedding-3-small (1536-dim)
-      // or text-embedding-ada-002 (1536-dim) against a 3072-dim Qdrant
-      // collection — and surfaces an actionable error before Qdrant has
-      // a chance to reject the upsert with a generic "vector dim mismatch"
-      // minutes later.
-      for (const item of res.data) {
-        if (item.embedding.length !== QDRANT_DENSE_VECTOR_SIZE) {
-          throw new Error(
-            `Embedding model "${embedModel}" returned ${item.embedding.length}-dim vectors but the Qdrant collection is configured for ${QDRANT_DENSE_VECTOR_SIZE}. Either pick a model whose native dim matches the collection (text-embedding-3-large @ 3072 by default), or re-create the Qdrant collection at the model's dim.`,
-          );
-        }
-      }
-      for (const item of res.data) validVectors.push(item.embedding);
-      totalPromptTokens += res.usage.prompt_tokens;
+      res = await client.embeddings.create({
+        model: config.model,
+        input: batch,
+        ...(supportsDimensionsArg ? { dimensions: config.dim } : {}),
+      });
     } catch (err) {
+      // The split-on-token-limit recovery applies ONLY to OpenAI's
+      // "request too large" 400, never to any other error. Anything
+      // else (auth, network, our own dim-mismatch below) propagates
+      // up unchanged.
       const isTokenLimit =
         err instanceof OpenAI.APIError &&
         err.status === 400 &&
@@ -107,41 +172,106 @@ export async function createEmbeddings(
       const mid = Math.floor(batch.length / 2);
       await embedBatch(batch.slice(0, mid));
       await embedBatch(batch.slice(mid));
+      return;
     }
+    // Dim-mismatch check lives OUTSIDE the try above so the split-retry
+    // catch can't accidentally swallow / retry it. A misconfigured
+    // OCTOPUS_EMBED_DIM should fail loud and bubble to the caller, not
+    // get bisected into smaller and smaller still-wrong batches.
+    if (res.data.length > 0) {
+      const gotDim = res.data[0].embedding.length;
+      if (gotDim !== config.dim) {
+        throw new Error(
+          `OpenAI embeddings dim mismatch: model "${config.model}" returned ` +
+            `${gotDim}-dim vectors, but OCTOPUS_EMBED_DIM is ${config.dim}. ` +
+            `Set OCTOPUS_EMBED_DIM=${gotDim} (and wipe Qdrant collections so they get re-created).`,
+        );
+      }
+    }
+    for (const item of res.data) vectors.push(item.embedding);
+    promptTokens += res.usage.prompt_tokens;
   }
 
-  // Dynamic batching: stay under both MAX_BATCH_TOKENS and MAX_BATCH_ITEMS per request.
   let batchStart = 0;
-  while (batchStart < truncated.length) {
+  while (batchStart < texts.length) {
     let batchTokens = 0;
     let batchEnd = batchStart;
-    while (batchEnd < truncated.length && batchEnd - batchStart < MAX_BATCH_ITEMS) {
-      const itemTokens = estimateTokens(truncated[batchEnd]);
-      if (batchEnd > batchStart && batchTokens + itemTokens > MAX_BATCH_TOKENS) break;
+    while (batchEnd < texts.length && batchEnd - batchStart < OPENAI_MAX_BATCH_ITEMS) {
+      const itemTokens = estimateTokens(texts[batchEnd]);
+      if (batchEnd > batchStart && batchTokens + itemTokens > OPENAI_MAX_BATCH_TOKENS) break;
       batchTokens += itemTokens;
       batchEnd++;
     }
-
-    await embedBatch(truncated.slice(batchStart, batchEnd));
+    await embedBatch(texts.slice(batchStart, batchEnd));
     batchStart = batchEnd;
   }
 
-  // Map valid vectors back to original positions, empty array for filtered-out texts
-  const vectors: number[][] = texts.map(() => []);
-  for (let i = 0; i < validIndexes.length; i++) {
-    vectors[validIndexes[i]] = validVectors[i];
-  }
+  return { vectors, promptTokens };
+}
 
-  if (tracking) {
-    await logAiUsage({
-      provider: "openai",
-      model: embedModel,
-      operation: tracking.operation,
-      inputTokens: totalPromptTokens,
-      outputTokens: 0,
-      organizationId: tracking.organizationId,
+// Ollama processes embedding requests synchronously per call; large batches
+// would slow first-response wall time without saving wall time overall.
+// 64-item chunks keep each call well under typical timeout thresholds on
+// CPU-only setups.
+const OLLAMA_BATCH_ITEMS = 64;
+
+/**
+ * Call Ollama's /api/embed in modest batches. Ollama doesn't return usage
+ * accounting, so `promptTokens` is estimated client-side for the ai_usage
+ * row. The estimate undershoots — embedding is free for self-hosters anyway,
+ * so the metric is only useful for relative cost across repos.
+ */
+async function embedWithOllama(
+  texts: string[],
+  config: EmbedConfig,
+): Promise<{ vectors: number[][]; promptTokens: number }> {
+  if (!config.ollamaBaseUrl) {
+    throw new Error("Ollama embeddings selected but OCTOPUS_OLLAMA_BASE_URL not configured");
+  }
+  // Defense-in-depth: even though the URL is operator-controlled via env
+  // (low SSRF risk), route it through the same validator the per-org BYOK
+  // path uses. `hosted: false` mirrors the `SELF_HOSTED` env default and
+  // allows localhost / RFC1918 destinations for self-hosters.
+  const safeBaseUrl = validateProviderUrl(config.ollamaBaseUrl, {
+    hosted: process.env.SELF_HOSTED !== "true",
+  });
+  const vectors: number[][] = [];
+  let promptTokens = 0;
+
+  for (let i = 0; i < texts.length; i += OLLAMA_BATCH_ITEMS) {
+    const batch = texts.slice(i, i + OLLAMA_BATCH_ITEMS);
+    const res = await fetch(`${safeBaseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: config.model, input: batch }),
     });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(
+        `Ollama embeddings HTTP ${res.status} from ${safeBaseUrl}/api/embed: ${detail.slice(0, 200)}`,
+      );
+    }
+    const j = (await res.json()) as { embeddings?: number[][]; embedding?: number[] };
+    // /api/embed returns `embeddings`; the older /api/embeddings returned `embedding`
+    // (singular). Accept both shapes — keeps us forward-compatible if a self-hoster
+    // is on an older Ollama build.
+    const got = j.embeddings ?? (j.embedding ? [j.embedding] : null);
+    if (!got || got.length !== batch.length) {
+      throw new Error(
+        `Ollama embeddings: expected ${batch.length} vectors, got ${got?.length ?? 0}. ` +
+          `Check that model "${config.model}" is pulled (ollama pull ${config.model}).`,
+      );
+    }
+    if (got[0].length !== config.dim) {
+      throw new Error(
+        `Ollama embeddings dim mismatch: model "${config.model}" returned ` +
+          `${got[0].length}-dim vectors, but OCTOPUS_EMBED_DIM is ${config.dim}. ` +
+          `Set OCTOPUS_EMBED_DIM=${got[0].length} (and wipe Qdrant collections so they get re-created).`,
+      );
+    }
+    vectors.push(...got);
+    for (const t of batch) promptTokens += estimateTokens(t);
   }
 
-  return vectors;
+  return { vectors, promptTokens };
 }

--- a/apps/web/lib/index-chunking.ts
+++ b/apps/web/lib/index-chunking.ts
@@ -1,0 +1,106 @@
+import type { Ignore } from "@/lib/octopus-ignore";
+
+/**
+ * File-level + chunk-level helpers shared by every indexing entry point
+ * (the GitHub-tree path, the clone-based GitLab/Bitbucket path, and the
+ * CLI-uploaded local path). Kept in one place so that path filtering and
+ * chunk shape stay identical across all three — drift here is a silent
+ * way to make some indexing modes produce different retrieval quality.
+ */
+
+export const MAX_FILE_SIZE = 100_000; // 100 KB — skip larger files (binaries, dumps)
+export const CHUNK_SIZE = 1500; // ~375 tokens
+export const CHUNK_OVERLAP = 200;
+
+const CODE_EXTENSIONS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs", ".java", ".rb",
+  ".c", ".cpp", ".h", ".hpp", ".cs", ".swift", ".kt", ".scala",
+  ".vue", ".svelte", ".astro", ".html", ".css", ".scss",
+  ".sql", ".graphql", ".proto", ".yaml", ".yml", ".toml",
+  ".md", ".mdx", ".txt", ".json", ".xml",
+  ".sh", ".bash", ".zsh", ".fish",
+  ".dockerfile", ".prisma", ".env.example",
+]);
+
+const IGNORE_PATHS = [
+  "node_modules/", ".git/", "dist/", "build/", ".next/",
+  "vendor/", "__pycache__/", ".turbo/", "coverage/",
+  "package-lock.json", "bun.lock", "yarn.lock", "pnpm-lock.yaml",
+];
+
+export function shouldIndex(path: string, size?: number, ig?: Ignore): boolean {
+  if (size && size > MAX_FILE_SIZE) return false;
+  if (IGNORE_PATHS.some((p) => path.includes(p))) return false;
+  if (ig?.ignores(path)) return false;
+
+  const basename = path.split("/").pop() ?? "";
+
+  if (basename === "Dockerfile" || basename === "Makefile") return true;
+
+  // Extension match only — never collapse a dotless basename like `LICENSE`
+  // or `Procfile` to a fake extension. `lastIndexOf` returns -1 with no dot,
+  // and a leading-dot file (`.env`) has dot at index 0; both cases bail.
+  const dot = basename.lastIndexOf(".");
+  if (dot <= 0) return false;
+  const ext = basename.slice(dot).toLowerCase();
+  return CODE_EXTENSIONS.has(ext);
+}
+
+export function chunkText(
+  content: string,
+  filePath: string,
+): { text: string; startLine: number; endLine: number }[] {
+  const lines = content.split("\n");
+  const chunks: { text: string; startLine: number; endLine: number }[] = [];
+
+  let currentChunk = "";
+  let startLine = 1;
+  let currentLine = 1;
+
+  for (const line of lines) {
+    if (line.length > CHUNK_SIZE) {
+      if (currentChunk.length > 0) {
+        chunks.push({
+          text: `// File: ${filePath}\n${currentChunk}`,
+          startLine,
+          endLine: currentLine - 1,
+        });
+        currentChunk = "";
+      }
+
+      for (let j = 0; j < line.length; j += CHUNK_SIZE - CHUNK_OVERLAP) {
+        const piece = line.slice(j, j + CHUNK_SIZE);
+        chunks.push({
+          text: `// File: ${filePath}\n${piece}`,
+          startLine: currentLine,
+          endLine: currentLine,
+        });
+      }
+
+      startLine = currentLine + 1;
+    } else if (currentChunk.length + line.length + 1 > CHUNK_SIZE && currentChunk.length > 0) {
+      chunks.push({
+        text: `// File: ${filePath}\n${currentChunk}`,
+        startLine,
+        endLine: currentLine - 1,
+      });
+
+      const overlapLines = currentChunk.split("\n").slice(-3);
+      currentChunk = overlapLines.join("\n") + "\n" + line;
+      startLine = currentLine - overlapLines.length;
+    } else {
+      currentChunk += (currentChunk ? "\n" : "") + line;
+    }
+    currentLine++;
+  }
+
+  if (currentChunk.trim()) {
+    chunks.push({
+      text: `// File: ${filePath}\n${currentChunk}`,
+      startLine,
+      endLine: currentLine - 1,
+    });
+  }
+
+  return chunks;
+}

--- a/apps/web/lib/index-local.ts
+++ b/apps/web/lib/index-local.ts
@@ -250,7 +250,7 @@ export async function prepareRepoForLocalIndex(
  */
 export async function recordLocalIndexProgress(
   repoId: string,
-  startedAt: number,
+  startedAt: number | null,
   delta: { indexedFiles: number; totalChunks: number; totalVectors: number; totalFiles?: number },
   commit: boolean,
 ): Promise<void> {
@@ -265,7 +265,12 @@ export async function recordLocalIndexProgress(
         ? {
             indexStatus: "indexed",
             indexedAt: new Date(),
-            indexDurationMs: Date.now() - startedAt,
+            // Only report a duration when the start time is reliable (a
+            // single-batch upload, where the finalizing request also began the
+            // index). Multi-batch uploads are stateless per request with no
+            // persisted whole-index start, so report null rather than a
+            // misleading last-batch-only duration.
+            indexDurationMs: startedAt != null ? Date.now() - startedAt : null,
           }
         : {}),
     },

--- a/apps/web/lib/index-local.ts
+++ b/apps/web/lib/index-local.ts
@@ -1,0 +1,280 @@
+import "server-only";
+import crypto from "node:crypto";
+import { prisma } from "@octopus/db";
+import { chunkText, shouldIndex, MAX_FILE_SIZE } from "@/lib/index-chunking";
+import { createEmbeddings } from "@/lib/embeddings";
+import { generateSparseVectors } from "@/lib/sparse-vector";
+import { upsertChunks, deleteRepoChunks } from "@/lib/qdrant";
+import { type Ignore } from "@/lib/octopus-ignore";
+
+/**
+ * CLI-driven local indexing.
+ *
+ * Mirror of the github/gitlab/bitbucket indexing paths in `indexer.ts`, but
+ * the file contents arrive over HTTP from the CLI instead of being cloned or
+ * fetched server-side. Shares `chunkText` + `shouldIndex` + embeddings + qdrant
+ * upsert with the canonical path so retrieval quality stays consistent —
+ * a CLI-indexed repo gets the same chunk shape as a webhook-indexed one.
+ *
+ * The CLI uploads files in byte-budgeted batches so a 50 MB repo doesn't
+ * have to fit in one HTTP request. Each batch is processed end-to-end
+ * synchronously (chunk → embed → upsert) so the CLI can render progress
+ * meaningfully — "batch 12/40 done" maps to real work. The repo row tracks
+ * the running indexedFiles count so a poll-based UI also works.
+ */
+
+/**
+ * Time after which an "indexing"-status repo is considered abandoned and
+ * may be re-claimed. Exported so the route's error message can quote the
+ * exact same value the guard uses — without this the message would drift
+ * out of sync with the guard.
+ */
+export const IN_FLIGHT_WINDOW_MS = 5 * 60 * 1000;
+
+export type LocalFile = { path: string; content: string };
+
+export type IndexLocalBatchResult = {
+  indexedInBatch: number;
+  skippedInBatch: number;
+  chunksInBatch: number;
+};
+
+/**
+ * Process one batch of CLI-uploaded files into chunks + embeddings + Qdrant
+ * points. `organizationId` is required so:
+ *   1. Embeddings resolve through the same `getEmbedModel(orgId, repoId)`
+ *      chain the review query path uses (review-core.ts:216). Without this
+ *      the index would embed with the env-default model while the query
+ *      embeds with the org/repo override — different embedding spaces,
+ *      sometimes different dims → Qdrant 400 or silently garbage retrieval.
+ *   2. `createEmbeddings` logs an `ai_usage` row (provider + tokens) so
+ *      CLI-driven indexing spend is visible to the spend-limit check and
+ *      billing/reporting, matching the review path.
+ */
+export async function indexLocalBatch(
+  repoId: string,
+  fullName: string,
+  organizationId: string,
+  files: LocalFile[],
+  ig?: Ignore,
+): Promise<IndexLocalBatchResult> {
+  let indexed = 0;
+  let skipped = 0;
+  const allChunks: { text: string; filePath: string; startLine: number; endLine: number }[] = [];
+
+  for (const file of files) {
+    if (!shouldIndex(file.path, file.content.length, ig)) {
+      skipped++;
+      continue;
+    }
+    if (file.content.length > MAX_FILE_SIZE) {
+      skipped++;
+      continue;
+    }
+    if (file.content.includes("\0")) {
+      skipped++;
+      continue;
+    }
+    const chunks = chunkText(file.content, file.path);
+    for (const c of chunks) {
+      allChunks.push({ text: c.text, filePath: file.path, startLine: c.startLine, endLine: c.endLine });
+    }
+    indexed++;
+  }
+
+  if (allChunks.length === 0) {
+    return { indexedInBatch: indexed, skippedInBatch: skipped, chunksInBatch: 0 };
+  }
+
+  // Embed + upsert. Single batch through createEmbeddings — its internal
+  // sub-batching handles OpenAI's 200k-token limit, so we don't double up.
+  // Tracking ensures: (a) the same getEmbedModel chain as the query path,
+  // (b) an ai_usage row so spend accounting is honest.
+  const texts = allChunks.map((c) => c.text);
+  const vectors = await createEmbeddings(texts, {
+    organizationId,
+    operation: "index-local",
+    repositoryId: repoId,
+  });
+
+  // Defense-in-depth: createEmbeddings returns empty vectors when the org
+  // is over its spend limit. The route gate ahead of us already 402s in
+  // that case, but if it ever fails open we'd upsert zero-length vectors
+  // which Qdrant accepts but produces garbage retrieval — fail loud
+  // instead so we never poison the index. Three checks because the
+  // failure modes are distinct:
+  //   1. vectors.length !== texts.length — createEmbeddings dropped some
+  //      inputs (whitespace filter) but the caller expects 1:1 here since
+  //      texts were already validated upstream
+  //   2. vectors.length === 0 — outer call returned nothing
+  //   3. any zero-length vector — over-spend-limit return shape
+  // The original `vectors.every(...)` returned true on `[]` (vacuously)
+  // and missed (1) + (2), so a fail-open in either of those would still
+  // produce a garbage index.
+  if (
+    vectors.length !== texts.length ||
+    vectors.length === 0 ||
+    vectors.some((v) => v.length === 0)
+  ) {
+    throw new Error(
+      `Embedding step returned ${vectors.length} vectors for ${texts.length} inputs (or empty vectors — likely org over spend limit). Aborting upsert to avoid poisoning the index.`,
+    );
+  }
+
+  const sparse = generateSparseVectors(texts);
+
+  const indexedAt = new Date().toISOString();
+  const points = allChunks.map((chunk, i) => ({
+    id: crypto.randomUUID(),
+    vector: vectors[i],
+    sparseVector: sparse[i],
+    payload: {
+      repoId,
+      fullName,
+      filePath: chunk.filePath,
+      startLine: chunk.startLine,
+      endLine: chunk.endLine,
+      text: chunk.text,
+      language: chunk.filePath.split(".").pop() ?? "unknown",
+      indexedAt,
+    },
+  }));
+
+  await upsertChunks(points);
+
+  return { indexedInBatch: indexed, skippedInBatch: skipped, chunksInBatch: points.length };
+}
+
+/**
+ * Find-or-create the Repository row for a CLI-uploaded index. Called from the
+ * first batch (batchIndex === 0). Existing rows with an `installationId` are
+ * rejected — those are managed by the git-platform webhook flow and the CLI
+ * shouldn't be racing the webhook's index runs against them.
+ *
+ * Returns the repoId on success or a typed reason on rejection so the
+ * endpoint can map it to a meaningful HTTP status.
+ */
+export async function prepareRepoForLocalIndex(
+  organizationId: string,
+  provider: "github" | "gitlab" | "bitbucket",
+  fullName: string,
+  defaultBranch: string,
+): Promise<
+  | { ok: true; repoId: string; reIndex: boolean }
+  | { ok: false; reason: "managed-by-platform"; repoId: string }
+  | { ok: false; reason: "in-flight"; repoId: string }
+> {
+  const existing = await prisma.repository.findFirst({
+    where: { organizationId, provider, fullName, isActive: true },
+    select: { id: true, installationId: true, externalId: true, indexStatus: true, updatedAt: true },
+  });
+
+  if (existing) {
+    // Only ever claim/wipe CLI-created rows (externalId "cli:<provider>:<fullName>").
+    // A row with an installationId OR any non-`cli:` externalId is managed by the
+    // platform webhook / GitHub-Action flow (the Action creates rows with a
+    // numeric externalId and installationId=null) — never hijack or wipe those.
+    if (existing.installationId != null || !existing.externalId?.startsWith("cli:")) {
+      return { ok: false, reason: "managed-by-platform", repoId: existing.id };
+    }
+    // Re-index guard: if a concurrent run is mid-way (indexStatus="indexing"
+    // and updated within the IN_FLIGHT_WINDOW_MS staleness window), reject
+    // this batch instead of wiping the in-flight run's chunks. Without
+    // this, a second `octp review --index` collides with the first — run
+    // B's first batch deletes A's already-upserted chunks and resets
+    // counters, then A's later batches keep upserting under A's repoId,
+    // ending in a partially-mixed chunk set and inconsistent counters.
+    //
+    // ATOMIC CLAIM: the prior implementation read+returned then updated,
+    // which was a textbook TOCTOU — two concurrent runs both saw status
+    // != "indexing", both passed the guard, both wiped. The current
+    // pattern issues ONE `updateMany` that conditionally flips status
+    // to "indexing" only if the existing row is not already in-flight.
+    // Whichever caller's updateMany count comes back as 1 owns the run;
+    // count===0 means someone else flipped it first, so we return
+    // in-flight without wiping. Postgres serialises updateMany on the
+    // matching rows, so there is no window between the WHERE and SET.
+    const inFlightCutoff = new Date(Date.now() - IN_FLIGHT_WINDOW_MS);
+    const claim = await prisma.repository.updateMany({
+      where: {
+        id: existing.id,
+        OR: [
+          { indexStatus: { not: "indexing" } },
+          { updatedAt: { lt: inFlightCutoff } },
+        ],
+      },
+      data: {
+        indexStatus: "indexing",
+        indexedFiles: 0,
+        totalFiles: 0,
+        totalChunks: 0,
+        totalVectors: 0,
+        indexDurationMs: null,
+      },
+    });
+    if (claim.count === 0) {
+      return { ok: false, reason: "in-flight", repoId: existing.id };
+    }
+    // We hold the claim now — safe to wipe chunks without racing another run.
+    await deleteRepoChunks(existing.id);
+    return { ok: true, repoId: existing.id, reIndex: true };
+  }
+
+  // New row. `externalId` would normally be the platform's repo ID — we don't
+  // have one, so fingerprint the local identity as `cli:<provider>:<fullName>`
+  // to satisfy the unique constraint without colliding with platform-managed rows.
+  const externalId = `cli:${provider}:${fullName}`;
+  const name = fullName.split("/").pop() ?? fullName;
+
+  const repo = await prisma.repository.create({
+    data: {
+      organizationId,
+      provider,
+      fullName,
+      name,
+      externalId,
+      defaultBranch,
+      installationId: null,
+      isActive: true,
+      autoReview: false, // no webhooks for CLI-local repos — auto-review doesn't apply
+      indexStatus: "indexing",
+    },
+    select: { id: true },
+  });
+  return { ok: true, repoId: repo.id, reIndex: false };
+}
+
+/**
+ * Apply per-batch progress to the Repository row. Called after each batch
+ * succeeds. `commit` flips the status to "indexed" on the final batch.
+ */
+export async function recordLocalIndexProgress(
+  repoId: string,
+  startedAt: number,
+  delta: { indexedFiles: number; totalChunks: number; totalVectors: number; totalFiles?: number },
+  commit: boolean,
+): Promise<void> {
+  await prisma.repository.update({
+    where: { id: repoId },
+    data: {
+      indexedFiles: { increment: delta.indexedFiles },
+      totalChunks: { increment: delta.totalChunks },
+      totalVectors: { increment: delta.totalVectors },
+      ...(delta.totalFiles != null ? { totalFiles: delta.totalFiles } : {}),
+      ...(commit
+        ? {
+            indexStatus: "indexed",
+            indexedAt: new Date(),
+            indexDurationMs: Date.now() - startedAt,
+          }
+        : {}),
+    },
+  });
+}
+
+export async function markLocalIndexFailed(repoId: string): Promise<void> {
+  await prisma.repository.update({
+    where: { id: repoId },
+    data: { indexStatus: "failed" },
+  });
+}

--- a/apps/web/lib/indexer.ts
+++ b/apps/web/lib/indexer.ts
@@ -10,30 +10,11 @@ import * as gitlabLib from "@/lib/gitlab";
 import { ensureCollection, upsertChunks, deleteRepoChunks, deleteRepoFileChunks } from "@/lib/qdrant";
 import { generateSparseVectors } from "@/lib/sparse-vector";
 import { parseOctopusIgnore, type Ignore } from "@/lib/octopus-ignore";
+import { shouldIndex, chunkText, MAX_FILE_SIZE } from "@/lib/index-chunking";
 
 const execFileAsync = promisify(execFile);
 
 const GITHUB_API = "https://api.github.com";
-const MAX_FILE_SIZE = 100_000; // 100KB — skip larger files
-const CHUNK_SIZE = 1500; // ~375 tokens
-const CHUNK_OVERLAP = 200;
-
-// File extensions we want to index
-const CODE_EXTENSIONS = new Set([
-  ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs", ".java", ".rb",
-  ".c", ".cpp", ".h", ".hpp", ".cs", ".swift", ".kt", ".scala",
-  ".vue", ".svelte", ".astro", ".html", ".css", ".scss",
-  ".sql", ".graphql", ".proto", ".yaml", ".yml", ".toml",
-  ".md", ".mdx", ".txt", ".json", ".xml",
-  ".sh", ".bash", ".zsh", ".fish",
-  ".dockerfile", ".prisma", ".env.example",
-]);
-
-const IGNORE_PATHS = [
-  "node_modules/", ".git/", "dist/", "build/", ".next/",
-  "vendor/", "__pycache__/", ".turbo/", "coverage/",
-  "package-lock.json", "bun.lock", "yarn.lock", "pnpm-lock.yaml",
-];
 
 interface TreeItem {
   path: string;
@@ -45,83 +26,6 @@ interface TreeItem {
 export type LogLevel = "info" | "success" | "error" | "warning";
 
 export type OnLog = (message: string, level?: LogLevel) => void;
-
-function shouldIndex(path: string, size?: number, ig?: Ignore): boolean {
-  if (size && size > MAX_FILE_SIZE) return false;
-  if (IGNORE_PATHS.some((p) => path.includes(p))) return false;
-  if (ig?.ignores(path)) return false;
-
-  const ext = "." + path.split(".").pop()?.toLowerCase();
-  const basename = path.split("/").pop() ?? "";
-
-  // Handle extensionless files like Dockerfile, Makefile
-  if (basename === "Dockerfile" || basename === "Makefile") return true;
-
-  return CODE_EXTENSIONS.has(ext);
-}
-
-function chunkText(
-  content: string,
-  filePath: string,
-): { text: string; startLine: number; endLine: number }[] {
-  const lines = content.split("\n");
-  const chunks: { text: string; startLine: number; endLine: number }[] = [];
-
-  let currentChunk = "";
-  let startLine = 1;
-  let currentLine = 1;
-
-  for (const line of lines) {
-    // If a single line exceeds CHUNK_SIZE, split it into smaller pieces
-    if (line.length > CHUNK_SIZE) {
-      // First, flush any accumulated chunk
-      if (currentChunk.length > 0) {
-        chunks.push({
-          text: `// File: ${filePath}\n${currentChunk}`,
-          startLine,
-          endLine: currentLine - 1,
-        });
-        currentChunk = "";
-      }
-
-      // Split the long line into CHUNK_SIZE pieces
-      for (let j = 0; j < line.length; j += CHUNK_SIZE - CHUNK_OVERLAP) {
-        const piece = line.slice(j, j + CHUNK_SIZE);
-        chunks.push({
-          text: `// File: ${filePath}\n${piece}`,
-          startLine: currentLine,
-          endLine: currentLine,
-        });
-      }
-
-      startLine = currentLine + 1;
-    } else if (currentChunk.length + line.length + 1 > CHUNK_SIZE && currentChunk.length > 0) {
-      chunks.push({
-        text: `// File: ${filePath}\n${currentChunk}`,
-        startLine,
-        endLine: currentLine - 1,
-      });
-
-      // Overlap: go back a few lines
-      const overlapLines = currentChunk.split("\n").slice(-3);
-      currentChunk = overlapLines.join("\n") + "\n" + line;
-      startLine = currentLine - overlapLines.length;
-    } else {
-      currentChunk += (currentChunk ? "\n" : "") + line;
-    }
-    currentLine++;
-  }
-
-  if (currentChunk.trim()) {
-    chunks.push({
-      text: `// File: ${filePath}\n${currentChunk}`,
-      startLine,
-      endLine: currentLine - 1,
-    });
-  }
-
-  return chunks;
-}
 
 export interface Contributor {
   login: string;

--- a/apps/web/lib/providers/url-validation.ts
+++ b/apps/web/lib/providers/url-validation.ts
@@ -1,0 +1,102 @@
+/**
+ * URL validation for provider base URLs accepted from per-org configuration.
+ *
+ * Several providers (ollama, acp, opencode, claude-code, future custom
+ * endpoints) let an org admin set a `<provider>BaseUrl` column that becomes
+ * the target of a server-side fetch. Without validation this is a classic
+ * SSRF primitive — an admin can point at:
+ *
+ *   - cloud metadata endpoints (169.254.169.254 on AWS / Azure / GCP)
+ *   - internal services on the deployment's VPC
+ *   - arbitrary external hosts (for exfiltration of prompt content, which
+ *     in code-review can include source code from indexed repos)
+ *
+ * Use `validateProviderUrl(raw, { hosted })` at the boundary where the
+ * org-supplied URL becomes a `fetch()` baseURL. Throws on any rejection so
+ * the provider can surface a clear error rather than performing the request.
+ *
+ * In self-hosted mode we permit private / loopback / link-local hosts since
+ * those are how operators connect to Ollama-on-the-same-machine or
+ * acp-on-an-internal-LAN. The `hosted` flag flips the default behavior:
+ * hosted=true → block private ranges; hosted=false (or absent) → allow.
+ */
+
+export type UrlValidationOptions = {
+  /**
+   * When true, block private / loopback / link-local hosts. Defaults to
+   * `process.env.SELF_HOSTED !== "true"` so cloud deployments are protected
+   * by default and self-hosted users can point at localhost / 10.x / 192.168.x.
+   */
+  hosted?: boolean;
+};
+
+// Patterns run against the WHATWG-canonicalized hostname (brackets stripped),
+// so we only need to match canonical forms — e.g. `[0:0:0:0:0:0:0:1]` already
+// canonicalizes to `::1` before reaching these patterns.
+const PRIVATE_HOST_PATTERNS: RegExp[] = [
+  /^localhost$/i,
+  /^127\./,                                  // loopback
+  /^0\.0\.0\.0$/,                            // IPv4 wildcard — Linux/macOS route this to loopback
+  /^10\./,                                   // RFC1918
+  /^192\.168\./,                             // RFC1918
+  /^172\.(1[6-9]|2\d|3[01])\./,              // RFC1918
+  /^169\.254\./,                             // link-local (cloud metadata!)
+  /^fe80:/i,                                 // IPv6 link-local
+  /^::1$/i,                                  // IPv6 loopback
+  /^::$/,                                    // IPv6 unspecified
+  /^::ffff:/i,                               // IPv4-mapped IPv6 — kernel routes to embedded v4 (bypasses 169.254. via [::ffff:169.254.169.254])
+  /^2002:/i,                                 // 6to4 (RFC 3056) — embeds a v4 in the next 32 bits; [2002:7f00:1::] reaches 127.0.0.1
+  /^64:ff9b:/i,                              // NAT64 well-known prefix (RFC 6052) — last 32 bits is v4; [64:ff9b::a9fe:a9fe] reaches 169.254.169.254
+  /^::[0-9a-f]{1,4}:[0-9a-f]{1,4}$/i,        // IPv4-compatible IPv6 (RFC 4291 §2.5.5.1, deprecated) — `::a.b.c.d` canonicalizes to `::H:H` and reaches embedded v4
+  /^fc[0-9a-f][0-9a-f]:/i,                   // IPv6 unique local (fc00::/7)
+  /^fd[0-9a-f][0-9a-f]:/i,                   // IPv6 unique local
+];
+
+/**
+ * Normalize the hostname returned by `URL` so the patterns above match
+ * canonical strings only. `URL.hostname` keeps brackets on IPv6, and we
+ * want consistent lowercase comparisons.
+ */
+function canonicalHost(parsed: URL): string {
+  return parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+}
+
+/**
+ * Validate and normalize a provider base URL. Returns the canonical origin
+ * (scheme + host + port) with any path / query / fragment stripped and
+ * trailing slashes removed. Throws on rejection.
+ */
+export function validateProviderUrl(
+  raw: string,
+  options: UrlValidationOptions = {},
+): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw new Error("Provider URL is empty");
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Provider URL is not parseable: ${trimmed.slice(0, 80)}`);
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`Provider URL must use http(s); got ${parsed.protocol}`);
+  }
+
+  const host = canonicalHost(parsed);
+  const hosted = options.hosted ?? process.env.SELF_HOSTED !== "true";
+  if (hosted) {
+    if (PRIVATE_HOST_PATTERNS.some((re) => re.test(host))) {
+      throw new Error(
+        `Provider URL host "${host}" is private/loopback/link-local; ` +
+          "rejected in hosted mode (set SELF_HOSTED=true on the deployment if intentional).",
+      );
+    }
+  }
+
+  // Return origin only — drop any path / query / fragment that came in.
+  return parsed.origin;
+}

--- a/apps/web/lib/qdrant.ts
+++ b/apps/web/lib/qdrant.ts
@@ -1,6 +1,7 @@
 import { createHash } from "crypto";
 import { QdrantClient } from "@qdrant/js-client-rest";
 import { generateSparseVector } from "@/lib/sparse-vector";
+import { getEmbedConfig } from "@/lib/embed-config";
 
 // Qdrant point IDs must be uint or UUID. Existing UUID inputs pass through
 // unchanged (so callers using crypto.randomUUID() are unaffected); non-UUID
@@ -95,7 +96,12 @@ async function withQdrantRetry<T>(fn: () => Promise<T>, label: string, maxAttemp
 }
 
 const COLLECTION_NAME = "code_chunks";
-const VECTOR_SIZE = 3072; // text-embedding-3-large
+// Dense-vector dim resolved from env via getEmbedConfig() (default 3072 for
+// text-embedding-3-large) so self-hosters can swap to Ollama embeddings (eg.
+// 768 for nomic-embed-text) without source edits. Resolved once at module
+// load; changing OCTOPUS_EMBED_DIM after collections exist requires recreating
+// them, since different models produce non-comparable vectors.
+const VECTOR_SIZE = getEmbedConfig().dim;
 /**
  * The dim used for dense vectors in EVERY collection this module creates —
  * code_chunks, knowledge, review, chat, diagram, feedback, docs. They all

--- a/apps/web/scripts/migrate-collections-sparse.ts
+++ b/apps/web/scripts/migrate-collections-sparse.ts
@@ -14,8 +14,12 @@
 
 import { QdrantClient } from "@qdrant/js-client-rest";
 import { generateSparseVector } from "@/lib/sparse-vector";
+import { getEmbedConfig } from "@/lib/embed-config";
 
-const VECTOR_SIZE = 3072;
+// Match the dim the app uses (env-resolved via getEmbedConfig, default 3072)
+// so a self-hoster on a non-default OCTOPUS_EMBED_DIM recreates collections
+// at the right size instead of a hardcoded 3072.
+const VECTOR_SIZE = getEmbedConfig().dim;
 const SPARSE_VECTOR_NAME = "sparse";
 const BATCH_SIZE = 100;
 


### PR DESCRIPTION
## What
Second slice of the octp CLI backend: local indexing (for `octp review --index`) + optional **all-local Ollama embeddings**. Additive — no schema change.

- **`embeddings.ts`** — OpenAI **or** Ollama, selected via env (`getEmbedConfig`). Per-org embed-model override applies to OpenAI only; in Ollama mode the env model wins (otherwise `getEmbedModel`'s OpenAI fallback would be POSTed to Ollama and fail).
- **`embed-config.ts`** — `OCTOPUS_EMBED_PROVIDER/MODEL/DIM/OLLAMA_BASE_URL` (defaults: openai / text-embedding-3-large / 3072 → behavior unchanged when unset).
- **`index-chunking.ts`** — `shouldIndex/chunkText/MAX_FILE_SIZE` extracted from `indexer.ts` (single source of truth). **`url-validation.ts`** — SSRF guard for the Ollama embed URL.
- **`index-local.ts` + `api/cli/repos/index-local`** — byte-budgeted upload to index an unconnected working tree. Auth + spend-gated; only ever claims **CLI-created (`cli:`) Repository rows** so it can never wipe/hijack a platform- or GitHub-Action-managed repo; spend pre-check before the row is created.
- **`qdrant.ts`** — `VECTOR_SIZE` from env, but **keeps** the `QDRANT_DENSE_VECTOR_SIZE` export and the empty-vector upsert guards (the fork had dropped both). `migrate-collections-sparse` uses the env dim.

## 3-way-merge safety (no origin regression)
- `createEmbeddings` keeps origin's contract (returns `[]` over spend limit / for filtered inputs, positional mapping intact); the dim-mismatch guard is preserved for both providers (test rewritten to the new message).
- qdrant empty-vector guards + the dim export are retained (fork had removed them).
- Default (no `OCTOPUS_EMBED_*`) = OpenAI / 3072 — existing deployments unaffected.

## Validation
Adversarial pass (embeddings/qdrant no-regression / index-local / scope): embeddings+qdrant SOLID; fixed the blocker it found (Ollama org-path was sending the OpenAI model — now provider-aware) and the major (index-local could claim a GitHub-Action repo — now `cli:`-row-only) + a phantom-row minor.

## Test plan
- [x] typecheck / lint / build clean; `bun test` embeddings-dim-check + embed-config + url-validation = 35/0. index-local exercised by the CLI (Slice 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)