### PR TITLE
feat(cli): octp — native CLI (onboarding, review, agent serve, doctor)

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md — apps/cli
+
+Scoped rules for this package. The root [AGENTS.md](../../AGENTS.md) still applies.
+
+This package is **the Octopus CLI** (`octp` binary). It replaces the previous npm-published `@octp/cli` — distributed natively via curl/irm, includes onboarding as a built-in TUI wizard.
+
+## Stack constraints
+
+- Built with **ink ^6** (React for terminals). Do **not** introduce a second TUI library.
+- No Next.js, no Prisma, no database access. This package runs on the user's laptop with zero infrastructure.
+- All persistence is to files under `$OCTOPUS_HOME` (default `~/.octopus/`). HTTP calls allowed for explicit needs only (auth, provider validation, repo listing).
+- Secrets stay in `byok.json` / `credentials` — never in `config.json` (the prefs file must remain safe to `cat`).
+
+## Subcommand conventions
+
+- Subcommands dispatch from `src/index.tsx`'s `main()`. The set of recognised commands is the `KNOWN_SUBCOMMANDS` set — keep it in sync with `printHelp()`.
+- Unknown subcommands and unknown flags fail fast with exit code 2 and a help hint. **Do not silently accept** unknown input; that's how typos waste users' time.
+- New subcommands belong in `src/commands/<name>.ts`, exporting an async function that returns an exit code. `main()` should be a one-line dispatch per command, not a place for business logic.
+
+## Step component conventions (onboarding)
+
+- Each step is a self-contained component in `src/steps/`.
+- Props: `{ onNext: (patch?) => void; onBack?: () => void }`. The wizard owns the answer accumulator; the step calls `onNext` with the fields it collected.
+- Steps that do work (auth, validation, save) hold an internal `phase` state of `running | done | failed | skipped`. On `failed`, surface the error inline and offer `Enter to retry / Esc to skip`.
+- Footer hint convention: `Press Enter to continue · Esc to skip · Left to go back`. Keep it on the last line of every step.
+
+## Don't
+
+- Don't render to `process.stdout` directly. Pipe subprocess output into React state, then render it.
+- Don't `process.exit()` from a step. Call `useApp().exit()` so ink can clean up the terminal.
+- Don't add `chalk` / `kleur` / other color libraries — use ink's `<Text color>` prop.
+- Don't add a Node-only dependency that breaks Bun's `--compile` (no native modules without testing the cross-compile path).
+
+## Testing
+
+- `bun test` with `bun:test`. Use a per-test `OCTOPUS_HOME = mkdtemp()` and clean up in `afterEach`.
+- Step components don't need full ink render tests yet (testing ink is awkward); cover the `lib/` utilities thoroughly instead and integration-test the wizard end-to-end in a follow-up.
+
+## Release flow
+
+1. Bump `package.json` version
+2. `git tag octp-v0.X.Y && git push <remote> octp-v0.X.Y`
+3. `.github/workflows/octp-release.yml` cross-compiles all five targets and publishes the GitHub Release with `SHA256SUMS.txt`
+4. `install.sh` / `install.ps1` automatically pick it up — no manual update needed

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,121 @@
+# @octopus/cli
+
+The Octopus CLI. Built with [ink](https://github.com/vadimdemedes/ink) (React for terminals), distributed as a **native single binary** (Bun-compiled). No Node, no npm install, no runtime dependencies.
+
+Replaces the previous npm-published `@octp/cli` package — different distribution model, more features.
+
+## Install
+
+### macOS / Linux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/octopusreview/octopus/master/apps/cli/install/install.sh | bash
+```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/octopusreview/octopus/master/apps/cli/install/install.ps1 | iex
+```
+
+Both installers:
+
+1. Detect your OS + CPU architecture
+2. Fetch the latest `octp-v*` release from GitHub
+3. Download the matching binary
+4. Install it to `~/.octopus/bin/octp` (override with `OCTOPUS_INSTALL_DIR`)
+5. Print a one-liner to add the install directory to your `PATH` (or update it directly on Windows)
+
+Environment variables both installers respect:
+
+| Variable | Purpose |
+|---|---|
+| `OCTOPUS_INSTALL_DIR` | Override install directory |
+| `OCTOPUS_INSTALL_REPO` | Override the GitHub repo (e.g. for forks) |
+| `OCTOPUS_INSTALL_TAG` | Pin a specific tag instead of fetching latest |
+
+## Commands
+
+```
+octp                       Launch the onboarding wizard (first run) or dashboard
+octp onboard [--reset]     Run the onboarding wizard explicitly
+octp review [--staged]     Review local changes before opening a PR
+                           --staged: only diff what's in the staging index
+                           --since <ref>: diff from <ref> instead of HEAD
+                           --index: index the working tree for context-aware review
+                           --no-index: skip the index prompt, review in bare mode
+octp agent serve           Start the local-agent bridge for Ollama / Claude CLI
+octp doctor                Environment + auth health check
+octp config <get|set>      Manage ~/.octopus/config.json               (coming soon)
+octp --version | -v        Print version
+octp --help | -h           Print this help
+```
+
+The first invocation of bare `octp` triggers the onboarding wizard:
+
+1. **Welcome** — what Octopus is, in three sentences
+2. **Auth** — sign in to the hosted Octopus account *or* point at a self-hosted instance
+3. **Org** — pick the organisation context (hosted only)
+4. **Provider** — pick which AI provider runs the review (Claude / OpenAI / Google / Cohere; with Workstream 5 also Grok / ACPX / OpenCode / Ollama)
+5. **Model** — pick a model from the chosen provider
+6. **BYOK** — enter the API key (or skip and use the org's platform key)
+7. **Validate** — live API ping to confirm the key works
+8. **Repo install** — pick a GitHub repo and install the Octopus App (hosted only)
+9. **Done** — summary of what was configured + next steps
+
+Each step is small, has phase-state (`running | done | failed | skipped`), and follows the same footer convention: `Enter to continue · Esc to skip · Left to go back`.
+
+## Persistence
+
+State lives under `$OCTOPUS_HOME` (default `~/.octopus/`) in three files, all mode `0600` in a mode `0700` directory:
+
+| File | Purpose | Safe to cat? |
+|---|---|---|
+| `config.json` | Versioned prefs (chosen provider/model, defaults). Presence of `onboardedAt` gates first-run. | Yes |
+| `byok.json` | Provider API keys, separated from prefs. | No |
+| `credentials` | Auth tokens for the hosted Octopus account. | No |
+
+A corrupt or unreadable `config.json` is treated as missing — the onboarding wizard re-runs instead of crashing.
+
+## Opt-outs
+
+- `OCTOPUS_NO_ONBOARD=1` — permanent skip (env var)
+- `--skip-onboard` — one-shot skip (CLI flag)
+- `--reset` — re-runs the wizard, pre-seeding existing config
+
+## Build from source
+
+```bash
+cd apps/cli
+bun install
+bun run dev                       # run from source in your terminal
+bun run build:compile             # cross-compile all 5 native targets to dist/
+bun run build:compile:darwin-arm64  # single target
+bun test                          # run unit tests
+```
+
+Cross-compile targets:
+
+| Asset | Platform |
+|---|---|
+| `octp-linux-x64` | Linux Intel/AMD |
+| `octp-linux-arm64` | Linux ARM (Raspberry Pi, AWS Graviton) |
+| `octp-darwin-x64` | macOS Intel |
+| `octp-darwin-arm64` | macOS Apple Silicon |
+| `octp-windows-x64.exe` | Windows Intel/AMD |
+
+## Releases
+
+Tagging `octp-v<semver>` on the upstream repo triggers `.github/workflows/octp-release.yml`, which cross-compiles all five binaries, generates SHA256 checksums, and publishes a GitHub Release with auto-generated notes. The install scripts always fetch the latest tagged release.
+
+```bash
+# bump apps/cli/package.json version first, commit, then:
+git tag octp-v0.1.0
+git push origin octp-v0.1.0
+```
+
+## Status
+
+The onboarding wizard, `octp review`, `octp agent serve`, and `octp doctor`
+all ship. Only `octp config <get|set>` is still on the roadmap — set
+config values via the wizard (`octp onboard --reset`) until then.

--- a/apps/cli/install/install.ps1
+++ b/apps/cli/install/install.ps1
@@ -1,0 +1,125 @@
+# Octopus CLI installer (Windows / PowerShell).
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/octopusreview/octopus/master/apps/cli/install/install.ps1 | iex
+#
+# What it does:
+#   1. Detects your CPU architecture
+#   2. Fetches the latest `octp-v*` release from GitHub
+#   3. Downloads the matching native .exe
+#   4. Installs it to $env:USERPROFILE\.octopus\bin\octp.exe (or $env:OCTOPUS_INSTALL_DIR)
+#   5. Adds the install directory to your user PATH (idempotent)
+#
+# After install, run `octp` to launch the first-run onboarding wizard.
+#
+# Environment variables:
+#   $env:OCTOPUS_INSTALL_DIR   Override install directory
+#   $env:OCTOPUS_INSTALL_REPO  Override the GitHub repo (default: octopusreview/octopus)
+#   $env:OCTOPUS_INSTALL_TAG   Install a specific tag instead of latest
+
+$ErrorActionPreference = "Stop"
+
+$Repo        = if ($env:OCTOPUS_INSTALL_REPO) { $env:OCTOPUS_INSTALL_REPO } else { "octopusreview/octopus" }
+$InstallDir  = if ($env:OCTOPUS_INSTALL_DIR)  { $env:OCTOPUS_INSTALL_DIR }  else { Join-Path $env:USERPROFILE ".octopus\bin" }
+$BinaryName  = "octp.exe"
+
+# ── Step 1: arch ─────────────────────────────────────────────────────────────
+
+# We only ship x64 today. ARM64 Windows can fall back to x64 emulation; if a
+# native ARM64 build is added later, expand this map.
+$arch = "x64"
+$asset = "octp-windows-${arch}.exe"
+
+# ── Step 2: resolve release tag ──────────────────────────────────────────────
+
+if ($env:OCTOPUS_INSTALL_TAG) {
+  $tag = $env:OCTOPUS_INSTALL_TAG
+  Write-Host "Installing pinned version: $tag"
+} else {
+  Write-Host "Looking up latest octp release on $Repo ..."
+  # Find the most recent NON-DRAFT, NON-PRERELEASE octp-v* tag.
+  # Users testing prerelease tags can override via $env:OCTOPUS_INSTALL_TAG.
+  $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=30" -Headers @{ "User-Agent" = "octp-installer" }
+  $tag = (
+    $releases |
+      Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name -like "octp-v*" } |
+      Select-Object -First 1
+  ).tag_name
+  if (-not $tag) {
+    Write-Error "Could not find any non-prerelease octp-v* on $Repo. Pin a tag with `$env:OCTOPUS_INSTALL_TAG = 'octp-v0.X.Y'`."
+    exit 1
+  }
+  Write-Host "Latest release: $tag"
+}
+
+# ── Step 3: download ─────────────────────────────────────────────────────────
+
+$downloadUrl = "https://github.com/$Repo/releases/download/$tag/$asset"
+$sumsUrl = "https://github.com/$Repo/releases/download/$tag/SHA256SUMS.txt"
+Write-Host "Downloading $downloadUrl ..."
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+$target = Join-Path $InstallDir $BinaryName
+
+try {
+  Invoke-WebRequest -Uri $downloadUrl -OutFile $target -UseBasicParsing
+} catch {
+  Write-Error "Failed to download $asset from $tag. The release might not have a Windows binary."
+  exit 1
+}
+
+# ── Step 3b: verify SHA256 checksum ──────────────────────────────────────────
+# octp-release.yml generates SHA256SUMS.txt and attaches it to every release.
+# Verifying the binary against the published sum protects against in-flight
+# tampering and truncated downloads. Set $env:OCTOPUS_INSTALL_SKIP_VERIFY="1"
+# to bypass (only do this when pinning a tag pre-dating the sums workflow).
+
+if ($env:OCTOPUS_INSTALL_SKIP_VERIFY -eq "1") {
+  Write-Host "SKIPPING SHA256 verification (OCTOPUS_INSTALL_SKIP_VERIFY=1)."
+} else {
+  $sumsTmp = New-TemporaryFile
+  try {
+    try {
+      Invoke-WebRequest -Uri $sumsUrl -OutFile $sumsTmp -UseBasicParsing
+    } catch {
+      Remove-Item $target -Force -ErrorAction SilentlyContinue
+      Write-Error "Could not download SHA256SUMS.txt from $tag. Older releases pre-date the sums workflow — set `$env:OCTOPUS_INSTALL_SKIP_VERIFY='1' if you accept that risk."
+      exit 1
+    }
+    $expectedLine = Get-Content $sumsTmp | Where-Object { $_ -match "  $([Regex]::Escape($asset))$" } | Select-Object -First 1
+    if (-not $expectedLine) {
+      Remove-Item $target -Force -ErrorAction SilentlyContinue
+      Write-Error "No SHA256SUMS.txt entry for $asset on $tag. Set `$env:OCTOPUS_INSTALL_SKIP_VERIFY='1' to bypass (NOT recommended)."
+      exit 1
+    }
+    $expected = ($expectedLine -split "\s+")[0]
+    $actual = (Get-FileHash -Algorithm SHA256 -Path $target).Hash.ToLower()
+    if ($expected -ne $actual) {
+      Remove-Item $target -Force -ErrorAction SilentlyContinue
+      Write-Error "SHA256 mismatch for $asset. expected=$expected actual=$actual. The download may be corrupt or tampered. Aborting."
+      exit 1
+    }
+    Write-Host "Verified SHA256 ($expected)"
+  } finally {
+    Remove-Item $sumsTmp -Force -ErrorAction SilentlyContinue
+  }
+}
+
+Write-Host ""
+Write-Host "Installed octp → $target"
+
+# ── Step 4: PATH ─────────────────────────────────────────────────────────────
+
+$userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+$pathEntries = $userPath -split ";" | Where-Object { $_ -ne "" }
+if ($pathEntries -notcontains $InstallDir) {
+  $newPath = ($pathEntries + $InstallDir) -join ";"
+  [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+  Write-Host "Added $InstallDir to your user PATH."
+  Write-Host ""
+  Write-Host "Open a new PowerShell window, then run: octp"
+} else {
+  Write-Host "$InstallDir is already on your PATH."
+  Write-Host ""
+  Write-Host "Get started: octp"
+}

--- a/apps/cli/install/install.sh
+++ b/apps/cli/install/install.sh
@@ -134,16 +134,16 @@ if [ "${OCTOPUS_INSTALL_SKIP_VERIFY:-0}" = "1" ]; then
   echo "SKIPPING SHA256 verification (OCTOPUS_INSTALL_SKIP_VERIFY=1)."
 else
   if curl -fsSL -o "$sums_file" "$sums_url"; then
-    expected=$(grep -F "  $asset" "$sums_file" | awk '{print $1}')
+    expected=$(grep -F "  $asset" "$sums_file" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')
     if [ -z "$expected" ]; then
       echo "Error: no SHA256SUMS.txt entry for $asset on $tag." >&2
       echo "Run with OCTOPUS_INSTALL_SKIP_VERIFY=1 to bypass (NOT recommended)." >&2
       exit 1
     fi
     if command -v sha256sum >/dev/null 2>&1; then
-      actual=$(sha256sum "$tmp_file" | awk '{print $1}')
+      actual=$(sha256sum "$tmp_file" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')
     elif command -v shasum >/dev/null 2>&1; then
-      actual=$(shasum -a 256 "$tmp_file" | awk '{print $1}')
+      actual=$(shasum -a 256 "$tmp_file" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')
     else
       echo "Error: neither sha256sum nor shasum found; cannot verify the download." >&2
       echo "Run with OCTOPUS_INSTALL_SKIP_VERIFY=1 to bypass (NOT recommended)." >&2
@@ -168,7 +168,12 @@ fi
 # ── Step 4: install ──────────────────────────────────────────────────────────
 
 target="${INSTALL_DIR}/${BINARY_NAME}"
-mv "$tmp_file" "$target"
+# Keep the EXIT trap active across the move so a failed mv (bad perms / missing
+# INSTALL_DIR) still cleans up $tmp_file instead of leaking it.
+if ! mv "$tmp_file" "$target"; then
+  echo "Error: failed to install to $target (check permissions / INSTALL_DIR)." >&2
+  exit 1
+fi
 chmod +x "$target"
 trap - EXIT
 

--- a/apps/cli/install/install.sh
+++ b/apps/cli/install/install.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# Octopus CLI installer (Linux / macOS).
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/octopusreview/octopus/master/apps/cli/install/install.sh | bash
+#
+# The script's shebang is /usr/bin/env bash and it uses bash-isms
+# (set -o pipefail, `[[...]]` would-be patterns) — piping into `sh`
+# can break on dash/ash. Documented `| bash` accordingly.
+#
+# What it does:
+#   1. Detects your OS + CPU architecture
+#   2. Fetches the latest `octp-v*` release from GitHub
+#   3. Downloads the matching native binary
+#   4. Installs it to ~/.octopus/bin/octp (or $OCTOPUS_INSTALL_DIR)
+#   5. Prints a one-line instruction to add ~/.octopus/bin to your PATH (if not already there)
+#
+# After install, run `octp` to launch the first-run onboarding wizard.
+#
+# Environment variables:
+#   OCTOPUS_INSTALL_DIR  Override install directory (default: $HOME/.octopus/bin)
+#   OCTOPUS_INSTALL_REPO Override the GitHub repo (default: octopusreview/octopus)
+#   OCTOPUS_INSTALL_TAG  Install a specific tag instead of latest (e.g. octp-v0.2.0)
+#
+# Exit codes:
+#   0 success
+#   1 unsupported OS/arch, network failure, or write failure
+
+set -euo pipefail
+
+REPO="${OCTOPUS_INSTALL_REPO:-octopusreview/octopus}"
+INSTALL_DIR="${OCTOPUS_INSTALL_DIR:-$HOME/.octopus/bin}"
+BINARY_NAME="octp"
+
+# ── Step 1: detect platform ──────────────────────────────────────────────────
+
+uname_s=$(uname -s 2>/dev/null || echo "")
+uname_m=$(uname -m 2>/dev/null || echo "")
+
+case "$uname_s" in
+  Linux)  os="linux"  ;;
+  Darwin) os="darwin" ;;
+  *)
+    echo "Error: unsupported OS: $uname_s" >&2
+    echo "Supported: Linux, macOS. On Windows, use install.ps1 (PowerShell)." >&2
+    exit 1
+    ;;
+esac
+
+case "$uname_m" in
+  x86_64|amd64) arch="x64"   ;;
+  arm64|aarch64) arch="arm64" ;;
+  *)
+    echo "Error: unsupported CPU architecture: $uname_m" >&2
+    echo "Supported: x86_64, arm64." >&2
+    exit 1
+    ;;
+esac
+
+asset="${BINARY_NAME}-${os}-${arch}"
+
+# ── Step 2: resolve the release tag ──────────────────────────────────────────
+
+if [ -n "${OCTOPUS_INSTALL_TAG:-}" ]; then
+  tag="$OCTOPUS_INSTALL_TAG"
+  echo "Installing pinned version: $tag"
+else
+  echo "Looking up latest octp release on $REPO ..."
+  # Find the most recent NON-DRAFT, NON-PRERELEASE octp-v* tag.
+  # `jq` is not assumed (some minimal install targets — alpine, distroless,
+  # CI runners — don't have it), so parse with sed/grep. GitHub returns
+  # `/releases` as a JSON ARRAY where each release is one object on the
+  # same line. We split objects by inserting a real newline at every
+  # `},{` boundary so line-oriented grep can filter by draft/prerelease
+  # siblings without false-matching across objects.
+  #
+  # macOS portability: BSD sed treats `\n` in the REPLACEMENT as a
+  # literal `n` (only the recognise-`\n`-in-pattern semantics is shared
+  # with GNU sed). Use the portable form — a backslash immediately
+  # followed by a real newline character inside the s/// replacement,
+  # which both GNU and BSD sed interpret as a newline. The `[[:space:]]`
+  # POSIX class is used everywhere else for the same portability reason
+  # (GNU `\s` would silently match "s" on busybox grep / BSD sed).
+  # Users testing prerelease tags can still override via OCTOPUS_INSTALL_TAG.
+  api_url="https://api.github.com/repos/${REPO}/releases?per_page=30"
+  tag=$(
+    curl -fsSL "$api_url" \
+      | sed 's/},{/}\
+{/g' \
+      | grep -v '"draft"[[:space:]]*:[[:space:]]*true' \
+      | grep -v '"prerelease"[[:space:]]*:[[:space:]]*true' \
+      | grep -E '"tag_name"[[:space:]]*:[[:space:]]*"octp-v' \
+      | head -1 \
+      | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+  )
+  if [ -z "$tag" ]; then
+    echo "Error: could not find any non-prerelease octp-v* on $REPO." >&2
+    echo "If you are testing a prerelease, pin a tag with OCTOPUS_INSTALL_TAG=octp-v0.X.Y" >&2
+    exit 1
+  fi
+  echo "Latest release: $tag"
+fi
+
+# ── Step 3: download ─────────────────────────────────────────────────────────
+
+download_url="https://github.com/${REPO}/releases/download/${tag}/${asset}"
+sums_url="https://github.com/${REPO}/releases/download/${tag}/SHA256SUMS.txt"
+echo "Downloading $download_url ..."
+
+mkdir -p "$INSTALL_DIR"
+tmp_file="$(mktemp)"
+sums_file="$(mktemp)"
+trap 'rm -f "$tmp_file" "$sums_file"' EXIT
+
+if ! curl -fL --progress-bar -o "$tmp_file" "$download_url"; then
+  echo "Error: failed to download $asset from $tag." >&2
+  echo "The release might not have a binary for ${os}-${arch}." >&2
+  exit 1
+fi
+
+# ── Step 3b: verify SHA256 checksum ──────────────────────────────────────────
+# octp-release.yml generates SHA256SUMS.txt and attaches it to every release.
+# Verifying the binary against the published sum protects against:
+#   - In-flight tampering on a compromised mirror (GitHub itself signs the
+#     download but the asset chain is still worth re-checking).
+#   - Truncated downloads (curl exit code is the only signal otherwise).
+# If sums file is missing on a release (older builds), we abort with a clear
+# message — passing OCTOPUS_INSTALL_SKIP_VERIFY=1 documents the trade-off
+# explicitly when the user knowingly accepts the risk (e.g. CI pinning a tag
+# pre-dating the sums-generation workflow).
+
+if [ "${OCTOPUS_INSTALL_SKIP_VERIFY:-0}" = "1" ]; then
+  echo "SKIPPING SHA256 verification (OCTOPUS_INSTALL_SKIP_VERIFY=1)."
+else
+  if curl -fsSL -o "$sums_file" "$sums_url"; then
+    expected=$(grep -F "  $asset" "$sums_file" | awk '{print $1}')
+    if [ -z "$expected" ]; then
+      echo "Error: no SHA256SUMS.txt entry for $asset on $tag." >&2
+      echo "Run with OCTOPUS_INSTALL_SKIP_VERIFY=1 to bypass (NOT recommended)." >&2
+      exit 1
+    fi
+    if command -v sha256sum >/dev/null 2>&1; then
+      actual=$(sha256sum "$tmp_file" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+      actual=$(shasum -a 256 "$tmp_file" | awk '{print $1}')
+    else
+      echo "Error: neither sha256sum nor shasum found; cannot verify the download." >&2
+      echo "Run with OCTOPUS_INSTALL_SKIP_VERIFY=1 to bypass (NOT recommended)." >&2
+      exit 1
+    fi
+    if [ "$expected" != "$actual" ]; then
+      echo "Error: SHA256 mismatch for $asset." >&2
+      echo "  expected: $expected" >&2
+      echo "  actual:   $actual" >&2
+      echo "The download may be corrupt or tampered. Aborting." >&2
+      exit 1
+    fi
+    echo "✓ Verified SHA256 ($expected)"
+  else
+    echo "Error: could not download SHA256SUMS.txt from $tag." >&2
+    echo "Older releases pre-date the sums workflow — re-run with" >&2
+    echo "OCTOPUS_INSTALL_SKIP_VERIFY=1 if you accept that risk." >&2
+    exit 1
+  fi
+fi
+
+# ── Step 4: install ──────────────────────────────────────────────────────────
+
+target="${INSTALL_DIR}/${BINARY_NAME}"
+mv "$tmp_file" "$target"
+chmod +x "$target"
+trap - EXIT
+
+echo ""
+echo "Installed $BINARY_NAME → $target"
+
+# ── Step 5: PATH hint ────────────────────────────────────────────────────────
+
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*)
+    echo "$INSTALL_DIR is already on your PATH."
+    echo ""
+    echo "Get started: $BINARY_NAME"
+    ;;
+  *)
+    echo ""
+    echo "Add this line to your shell rc (~/.zshrc, ~/.bashrc, etc.):"
+    echo ""
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo ""
+    echo "Then restart your shell and run: $BINARY_NAME"
+    ;;
+esac

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@octopus/cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Octopus CLI. Native single-binary distribution via curl/irm. Includes a first-run TUI onboarding wizard.",
+  "scripts": {
+    "dev": "bun src/index.tsx",
+    "build": "bun build src/index.tsx --outdir dist --target node --minify",
+    "build:compile": "bun run build:compile:linux-x64 && bun run build:compile:linux-arm64 && bun run build:compile:darwin-x64 && bun run build:compile:darwin-arm64 && bun run build:compile:windows-x64",
+    "build:compile:linux-x64": "bun build src/index.tsx --compile --target=bun-linux-x64-modern --outfile=dist/octp-linux-x64",
+    "build:compile:linux-arm64": "bun build src/index.tsx --compile --target=bun-linux-arm64 --outfile=dist/octp-linux-arm64",
+    "build:compile:darwin-x64": "bun build src/index.tsx --compile --target=bun-darwin-x64 --outfile=dist/octp-darwin-x64",
+    "build:compile:darwin-arm64": "bun build src/index.tsx --compile --target=bun-darwin-arm64 --outfile=dist/octp-darwin-arm64",
+    "build:compile:windows-x64": "bun build src/index.tsx --compile --target=bun-windows-x64-modern --outfile=dist/octp-windows-x64.exe",
+    "lint": "echo 'lint: noop for now'",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "ink": "^6.8.0",
+    "ink-select-input": "^6.2.0",
+    "ink-text-input": "^6.0.0",
+    "react": "19.2.5",
+    "react-devtools-core": "^7.0.1"
+  },
+  "devDependencies": {
+    "@octopus/tsconfig": "workspace:*",
+    "@types/react": "^19",
+    "bun-types": "^1.3.12",
+    "typescript": "^5"
+  }
+}

--- a/apps/cli/src/OnboardWizard.tsx
+++ b/apps/cli/src/OnboardWizard.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Box } from "ink";
+import { Header } from "./components/Header.js";
+import { WelcomeStep } from "./steps/WelcomeStep.js";
+import { AuthStep } from "./steps/AuthStep.js";
+import { OrgStep } from "./steps/OrgStep.js";
+import { ProviderStep } from "./steps/ProviderStep.js";
+import { ModelStep } from "./steps/ModelStep.js";
+import { ByokStep } from "./steps/ByokStep.js";
+import { OllamaSetupStep } from "./steps/OllamaSetupStep.js";
+import { ValidateStep } from "./steps/ValidateStep.js";
+import { RepoStep } from "./steps/RepoStep.js";
+import { DoneStep } from "./steps/DoneStep.js";
+import { loadConfig, type OctopusConfig } from "./lib/config.js";
+
+/**
+ * Linear wizard with conditional skips via useMemo<StepKey[]>. Each step is
+ * a small component that calls `onNext(answers)` when the user advances; the
+ * wizard owns the answer accumulator and the step index. Add a new step by
+ * (1) adding a key to StepKey, (2) appending the component to the switch
+ * below, and (3) including/excluding it in the sequence useMemo based on
+ * environment (self-hosted vs hosted, etc.).
+ *
+ * Full flow: Welcome → Auth → Org → Provider → Model → BYOK → Validate →
+ * Repo → Done.
+ *
+ * When `reset` is true (invoked via `octp onboard --reset`) the wizard
+ * pre-seeds answers from the saved config so the user only fixes what's
+ * wrong instead of re-entering everything. Filesystem state (credentials,
+ * byok) is preserved — only prefs are re-prompted.
+ */
+export type StepKey =
+  | "welcome"
+  | "auth"
+  | "org"
+  | "provider"
+  | "model"
+  | "byok"
+  | "ollama-setup"
+  | "validate"
+  | "repo"
+  | "done";
+
+const STEPS: { key: StepKey; label: string }[] = [
+  { key: "welcome", label: "Welcome" },
+  { key: "auth", label: "Auth" },
+  { key: "org", label: "Org" },
+  { key: "provider", label: "Provider" },
+  { key: "model", label: "Model" },
+  { key: "byok", label: "BYOK" },
+  { key: "ollama-setup", label: "Ollama" },
+  { key: "validate", label: "Validate" },
+  { key: "repo", label: "Repo" },
+  { key: "done", label: "Done" },
+];
+
+export type OnboardWizardProps = {
+  /** When true, pre-seed answers from the saved config. */
+  reset?: boolean;
+};
+
+export function OnboardWizard({ reset = false }: OnboardWizardProps = {}) {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [answers, setAnswers] = useState<Partial<OctopusConfig>>({});
+  const [seeded, setSeeded] = useState(!reset); // skip the seed effect when not in --reset mode
+  // Provider-shape tabs (Ollama vs the rest) only diverge AFTER the user
+  // has passed through ProviderStep this session. Until then we don't
+  // know what they actually want — `answers.provider` may be pre-seeded
+  // from a prior --reset run, but pre-seeding shouldn't dictate the
+  // header layout while they're still on Auth/Org. ProviderStep flips
+  // this true as it advances.
+  const [providerConfirmed, setProviderConfirmed] = useState(false);
+
+  // Conditional sequence. Steps that don't apply for the current answers
+  // are filtered out:
+  //   - For Ollama, the "ollama-setup" step does everything (URL prompt,
+  //     daemon probe, model picker/puller) so the separate "model", "byok",
+  //     and "validate" steps are all redundant. Validate would just re-probe
+  //     the same URL ollama-setup already probed; byok asks for a key
+  //     Ollama doesn't have. Skipping them gets the user to Done faster
+  //     and removes empty tabs from the header.
+  //   - "ollama-setup" is also skipped for non-Ollama providers.
+  //
+  // The Ollama-vs-rest reshape only takes effect once ProviderStep has
+  // been passed through this session (`providerConfirmed`). Before that
+  // we show the full sequence so a --reset user who wants to switch
+  // away from Ollama isn't confused by the Ollama tab in the header.
+  const sequence = useMemo<StepKey[]>(() => {
+    const isOllama = providerConfirmed && answers.provider === "ollama";
+    return STEPS.map((s) => s.key).filter((k) => {
+      if (isOllama) {
+        if (k === "model" || k === "byok" || k === "validate") return false;
+      } else {
+        if (k === "ollama-setup") return false;
+      }
+      return true;
+    });
+  }, [answers.provider, providerConfirmed]);
+
+  // One-shot: load existing config and use as initial answers (--reset).
+  useEffect(() => {
+    if (seeded) return;
+    (async () => {
+      const existing = await loadConfig();
+      const { version: _v, onboardedAt: _o, ...prefs } = existing;
+      setAnswers(prefs);
+      setSeeded(true);
+    })();
+  }, [seeded]);
+
+  const activeKey = sequence[stepIndex];
+  const headerSteps = useMemo(
+    () => STEPS.filter((s) => sequence.includes(s.key)),
+    [sequence],
+  );
+
+  const next = (patch: Partial<OctopusConfig> = {}) => {
+    setAnswers((a) => ({ ...a, ...patch }));
+    setStepIndex((i) => Math.min(i + 1, sequence.length - 1));
+  };
+
+  // Jump back to a specific step key. Used by OrgStep → Auth ("switch org")
+  // and ValidateStep → BYOK ("edit key").
+  const jumpTo = (key: StepKey) => {
+    const idx = sequence.indexOf(key);
+    if (idx >= 0) setStepIndex(idx);
+  };
+
+  return (
+    <Box flexDirection="column" paddingY={1}>
+      <Header steps={headerSteps} activeKey={activeKey} />
+      {activeKey === "welcome" && <WelcomeStep onNext={() => next()} />}
+      {activeKey === "auth" && <AuthStep onNext={(p) => next(p)} />}
+      {activeKey === "org" && <OrgStep onNext={() => next()} onSwitchOrg={() => jumpTo("auth")} />}
+      {activeKey === "provider" && (
+        <ProviderStep
+          onNext={(p) => {
+            setProviderConfirmed(true);
+            next(p);
+          }}
+        />
+      )}
+      {activeKey === "model" && (
+        <ModelStep provider={answers.provider ?? ""} onNext={(p) => next(p)} />
+      )}
+      {activeKey === "byok" && (
+        <ByokStep
+          provider={answers.provider ?? ""}
+          onNext={() => next()}
+        />
+      )}
+      {activeKey === "ollama-setup" && (
+        <OllamaSetupStep
+          ollamaBaseUrl={answers.ollamaBaseUrl}
+          onNext={(p) => next(p)}
+        />
+      )}
+      {activeKey === "validate" && (
+        <ValidateStep
+          provider={answers.provider ?? ""}
+          onNext={() => next()}
+          onEditKey={() => jumpTo("byok")}
+        />
+      )}
+      {activeKey === "repo" && <RepoStep onNext={() => next()} />}
+      {activeKey === "done" && <DoneStep answers={answers} />}
+    </Box>
+  );
+}

--- a/apps/cli/src/__tests__/api.test.ts
+++ b/apps/cli/src/__tests__/api.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "bun:test";
+import { normalizeBaseUrl } from "../lib/api";
+
+describe("normalizeBaseUrl", () => {
+  it("strips trailing slashes", () => {
+    expect(normalizeBaseUrl("https://example.com/")).toBe("https://example.com");
+    expect(normalizeBaseUrl("https://example.com///")).toBe("https://example.com");
+  });
+
+  it("returns the origin (drops path and query)", () => {
+    expect(normalizeBaseUrl("https://example.com/some/path?foo=bar")).toBe("https://example.com");
+  });
+
+  it("accepts http", () => {
+    expect(normalizeBaseUrl("http://localhost:3000")).toBe("http://localhost:3000");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeBaseUrl("  https://example.com  ")).toBe("https://example.com");
+  });
+
+  it("returns null for empty input", () => {
+    expect(normalizeBaseUrl("")).toBeNull();
+    expect(normalizeBaseUrl("   ")).toBeNull();
+  });
+
+  it("returns null for non-http schemes", () => {
+    expect(normalizeBaseUrl("ftp://example.com")).toBeNull();
+    expect(normalizeBaseUrl("file:///tmp/x")).toBeNull();
+    expect(normalizeBaseUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  it("returns null for garbage", () => {
+    expect(normalizeBaseUrl("not a url")).toBeNull();
+    expect(normalizeBaseUrl("example.com")).toBeNull(); // no scheme
+  });
+});

--- a/apps/cli/src/__tests__/config.test.ts
+++ b/apps/cli/src/__tests__/config.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CONFIG_VERSION, isOnboarded, loadConfig, saveConfig } from "../lib/config";
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = await mkdtemp(join(tmpdir(), "octp-cfg-"));
+  process.env.OCTOPUS_HOME = tmpHome;
+});
+
+afterEach(async () => {
+  delete process.env.OCTOPUS_HOME;
+  await rm(tmpHome, { recursive: true, force: true });
+});
+
+describe("loadConfig", () => {
+  it("returns an empty config when the file is missing", async () => {
+    const c = await loadConfig();
+    expect(c.version).toBe(CONFIG_VERSION);
+    expect(c.onboardedAt).toBeUndefined();
+    expect(isOnboarded(c)).toBe(false);
+  });
+
+  it("returns an empty config when the file is unparseable", async () => {
+    await writeFile(join(tmpHome, "config.json"), "{ not json");
+    const c = await loadConfig();
+    expect(c.version).toBe(CONFIG_VERSION);
+    expect(isOnboarded(c)).toBe(false);
+  });
+
+  it("returns an empty config when the file has a stale version", async () => {
+    await writeFile(
+      join(tmpHome, "config.json"),
+      JSON.stringify({ version: 0, onboardedAt: "2020-01-01" }),
+    );
+    const c = await loadConfig();
+    expect(c.version).toBe(CONFIG_VERSION);
+    expect(c.onboardedAt).toBeUndefined();
+  });
+
+  it("returns the saved config when version matches", async () => {
+    await writeFile(
+      join(tmpHome, "config.json"),
+      JSON.stringify({
+        version: CONFIG_VERSION,
+        onboardedAt: "2026-05-17T00:00:00.000Z",
+        provider: "anthropic",
+      }),
+    );
+    const c = await loadConfig();
+    expect(c.provider).toBe("anthropic");
+    expect(isOnboarded(c)).toBe(true);
+  });
+
+  it("remaps legacy undated Anthropic model IDs to the dated forms", async () => {
+    const cases: Array<[string, string]> = [
+      ["claude-sonnet-4-6", "claude-sonnet-4-6-20250619"],
+      ["claude-opus-4-7", "claude-opus-4-6-20250619"],
+      ["claude-haiku-4-5", "claude-haiku-4-5-20251001"],
+    ];
+    for (const [stored, expected] of cases) {
+      await writeFile(
+        join(tmpHome, "config.json"),
+        JSON.stringify({
+          version: CONFIG_VERSION,
+          onboardedAt: "2026-05-17T00:00:00.000Z",
+          provider: "anthropic",
+          model: stored,
+        }),
+      );
+      const c = await loadConfig();
+      expect(c.model).toBe(expected);
+    }
+  });
+
+  it("leaves non-legacy model IDs unchanged", async () => {
+    await writeFile(
+      join(tmpHome, "config.json"),
+      JSON.stringify({
+        version: CONFIG_VERSION,
+        onboardedAt: "2026-05-17T00:00:00.000Z",
+        provider: "openai",
+        model: "gpt-4o",
+      }),
+    );
+    const c = await loadConfig();
+    expect(c.model).toBe("gpt-4o");
+  });
+});
+
+describe("saveConfig", () => {
+  it("stamps onboardedAt when not provided", async () => {
+    await saveConfig({ version: CONFIG_VERSION, provider: "openai" });
+    const c = await loadConfig();
+    expect(c.onboardedAt).toBeDefined();
+    expect(c.provider).toBe("openai");
+  });
+
+  it("preserves onboardedAt when explicitly provided", async () => {
+    const stamp = "2026-05-17T00:00:00.000Z";
+    await saveConfig({ version: CONFIG_VERSION, onboardedAt: stamp });
+    const c = await loadConfig();
+    expect(c.onboardedAt).toBe(stamp);
+  });
+
+  it("creates the OCTOPUS_HOME directory when missing", async () => {
+    await rm(tmpHome, { recursive: true, force: true });
+    await saveConfig({ version: CONFIG_VERSION });
+    const c = await loadConfig();
+    expect(c.onboardedAt).toBeDefined();
+  });
+});

--- a/apps/cli/src/__tests__/credentials.test.ts
+++ b/apps/cli/src/__tests__/credentials.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { clearCredentials, loadCredentials, saveCredentials, type Credentials } from "../lib/credentials";
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = await mkdtemp(join(tmpdir(), "octp-creds-"));
+  process.env.OCTOPUS_HOME = tmpHome;
+});
+
+afterEach(async () => {
+  delete process.env.OCTOPUS_HOME;
+  await rm(tmpHome, { recursive: true, force: true });
+});
+
+const valid: Credentials = {
+  baseUrl: "https://octopus-review.ai",
+  token: "secret-token-123",
+  orgId: "org_xyz",
+  orgSlug: "acme",
+  orgName: "Acme Inc",
+  userName: "Test User",
+  userEmail: "test@example.com",
+  approvedAt: "2026-05-17T00:00:00.000Z",
+};
+
+describe("loadCredentials", () => {
+  it("returns null when the file does not exist", async () => {
+    expect(await loadCredentials()).toBeNull();
+  });
+
+  it("returns null when the file is unparseable", async () => {
+    await writeFile(join(tmpHome, "credentials"), "{ not json");
+    expect(await loadCredentials()).toBeNull();
+  });
+
+  it("returns null when the file lacks required fields", async () => {
+    await writeFile(
+      join(tmpHome, "credentials"),
+      JSON.stringify({ baseUrl: "https://x", token: "y" }), // missing orgId/etc
+    );
+    expect(await loadCredentials()).toBeNull();
+  });
+
+  it("returns the credentials when the file is well-formed", async () => {
+    await saveCredentials(valid);
+    const loaded = await loadCredentials();
+    expect(loaded).toEqual(valid);
+  });
+});
+
+describe("saveCredentials", () => {
+  it("creates the OCTOPUS_HOME directory if missing", async () => {
+    await rm(tmpHome, { recursive: true, force: true });
+    await saveCredentials(valid);
+    const loaded = await loadCredentials();
+    expect(loaded?.token).toBe(valid.token);
+  });
+
+  it("round-trips all fields", async () => {
+    await saveCredentials(valid);
+    const loaded = await loadCredentials();
+    expect(loaded).toEqual(valid);
+  });
+});
+
+describe("clearCredentials", () => {
+  it("is a no-op when the file does not exist", async () => {
+    await clearCredentials();
+    expect(await loadCredentials()).toBeNull();
+  });
+
+  it("makes a previously-loaded credentials unloadable", async () => {
+    await saveCredentials(valid);
+    expect(await loadCredentials()).not.toBeNull();
+    await clearCredentials();
+    expect(await loadCredentials()).toBeNull();
+  });
+});

--- a/apps/cli/src/__tests__/keys.test.ts
+++ b/apps/cli/src/__tests__/keys.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "bun:test";
+import { hintFor, KEY_HINTS } from "../lib/keys";
+
+describe("hintFor", () => {
+  it("returns provider-specific hints for known providers", () => {
+    expect(hintFor("anthropic").placeholder).toContain("sk-ant-");
+    expect(hintFor("openai").placeholder).toContain("sk-");
+    expect(hintFor("google").placeholder).toContain("AIza");
+  });
+
+  it("marks keyless providers", () => {
+    expect(hintFor("ollama").keyless).toBe(true);
+    expect(hintFor("claude-code").keyless).toBe(true);
+    expect(hintFor("codex").keyless).toBe(true);
+  });
+
+  it("returns a generic fallback for unknown providers", () => {
+    const h = hintFor("not-a-real-provider");
+    expect(h.placeholder).toBe("API key…");
+    expect(h.dashboardUrl).toBe("");
+    expect(h.keyless).toBeUndefined();
+  });
+});
+
+describe("KEY_HINTS invariants", () => {
+  it("every entry has a placeholder", () => {
+    for (const [provider, hint] of Object.entries(KEY_HINTS)) {
+      expect(hint.placeholder.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("non-keyless entries link to a dashboard URL", () => {
+    for (const [provider, hint] of Object.entries(KEY_HINTS)) {
+      if (!hint.keyless) {
+        expect(hint.dashboardUrl.length).toBeGreaterThan(0);
+        expect(hint.dashboardUrl).toMatch(/^https?:\/\//);
+      }
+    }
+  });
+
+  it("keyless entries set minLength to 0", () => {
+    for (const hint of Object.values(KEY_HINTS)) {
+      if (hint.keyless) expect(hint.minLength).toBe(0);
+    }
+  });
+});

--- a/apps/cli/src/__tests__/models.test.ts
+++ b/apps/cli/src/__tests__/models.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "bun:test";
+import { defaultModelFor, formatPrice, modelsFor, MODELS_BY_PROVIDER } from "../lib/models";
+
+describe("modelsFor", () => {
+  it("returns the catalogue for a known provider", () => {
+    const models = modelsFor("anthropic");
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.every((m) => m.modelId.length > 0)).toBe(true);
+  });
+
+  it("returns [] for an unknown provider", () => {
+    expect(modelsFor("nonexistent")).toEqual([]);
+  });
+
+  it("returns [] for coming-soon providers (until backend seeds them)", () => {
+    expect(modelsFor("ollama")).toEqual([]);
+    expect(modelsFor("openrouter")).toEqual([]);
+    expect(modelsFor("claude-code")).toEqual([]);
+  });
+});
+
+describe("defaultModelFor", () => {
+  it("returns the isDefault model when one is marked", () => {
+    expect(defaultModelFor("anthropic")?.modelId).toBe("claude-sonnet-4-6-20250619");
+    expect(defaultModelFor("openai")?.modelId).toBe("gpt-4o");
+    expect(defaultModelFor("google")?.modelId).toBe("gemini-2.5-pro");
+  });
+
+  it("returns null for an empty catalogue", () => {
+    expect(defaultModelFor("ollama")).toBeNull();
+  });
+});
+
+describe("MODELS_BY_PROVIDER invariants", () => {
+  it("every model has unique modelId within its provider", () => {
+    for (const [provider, models] of Object.entries(MODELS_BY_PROVIDER)) {
+      const ids = models.map((m) => m.modelId);
+      expect(new Set(ids).size).toBe(ids.length);
+    }
+  });
+
+  it("at most one default per provider", () => {
+    for (const [provider, models] of Object.entries(MODELS_BY_PROVIDER)) {
+      const defaults = models.filter((m) => m.isDefault);
+      expect(defaults.length).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("prices are non-negative", () => {
+    for (const models of Object.values(MODELS_BY_PROVIDER)) {
+      for (const m of models) {
+        expect(m.inputPrice).toBeGreaterThanOrEqual(0);
+        expect(m.outputPrice).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+});
+
+describe("formatPrice", () => {
+  it("renders whole-dollar prices without decimals", () => {
+    expect(formatPrice({ modelId: "x", displayName: "x", inputPrice: 3, outputPrice: 15 })).toBe(
+      "$3 / $15 per 1M",
+    );
+  });
+
+  it("renders sub-dollar prices with trailing-zero trim", () => {
+    expect(formatPrice({ modelId: "x", displayName: "x", inputPrice: 0.15, outputPrice: 0.6 })).toBe(
+      "$0.15 / $0.6 per 1M",
+    );
+  });
+});

--- a/apps/cli/src/__tests__/paths.test.ts
+++ b/apps/cli/src/__tests__/paths.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import {
+  ensureOctopusHome,
+  getByokPath,
+  getConfigPath,
+  getCredentialsPath,
+  getOctopusHome,
+} from "../lib/paths";
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = await mkdtemp(join(tmpdir(), "octp-paths-"));
+  process.env.OCTOPUS_HOME = tmpHome;
+});
+
+afterEach(async () => {
+  delete process.env.OCTOPUS_HOME;
+  await rm(tmpHome, { recursive: true, force: true });
+});
+
+describe("getOctopusHome", () => {
+  it("honors OCTOPUS_HOME when set", () => {
+    expect(getOctopusHome()).toBe(tmpHome);
+  });
+
+  it("falls back to ~/.octopus when OCTOPUS_HOME is unset", () => {
+    delete process.env.OCTOPUS_HOME;
+    const home = getOctopusHome();
+    // Use platform-aware separator instead of "/.octopus" so the test
+    // also passes on Windows where path.join produces "\.octopus".
+    expect(home.endsWith(`${sep}.octopus`)).toBe(true);
+  });
+});
+
+describe("path helpers", () => {
+  it("places config, byok, and credentials inside OCTOPUS_HOME", () => {
+    expect(getConfigPath()).toBe(join(tmpHome, "config.json"));
+    expect(getByokPath()).toBe(join(tmpHome, "byok.json"));
+    expect(getCredentialsPath()).toBe(join(tmpHome, "credentials"));
+  });
+});
+
+describe("ensureOctopusHome", () => {
+  it("creates the directory if absent", async () => {
+    await rm(tmpHome, { recursive: true, force: true });
+    await ensureOctopusHome();
+    const st = await stat(tmpHome);
+    expect(st.isDirectory()).toBe(true);
+  });
+
+  it("is idempotent — no error when the directory already exists", async () => {
+    await ensureOctopusHome();
+    await ensureOctopusHome();
+    const st = await stat(tmpHome);
+    expect(st.isDirectory()).toBe(true);
+  });
+});

--- a/apps/cli/src/__tests__/providers.test.ts
+++ b/apps/cli/src/__tests__/providers.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "bun:test";
+import { PROVIDERS, providersByType } from "../lib/providers";
+
+describe("PROVIDERS catalogue", () => {
+  it("every provider has a unique slug", () => {
+    const slugs = PROVIDERS.map((p) => p.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("ready providers cover the three direct vendors", () => {
+    const ready = PROVIDERS.filter((p) => p.status === "ready").map((p) => p.slug);
+    expect(ready).toContain("anthropic");
+    expect(ready).toContain("openai");
+    expect(ready).toContain("google");
+  });
+
+  it("every provider has displayName and blurb populated", () => {
+    for (const p of PROVIDERS) {
+      expect(p.displayName.length).toBeGreaterThan(0);
+      expect(p.blurb.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("providersByType", () => {
+  it("returns only direct providers for 'direct'", () => {
+    for (const p of providersByType("direct")) expect(p.type).toBe("direct");
+  });
+
+  it("returns harnesses including claude-code + codex + opencode", () => {
+    const slugs = providersByType("harness").map((p) => p.slug);
+    expect(slugs).toContain("claude-code");
+    expect(slugs).toContain("codex");
+    expect(slugs).toContain("opencode");
+  });
+
+  it("returns gateways including openrouter + acp", () => {
+    const slugs = providersByType("gateway").map((p) => p.slug);
+    expect(slugs).toContain("openrouter");
+    expect(slugs).toContain("acp");
+  });
+
+  it("returns local including ollama", () => {
+    expect(providersByType("local").map((p) => p.slug)).toContain("ollama");
+  });
+});

--- a/apps/cli/src/__tests__/review.test.ts
+++ b/apps/cli/src/__tests__/review.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "bun:test";
+import { isLocalServer } from "../commands/review";
+
+describe("isLocalServer", () => {
+  it("treats localhost as local", () => {
+    expect(isLocalServer("http://localhost:3000")).toBe(true);
+    expect(isLocalServer("https://LOCALHOST")).toBe(true);
+  });
+
+  it("treats IPv4 loopback as local", () => {
+    expect(isLocalServer("http://127.0.0.1")).toBe(true);
+    expect(isLocalServer("http://127.42.0.5:8080")).toBe(true);
+  });
+
+  it("treats IPv6 loopback as local", () => {
+    expect(isLocalServer("http://[::1]:3000")).toBe(true);
+  });
+
+  it("treats IPv6 unspecified `::` as local", () => {
+    expect(isLocalServer("http://[::]:3000")).toBe(true);
+  });
+
+  it("treats IPv4 unspecified `0.0.0.0` as local", () => {
+    expect(isLocalServer("http://0.0.0.0:3000")).toBe(true);
+  });
+
+  it("treats IPv6 link-local as local (compressed form)", () => {
+    expect(isLocalServer("http://[fe80::1]:3000")).toBe(true);
+  });
+
+  it("treats RFC1918 private IPv4 as local", () => {
+    expect(isLocalServer("http://10.0.0.5")).toBe(true);
+    expect(isLocalServer("http://192.168.1.10:3000")).toBe(true);
+    expect(isLocalServer("http://172.16.5.5")).toBe(true);
+    expect(isLocalServer("http://172.31.255.255")).toBe(true);
+  });
+
+  it("treats *.local mDNS hosts as local", () => {
+    expect(isLocalServer("http://my-laptop.local:3000")).toBe(true);
+  });
+
+  it("rejects IPv4 outside RFC1918 ranges", () => {
+    expect(isLocalServer("http://172.15.0.1")).toBe(false);
+    expect(isLocalServer("http://172.32.0.1")).toBe(false);
+    expect(isLocalServer("http://8.8.8.8")).toBe(false);
+  });
+
+  it("rejects public hostnames", () => {
+    expect(isLocalServer("https://octopus-review.ai")).toBe(false);
+    expect(isLocalServer("https://example.com")).toBe(false);
+  });
+
+  it("rejects unparseable URLs", () => {
+    expect(isLocalServer("not a url")).toBe(false);
+    expect(isLocalServer("")).toBe(false);
+  });
+});

--- a/apps/cli/src/commands/agent-serve.ts
+++ b/apps/cli/src/commands/agent-serve.ts
@@ -1,0 +1,395 @@
+import os from "node:os";
+import { loadCredentials, type Credentials } from "../lib/credentials.js";
+import { loadConfig, DEFAULT_OLLAMA_BASE_URL } from "../lib/config.js";
+import { getJson, postJson } from "../lib/api.js";
+
+/**
+ * `octp agent serve` — register this machine as a local agent for the
+ * authenticated organisation and run a polling loop that claims LLM
+ * tasks dispatched by cloud Octopus, runs them against local Ollama,
+ * and posts the results back.
+ *
+ * Why: lets a developer host their org's review-LLM workload on their
+ * own laptop. Cloud Octopus can use models the user has Ollama-pulled
+ * locally without paying any API cost.
+ *
+ * Lifecycle:
+ *   1. Read ~/.octopus/credentials. Exit with a helpful message if not signed in.
+ *   2. POST /api/agent/register → get agentId (or reuse existing by name).
+ *   3. Heartbeat every 30s.
+ *   4. Poll /api/agent/llm-tasks every 2s. For each claimed task:
+ *        run via local Ollama → POST /api/agent/llm-tasks/<id>/complete.
+ *   5. On SIGINT: POST /api/agent/disconnect, exit 0.
+ *
+ * Ollama URL precedence: OLLAMA_BASE_URL env (wins) → ollamaBaseUrl in
+ * ~/.octopus/config.json (set by the wizard) → built-in default
+ * http://localhost:11434.
+ */
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const POLL_INTERVAL_MS = 2000;
+// Bound Ollama calls — without this a stuck model load or hung GPU hangs the
+// agent indefinitely, which then misses heartbeats. Override via
+// OCTP_OLLAMA_TIMEOUT_MS for large models that legitimately need more time.
+// Guarded the same way as RAW_CONCURRENCY below: Number("5m") is NaN, and
+// setTimeout(cb, NaN) fires after ~1ms, so every claimed task would abort
+// instantly with "timed out after NaNs". Reject malformed values and fall
+// back to the default.
+const RAW_OLLAMA_TIMEOUT_MS = Number(process.env.OCTP_OLLAMA_TIMEOUT_MS ?? 5 * 60_000);
+const OLLAMA_TIMEOUT_MS =
+  Number.isFinite(RAW_OLLAMA_TIMEOUT_MS) && RAW_OLLAMA_TIMEOUT_MS > 0
+    ? RAW_OLLAMA_TIMEOUT_MS
+    : 5 * 60_000;
+// How many tasks to run in parallel. Default 1 (serial) — Ollama generally
+// shares a single GPU and parallel calls just queue inside the daemon. Bump
+// to N (e.g. 2-4) on multi-GPU rigs or when running a tiny model that fits
+// many copies in memory. Clamped to [1, 16] so a typo can't kick off 1000
+// concurrent fetches.
+const RAW_CONCURRENCY = Number(process.env.OCTP_AGENT_CONCURRENCY ?? 1);
+const CONCURRENCY = Math.max(
+  1,
+  Math.min(16, Number.isFinite(RAW_CONCURRENCY) ? Math.floor(RAW_CONCURRENCY) : 1),
+);
+
+type AgentRegisterResponse = {
+  agentId: string;
+  agentName: string;
+};
+
+type LlmTask = {
+  id: string;
+  modelId: string;
+  system: string | null;
+  messages: { role: "user" | "assistant"; content: string }[];
+  maxTokens: number;
+  createdAt: string;
+};
+
+type OllamaResponse = {
+  choices?: { message?: { content?: string } }[];
+  usage?: { prompt_tokens?: number; completion_tokens?: number };
+};
+
+export async function agentServeCommand(argv: string[]): Promise<number> {
+  const creds = await loadCredentials();
+  if (!creds) {
+    console.error(
+      "No credentials. Run `octp` to sign in first, or `octp onboard` to redo the wizard.",
+    );
+    return 2;
+  }
+
+  // Parse optional flags
+  const explicitName = flagValue(argv, "--name");
+  const agentName = explicitName ?? defaultAgentName();
+  const verbose = argv.includes("--verbose") || argv.includes("-v");
+
+  // Warn (don't fail) when default name + a generic-looking hostname mean
+  // the agent will be hard to tell apart on the server. Generic hostnames
+  // are common in container / VM defaults and almost guarantee a collision
+  // if more than one host is involved.
+  if (!explicitName) {
+    const h = agentName.toLowerCase();
+    const looksGeneric =
+      h === "agent" ||
+      h === "localhost" ||
+      h === "ubuntu" ||
+      h === "debian" ||
+      /^[a-f0-9-]{8,}$/.test(h);
+    if (looksGeneric) {
+      console.warn(
+        `! Default agent name is "${agentName}" — generic hostname likely to collide ` +
+          `with other agents. Pass --name <distinguishing-suffix> if running multiple.`,
+      );
+    }
+  }
+
+  // Resolve Ollama URL: env wins, then wizard-saved config, then default.
+  const config = await loadConfig();
+  const ollamaBaseUrl =
+    process.env.OLLAMA_BASE_URL ?? config.ollamaBaseUrl ?? DEFAULT_OLLAMA_BASE_URL;
+
+  console.log(`octp agent serve — connecting to ${creds.baseUrl} as ${creds.orgName} / ${agentName}`);
+
+  // Quick Ollama health-check so the user finds out about a stopped daemon
+  // before tasks start landing.
+  const ollamaUp = await checkOllama(ollamaBaseUrl);
+  if (!ollamaUp) {
+    console.error(
+      `Could not reach Ollama at ${ollamaBaseUrl}. Start it with \`ollama serve\` and try again.`,
+    );
+    return 2;
+  }
+  console.log(`✓ Ollama reachable at ${ollamaBaseUrl}`);
+
+  const reg = await registerAgent(creds, agentName);
+  if (!reg.ok) {
+    console.error(`Register failed: ${reg.error}`);
+    return 1;
+  }
+  const { agentId } = reg.data;
+  console.log(`✓ Registered as agent ${agentId}`);
+
+  // Shutdown: clear timers, wait briefly for in-flight tasks to post their
+  // results so the server doesn't see hung "claimed" tasks, then disconnect.
+  // The shuttingDown flag is checked inside the poll/heartbeat loops so they
+  // exit before this function calls process.exit().
+  let shuttingDown = false;
+  const inFlight = new Set<Promise<void>>();
+  const SHUTDOWN_GRACE_MS = 5000;
+  let heartbeat: ReturnType<typeof setInterval> | null = null;
+  const shutdown = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log("\nShutting down — sending disconnect …");
+    if (heartbeat) clearInterval(heartbeat);
+    // Give the in-flight task(s) up to SHUTDOWN_GRACE_MS to post their results.
+    if (inFlight.size > 0) {
+      await Promise.race([
+        Promise.all(Array.from(inFlight)),
+        sleep(SHUTDOWN_GRACE_MS),
+      ]).catch(() => {});
+    }
+    await postJson(`${creds.baseUrl}/api/agent/disconnect`, { agentId }, creds.token).catch(() => {});
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  // Heartbeat loop
+  heartbeat = setInterval(async () => {
+    if (shuttingDown) return;
+    await postJson(`${creds.baseUrl}/api/agent/heartbeat`, { agentId }, creds.token).catch((e) => {
+      if (verbose) console.error("[heartbeat]", e instanceof Error ? e.message : String(e));
+    });
+  }, HEARTBEAT_INTERVAL_MS);
+  heartbeat.unref();
+
+  // Polling loop. Tasks within a single poll run with up to CONCURRENCY
+  // parallelism — see RAW_CONCURRENCY at top-of-file for the env override.
+  // Default 1 (serial) matches the single-GPU-Ollama common case.
+  console.log(
+    `Polling for tasks every ${POLL_INTERVAL_MS / 1000}s (concurrency=${CONCURRENCY}). Ctrl+C to stop.`,
+  );
+  let exitCode = 0;
+  while (!shuttingDown) {
+    try {
+      const tasks = await fetchTasks(creds, agentId);
+      // Process tasks in chunks of CONCURRENCY so shutdown can break between
+      // chunks rather than waiting for every claimed task to finish.
+      for (let i = 0; i < tasks.length; i += CONCURRENCY) {
+        if (shuttingDown) break;
+        const chunk = tasks.slice(i, i + CONCURRENCY);
+        if (verbose) {
+          for (const task of chunk) console.log(`  task ${task.id} model=${task.modelId}`);
+        }
+        const promises = chunk.map((task) => {
+          const p = runOneTask(creds, agentId, task, ollamaBaseUrl, verbose).finally(() => {
+            inFlight.delete(p);
+          });
+          inFlight.add(p);
+          return p;
+        });
+        await Promise.all(promises).catch(() => {
+          // runOneTask catches its own errors and reports failure via /complete;
+          // a rejection here would only come from an unexpected throw and is
+          // already logged by runOneTask.
+        });
+      }
+    } catch (e) {
+      // Auth failure won't recover by retrying — surface and exit so a
+      // revoked or expired token doesn't generate an endless 401 stream.
+      if (e instanceof AuthError) {
+        console.error(`\nAuthentication rejected (HTTP ${e.status}): ${e.message}`);
+        console.error("Run `octp` to re-authenticate, then start the agent again.");
+        exitCode = 2;
+        break;
+      }
+      if (verbose) console.error("[poll]", e instanceof Error ? e.message : String(e));
+    }
+    if (!shuttingDown) await sleep(POLL_INTERVAL_MS);
+  }
+
+  if (heartbeat) clearInterval(heartbeat);
+  await postJson(`${creds.baseUrl}/api/agent/disconnect`, { agentId }, creds.token).catch(() => {});
+  return exitCode;
+}
+
+async function checkOllama(ollamaBaseUrl: string): Promise<boolean> {
+  try {
+    const r = await fetch(`${ollamaBaseUrl}/api/tags`);
+    return r.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function registerAgent(creds: Credentials, agentName: string) {
+  return await postJson<AgentRegisterResponse>(
+    `${creds.baseUrl}/api/agent/register`,
+    {
+      name: agentName,
+      // Server validation requires Array.isArray(repoFullNames); the agent
+      // serves any LLM task for the org regardless of source repo, so we
+      // send an empty array rather than enumerating. Without this, every
+      // registration was rejected with 400 "name and repoFullNames are
+      // required" — the bridge feature was dead on arrival.
+      repoFullNames: [],
+      capabilities: ["llm-completion", "ollama"],
+      machineInfo: {
+        os: process.platform,
+        hostname: process.env.HOSTNAME ?? "",
+        nodeVersion: process.version,
+      },
+    },
+    creds.token,
+  );
+}
+
+// Raised by fetchTasks on auth failure (401/403). The polling loop checks
+// for this and exits — retrying a revoked or expired token would never
+// recover and would spam the server indefinitely.
+class AuthError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+  }
+}
+
+async function fetchTasks(creds: Credentials, agentId: string): Promise<LlmTask[]> {
+  const res = await getJson<{ tasks: LlmTask[] }>(
+    `${creds.baseUrl}/api/agent/llm-tasks?agentId=${encodeURIComponent(agentId)}`,
+    { headers: { authorization: `Bearer ${creds.token}` } },
+  );
+  if (!res.ok) {
+    if (res.status === 401 || res.status === 403) {
+      throw new AuthError(res.status, res.error);
+    }
+    // 404 = the agent's LocalAgent row no longer exists — the operator
+    // revoked it via DELETE /api/agent/[id]. Retrying would 404 forever
+    // (the row's gone, the token may even still work). Surface as AuthError
+    // so the polling loop exits with the actionable "restart to re-register"
+    // message instead of silently spinning until the user notices.
+    if (res.status === 404) {
+      throw new AuthError(
+        res.status,
+        "This agent was revoked from the dashboard. Re-running `octp agent serve` " +
+          "creates a fresh registration (it is not retrying the failed call) — confirm in the " +
+          "dashboard's Local Agents page that the revocation was intentional first; otherwise " +
+          "the new registration will be revoked again.",
+      );
+    }
+    throw new Error(res.error);
+  }
+  return res.data.tasks;
+}
+
+async function runOneTask(
+  creds: Credentials,
+  agentId: string,
+  task: LlmTask,
+  ollamaBaseUrl: string,
+  verbose: boolean,
+): Promise<void> {
+  const completeUrl = `${creds.baseUrl}/api/agent/llm-tasks/${task.id}/complete`;
+  try {
+    if (!task.modelId.startsWith("ollama:") && !task.modelId.includes(":")) {
+      // Not an Ollama-prefixed model and not bare — assume Ollama anyway,
+      // but log so the user knows what's happening.
+      if (verbose) console.log(`  (assuming Ollama for unprefixed model "${task.modelId}")`);
+    }
+    const model = task.modelId.startsWith("ollama:") ? task.modelId.slice(7) : task.modelId;
+
+    const messages: { role: string; content: string }[] = [];
+    if (task.system) messages.push({ role: "system", content: task.system });
+    for (const m of task.messages) messages.push({ role: m.role, content: m.content });
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), OLLAMA_TIMEOUT_MS);
+    let response: Response;
+    try {
+      response = await fetch(`${ollamaBaseUrl}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: "Bearer ollama" },
+        body: JSON.stringify({ model, max_tokens: task.maxTokens, messages, stream: false }),
+        signal: controller.signal,
+      });
+    } catch (e) {
+      if (controller.signal.aborted) {
+        throw new Error(`Ollama timed out after ${Math.round(OLLAMA_TIMEOUT_MS / 1000)}s`);
+      }
+      throw e;
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!response.ok) {
+      throw new Error(`Ollama returned ${response.status}: ${(await response.text()).slice(0, 200)}`);
+    }
+    const body = (await response.json()) as OllamaResponse;
+    const text = body.choices?.[0]?.message?.content ?? "";
+
+    // agentId is REQUIRED by the server's /complete endpoint: it verifies
+    // the caller is the agent that originally claimed the task and returns
+    // 403 on mismatch, preventing one agent from overwriting another's
+    // in-flight result.
+    //
+    // postJson never rejects — it resolves {ok:false} on HTTP/network errors.
+    // Failing to deliver the result must be loud (the work is lost, the
+    // server-side task stays "claimed" until the provider's 5-minute timeout
+    // fails the review). Capture the result and log + throw on !ok so the
+    // outer catch posts the error to /complete for fast surface.
+    const deliver = await postJson(
+      completeUrl,
+      {
+        agentId,
+        text,
+        usage: {
+          inputTokens: body.usage?.prompt_tokens ?? 0,
+          outputTokens: body.usage?.completion_tokens ?? 0,
+        },
+      },
+      creds.token,
+    );
+    if (!deliver.ok) {
+      throw new Error(
+        `failed to deliver result to /complete (HTTP ${deliver.status}: ${deliver.error})`,
+      );
+    }
+    if (verbose) console.log(`  ✓ completed ${task.id} (${text.length} chars)`);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`  ✗ failed ${task.id}: ${msg}`);
+    // Best-effort error-side delivery. postJson resolves {ok:false} so the
+    // catch is technically dead today, but harmless and defends against
+    // a future change.
+    await postJson(completeUrl, { agentId, error: msg }, creds.token).catch(() => {});
+  }
+}
+
+function flagValue(argv: string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  if (i === -1) return undefined;
+  const v = argv[i + 1];
+  if (!v || v.startsWith("-")) return undefined;
+  return v;
+}
+
+function defaultAgentName(): string {
+  // process.env.HOSTNAME is unset in most macOS/Linux shells (zsh exports
+  // HOST, not HOSTNAME; node doesn't pull it in either), so the previous
+  // default "agent-<pid>" changed every restart and the server's upsert
+  // on (org, name) never reused the row. Using os.hostname() (the OS-level
+  // hostname) keeps the same machine's agent row stable across restarts —
+  // matches the file's own "reuse existing by name" lifecycle comment.
+  // Drop the pid suffix for the same reason.
+  //
+  // Trade-off: two agents on the SAME host will collide on this default
+  // (each one's heartbeat overwrites the other's row, and dispatch routes
+  // to whichever heartbeated last). Operators running multi-agent setups
+  // on one host must pass `--name <distinguishing-suffix>` — the startup
+  // banner below logs the chosen name so the collision is visible.
+  return os.hostname() || "agent";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,0 +1,127 @@
+import { loadConfig, isOnboarded, DEFAULT_OLLAMA_BASE_URL } from "../lib/config.js";
+import { loadCredentials } from "../lib/credentials.js";
+import { loadByok } from "../lib/byok.js";
+import { getJson } from "../lib/api.js";
+import { getOctopusHome } from "../lib/paths.js";
+
+/**
+ * `octp doctor` — environment + auth health check. Prints one line per
+ * check: ✓ ok, ⚠ degraded, ✗ broken, · skipped (not configured).
+ *
+ * Designed for two audiences:
+ *   - Developers troubleshooting their CLI install ("why doesn't `octp`
+ *     work" — doctor names the broken link)
+ *   - Bug reports ("paste the doctor output" lets us see config without
+ *     leaking the actual credential values)
+ *
+ * The output is intentionally machine-parseable for the latter: every
+ * line starts with one of the four status glyphs.
+ */
+export async function doctorCommand(_argv: string[]): Promise<number> {
+  let hadError = false;
+
+  const line = (status: "ok" | "warn" | "error" | "skip", label: string, detail?: string) => {
+    const glyph = { ok: "✓", warn: "⚠", error: "✗", skip: "·" }[status];
+    console.log(`${glyph} ${label}${detail ? ` — ${detail}` : ""}`);
+    if (status === "error") hadError = true;
+  };
+
+  console.log("octp doctor");
+  console.log("─".repeat(40));
+
+  // ── Config ─────────────────────────────────────────────────────────────────
+  console.log("\nConfig:");
+  const config = await loadConfig();
+  line("ok", `${getOctopusHome()}/config.json`, isOnboarded(config) ? "onboarded" : "not yet onboarded");
+  if (config.provider) line("ok", "provider", config.provider);
+  else line("warn", "provider", "not chosen — run `octp onboard`");
+  if (config.model) line("ok", "model", config.model);
+  else line("warn", "model", "not chosen");
+  if (config.selfHostedBaseUrl) line("ok", "self-hosted base URL", config.selfHostedBaseUrl);
+  else line("skip", "self-hosted base URL", "using hosted (octopus-review.ai)");
+
+  // ── Credentials ────────────────────────────────────────────────────────────
+  console.log("\nAuth:");
+  const creds = await loadCredentials();
+  if (!creds) {
+    line("warn", "credentials", "no ~/.octopus/credentials — run `octp` to sign in");
+  } else {
+    line("ok", "credentials", `${creds.orgName} (${creds.orgSlug}) on ${creds.baseUrl}`);
+
+    // Live token check — hits /api/cli/me with the saved bearer.
+    const res = await getJson(`${creds.baseUrl}/api/cli/me`, {
+      headers: { authorization: `Bearer ${creds.token}` },
+    });
+    if (res.ok) line("ok", "token", "accepted by server");
+    else if (res.status === 401) line("error", "token", "rejected (401) — re-sign in with `octp onboard`");
+    else if (res.status === 0) line("error", "token", `network error: ${res.error}`);
+    else line("warn", "token", `unexpected HTTP ${res.status}`);
+  }
+
+  // ── BYOK keys ──────────────────────────────────────────────────────────────
+  console.log("\nBYOK keys (~/.octopus/byok.json):");
+  const byok = await loadByok();
+  const keys = Object.keys(byok.keys);
+  if (keys.length === 0) {
+    line("skip", "no provider keys saved", "using platform keys via the org");
+  } else {
+    for (const provider of keys) {
+      const len = byok.keys[provider]?.length ?? 0;
+      line("ok", provider, `${len}-char key (last edited ${byok.updatedAt ?? "?"})`);
+    }
+  }
+
+  // ── Ollama (if relevant) ───────────────────────────────────────────────────
+  console.log("\nOllama:");
+  if (config.provider !== "ollama") {
+    line("skip", "not selected provider");
+  } else {
+    // URL precedence matches agent-serve / validate (per config.ts:20-28):
+    // env wins, then wizard-saved ollamaBaseUrl, then default.
+    const base =
+      process.env.OLLAMA_BASE_URL ?? config.ollamaBaseUrl ?? DEFAULT_OLLAMA_BASE_URL;
+    try {
+      const r = await fetch(`${base}/api/tags`);
+      if (r.ok) {
+        const data = (await r.json()) as { models?: { name?: string }[] };
+        const count = data.models?.length ?? 0;
+        line("ok", `reachable at ${base}`, `${count} local model${count === 1 ? "" : "s"}`);
+      } else {
+        line("error", `reachable at ${base}`, `HTTP ${r.status}`);
+      }
+    } catch (e) {
+      line("error", `reachable at ${base}`, `${e instanceof Error ? e.message : String(e)}; try \`ollama serve\``);
+    }
+  }
+
+  // ── Local agent registration (if any) ──────────────────────────────────────
+  if (creds) {
+    console.log("\nLocal agents for this org:");
+    // /api/agent/status requires `orgId` as a query param and 400s without
+    // it. The endpoint already filters to agents with a fresh heartbeat,
+    // so any agent it returns is considered live — no need to inspect a
+    // per-agent `status` field (the endpoint doesn't return one anyway).
+    const url = `${creds.baseUrl}/api/agent/status?orgId=${encodeURIComponent(creds.orgId)}`;
+    const res = await getJson<{ agents: { id: string; name: string; lastSeenAt: string | null }[] }>(
+      url,
+      { headers: { authorization: `Bearer ${creds.token}` } },
+    );
+    if (!res.ok) {
+      line("warn", "agent status unavailable", res.error);
+    } else if (res.data.agents.length === 0) {
+      line("skip", "no agents registered", "run `octp agent serve` to register one");
+    } else {
+      for (const a of res.data.agents) {
+        line("ok", a.name, `online${a.lastSeenAt ? ` (last seen ${a.lastSeenAt})` : ""}`);
+      }
+    }
+  }
+
+  console.log("\n" + "─".repeat(40));
+  if (hadError) {
+    console.log("Some checks failed. Fix the ✗ items above.");
+    return 1;
+  }
+  console.log("All checks passed.");
+  return 0;
+}

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -1,0 +1,636 @@
+import { spawnSync } from "node:child_process";
+import { createInterface } from "node:readline";
+import { loadCredentials } from "../lib/credentials.js";
+import { loadConfig } from "../lib/config.js";
+import { getJson, postJson } from "../lib/api.js";
+import { ensureRepoIndexed } from "../lib/local-index.js";
+
+/**
+ * `octp review` — pre-PR review of local changes.
+ *
+ * Computes a diff of your working tree (or staged-only, or since-ref),
+ * resolves the current git remote to a registered Octopus repository,
+ * and posts the diff to the existing /api/cli/repos/<id>/local-review
+ * endpoint — the same one the canonical review pipeline uses. The
+ * server runs the diff through `generateLocalReview` which includes
+ * context search against the indexed repo, two-pass review, finding
+ * capping, and the operation-tagged ai_usage row.
+ *
+ * Local-only mode (no registered repo) is intentionally NOT supported:
+ * the review quality without indexed context is materially worse and
+ * we don't want a feature with two reliability tiers. If the repo
+ * isn't registered, surface a clear "register it first" message.
+ *
+ * Additive to the cloud PR review — the cloud review still runs on
+ * every PR when it opens, so coverage isn't gated on the CLI being
+ * installed. This is just the fast individual-dev feedback loop.
+ */
+
+// Mirror of `MAX_LOCAL_REVIEW_DIFF_BYTES` in apps/web/lib/cli-limits.ts.
+// Drift between the two is a bug — the CLI truncates to this value and the
+// server rejects anything larger; if the numbers disagree, requests in the
+// gap pass client-side and fail server-side with HTTP 413.
+const MAX_DIFF_BYTES = 500 * 1024;
+// CLI-side timeout on the review request. Without this the CLI hangs
+// indefinitely if the server's LLM call stalls (eg. Ollama daemon down,
+// or a long context-building step). 5 min is generous enough for the
+// largest real reviews; override with OCTP_REVIEW_TIMEOUT_MS for outliers.
+const REVIEW_TIMEOUT_MS = Number(process.env.OCTP_REVIEW_TIMEOUT_MS ?? 5 * 60_000);
+
+type Finding = {
+  severity: string;
+  title: string;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  category: string;
+  description: string;
+  suggestion: string;
+  confidence: number;
+  whyTestsDoNotAlreadyCoverThis?: string;
+  suggestedRegressionTest?: string;
+  minimumFixScope?: string;
+};
+
+type ReviewResponse = {
+  findings: Finding[];
+  summary?: string;
+  model: string;
+  usage: { inputTokens: number; outputTokens: number };
+  /** Server flag — true when the bare (no-repo-context) path was used. */
+  bareMode?: boolean;
+};
+
+type RepoMatch = { id: string; fullName: string; provider: string };
+
+type ReviewMode =
+  | { kind: "default" } // upstream..HEAD plus uncommitted
+  | { kind: "staged" }
+  | { kind: "since"; ref: string };
+
+export async function reviewCommand(argv: string[]): Promise<number> {
+  const creds = await loadCredentials();
+  if (!creds) {
+    console.error(
+      "No credentials. Run `octp` to sign in first, or `octp onboard` to redo the wizard.",
+    );
+    return 2;
+  }
+
+  if (argv.includes("--help") || argv.includes("-h")) {
+    printHelp();
+    return 0;
+  }
+
+  const mode = parseMode(argv);
+  if (!mode) return 2;
+
+  const strict = argv.includes("--strict");
+  const format = (flagValue(argv, "--format") ?? "human") as "human" | "json" | "markdown";
+  if (!["human", "json", "markdown"].includes(format)) {
+    console.error(`Unknown --format: ${format}. Use human | json | markdown.`);
+    return 2;
+  }
+  const verbose = argv.includes("--verbose") || argv.includes("-v");
+  const indexFlag = argv.includes("--index");
+  const noIndexFlag = argv.includes("--no-index");
+  if (indexFlag && noIndexFlag) {
+    console.error("--index and --no-index are mutually exclusive.");
+    return 2;
+  }
+
+  // Compute the diff
+  const diffResult = computeDiff(mode);
+  if (!diffResult.ok) {
+    console.error(diffResult.error);
+    return 2;
+  }
+  let diff = diffResult.diff;
+  let truncated = false;
+  if (diff.length > MAX_DIFF_BYTES) {
+    if (verbose) {
+      console.error(
+        `Diff is ${diff.length} bytes — truncating to ${MAX_DIFF_BYTES} so it fits the review budget.`,
+      );
+    }
+    diff = diff.slice(0, MAX_DIFF_BYTES);
+    truncated = true;
+  }
+  if (diff.trim().length === 0) {
+    if (format === "human") console.log("No changes to review.");
+    return 0;
+  }
+
+  // Try to resolve the git remote → Octopus repo id. If the repo is
+  // registered, we use the context-aware path. If not, offer to index
+  // the working tree locally (CLI uploads files; server embeds + stores
+  // in qdrant) so the next review — and this one — gets codebase context
+  // without requiring the GitHub App install. The bare-mode fallback
+  // remains for "no remote at all" and "user declined indexing."
+  const remoteUrl = gitRemoteUrl();
+  let repoMatch: RepoMatch | null = null;
+  if (!remoteUrl) {
+    console.error(
+      "No git remote configured — falling back to bare mode (no codebase context). " +
+        "Add a remote and re-run to index this repo for context-aware reviews.",
+    );
+  } else {
+    if (verbose) console.error(`Resolving repo for ${remoteUrl}…`);
+    const resolveRes = await getJson<RepoMatch>(
+      `${creds.baseUrl}/api/cli/repos/by-remote?url=${encodeURIComponent(remoteUrl)}`,
+      { headers: { authorization: `Bearer ${creds.token}` } },
+    );
+    if (resolveRes.ok) {
+      repoMatch = resolveRes.data;
+    } else if (resolveRes.status === 404) {
+      // Repo isn't connected yet. Offer to index the working tree (or
+      // auto-index when --index is passed). Skipping (--no-index or "n"
+      // at the prompt) falls through to bare mode like the old behaviour.
+      const decision = await decideIndex({
+        autoYes: indexFlag,
+        autoNo: noIndexFlag,
+        baseUrl: creds.baseUrl,
+      });
+      if (decision === "yes") {
+        console.error(
+          `\nIndexing working tree for context-aware reviews. ` +
+            `This sends file contents to ${creds.baseUrl} — same trust ` +
+            `boundary as cloud PR reviews. Skip with --no-index.\n`,
+        );
+        const indexResult = await ensureRepoIndexed(creds, remoteUrl, process.cwd(), {
+          tty: Boolean(process.stderr.isTTY),
+        });
+        if (indexResult.ok) {
+          // Either we just indexed (kind: "indexed") or the server told us
+          // the repo is already managed via the platform install
+          // (kind: "platform-managed"). Both cases want the canonical
+          // review path against an existing repoId, so a single by-remote
+          // re-fetch covers them — no caller-side branching needed.
+          repoMatch = await refetchRepoMatch(creds, remoteUrl, verbose);
+          if (!repoMatch) {
+            // shouldn't happen — but if it does, fall back to bare mode
+            // rather than crashing.
+            console.error(
+              "Index step succeeded but the repo couldn't be resolved by-remote. Continuing in bare mode.",
+            );
+          } else if (verbose) {
+            console.error(`Indexed — now reviewing against ${repoMatch.fullName}.`);
+          }
+        } else if (indexResult.reason === "timeout") {
+          console.error(
+            "Indexing is still running on the server (timed out after 10 min). " +
+              "Continuing in bare mode for this run — re-run `octp review` later for context-aware output.",
+          );
+        } else {
+          console.error(
+            `Indexing failed (${indexResult.error}). Continuing in bare mode for this run.`,
+          );
+        }
+      }
+      // decision === "no" → silent fallthrough to bare mode (renderer
+      // surfaces the caveat in the output banner).
+    } else {
+      console.error(
+        `Could not check whether this repo is connected to Octopus ` +
+          `(HTTP ${resolveRes.status}: ${resolveRes.error}). ` +
+          `Falling back to bare mode — review quality will be lower than usual.`,
+      );
+    }
+  }
+
+  // Honour the wizard's model pick if it set one. The server's
+  // `getReviewModel` chain only considers repo/org/platform defaults, not
+  // anything saved to ~/.octopus/config.json. Without this pass-through,
+  // a user who picked Ollama in the wizard would still get hit by whatever
+  // the org default is (often missing API key → 500).
+  const localConfig = await loadConfig();
+  const modelOverride = localConfig.model || undefined;
+  if (modelOverride && verbose) {
+    console.error(`Using locally-configured model: ${modelOverride}`);
+  }
+
+  if (verbose) {
+    const sizeKb = (diff.length / 1024).toFixed(1);
+    if (repoMatch) {
+      console.error(`Reviewing ${sizeKb} KB of diff against ${repoMatch.fullName}…`);
+    } else {
+      console.error(`Reviewing ${sizeKb} KB of diff in bare mode (no repo context)…`);
+    }
+  }
+
+  const endpoint = repoMatch
+    ? `${creds.baseUrl}/api/cli/repos/${encodeURIComponent(repoMatch.id)}/local-review`
+    : `${creds.baseUrl}/api/cli/review-local`;
+
+  if (verbose) {
+    const mins = (REVIEW_TIMEOUT_MS / 60_000).toFixed(0);
+    console.error(`Request timeout: ${mins} min (override with OCTP_REVIEW_TIMEOUT_MS)`);
+  }
+  const res = await postJson<ReviewResponse>(
+    endpoint,
+    {
+      diff,
+      title: commitSubject() ?? undefined,
+      author: gitAuthorName() ?? undefined,
+      model: modelOverride,
+    },
+    creds.token,
+    { timeoutMs: REVIEW_TIMEOUT_MS },
+  );
+  if (!res.ok) {
+    if (res.status === 402) {
+      console.error(
+        "Monthly spend limit reached for this org. Adjust in /settings/billing or wait until next cycle.",
+      );
+    } else if (res.status === 422) {
+      // ReviewConfigError on the server — message is safe to show and
+      // is actionable (set API key, pick a model, start Ollama, etc.).
+      console.error(res.error);
+    } else if (res.status === 0) {
+      // Timeout / network failure from the CLI side. Already prefixed
+      // "Request timed out — …" in api.ts when it's an abort.
+      console.error(res.error);
+    } else {
+      // Server returns a generic message in production and a "<generic>:
+      // <real error>" form in development — same wrapper either way.
+      console.error(`Review request failed (HTTP ${res.status}): ${res.error}`);
+    }
+    return 1;
+  }
+  const data = { ...res.data, truncated };
+
+  if (format === "json") {
+    console.log(JSON.stringify(data, null, 2));
+  } else if (format === "markdown") {
+    console.log(renderMarkdown(data));
+  } else {
+    renderHuman(data, repoMatch?.fullName ?? "(bare mode, no repo context)");
+  }
+
+  if (strict) {
+    const criticalCount = data.findings.filter((f) => isCritical(f.severity)).length;
+    if (criticalCount > 0) return 1;
+  }
+  return 0;
+}
+
+// ── Indexing prompt ──────────────────────────────────────────────────────────
+
+/**
+ * Decide whether to offer (or skip) the local-indexing flow when the repo
+ * isn't yet connected. Order of precedence:
+ *   1. --no-index flag → "no" (script-friendly: never prompt, never index)
+ *   2. --index flag → "yes" (script-friendly: always index without prompt)
+ *   3. stdin not a TTY → "no" (CI/scripts: don't hang waiting for input)
+ *   4. interactive → ask the user; default depends on `baseUrl`
+ *
+ * The default on bare Enter depends on whether the configured server is
+ * reachable only from the local machine / private network:
+ *   - localhost / 127.x.x.x / ::1 / *.local / RFC1918 IPs → default "yes".
+ *     There's no data egress beyond what the user already controls, so
+ *     the prompt is just a heads-up about the action.
+ *   - anything else (cloud / public host) → default "no". This is a
+ *     one-way upload of working-tree contents (untracked-but-unignored
+ *     secrets, proprietary code) that we don't want to exfiltrate on
+ *     an accidental Enter.
+ *
+ * The flag-driven paths (`--index`, `--no-index`) are unaffected by the
+ * host classification.
+ */
+async function decideIndex(opts: {
+  autoYes: boolean;
+  autoNo: boolean;
+  baseUrl: string;
+}): Promise<"yes" | "no"> {
+  if (opts.autoNo) return "no";
+  if (opts.autoYes) return "yes";
+  if (!process.stdin.isTTY) return "no";
+
+  const local = isLocalServer(opts.baseUrl);
+  const yesLabel = local ? "[Y]" : "[y]";
+  const noLabel = local ? "[n]" : "[N]";
+  const def = local ? "Y" : "N";
+  const hostHint = local ? ` (local server — ${opts.baseUrl})` : "";
+
+  process.stderr.write(
+    "\nThis repo isn't indexed in Octopus yet.\n" +
+      `Index it now for context-aware reviews? Files are uploaded to your Octopus server${hostHint}.\n` +
+      `  ${yesLabel} yes   ${noLabel} no, just review the diff in bare mode   (default: ${def})\n> `,
+  );
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    // `once("line")` and `once("close")` race — the loser stays registered
+    // unless explicitly removed. Without the off() calls, the listener that
+    // didn't fire leaks until the process exits, and a future close fires
+    // a no-op handler (or worse, if we later re-use rl).
+    const answer = await new Promise<string>((resolveAnswer) => {
+      const onLine = (s: string) => {
+        rl.off("close", onClose);
+        resolveAnswer(s);
+      };
+      const onClose = () => {
+        rl.off("line", onLine);
+        resolveAnswer("");
+      };
+      rl.once("line", onLine);
+      rl.once("close", onClose);
+    });
+    const trimmed = answer.trim().toLowerCase();
+    if (trimmed === "") return local ? "yes" : "no";
+    return trimmed[0] === "y" ? "yes" : "no";
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Treat the server as "local" (and therefore safe to default to indexing on)
+ * when it's reachable only from the same machine / private LAN. The
+ * classification is conservative — any URL we can't parse, or any public
+ * hostname, gets treated as non-local so default-no applies.
+ *
+ * Covered:
+ *   - hostname `localhost` (any case)
+ *   - IPv4 loopback `127.0.0.0/8`
+ *   - IPv6 loopback `::1`
+ *   - mDNS `*.local` hostnames
+ *   - RFC1918 private IPv4 (10/8, 172.16/12, 192.168/16)
+ *   - IPv6 link-local (fe80::/10) and unique-local (fc00::/7)
+ */
+export function isLocalServer(baseUrl: string): boolean {
+  let host: string;
+  try {
+    const u = new URL(baseUrl);
+    host = u.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  } catch {
+    return false;
+  }
+  if (host === "localhost" || host === "::1" || host === "::") return true;
+  if (host.endsWith(".local")) return true;
+  // IPv4
+  const v4 = host.split(".");
+  if (v4.length === 4 && v4.every((p) => /^\d+$/.test(p))) {
+    const [a, b] = v4.map(Number);
+    // 0.0.0.0 is the wildcard bind address — a `baseUrl` pointing at it
+    // can only mean "this machine", same as 127.x.
+    if (a === 0 && b === 0 && v4[2] === "0" && v4[3] === "0") return true;
+    if (a === 127) return true;
+    if (a === 10) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    return false;
+  }
+  // IPv6 — rough prefix match for link-local / unique-local. `fe80:` alone
+  // catches both the compressed (`fe80::1`) and uncompressed forms because
+  // both share the same leading 5 chars.
+  if (host.startsWith("fe80:")) return true;
+  if (/^f[cd]/.test(host)) return true;
+  return false;
+}
+
+async function refetchRepoMatch(
+  creds: { baseUrl: string; token: string },
+  remoteUrl: string,
+  verbose: boolean,
+): Promise<RepoMatch | null> {
+  const res = await getJson<RepoMatch>(
+    `${creds.baseUrl}/api/cli/repos/by-remote?url=${encodeURIComponent(remoteUrl)}`,
+    { headers: { authorization: `Bearer ${creds.token}` } },
+  );
+  if (res.ok) return res.data;
+  if (verbose) {
+    console.error(`by-remote re-fetch failed: HTTP ${res.status} — ${res.error}`);
+  }
+  return null;
+}
+
+// ── Flag parsing ─────────────────────────────────────────────────────────────
+
+function parseMode(argv: string[]): ReviewMode | null {
+  if (argv.includes("--staged")) return { kind: "staged" };
+  const since = flagValue(argv, "--since");
+  if (since) return { kind: "since", ref: since };
+  return { kind: "default" };
+}
+
+function flagValue(argv: string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  if (i === -1) return undefined;
+  const v = argv[i + 1];
+  if (!v || v.startsWith("-")) return undefined;
+  return v;
+}
+
+// ── Git ──────────────────────────────────────────────────────────────────────
+
+function computeDiff(mode: ReviewMode): { ok: true; diff: string } | { ok: false; error: string } {
+  if (!isGitRepo()) {
+    return {
+      ok: false,
+      error:
+        "Not a git repository. Run `octp review` from inside a repo, or `cd` into one first.",
+    };
+  }
+  if (mode.kind === "staged") {
+    return { ok: true, diff: git(["diff", "--staged"]) ?? "" };
+  }
+  if (mode.kind === "since") {
+    const tree = git(["diff", `${mode.ref}..HEAD`]) ?? "";
+    const uncommitted = git(["diff"]) ?? "";
+    return { ok: true, diff: combine(tree, uncommitted) };
+  }
+  // default: upstream..HEAD plus uncommitted. Fall through to main/master
+  // when there's no upstream tracking branch (common right after `git init`
+  // or for branches not yet pushed).
+  const upstream =
+    git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]) ??
+    git(["rev-parse", "--abbrev-ref", "main"]) ??
+    git(["rev-parse", "--abbrev-ref", "master"]);
+  if (!upstream) {
+    return { ok: true, diff: git(["diff", "HEAD"]) ?? "" };
+  }
+  const base = git(["merge-base", upstream.trim(), "HEAD"]);
+  if (!base) {
+    return { ok: true, diff: git(["diff", "HEAD"]) ?? "" };
+  }
+  const tree = git(["diff", `${base.trim()}..HEAD`]) ?? "";
+  const uncommitted = git(["diff"]) ?? "";
+  return { ok: true, diff: combine(tree, uncommitted) };
+}
+
+function combine(a: string, b: string): string {
+  if (!a) return b;
+  if (!b) return a;
+  return `${a}\n${b}`;
+}
+
+function isGitRepo(): boolean {
+  const r = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], { encoding: "utf8" });
+  return r.status === 0 && r.stdout.trim() === "true";
+}
+
+function git(args: string[]): string | null {
+  const r = spawnSync("git", args, { encoding: "utf8" });
+  if (r.status !== 0) return null;
+  return r.stdout;
+}
+
+function gitRemoteUrl(): string | null {
+  // Prefer "origin"; fall back to the first remote we can find.
+  const origin = git(["remote", "get-url", "origin"]);
+  if (origin) return origin.trim();
+  const remotes = git(["remote"]);
+  const first = remotes?.split("\n").map((s) => s.trim()).filter(Boolean)[0];
+  if (!first) return null;
+  return git(["remote", "get-url", first])?.trim() ?? null;
+}
+
+function commitSubject(): string | null {
+  return git(["log", "-1", "--pretty=%s"])?.trim() ?? null;
+}
+
+function gitAuthorName(): string | null {
+  return git(["config", "user.name"])?.trim() ?? null;
+}
+
+// ── Output renderers ─────────────────────────────────────────────────────────
+
+const COLOR = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  green: "\x1b[32m",
+};
+
+function isCritical(severity: string): boolean {
+  return /critical|🔴/i.test(severity);
+}
+
+function severityGlyph(severity: string): string {
+  const s = severity.toLowerCase();
+  if (s.includes("critical") || severity.includes("🔴")) return "🔴";
+  if (s.includes("high") || severity.includes("🟠")) return "🟠";
+  if (s.includes("medium") || severity.includes("🟡")) return "🟡";
+  if (s.includes("low") || severity.includes("🔵")) return "🔵";
+  return "💡";
+}
+
+type RenderedData = ReviewResponse & { truncated?: boolean };
+
+function renderHuman(data: RenderedData, repoFullName: string): void {
+  const { findings, model, usage } = data;
+  console.log(
+    `${COLOR.bold}🐙 octp review${COLOR.reset}  ${COLOR.dim}${repoFullName} · ${model} · ${usage.inputTokens}→${usage.outputTokens} tokens${COLOR.reset}`,
+  );
+  if (data.bareMode) {
+    console.log(
+      `${COLOR.yellow}ℹ bare mode — no codebase context. Connect the repo at /settings/integrations for higher-quality reviews.${COLOR.reset}`,
+    );
+  }
+  if (data.truncated) {
+    console.log(
+      `${COLOR.yellow}⚠ diff truncated to ${(MAX_DIFF_BYTES / 1024).toFixed(0)} KB — findings may be incomplete${COLOR.reset}`,
+    );
+  }
+  if (findings.length === 0) {
+    console.log(`${COLOR.green}✓ no findings${COLOR.reset}`);
+    return;
+  }
+  console.log("");
+  for (const f of findings) {
+    console.log(
+      `${severityGlyph(f.severity)} ${COLOR.bold}${f.severity}${COLOR.reset}  ${COLOR.cyan}${f.filePath}:${f.startLine}${COLOR.reset}`,
+    );
+    console.log(`  ${COLOR.bold}${f.title}${COLOR.reset}`);
+    console.log(`  ${f.description}`);
+    if (f.suggestion) console.log(`  ${COLOR.dim}suggestion:${COLOR.reset} ${f.suggestion}`);
+    if (f.suggestedRegressionTest)
+      console.log(`  ${COLOR.dim}test:${COLOR.reset} ${f.suggestedRegressionTest}`);
+    console.log("");
+  }
+  const buckets: Record<string, number> = {};
+  for (const f of findings) {
+    const g = severityGlyph(f.severity);
+    buckets[g] = (buckets[g] ?? 0) + 1;
+  }
+  const summary = Object.entries(buckets)
+    .map(([g, n]) => `${n} ${g}`)
+    .join(" · ");
+  console.log(
+    `${COLOR.bold}${findings.length} finding${findings.length === 1 ? "" : "s"}${COLOR.reset}  ${COLOR.dim}${summary}${COLOR.reset}`,
+  );
+}
+
+function renderMarkdown(data: RenderedData): string {
+  const lines: string[] = [];
+  lines.push(`# octp review`);
+  lines.push("");
+  lines.push(`Model: \`${data.model}\``);
+  if (data.truncated) lines.push(`> ⚠ diff was truncated — findings may be incomplete`);
+  if (data.summary) {
+    lines.push("");
+    lines.push(data.summary);
+  }
+  lines.push("");
+  if (data.findings.length === 0) {
+    lines.push("✓ no findings");
+    return lines.join("\n");
+  }
+  for (const f of data.findings) {
+    lines.push(`## ${severityGlyph(f.severity)} ${f.title}`);
+    lines.push("");
+    lines.push(`**File:** \`${f.filePath}:${f.startLine}\`  `);
+    lines.push(`**Severity:** ${f.severity}  `);
+    if (f.category) lines.push(`**Category:** ${f.category}  `);
+    lines.push("");
+    lines.push(f.description);
+    if (f.suggestion) {
+      lines.push("");
+      lines.push(`**Suggestion:** ${f.suggestion}`);
+    }
+    if (f.suggestedRegressionTest) {
+      lines.push("");
+      lines.push(`**Test idea:** ${f.suggestedRegressionTest}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+// ── Help ─────────────────────────────────────────────────────────────────────
+
+function printHelp(): void {
+  console.log(`octp review — pre-PR review of local changes
+
+Usage:
+  octp review                        Review upstream..HEAD plus uncommitted changes
+  octp review --staged               Review only \`git diff --staged\` output
+  octp review --since <ref>          Review since a given ref (eg. HEAD~3, main)
+
+Flags:
+  --strict                           Exit 1 if any critical (🔴) findings — for pre-commit hooks
+  --format <human|json|markdown>     Output format (default: human)
+  --index                            Index the working tree now without prompting (script-friendly)
+  --no-index                         Skip the index prompt — always review in bare mode
+  --verbose, -v                      Log progress to stderr
+  --help, -h                         This help
+
+Notes:
+  • If the repo is connected to Octopus (Settings → Integrations), reviews
+    use the canonical pipeline with codebase context, finding capping, and
+    your repo's reviewConfig — same as cloud PR reviews.
+  • If the repo isn't connected, you'll be prompted to index the working
+    tree (files are uploaded to your Octopus server). The bare-Enter
+    default is "yes" for local servers (localhost / private LAN) and
+    "no" for public hosts. Once indexed, subsequent reviews use the
+    same context-aware path as cloud reviews.
+  • Decline the index prompt (or pass --no-index) to review in "bare mode"
+    instead — same LLM call but no codebase context.
+  • The cloud PR review still runs on every PR — this is additive feedback
+    for individual developers before they push.
+  • Hard cap of 500 KB diff. Larger diffs get truncated with a warning.
+`);
+}

--- a/apps/cli/src/components/Header.tsx
+++ b/apps/cli/src/components/Header.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Box, Text } from "ink";
+
+export type HeaderProps = {
+  steps: { key: string; label: string }[];
+  activeKey: string;
+};
+
+/**
+ * Single-row numbered breadcrumb. Active step is bold + cyan; others gray.
+ * Skipped or future steps look identical — the wizard owns sequencing.
+ */
+export function Header({ steps, activeKey }: HeaderProps) {
+  return (
+    <Box marginBottom={1}>
+      {steps.map((step, i) => {
+        const isActive = step.key === activeKey;
+        return (
+          <Text
+            key={step.key}
+            color={isActive ? "cyan" : "gray"}
+            bold={isActive}
+          >
+            {`${i + 1}. ${step.label}`}
+            {i < steps.length - 1 ? "   " : ""}
+          </Text>
+        );
+      })}
+    </Box>
+  );
+}

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+import React from "react";
+import { render } from "ink";
+import { OnboardWizard } from "./OnboardWizard.js";
+import { isOnboarded, loadConfig } from "./lib/config.js";
+import { agentServeCommand } from "./commands/agent-serve.js";
+import { doctorCommand } from "./commands/doctor.js";
+import { reviewCommand } from "./commands/review.js";
+
+const VERSION = "0.1.0";
+
+/**
+ * Top-level CLI entry. Parses the first arg as a subcommand and dispatches.
+ *
+ * Layout:
+ *   octp                  → if not onboarded, run the wizard; otherwise print
+ *                           a one-line hint. With --skip-onboard or non-TTY
+ *                           stdin, exit 0 without rendering.
+ *   octp onboard [--reset]→ run the wizard explicitly
+ *   octp review <pr>      → trigger a review on demand          (TODO — WS2/CLI)
+ *   octp agent serve      → start the local-agent bridge        (TODO — WS2.7)
+ *   octp config <get|set> → manage ~/.octopus/config.json       (TODO)
+ *   octp doctor           → environment + auth health check     (TODO — WS6.6)
+ *   octp --version | -v   → print version
+ *   octp --help | -h      → print help
+ *
+ * Unknown subcommands and flags fail fast with a help hint — the WS6.6 pattern.
+ */
+
+const KNOWN_SUBCOMMANDS = new Set([
+  "onboard",
+  "review",
+  "agent",
+  "config",
+  "doctor",
+]);
+
+function printHelp(): void {
+  console.log(`octp ${VERSION} — Octopus CLI
+
+Usage:
+  octp                       Launch the onboarding wizard (first run) or dashboard
+  octp onboard [--reset]     Run the onboarding wizard explicitly
+  octp review [--staged]     Review local changes pre-PR (see \`octp review --help\`)
+  octp agent serve           Run as a local-agent bridge (poll for tasks, run via Ollama)
+  octp config <get|set>      Manage ~/.octopus/config.json               (coming soon)
+  octp doctor                Environment + auth health check
+
+octp agent serve flags:
+  --name <name>              Agent name reported to the server (default: hostname-pid)
+  --verbose, -v              Log every task claim + completion
+
+Flags:
+  --skip-onboard             Skip the first-run wizard
+  --reset                    Re-run the onboarding wizard, pre-seeding existing config
+  --version, -v              Print version
+  --help, -h                 Print this help
+
+Environment:
+  OCTOPUS_HOME               Override the config/secrets directory (default ~/.octopus)
+  OCTOPUS_NO_ONBOARD=1       Permanently skip the first-run wizard
+
+Docs:  https://github.com/octopusreview/octopus
+`);
+}
+
+async function main(argv: string[]): Promise<number> {
+  const first = argv[0];
+
+  if (first === "--version" || first === "-v") {
+    console.log(VERSION);
+    return 0;
+  }
+  if (first === "--help" || first === "-h") {
+    printHelp();
+    return 0;
+  }
+
+  // No subcommand: gate on first-run + TTY, then render the wizard (or exit cleanly).
+  if (first === undefined || first.startsWith("-")) {
+    if (argv.includes("--skip-onboard")) return 0;
+    if (process.env.OCTOPUS_NO_ONBOARD === "1") return 0;
+    if (!process.stdin.isTTY) return 0;
+
+    const config = await loadConfig();
+    if (isOnboarded(config) && !argv.includes("--reset")) {
+      // For now, an onboarded user with no subcommand just sees a one-line hint.
+      // Interactive dashboard belongs in a follow-up PR.
+      console.log("You're set. Try `octp --help` for available commands.");
+      return 0;
+    }
+    return await renderWizard(argv.includes("--reset"));
+  }
+
+  if (first === "onboard") {
+    return await renderWizard(argv.includes("--reset"));
+  }
+
+  if (first === "agent") {
+    const sub = argv[1];
+    if (sub === "serve") {
+      return await agentServeCommand(argv.slice(2));
+    }
+    console.error(`Unknown agent subcommand: ${sub ?? "(none)"}`);
+    console.error("Try: octp agent serve");
+    return 2;
+  }
+
+  if (first === "doctor") {
+    return await doctorCommand(argv.slice(1));
+  }
+
+  if (first === "review") {
+    return await reviewCommand(argv.slice(1));
+  }
+
+  if (KNOWN_SUBCOMMANDS.has(first)) {
+    console.error(`octp ${first}: not yet implemented in this build.`);
+    console.error("Tracking: https://github.com/cemoso/octopus/issues?q=workstream%3A");
+    return 2;
+  }
+
+  console.error(`Unknown command: ${first}`);
+  console.error("Run `octp --help` for a list of commands.");
+  return 2;
+}
+
+async function renderWizard(reset = false): Promise<number> {
+  await new Promise<void>((resolve) => {
+    const { waitUntilExit } = render(<OnboardWizard reset={reset} />);
+    waitUntilExit().then(() => resolve());
+  });
+  return 0;
+}
+
+// Reusable entry point for other packages that want to embed onboarding.
+export async function ensureOnboardCompleted(argv: string[] = process.argv.slice(2)): Promise<void> {
+  if (argv.includes("--skip-onboard")) return;
+  if (process.env.OCTOPUS_NO_ONBOARD === "1") return;
+  if (!process.stdin.isTTY) return;
+
+  const config = await loadConfig();
+  const reset = argv.includes("--reset") || argv.includes("--reset-onboard");
+  if (isOnboarded(config) && !reset) return;
+
+  await renderWizard(reset);
+}
+
+// When invoked directly (octp binary), parse argv and dispatch.
+// Path-suffix sniffing was fragile across platforms (Windows backslash,
+// .exe vs no .exe, custom rename, install path). The ES-module-standard
+// `import.meta.url` equality check works the same way on every platform
+// and correctly distinguishes "this file is the entrypoint" from "this
+// file was imported by something else."
+//
+// On Bun's --compile binary, `import.meta.url` is a file://... URL pointing
+// at the compiled entry; comparing against pathToFileURL(process.argv[1])
+// (the executable Node-style first arg) matches when invoked directly and
+// not when imported as a library.
+import { pathToFileURL } from "node:url";
+
+const isDirectInvocation =
+  typeof process !== "undefined" &&
+  typeof process.argv?.[1] === "string" &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectInvocation) {
+  main(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/apps/cli/src/lib/api.ts
+++ b/apps/cli/src/lib/api.ts
@@ -1,0 +1,149 @@
+/**
+ * Tiny JSON-over-HTTP helpers for the CLI. No external HTTP library —
+ * keeps the compiled binary slim and avoids dependency surface.
+ *
+ * Convention: every call returns { ok: true, data } | { ok: false, status, error }.
+ * Callers branch on `.ok` instead of try/catch around fetch.
+ */
+
+export type ApiOk<T> = { ok: true; data: T };
+export type ApiErr = { ok: false; status: number; error: string };
+export type ApiResult<T> = ApiOk<T> | ApiErr;
+
+const USER_AGENT = "octp-cli/0.1";
+
+export type PostJsonOptions = {
+  /**
+   * Per-request timeout in ms. Pass when the call may legitimately take a
+   * long time (eg. LLM-backed review endpoints) — without it the CLI hangs
+   * indefinitely if the server stalls. Implemented with AbortController.
+   */
+  timeoutMs?: number;
+};
+
+export async function postJson<T>(
+  url: string,
+  body: unknown,
+  bearerToken?: string,
+  options: PostJsonOptions = {},
+): Promise<ApiResult<T>> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "user-agent": USER_AGENT,
+  };
+  if (bearerToken) headers.authorization = `Bearer ${bearerToken}`;
+
+  const init: RequestInit = {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  };
+  if (options.timeoutMs && options.timeoutMs > 0) {
+    init.signal = AbortSignal.timeout(options.timeoutMs);
+  }
+  return await jsonRequest<T>(url, init);
+}
+
+export async function getJson<T>(url: string, init: RequestInit = {}): Promise<ApiResult<T>> {
+  return await jsonRequest<T>(url, {
+    ...init,
+    method: "GET",
+    headers: { "user-agent": USER_AGENT, ...(init.headers || {}) },
+  });
+}
+
+async function jsonRequest<T>(url: string, init: RequestInit): Promise<ApiResult<T>> {
+  let response: Response;
+  try {
+    response = await fetch(url, init);
+  } catch (e) {
+    // AbortError surfaces as a generic "AbortError" which is unhelpful; map
+    // it to something the user can act on. Network failures bubble through
+    // unchanged.
+    const msg = e instanceof Error ? e.message : String(e);
+    if (e instanceof Error && (e.name === "AbortError" || e.name === "TimeoutError")) {
+      return { ok: false, status: 0, error: `Request timed out — ${msg}` };
+    }
+    return { ok: false, status: 0, error: msg };
+  }
+
+  const text = await response.text();
+  let parsed: unknown = undefined;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      // Non-JSON body — return the raw text as the error message for diagnostics.
+      if (!response.ok) {
+        return { ok: false, status: response.status, error: text.slice(0, 200) };
+      }
+    }
+  }
+
+  if (!response.ok) {
+    const error =
+      typeof parsed === "object" && parsed !== null && "error" in parsed
+        ? String((parsed as { error: unknown }).error)
+        : `HTTP ${response.status}`;
+    return { ok: false, status: response.status, error };
+  }
+
+  return { ok: true, data: parsed as T };
+}
+
+/**
+ * Normalise a base URL — strip trailing slashes, ensure scheme. Returns null
+ * if the input is not a parseable http/https URL.
+ */
+export function normalizeBaseUrl(input: string): string | null {
+  const trimmed = input.trim().replace(/\/+$/, "");
+  if (!trimmed) return null;
+  try {
+    const u = new URL(trimmed);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    return u.origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Classify a base URL as "transport-safe to send bearer tokens over":
+ * HTTPS to any host, or HTTP to a loopback / private-LAN host. Cleartext
+ * HTTP to a public host should warn the user before we POST the auth
+ * token — that's a one-way credential leak to any on-path observer.
+ *
+ * Callers: AuthStep (warn before sign-in to a self-hosted http:// URL on
+ * a non-local host). Returns true when transport is safe; false when the
+ * caller should surface a warning + require explicit confirmation.
+ */
+export function isTransportSafe(baseUrl: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(baseUrl);
+  } catch {
+    return false;
+  }
+  if (u.protocol === "https:") return true;
+  if (u.protocol !== "http:") return false;
+  const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (host === "localhost" || host === "::1" || host === "::" || host.endsWith(".local")) return true;
+  const v4 = host.split(".");
+  if (v4.length === 4 && v4.every((p) => /^\d+$/.test(p))) {
+    const [a, b] = v4.map(Number);
+    if (a === 127) return true;
+    if (a === 0 && b === 0 && v4[2] === "0" && v4[3] === "0") return true;
+    if (a === 10) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+  }
+  // IPv6 link-local (fe80::/10) and ULA (fc00::/7) — must be IPv6 literals,
+  // not just any hostname starting with "fc"/"fd" (the old `/^f[cd]/` test
+  // matched public hostnames like "fc-host.example.com"). All IPv6 literals
+  // contain a colon by definition, so requiring one rules out the false
+  // positive without complicating the rest of the check.
+  if (host.includes(":") && (host.startsWith("fe80:") || /^f[cd][0-9a-f]{2}:/.test(host))) {
+    return true;
+  }
+  return false;
+}

--- a/apps/cli/src/lib/byok.ts
+++ b/apps/cli/src/lib/byok.ts
@@ -1,0 +1,69 @@
+import { chmod, readFile, writeFile } from "node:fs/promises";
+import { ensureOctopusHome, getByokPath } from "./paths.js";
+
+/**
+ * Provider API keys live in a separate file from `config.json` so the prefs
+ * file stays "safe to cat" while keys are protected as their own secret.
+ * File permissions: 0600 in a 0700 directory.
+ */
+export type ByokFile = {
+  /** Map of provider slug ("anthropic" | "openai" | "google" | …) to API key. */
+  keys: Record<string, string>;
+  /** ISO timestamp of the most recent key edit. */
+  updatedAt?: string;
+};
+
+const EMPTY: ByokFile = { keys: {} };
+
+export async function loadByok(): Promise<ByokFile> {
+  try {
+    const raw = await readFile(getByokPath(), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    // `typeof null === "object"` and `typeof [] === "object"`, so the
+    // existing shape guard accepted both `{"keys": null}` and `{"keys": []}`.
+    // Either form crashed downstream (`byok.keys[provider]` on null →
+    // TypeError; `provider in []` is fine but `Object.keys` on an array
+    // returned indices). Fall back to EMPTY in both cases.
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "keys" in parsed &&
+      (parsed as ByokFile).keys !== null &&
+      typeof (parsed as ByokFile).keys === "object" &&
+      !Array.isArray((parsed as ByokFile).keys)
+    ) {
+      return parsed as ByokFile;
+    }
+    return { ...EMPTY };
+  } catch {
+    return { ...EMPTY };
+  }
+}
+
+export async function setByokKey(provider: string, apiKey: string): Promise<void> {
+  await ensureOctopusHome();
+  const current = await loadByok();
+  const next: ByokFile = {
+    keys: { ...current.keys, [provider]: apiKey },
+    updatedAt: new Date().toISOString(),
+  };
+  const p = getByokPath();
+  await writeFile(p, JSON.stringify(next, null, 2), { mode: 0o600 });
+  // writeFile's `mode` only applies on FILE CREATION. If byok.json already
+  // existed with looser permissions (older build, restored from a sync
+  // tool, touched under a different umask), rewriting it leaves the loose
+  // bits intact. Force-chmod after every write so the documented 0600
+  // promise actually holds on pre-existing files too.
+  await chmod(p, 0o600);
+}
+
+export async function clearByokKey(provider: string): Promise<void> {
+  const current = await loadByok();
+  if (!(provider in current.keys)) return;
+  const { [provider]: _removed, ...rest } = current.keys;
+  await writeFile(
+    getByokPath(),
+    JSON.stringify({ keys: rest, updatedAt: new Date().toISOString() }, null, 2),
+    { mode: 0o600 },
+  );
+}

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -1,0 +1,111 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { ensureOctopusHome, getConfigPath } from "./paths.js";
+
+/**
+ * Bumped when the on-disk shape changes. An older or unparseable file is
+ * treated as missing — the wizard re-runs instead of crashing on a stale file.
+ */
+export const CONFIG_VERSION = 1;
+
+export type OctopusConfig = {
+  version: number;
+  /** ISO timestamp of when the user completed the wizard. Presence gates first-run. */
+  onboardedAt?: string;
+  /** Provider slug chosen during onboarding ("anthropic" | "openai" | "google" | …). */
+  provider?: string;
+  /** Model ID chosen during onboarding (e.g. "claude-sonnet-4-6-20250619", "gpt-4o"). */
+  model?: string;
+  /** Hosted API base URL when self-hosting. Absent when using the SaaS. */
+  selfHostedBaseUrl?: string;
+  /**
+   * Custom Ollama base URL. Only set when the user picked Ollama in the wizard
+   * AND overrode the default. `octp agent serve` reads this — env var
+   * OLLAMA_BASE_URL still wins, then this, then the built-in default
+   * `http://localhost:11434`.
+   */
+  ollamaBaseUrl?: string;
+};
+
+export const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
+
+/**
+ * One-shot remap for Anthropic model IDs persisted by older CLI versions.
+ * The pre-dated-IDs catalog wrote `claude-sonnet-4-6` / `claude-opus-4-7` /
+ * `claude-haiku-4-5` to ~/.octopus/config.json, but those strings are NOT in
+ * the server's exact-key pricing map, so usage logged under them prices to
+ * $0 and bypasses the org spend-limit check — the exact bypass the catalog
+ * fix was meant to close. Bumping CONFIG_VERSION would force re-onboarding
+ * (worse UX); a silent remap on load keeps users billable without surprise.
+ *
+ * Safe to leave in indefinitely: the new IDs ARE the canonical Anthropic
+ * model IDs, so re-saving the config writes the dated form back to disk.
+ */
+const LEGACY_MODEL_REMAP: Record<string, string> = {
+  "claude-sonnet-4-6": "claude-sonnet-4-6-20250619",
+  "claude-opus-4-7": "claude-opus-4-6-20250619",
+  "claude-haiku-4-5": "claude-haiku-4-5-20251001",
+};
+
+const EMPTY: OctopusConfig = { version: CONFIG_VERSION };
+
+/**
+ * Load the config. Returns an empty (un-onboarded) config when the file is
+ * missing, unreadable, unparseable, or has a different version — never throws
+ * for filesystem or schema reasons. The wizard treats all of these as "needs
+ * to re-run".
+ */
+export async function loadConfig(): Promise<OctopusConfig> {
+  try {
+    const raw = await readFile(getConfigPath(), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "version" in parsed &&
+      (parsed as OctopusConfig).version === CONFIG_VERSION
+    ) {
+      const cfg = parsed as OctopusConfig;
+      if (cfg.model && LEGACY_MODEL_REMAP[cfg.model]) {
+        cfg.model = LEGACY_MODEL_REMAP[cfg.model];
+      }
+      return cfg;
+    }
+    return { ...EMPTY };
+  } catch {
+    return { ...EMPTY };
+  }
+}
+
+/**
+ * Persist the config with restrictive permissions. Creates the home dir if it
+ * doesn't exist. Stamps `onboardedAt` to now when missing OR when the
+ * incoming value is unparseable / in the future (a tampered config file
+ * could otherwise pin a bogus future date that would never become "stale"
+ * by any time-based logic downstream).
+ */
+export async function saveConfig(next: OctopusConfig): Promise<void> {
+  await ensureOctopusHome();
+  const out: OctopusConfig = {
+    ...next,
+    version: CONFIG_VERSION,
+    onboardedAt: stableOnboardedAt(next.onboardedAt),
+  };
+  await writeFile(getConfigPath(), JSON.stringify(out, null, 2), { mode: 0o600 });
+}
+
+function stableOnboardedAt(incoming: string | undefined): string {
+  if (!incoming) return new Date().toISOString();
+  const parsed = new Date(incoming).getTime();
+  // Reject unparseable timestamps + anything more than 60s in the future
+  // (small grace for clock skew between machines). The threshold is
+  // deliberately small — onboardedAt is a personal-machine artifact, not
+  // a distributed log.
+  if (Number.isNaN(parsed) || parsed > Date.now() + 60_000) {
+    return new Date().toISOString();
+  }
+  return incoming;
+}
+
+export function isOnboarded(c: OctopusConfig): boolean {
+  return Boolean(c.onboardedAt);
+}

--- a/apps/cli/src/lib/credentials.ts
+++ b/apps/cli/src/lib/credentials.ts
@@ -1,0 +1,86 @@
+import { chmod, readFile, writeFile, unlink } from "node:fs/promises";
+import { ensureOctopusHome, getCredentialsPath } from "./paths.js";
+
+/**
+ * Auth state for the hosted Octopus API (or a self-hosted instance with the
+ * same device-flow endpoints). Stored as a separate file from prefs and BYOK
+ * keys so it can be revoked / deleted in isolation.
+ *
+ * File: ~/.octopus/credentials, mode 0600.
+ */
+export type Credentials = {
+  /** API base URL — `https://octopus-review.ai` for hosted, custom for self-hosted. */
+  baseUrl: string;
+  /** Long-lived API token returned by the approve flow. */
+  token: string;
+  /** Org context at the time of approval. */
+  orgId: string;
+  orgSlug: string;
+  orgName: string;
+  /** User identity at the time of approval (display purposes only). */
+  userName?: string;
+  userEmail?: string;
+  /** ISO timestamp of when the token was issued. */
+  approvedAt: string;
+};
+
+/**
+ * Load credentials. Returns null when the file is missing, unreadable, or
+ * has the wrong shape — never throws. Callers treat null as "not signed in."
+ */
+export async function loadCredentials(): Promise<Credentials | null> {
+  try {
+    const raw = await readFile(getCredentialsPath(), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (isCredentials(parsed)) return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveCredentials(c: Credentials): Promise<void> {
+  await ensureOctopusHome();
+  const p = getCredentialsPath();
+  await writeFile(p, JSON.stringify(c, null, 2), { mode: 0o600 });
+  // writeFile's `mode` only applies on file CREATION. If the file already
+  // exists with looser bits (older build, sync tool, different umask),
+  // rewriting leaves the loose bits intact. chmod after the write so the
+  // documented 0600 guarantee holds on pre-existing files too.
+  await chmod(p, 0o600);
+}
+
+/**
+ * Remove the credentials file. No-op if absent.
+ *
+ * We `unlink` rather than truncate so callers using a `stat`-based "is the
+ * user signed in?" check see the file actually disappear. `loadCredentials`
+ * already tolerates a missing file (returns null), so this is purely a
+ * disk-state correctness fix.
+ */
+export async function clearCredentials(): Promise<void> {
+  try {
+    await unlink(getCredentialsPath());
+  } catch (e) {
+    // ENOENT is fine — file already gone is the success state. Anything
+    // else (EPERM, EBUSY, file-locked-on-Windows, EROFS) means the token
+    // is STILL on disk; the sign-out attempt did not complete. Surface
+    // so the caller can warn the user rather than silently claiming
+    // success while their credential is still readable.
+    if (e instanceof Error && "code" in e && (e as { code: string }).code === "ENOENT") return;
+    throw e;
+  }
+}
+
+function isCredentials(value: unknown): value is Credentials {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.baseUrl === "string" &&
+    typeof v.token === "string" &&
+    typeof v.orgId === "string" &&
+    typeof v.orgSlug === "string" &&
+    typeof v.orgName === "string" &&
+    typeof v.approvedAt === "string"
+  );
+}

--- a/apps/cli/src/lib/keys.ts
+++ b/apps/cli/src/lib/keys.ts
@@ -1,0 +1,85 @@
+/**
+ * Per-provider input hints for the BYOK step. Keeps the wizard helpful
+ * without forcing the user to context-switch into a browser to figure out
+ * what format their key takes or where to get one.
+ */
+export type KeyHint = {
+  /** Placeholder text shown in the masked input. */
+  placeholder: string;
+  /** URL where the user creates a key for this provider. */
+  dashboardUrl: string;
+  /** Minimum sensible length — guards against pasted partial keys. */
+  minLength: number;
+  /** Whether the provider needs no key (local, harness-with-CLI-auth, etc.). */
+  keyless?: boolean;
+};
+
+export const KEY_HINTS: Record<string, KeyHint> = {
+  anthropic: {
+    placeholder: "sk-ant-…",
+    dashboardUrl: "https://console.anthropic.com/settings/keys",
+    minLength: 20,
+  },
+  openai: {
+    placeholder: "sk-…",
+    dashboardUrl: "https://platform.openai.com/api-keys",
+    minLength: 20,
+  },
+  google: {
+    placeholder: "AIza…",
+    dashboardUrl: "https://aistudio.google.com/app/apikey",
+    minLength: 20,
+  },
+  grok: {
+    placeholder: "xai-…",
+    dashboardUrl: "https://console.x.ai",
+    minLength: 20,
+  },
+  openrouter: {
+    placeholder: "sk-or-…",
+    dashboardUrl: "https://openrouter.ai/keys",
+    minLength: 20,
+  },
+  // Harnesses where the CLI tool carries its own auth — no key needed
+  // unless the user explicitly picks "API key mode."
+  "claude-code": {
+    placeholder: "(skip if claude CLI is already signed in)",
+    dashboardUrl: "https://console.anthropic.com/settings/keys",
+    minLength: 0,
+    keyless: true,
+  },
+  codex: {
+    placeholder: "(skip if codex CLI is already signed in)",
+    dashboardUrl: "https://platform.openai.com/api-keys",
+    minLength: 0,
+    keyless: true,
+  },
+  opencode: {
+    placeholder: "(varies — see docs)",
+    dashboardUrl: "https://opencode.dev",
+    minLength: 0,
+    keyless: true,
+  },
+  acp: {
+    placeholder: "(ACPX base URL credentials)",
+    dashboardUrl: "https://github.com/anthropics/agent-communication-protocol",
+    minLength: 0,
+    keyless: true,
+  },
+  ollama: {
+    placeholder: "(Ollama is local — no key required)",
+    dashboardUrl: "https://ollama.com",
+    minLength: 0,
+    keyless: true,
+  },
+};
+
+export function hintFor(provider: string): KeyHint {
+  return (
+    KEY_HINTS[provider] ?? {
+      placeholder: "API key…",
+      dashboardUrl: "",
+      minLength: 8,
+    }
+  );
+}

--- a/apps/cli/src/lib/local-index.ts
+++ b/apps/cli/src/lib/local-index.ts
@@ -1,0 +1,309 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { postJson } from "./api.js";
+import { type Credentials } from "./credentials.js";
+
+/**
+ * CLI-driven local indexing. Talks to /api/cli/repos/index-local in
+ * byte-budgeted batches, then polls until the server flips the repo's
+ * indexStatus to "indexed" (or "failed"). Shared by `octp review` when the
+ * working-tree repo isn't yet connected to Octopus.
+ *
+ * Why batches: even a moderate codebase produces a few MB of raw content,
+ * which exceeds typical proxy + Next.js body limits in a single POST. Each
+ * batch is its own request, processed end-to-end on the server (chunk →
+ * embed → upsert) so the CLI can render meaningful per-batch progress.
+ */
+
+// Per-batch byte budget — picked low enough to survive Vercel-class
+// proxies (4 MB hard cap) and conservative reverse-proxy defaults. JSON
+// encoding inflates content ~5–10%, so 3 MB raw → ~3.3 MB on the wire.
+const BATCH_TARGET_BYTES = 3 * 1024 * 1024;
+const MAX_FILE_BYTES = 100_000;
+const POLL_INTERVAL_MS = 1500;
+const POLL_MAX_MS = 10 * 60_000;
+
+/**
+ * Match the server's `shouldIndex` filter so we don't waste bandwidth
+ * uploading files the server will discard. Kept in sync with
+ * `apps/web/lib/index-chunking.ts` — if extensions diverge between client
+ * and server the user only loses recall on the divergent files, but
+ * still worth keeping in sync.
+ */
+const CODE_EXTENSIONS = new Set([
+  ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs", ".java", ".rb",
+  ".c", ".cpp", ".h", ".hpp", ".cs", ".swift", ".kt", ".scala",
+  ".vue", ".svelte", ".astro", ".html", ".css", ".scss",
+  ".sql", ".graphql", ".proto", ".yaml", ".yml", ".toml",
+  ".md", ".mdx", ".txt", ".json", ".xml",
+  ".sh", ".bash", ".zsh", ".fish",
+  ".dockerfile", ".prisma", ".env.example",
+]);
+
+const IGNORE_PATH_FRAGMENTS = [
+  "node_modules/", ".git/", "dist/", "build/", ".next/",
+  "vendor/", "__pycache__/", ".turbo/", "coverage/",
+];
+const IGNORE_BASENAMES = new Set([
+  "package-lock.json", "bun.lock", "yarn.lock", "pnpm-lock.yaml",
+]);
+
+/**
+ * Result shapes:
+ *   - `ok: true, kind: "indexed"` — CLI uploaded files and the server reported indexed.
+ *   - `ok: true, kind: "platform-managed"` — server told us the repo is already managed via the
+ *     platform install; caller should re-resolve by-remote and use the existing repoId. Modelled
+ *     as `ok: true` because from the caller's perspective the repo IS connected — same review
+ *     code path applies; we just skipped the upload.
+ *   - `ok: false, reason: "timeout"` — polling hit POLL_MAX_MS without the server settling.
+ *     Distinct from `failed` so the CLI can suggest "indexing is still running on the server,
+ *     try `octp review` again in a few minutes."
+ *   - `ok: false, reason: "failed"` — explicit server-reported failure or upload error.
+ */
+export type EnsureRepoIndexedResult =
+  | { ok: true; kind: "indexed"; repoId: string }
+  | { ok: true; kind: "platform-managed" }
+  | { ok: false; reason: "timeout" }
+  | { ok: false; reason: "failed"; error: string };
+
+export type EnsureRepoIndexedOptions = {
+  /** ANSI-colored progress will be drawn to stderr when true. */
+  tty: boolean;
+};
+
+/**
+ * End-to-end index flow: list eligible files, batch them, upload sequentially,
+ * poll for completion. Caller has already determined the repo isn't currently
+ * known to the server (by-remote 404) and has user consent.
+ */
+export async function ensureRepoIndexed(
+  creds: Credentials,
+  remoteUrl: string,
+  cwd: string,
+  opts: EnsureRepoIndexedOptions,
+): Promise<EnsureRepoIndexedResult> {
+  const files = collectEligibleFiles(cwd);
+  if (files.length === 0) {
+    return { ok: false, reason: "failed", error: "No indexable files found in the working tree." };
+  }
+
+  const batches = packBatches(files);
+  if (batches.length === 0) {
+    return { ok: false, reason: "failed", error: "No indexable content after batching." };
+  }
+
+  const defaultBranch = detectDefaultBranch(cwd);
+  let repoId: string | null = null;
+
+  drawProgress(0, batches.length, "starting", opts.tty);
+
+  for (let i = 0; i < batches.length; i++) {
+    const body: Record<string, unknown> =
+      i === 0
+        ? {
+            remoteUrl,
+            defaultBranch,
+            totalBatches: batches.length,
+            totalFiles: files.length,
+            batchIndex: 0,
+            files: batches[i],
+          }
+        : {
+            repoId,
+            totalBatches: batches.length,
+            batchIndex: i,
+            files: batches[i],
+          };
+
+    const res = await postJson<{ repoId: string; done: boolean; chunksInBatch: number }>(
+      `${creds.baseUrl}/api/cli/repos/index-local`,
+      body,
+      creds.token,
+      { timeoutMs: 4 * 60_000 },
+    );
+    if (!res.ok) {
+      if (i === 0 && res.status === 409) {
+        // Server says this repo is already managed via the platform install.
+        // No upload needed — caller will re-resolve via by-remote to get
+        // the repoId for the canonical review path.
+        drawProgressDone(opts.tty);
+        return { ok: true, kind: "platform-managed" };
+      }
+      drawProgressDone(opts.tty);
+      return {
+        ok: false,
+        reason: "failed",
+        error: `batch ${i + 1}/${batches.length}: HTTP ${res.status} — ${res.error}`,
+      };
+    }
+    if (i === 0) repoId = res.data.repoId;
+    drawProgress(i + 1, batches.length, "uploading", opts.tty);
+  }
+
+  if (!repoId) {
+    return { ok: false, reason: "failed", error: "Server did not return a repoId" };
+  }
+
+  // After the last batch the server already flipped status to indexed; one
+  // final poll covers the case where a tail status update was in flight.
+  const final = await pollStatus(creds, repoId, opts);
+  drawProgressDone(opts.tty);
+  if (final === "timeout") {
+    return { ok: false, reason: "timeout" };
+  }
+  if (final === "failed") {
+    return { ok: false, reason: "failed", error: "Server reported indexStatus=failed" };
+  }
+  return { ok: true, kind: "indexed", repoId };
+}
+
+/**
+ * Poll the repo status endpoint until the server flips to `indexed` / `failed`,
+ * or we hit `POLL_MAX_MS`. Returns a discriminated string so the caller can
+ * distinguish "indexing is still running, give up for now" (`timeout`) from
+ * "server explicitly said it failed" (`failed`).
+ */
+async function pollStatus(
+  creds: Credentials,
+  repoId: string,
+  opts: EnsureRepoIndexedOptions,
+): Promise<"indexed" | "failed" | "timeout"> {
+  const start = Date.now();
+  while (Date.now() - start < POLL_MAX_MS) {
+    const res = await fetch(
+      `${creds.baseUrl}/api/cli/repos/${encodeURIComponent(repoId)}/status`,
+      { headers: { authorization: `Bearer ${creds.token}` } },
+    );
+    if (res.ok) {
+      const j = (await res.json()) as { repo: { indexStatus: string; indexedFiles: number; totalFiles: number } };
+      if (j.repo.indexStatus === "indexed" || j.repo.indexStatus === "failed") {
+        return j.repo.indexStatus as "indexed" | "failed";
+      }
+      drawProgressIndexing(j.repo.indexedFiles, j.repo.totalFiles, opts.tty);
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  return "timeout";
+}
+
+// ── Walker ──────────────────────────────────────────────────────────────────
+
+function collectEligibleFiles(cwd: string): { path: string; bytes: number }[] {
+  // `git ls-files` respects .gitignore for free + lists only tracked files,
+  // which gives us a sane default for "what's in this repo." We then apply
+  // our own extension/size filter (mirrors the server's `shouldIndex`).
+  const result = spawnSync("git", ["ls-files", "-z"], { cwd, encoding: "buffer" });
+  if (result.status !== 0) return [];
+  const out: { path: string; bytes: number }[] = [];
+  const text = result.stdout.toString("utf8");
+  for (const path of text.split("\0").filter(Boolean)) {
+    if (!isEligible(path)) continue;
+    try {
+      const full = resolve(cwd, path);
+      const st = statSync(full);
+      if (st.size > MAX_FILE_BYTES) continue;
+      out.push({ path, bytes: st.size });
+    } catch {
+      // unreadable file — skip
+    }
+  }
+  return out;
+}
+
+function isEligible(path: string): boolean {
+  if (IGNORE_PATH_FRAGMENTS.some((f) => path.includes(f))) return false;
+  const basename = path.split("/").pop() ?? "";
+  if (IGNORE_BASENAMES.has(basename)) return false;
+  if (basename === "Dockerfile" || basename === "Makefile") return true;
+  // Extension match only — never collapse a dotless basename like `LICENSE`
+  // to a fake extension. Mirrors the server-side `shouldIndex` filter so
+  // CLI doesn't waste bandwidth uploading files the server would skip.
+  const dot = basename.lastIndexOf(".");
+  if (dot <= 0) return false;
+  const ext = basename.slice(dot).toLowerCase();
+  return CODE_EXTENSIONS.has(ext);
+}
+
+function packBatches(files: { path: string; bytes: number }[]): { path: string; content: string }[][] {
+  const batches: { path: string; content: string }[][] = [];
+  let current: { path: string; content: string }[] = [];
+  let currentBytes = 0;
+  for (const f of files) {
+    // Avoid over-stuffing — start a new batch if this file would push us
+    // past the target. A single file > target still ships in its own
+    // batch (size cap on the server-side per-file limit handles that).
+    if (currentBytes > 0 && currentBytes + f.bytes > BATCH_TARGET_BYTES) {
+      batches.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    try {
+      const content = readFileSync(f.path, "utf8");
+      // Skip files with NUL bytes — they're binary and will fail the
+      // server-side filter anyway; sending them just wastes bandwidth.
+      if (content.includes("\0")) continue;
+      current.push({ path: f.path, content });
+      currentBytes += content.length;
+    } catch {
+      // unreadable / not utf8 — skip
+    }
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+
+// ── Git helpers ─────────────────────────────────────────────────────────────
+
+function detectDefaultBranch(cwd: string): string {
+  // Default branch is what `origin/HEAD` points at. `HEAD` alone is the
+  // *currently checked-out* branch which is misleading on any feature
+  // branch (we'd record "fix/foo" as the repo's default). Strip the
+  // `origin/` prefix when present so we record just the branch name.
+  const r = spawnSync(
+    "git",
+    ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+    { cwd, encoding: "utf8" },
+  );
+  if (r.status === 0 && r.stdout.trim()) {
+    const ref = r.stdout.trim();
+    return ref.startsWith("origin/") ? ref.slice("origin/".length) : ref;
+  }
+  return "main";
+}
+
+// ── Progress rendering ──────────────────────────────────────────────────────
+
+function drawProgress(done: number, total: number, phase: string, tty: boolean): void {
+  if (!tty) {
+    if (done === 0 || done === total) {
+      process.stderr.write(`  indexing: ${phase} (batch ${done}/${total})\n`);
+    }
+    return;
+  }
+  const width = 20;
+  const ratio = total === 0 ? 0 : done / total;
+  const filled = Math.floor(ratio * width);
+  const bar = "█".repeat(filled) + "░".repeat(width - filled);
+  const pct = Math.floor(ratio * 100);
+  process.stderr.write(`\r  indexing  [${bar}] ${pct}%  ${phase} (${done}/${total})    `);
+}
+
+function drawProgressIndexing(indexed: number, total: number, tty: boolean): void {
+  if (!tty || total === 0) return;
+  const width = 20;
+  const ratio = Math.min(1, indexed / total);
+  const filled = Math.floor(ratio * width);
+  const bar = "█".repeat(filled) + "░".repeat(width - filled);
+  const pct = Math.floor(ratio * 100);
+  process.stderr.write(`\r  embedding [${bar}] ${pct}%  (${indexed}/${total} files)    `);
+}
+
+function drawProgressDone(tty: boolean): void {
+  if (!tty) return;
+  process.stderr.write("\n");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/apps/cli/src/lib/models.ts
+++ b/apps/cli/src/lib/models.ts
@@ -1,0 +1,71 @@
+/**
+ * Model catalogue per provider. Hardcoded today; matches the planned
+ * GET /api/cli/models?provider=<slug> endpoint shape so the upgrade path
+ * is one fetch swap.
+ *
+ * Prices are USD per million tokens (input / output). Reference prices as
+ * of 2026-05; keep in sync with apps/web/lib/cost.ts and the AvailableModel
+ * Prisma rows seeded in packages/db/prisma/seed.ts.
+ */
+export type ModelInfo = {
+  modelId: string;
+  displayName: string;
+  /** USD per million input tokens. */
+  inputPrice: number;
+  /** USD per million output tokens. */
+  outputPrice: number;
+  /** Default-recommended model for the provider. */
+  isDefault?: boolean;
+};
+
+// Anthropic model IDs are the *dated* canonical forms (matching what the
+// server seeds and prices). Undated aliases like "claude-sonnet-4-6" are
+// API aliases that route to the same model but DO NOT match server-side
+// pricing lookup (cost.ts does exact-key get with no alias fallback) —
+// so usage logged under an undated id silently prices to $0 and bypasses
+// the org spend-limit check. Pricing fields below match cost.ts's
+// FALLBACK_PRICING + seed.ts exactly.
+export const MODELS_BY_PROVIDER: Record<string, ModelInfo[]> = {
+  anthropic: [
+    { modelId: "claude-sonnet-4-6-20250619", displayName: "Claude Sonnet 4.6", inputPrice: 3, outputPrice: 15, isDefault: true },
+    { modelId: "claude-opus-4-6-20250619", displayName: "Claude Opus 4.6", inputPrice: 15, outputPrice: 75 },
+    { modelId: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5", inputPrice: 1, outputPrice: 5 },
+  ],
+  openai: [
+    { modelId: "gpt-4o", displayName: "GPT-4o", inputPrice: 2.5, outputPrice: 10, isDefault: true },
+    { modelId: "gpt-4o-mini", displayName: "GPT-4o mini", inputPrice: 0.15, outputPrice: 0.6 },
+    { modelId: "o4-mini", displayName: "o4-mini (reasoning)", inputPrice: 1.1, outputPrice: 4.4 },
+    { modelId: "codex-mini-latest", displayName: "Codex mini", inputPrice: 1.5, outputPrice: 6 },
+  ],
+  google: [
+    { modelId: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro", inputPrice: 1.25, outputPrice: 10, isDefault: true },
+    { modelId: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash", inputPrice: 0.15, outputPrice: 0.6 },
+  ],
+  // Coming-soon providers: empty until their model lists are seeded by the
+  // backend. The CLI handles the empty case with a friendly message.
+  "claude-code": [],
+  codex: [],
+  opencode: [],
+  grok: [],
+  openrouter: [],
+  acp: [],
+  ollama: [],
+};
+
+export function modelsFor(providerSlug: string): ModelInfo[] {
+  return MODELS_BY_PROVIDER[providerSlug] ?? [];
+}
+
+export function defaultModelFor(providerSlug: string): ModelInfo | null {
+  const list = modelsFor(providerSlug);
+  return list.find((m) => m.isDefault) ?? list[0] ?? null;
+}
+
+/**
+ * Format a price as "$3 / $15 per 1M tokens" — short enough to fit on one
+ * line in the SelectInput label.
+ */
+export function formatPrice(m: ModelInfo): string {
+  const fmt = (n: number) => (n >= 1 ? `$${n}` : `$${n.toFixed(2).replace(/\.?0+$/, "")}`);
+  return `${fmt(m.inputPrice)} / ${fmt(m.outputPrice)} per 1M`;
+}

--- a/apps/cli/src/lib/ollama.ts
+++ b/apps/cli/src/lib/ollama.ts
@@ -1,0 +1,224 @@
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+
+/**
+ * Ollama helper functions for the onboarding wizard.
+ *
+ * Two surfaces:
+ *   - HTTP API (`/api/tags`, `/api/pull`) for talking to whatever Ollama
+ *     the user pointed `ollamaBaseUrl` at — works for both localhost and
+ *     remote installs.
+ *   - Local shell (`ollama --version`, install scripts) only when the
+ *     configured URL is a localhost variant — we'd never want to mutate
+ *     a remote machine on the user's behalf.
+ */
+
+export type OllamaModel = {
+  name: string; // "qwen2.5-coder:32b"
+  sizeBytes: number;
+  modifiedAt: string;
+};
+
+export type CuratedModel = {
+  name: string;
+  displayName: string;
+  approxSizeGb: number;
+  blurb: string;
+};
+
+/**
+ * Curated picks the wizard shows when the user has no Ollama models
+ * installed yet. Ordered best-first for coding work; sizes are the
+ * Ollama download size at the time of writing (subject to drift).
+ */
+export const CURATED_MODELS: CuratedModel[] = [
+  {
+    name: "qwen2.5-coder:32b",
+    displayName: "Qwen 2.5 Coder 32B",
+    approxSizeGb: 20,
+    blurb: "Best overall for code review. Needs ~24GB RAM.",
+  },
+  {
+    name: "qwen2.5-coder:14b",
+    displayName: "Qwen 2.5 Coder 14B",
+    approxSizeGb: 9,
+    blurb: "Great quality/speed balance. Runs on most laptops.",
+  },
+  {
+    name: "qwen2.5-coder:7b",
+    displayName: "Qwen 2.5 Coder 7B",
+    approxSizeGb: 4.7,
+    blurb: "Fast, fits 8GB RAM Macs. Lower quality but usable.",
+  },
+  {
+    name: "deepseek-coder-v2:16b",
+    displayName: "DeepSeek Coder v2 16B",
+    approxSizeGb: 9,
+    blurb: "Strong alternative — different architecture, different bias.",
+  },
+  {
+    name: "codestral:22b",
+    displayName: "Codestral 22B (Mistral)",
+    approxSizeGb: 13,
+    blurb: "Mistral's coding model. Good multi-language support.",
+  },
+];
+
+export function isLocalhostUrl(url: string): boolean {
+  try {
+    // `URL.hostname` keeps the brackets on IPv6 (`new URL("http://[::1]").hostname`
+    // returns "[::1]"), so a bare `=== "::1"` check is dead. Strip brackets
+    // before comparing — matches the same handling in
+    // apps/cli/src/commands/review.ts:isLocalServer.
+    const host = new URL(url).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host === "0.0.0.0"
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check whether the `ollama` CLI is on PATH. Returns false on Windows
+ * (where `ollama` is typically an installer-launched service rather than
+ * a CLI on PATH) so the wizard always shows the install instructions
+ * there.
+ */
+export async function isOllamaInstalledLocally(): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    try {
+      const child = spawn("ollama", ["--version"], {
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+      child.on("close", (code) => resolve(code === 0));
+      child.on("error", () => resolve(false));
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+/**
+ * List models installed on the Ollama daemon at the given base URL.
+ * Returns null when the daemon isn't reachable (likely not running or
+ * the URL is wrong); empty array when reachable but no models pulled.
+ */
+export async function listOllamaModels(baseUrl: string): Promise<OllamaModel[] | null> {
+  try {
+    const r = await fetch(`${baseUrl}/api/tags`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!r.ok) return null;
+    const body = (await r.json()) as {
+      models?: { name: string; size?: number; modified_at?: string }[];
+    };
+    return (body.models ?? []).map((m) => ({
+      name: m.name,
+      sizeBytes: m.size ?? 0,
+      modifiedAt: m.modified_at ?? "",
+    }));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Platform-specific install command. Returned as a string the user can
+ * copy + paste — never executed for them, since installing system
+ * software without consent is too dangerous to do silently.
+ */
+export function installInstructionFor(): {
+  platform: "darwin" | "linux" | "windows" | "other";
+  command: string;
+  alternativeUrl: string;
+} {
+  const p = platform();
+  if (p === "darwin") {
+    return {
+      platform: "darwin",
+      command: "brew install ollama",
+      alternativeUrl: "https://ollama.com/download",
+    };
+  }
+  if (p === "linux") {
+    return {
+      platform: "linux",
+      command: "curl -fsSL https://ollama.com/install.sh | sh",
+      alternativeUrl: "https://ollama.com/download",
+    };
+  }
+  if (p === "win32") {
+    return {
+      platform: "windows",
+      command: "winget install Ollama.Ollama",
+      alternativeUrl: "https://ollama.com/download/windows",
+    };
+  }
+  return {
+    platform: "other",
+    command: "See the download page for your OS",
+    alternativeUrl: "https://ollama.com/download",
+  };
+}
+
+/**
+ * Pull a model via the Ollama HTTP API. Streams progress as ndjson;
+ * `onProgress` receives each status update. Resolves when the pull
+ * completes; rejects on network failure or non-success status.
+ *
+ * Caller MUST have already confirmed Ollama is reachable at `baseUrl` —
+ * we don't pre-check here because the pull will surface its own clear
+ * error if the daemon isn't running.
+ */
+export async function pullOllamaModel(
+  baseUrl: string,
+  model: string,
+  onProgress: (update: PullProgress) => void,
+): Promise<void> {
+  const r = await fetch(`${baseUrl}/api/pull`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name: model, stream: true }),
+  });
+  if (!r.ok || !r.body) {
+    throw new Error(`pull failed: HTTP ${r.status}`);
+  }
+
+  const reader = r.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    // ndjson — split on newline, parse each complete line
+    let nl: number;
+    while ((nl = buffer.indexOf("\n")) >= 0) {
+      const line = buffer.slice(0, nl).trim();
+      buffer = buffer.slice(nl + 1);
+      if (!line) continue;
+      let update: PullProgress;
+      try {
+        update = JSON.parse(line) as PullProgress;
+      } catch {
+        // Tolerate the occasional malformed line (rare); move on. We must
+        // not swallow `update.error` here — that's a real failure from the
+        // daemon and gets thrown unconditionally below the parse.
+        continue;
+      }
+      onProgress(update);
+      if (update.error) throw new Error(update.error);
+    }
+  }
+}
+
+export type PullProgress = {
+  status?: string; // "pulling manifest" | "downloading digestname" | "verifying sha256 digest" | "success"
+  completed?: number;
+  total?: number;
+  error?: string;
+};

--- a/apps/cli/src/lib/paths.ts
+++ b/apps/cli/src/lib/paths.ts
@@ -1,14 +1,17 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { mkdir } from "node:fs/promises";
 
 /**
  * Resolve the Octopus home directory.
- * Override via `OCTOPUS_HOME` for tests and non-standard installs.
+ * Override via `OCTOPUS_HOME` (trusted operator/test config) for non-standard
+ * installs. The override is resolved to an absolute path so a relative or
+ * `..`-containing value can't land config/credentials somewhere surprising
+ * relative to the current working directory.
  */
 export function getOctopusHome(): string {
   const override = process.env.OCTOPUS_HOME;
-  if (override) return override;
+  if (override) return resolve(override);
   return join(homedir(), ".octopus");
 }
 

--- a/apps/cli/src/lib/paths.ts
+++ b/apps/cli/src/lib/paths.ts
@@ -1,0 +1,33 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { mkdir } from "node:fs/promises";
+
+/**
+ * Resolve the Octopus home directory.
+ * Override via `OCTOPUS_HOME` for tests and non-standard installs.
+ */
+export function getOctopusHome(): string {
+  const override = process.env.OCTOPUS_HOME;
+  if (override) return override;
+  return join(homedir(), ".octopus");
+}
+
+export function getConfigPath(): string {
+  return join(getOctopusHome(), "config.json");
+}
+
+export function getByokPath(): string {
+  return join(getOctopusHome(), "byok.json");
+}
+
+export function getCredentialsPath(): string {
+  return join(getOctopusHome(), "credentials");
+}
+
+/**
+ * Ensure the Octopus home directory exists with restrictive permissions.
+ * Idempotent — safe to call on every launch.
+ */
+export async function ensureOctopusHome(): Promise<void> {
+  await mkdir(getOctopusHome(), { recursive: true, mode: 0o700 });
+}

--- a/apps/cli/src/lib/providers.ts
+++ b/apps/cli/src/lib/providers.ts
@@ -1,0 +1,103 @@
+/**
+ * Provider catalogue for the onboarding wizard.
+ *
+ * Hardcoded today. When `/api/cli/providers` lands as a backend endpoint
+ * (separate PR), the catalogue will be fetched at runtime so new providers
+ * appear in the CLI without requiring users to upgrade. The shape of
+ * `ProviderInfo` is chosen to match that future API.
+ */
+export type ProviderType =
+  | "direct" // Raw API to the model vendor (Anthropic, OpenAI, Google)
+  | "harness" // Agent harness — shells out to a CLI (codex, claude-code, opencode)
+  | "gateway" // Multiplexer / aggregator (OpenRouter, ACPX)
+  | "local"; // Runs on the user's machine (Ollama)
+
+export type ProviderInfo = {
+  slug: string;
+  displayName: string;
+  type: ProviderType;
+  /** Short marketing-y blurb for the picker. */
+  blurb: string;
+  /** "ready" — usable today. "coming-soon" — planned, not yet implemented. */
+  status: "ready" | "coming-soon";
+};
+
+export const PROVIDERS: ProviderInfo[] = [
+  // Direct API providers — already implemented in apps/web/lib/ai-router.ts.
+  {
+    slug: "anthropic",
+    displayName: "Claude (Anthropic)",
+    type: "direct",
+    blurb: "Direct Anthropic API. BYOK with your sk-ant-… key.",
+    status: "ready",
+  },
+  {
+    slug: "openai",
+    displayName: "OpenAI",
+    type: "direct",
+    blurb: "Direct OpenAI API. BYOK with your sk-… key.",
+    status: "ready",
+  },
+  {
+    slug: "google",
+    displayName: "Gemini (Google)",
+    type: "direct",
+    blurb: "Direct Google Generative AI API. BYOK.",
+    status: "ready",
+  },
+
+  // Coming soon — tracked under Workstream 5.
+  {
+    slug: "claude-code",
+    displayName: "Claude Code (Anthropic CLI)",
+    type: "harness",
+    blurb: "Use your Claude Pro/Max subscription via the claude CLI, or BYOK.",
+    status: "coming-soon",
+  },
+  {
+    slug: "codex",
+    displayName: "Codex (OpenAI CLI)",
+    type: "harness",
+    blurb: "OpenAI Codex coding-agent CLI.",
+    status: "coming-soon",
+  },
+  {
+    slug: "opencode",
+    displayName: "OpenCode",
+    type: "harness",
+    blurb: "Open-source coding agent CLI.",
+    status: "coming-soon",
+  },
+  {
+    slug: "grok",
+    displayName: "Grok (xAI)",
+    type: "direct",
+    blurb: "OpenAI-compatible REST API. BYOK.",
+    status: "coming-soon",
+  },
+  {
+    slug: "openrouter",
+    displayName: "OpenRouter",
+    type: "gateway",
+    blurb: "Single key, 100+ models from many vendors.",
+    status: "coming-soon",
+  },
+  {
+    slug: "acp",
+    displayName: "ACPX (ACP-compatible: Claude/Pi/Gemini)",
+    type: "gateway",
+    blurb: "Multiplexer over multiple model vendors via ACP.",
+    status: "coming-soon",
+  },
+  {
+    slug: "ollama",
+    displayName: "Ollama (local)",
+    type: "local",
+    blurb: "Run Llama, Qwen, Mistral, Hermes locally. No API key.",
+    status: "ready",
+  },
+];
+
+export function providersByType(type: ProviderType): ProviderInfo[] {
+  return PROVIDERS.filter((p) => p.type === type);
+}

--- a/apps/cli/src/lib/validate.ts
+++ b/apps/cli/src/lib/validate.ts
@@ -1,0 +1,126 @@
+import { loadByok } from "./byok.js";
+import { loadConfig, DEFAULT_OLLAMA_BASE_URL } from "./config.js";
+
+/**
+ * Validate that a BYOK key actually works against the provider's API.
+ * Each provider has a different cheapest-possible check:
+ *
+ *   anthropic  → GET /v1/models
+ *   openai     → GET /v1/models
+ *   google     → GET /v1beta/models?key=…
+ *   grok       → GET /v1/models (OpenAI-compatible at https://api.x.ai/v1)
+ *   openrouter → GET /api/v1/models (no auth even, but we send the key for sanity)
+ *   ollama     → GET http://localhost:11434/api/tags (local; no key needed)
+ *
+ * For providers without a built-in validation path (acp / codex / opencode /
+ * claude-code) the result is `skipped` — the user gets a "validation isn't
+ * implemented for this provider yet" message and proceeds.
+ */
+export type ValidateResult =
+  | { ok: true; modelCount?: number }
+  | { ok: false; status: number; message: string }
+  | { ok: "skipped"; reason: string };
+
+export async function validateProvider(provider: string): Promise<ValidateResult> {
+  const byok = await loadByok();
+  const key = byok.keys[provider];
+
+  switch (provider) {
+    case "anthropic":
+      return await validateAnthropic(key);
+    case "openai":
+      return await validateOpenAi("https://api.openai.com/v1/models", key);
+    case "grok":
+      return await validateOpenAi("https://api.x.ai/v1/models", key);
+    case "openrouter":
+      return await validateOpenAi("https://openrouter.ai/api/v1/models", key);
+    case "google":
+      return await validateGoogle(key);
+    case "ollama":
+      return await validateOllama();
+    default:
+      return { ok: "skipped", reason: `Validation for "${provider}" is not implemented yet.` };
+  }
+}
+
+async function validateAnthropic(key: string | undefined): Promise<ValidateResult> {
+  if (!key) return { ok: "skipped", reason: "No API key saved." };
+  try {
+    const r = await fetch("https://api.anthropic.com/v1/models", {
+      headers: { "x-api-key": key, "anthropic-version": "2023-06-01" },
+    });
+    if (!r.ok) return { ok: false, status: r.status, message: await shortBody(r) };
+    const data = (await r.json()) as { data?: unknown[] };
+    return { ok: true, modelCount: data.data?.length };
+  } catch (e) {
+    return { ok: false, status: 0, message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+async function validateOpenAi(url: string, key: string | undefined): Promise<ValidateResult> {
+  if (!key) return { ok: "skipped", reason: "No API key saved." };
+  try {
+    const r = await fetch(url, { headers: { authorization: `Bearer ${key}` } });
+    if (!r.ok) return { ok: false, status: r.status, message: await shortBody(r) };
+    const data = (await r.json()) as { data?: unknown[] };
+    return { ok: true, modelCount: data.data?.length };
+  } catch (e) {
+    return { ok: false, status: 0, message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+async function validateGoogle(key: string | undefined): Promise<ValidateResult> {
+  if (!key) return { ok: "skipped", reason: "No API key saved." };
+  try {
+    const r = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(key)}`,
+    );
+    if (!r.ok) return { ok: false, status: r.status, message: await shortBody(r) };
+    const data = (await r.json()) as { models?: unknown[] };
+    return { ok: true, modelCount: data.models?.length };
+  } catch (e) {
+    return { ok: false, status: 0, message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+async function validateOllama(): Promise<ValidateResult> {
+  // URL precedence (matches config.ts:20-28 + agent-serve.ts:79-80):
+  //   1. OLLAMA_BASE_URL env (wins)
+  //   2. ollamaBaseUrl in ~/.octopus/config.json (set by the wizard)
+  //   3. Built-in default
+  // The previous version skipped step 2, so a user who pointed the wizard
+  // at a non-default Ollama URL got `validate` and `doctor` probing
+  // localhost — `octp doctor` then printed a hard ✗ error even though
+  // `octp agent serve` worked fine against the configured URL.
+  const config = await loadConfig();
+  const base =
+    process.env.OLLAMA_BASE_URL ?? config.ollamaBaseUrl ?? DEFAULT_OLLAMA_BASE_URL;
+  try {
+    const r = await fetch(`${base}/api/tags`);
+    if (!r.ok) {
+      return {
+        ok: false,
+        status: r.status,
+        message:
+          `Ollama responded ${r.status}. Is it running? Try \`ollama serve\` in another terminal.`,
+      };
+    }
+    const data = (await r.json()) as { models?: unknown[] };
+    return { ok: true, modelCount: data.models?.length };
+  } catch (e) {
+    return {
+      ok: false,
+      status: 0,
+      message: `Could not reach Ollama at ${base}. Try \`ollama serve\`. (${e instanceof Error ? e.message : String(e)})`,
+    };
+  }
+}
+
+async function shortBody(r: Response): Promise<string> {
+  try {
+    const text = (await r.text()).trim();
+    return text.slice(0, 200);
+  } catch {
+    return `HTTP ${r.status}`;
+  }
+}

--- a/apps/cli/src/steps/AuthStep.tsx
+++ b/apps/cli/src/steps/AuthStep.tsx
@@ -1,0 +1,272 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import TextInput from "ink-text-input";
+import { getJson, normalizeBaseUrl, postJson } from "../lib/api.js";
+import { saveCredentials, type Credentials } from "../lib/credentials.js";
+
+const HOSTED_BASE_URL = "https://octopus-review.ai";
+const POLL_INTERVAL_MS = 2000;
+
+type Mode = "choose-mode" | "self-hosted-url" | "requesting" | "waiting" | "approved" | "failed" | "skipped";
+
+type DeviceResponse = { deviceCode: string; expiresAt: string };
+type PollResponse =
+  | { status: "pending" }
+  | {
+      status: "approved";
+      token: string;
+      organization: { id: string; slug: string; name: string };
+      user: { name?: string; email?: string };
+    };
+
+export type AuthStepProps = {
+  /**
+   * Called with `selfHostedBaseUrl` set only when the user chose self-hosted.
+   * Hosted is the default so we do not store it in prefs.
+   */
+  onNext: (patch: { selfHostedBaseUrl?: string }) => void;
+};
+
+function buildPatch(baseUrl: string): { selfHostedBaseUrl?: string } {
+  return baseUrl && baseUrl !== HOSTED_BASE_URL ? { selfHostedBaseUrl: baseUrl } : {};
+}
+
+/**
+ * Step 2 of the onboarding wizard.
+ *
+ *   choose-mode      → "Hosted (octopus-review.ai)" vs "Self-hosted (enter URL)"
+ *     ↓
+ *   self-hosted-url  → text input for base URL (skipped in hosted mode)
+ *     ↓
+ *   requesting       → POST /api/cli/auth/device, get { deviceCode, expiresAt }
+ *     ↓
+ *   waiting          → render the URL + deviceCode, poll /api/cli/auth/poll every 2s
+ *     ↓
+ *   approved         → write credentials, call onNext({ baseUrl })
+ *
+ * Failures from any of the network steps land in `failed`. Esc skips at any
+ * point — the user can complete onboarding without auth and configure later.
+ */
+export function AuthStep({ onNext }: AuthStepProps) {
+  const [mode, setMode] = useState<Mode>("choose-mode");
+  const [baseUrl, setBaseUrl] = useState<string>("");
+  const [selfHostedInput, setSelfHostedInput] = useState<string>("");
+  const [deviceCode, setDeviceCode] = useState<string>("");
+  const [expiresAt, setExpiresAt] = useState<Date | null>(null);
+  const [error, setError] = useState<string>("");
+
+  // Global Esc → skip the whole step (user can configure auth later).
+  // Now also allowed during `requesting` so the wizard isn't hard-locked
+  // on a stalled host: the device-code request has a per-call timeout
+  // below, but a user staring at "Requesting device code from …" still
+  // wants an Esc that works rather than Ctrl+C'ing out of the whole
+  // onboarding wizard. `approved` and `waiting` are kept off-limits
+  // because in those states bailing would corrupt session state.
+  // From the failed phase: Enter retries with the current URL, `b` (or
+  // backspace) jumps back to URL entry so the user can fix a typo /
+  // re-point at the right host without bouncing through the whole step.
+  useInput((input, key) => {
+    if (key.escape && mode !== "approved" && mode !== "waiting") {
+      setMode("skipped");
+      onNext(buildPatch(baseUrl || HOSTED_BASE_URL));
+    }
+    if (mode === "failed") {
+      if (key.return) {
+        setError("");
+        setMode("requesting");
+      } else if (input === "b" || input === "B" || key.backspace || key.delete) {
+        setError("");
+        setMode("self-hosted-url");
+      }
+    }
+  });
+
+  // Kick off device-code request when entering `requesting`. Bounded by
+  // a 15s timeout so a firewalled / blackholed self-hosted URL doesn't
+  // hang the wizard indefinitely — the user gets a "Could not request
+  // device code" error and lands in `failed` where Enter retries and
+  // `b` returns to URL entry.
+  useEffect(() => {
+    if (mode !== "requesting") return;
+    let cancelled = false;
+    (async () => {
+      const url = `${baseUrl}/api/cli/auth/device`;
+      const res = await postJson<DeviceResponse>(url, {}, undefined, { timeoutMs: 15_000 });
+      if (cancelled) return;
+      if (!res.ok) {
+        setError(`Could not request device code: ${res.error}`);
+        setMode("failed");
+        return;
+      }
+      setDeviceCode(res.data.deviceCode);
+      setExpiresAt(new Date(res.data.expiresAt));
+      setMode("waiting");
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, baseUrl]);
+
+  // Poll while waiting.
+  useEffect(() => {
+    if (mode !== "waiting" || !deviceCode) return;
+    let cancelled = false;
+    const interval = setInterval(async () => {
+      if (expiresAt && new Date() > expiresAt) {
+        setError("Device code expired before approval. Press Enter to retry.");
+        setMode("failed");
+        return;
+      }
+      const url = `${baseUrl}/api/cli/auth/poll?device_code=${encodeURIComponent(deviceCode)}`;
+      const res = await getJson<PollResponse>(url);
+      if (cancelled) return;
+      if (!res.ok) {
+        setError(`Poll failed: ${res.error}`);
+        setMode("failed");
+        return;
+      }
+      if (res.data.status === "pending") return;
+      // Approved — persist + advance.
+      const creds: Credentials = {
+        baseUrl,
+        token: res.data.token,
+        orgId: res.data.organization.id,
+        orgSlug: res.data.organization.slug,
+        orgName: res.data.organization.name,
+        userName: res.data.user.name,
+        userEmail: res.data.user.email,
+        approvedAt: new Date().toISOString(),
+      };
+      try {
+        await saveCredentials(creds);
+      } catch (e) {
+        setError(`Could not save credentials: ${e instanceof Error ? e.message : String(e)}`);
+        setMode("failed");
+        return;
+      }
+      setMode("approved");
+      // Brief pause to let the user see the success line before advancing.
+      setTimeout(() => onNext(buildPatch(baseUrl)), 600);
+    }, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [mode, deviceCode, expiresAt, baseUrl, onNext]);
+
+  const verificationUrl = useMemo(() => {
+    if (!baseUrl || !deviceCode) return "";
+    return `${baseUrl}/cli/authorize?code=${deviceCode}`;
+  }, [baseUrl, deviceCode]);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  if (mode === "choose-mode") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Sign in to Octopus</Text>
+        <Text> </Text>
+        <SelectInput
+          items={[
+            { label: "Hosted — octopus-review.ai", value: "hosted" },
+            { label: "Self-hosted — I run my own instance", value: "self-hosted" },
+            { label: "Skip — I'll configure auth later", value: "skip" },
+          ]}
+          onSelect={(item) => {
+            if (item.value === "hosted") {
+              setBaseUrl(HOSTED_BASE_URL);
+              setMode("requesting");
+            } else if (item.value === "self-hosted") {
+              setMode("self-hosted-url");
+            } else {
+              setMode("skipped");
+              onNext({});
+            }
+          }}
+        />
+        <Text> </Text>
+        <Text dimColor>Use ↑/↓ to move, Enter to select · Esc to skip</Text>
+      </Box>
+    );
+  }
+
+  if (mode === "self-hosted-url") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Self-hosted Octopus base URL</Text>
+        <Text dimColor>Example: https://octopus.internal.acme.com</Text>
+        <Text> </Text>
+        <Text>URL: </Text>
+        <TextInput
+          value={selfHostedInput}
+          onChange={setSelfHostedInput}
+          onSubmit={(value) => {
+            const normalized = normalizeBaseUrl(value);
+            if (!normalized) {
+              setError("Not a valid http(s) URL. Please re-enter.");
+              return;
+            }
+            setError("");
+            setBaseUrl(normalized);
+            setMode("requesting");
+          }}
+        />
+        {error ? <Text color="red">{error}</Text> : null}
+        <Text> </Text>
+        <Text dimColor>Enter to submit · Esc to skip</Text>
+      </Box>
+    );
+  }
+
+  if (mode === "requesting") {
+    return (
+      <Box flexDirection="column">
+        <Text>Requesting device code from {baseUrl} …</Text>
+      </Box>
+    );
+  }
+
+  if (mode === "waiting") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Open this URL in your browser to approve:</Text>
+        <Text> </Text>
+        <Text color="cyan">{verificationUrl}</Text>
+        <Text> </Text>
+        <Text dimColor>Waiting for approval … (polls every {POLL_INTERVAL_MS / 1000}s)</Text>
+        {expiresAt ? (
+          <Text dimColor>Code expires at {expiresAt.toLocaleTimeString()}.</Text>
+        ) : null}
+        <Text> </Text>
+        <Text dimColor>Ctrl+C to abort</Text>
+      </Box>
+    );
+  }
+
+  if (mode === "approved") {
+    return (
+      <Box flexDirection="column">
+        <Text color="green" bold>Signed in.</Text>
+        <Text>Credentials saved to ~/.octopus/credentials.</Text>
+      </Box>
+    );
+  }
+
+  if (mode === "failed") {
+    return (
+      <Box flexDirection="column">
+        <Text color="red" bold>Sign-in failed.</Text>
+        <Text color="red">{error}</Text>
+        {baseUrl ? (
+          <Text dimColor>Base URL: {baseUrl}</Text>
+        ) : null}
+        <Text> </Text>
+        <Text dimColor>Enter: retry · B: edit URL · Esc: skip</Text>
+      </Box>
+    );
+  }
+
+  // skipped — already advanced; render nothing.
+  return null;
+}

--- a/apps/cli/src/steps/ByokStep.tsx
+++ b/apps/cli/src/steps/ByokStep.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import TextInput from "ink-text-input";
+import { setByokKey } from "../lib/byok.js";
+import { hintFor } from "../lib/keys.js";
+
+export type ByokStepProps = {
+  provider: string;
+  onNext: (patch: { byokSaved?: boolean }) => void;
+};
+
+type Mode = "intro" | "entering" | "saving" | "saved" | "failed" | "skipped";
+
+/**
+ * Collect an API key for the chosen provider. Two adornments:
+ *   - masked TextInput so the key isn't echoed to the terminal
+ *   - placeholder text + a one-line dashboard URL hint specific to the provider
+ *
+ * For keyless providers (the agent harnesses when the user already has their
+ * CLI authed) we offer a "skip" path up front rather than forcing the user
+ * through a meaningless prompt. Ollama doesn't reach this step at all — its
+ * URL + model setup happens in `OllamaSetupStep` which collapses what used to
+ * be three separate tabs into one.
+ */
+export function ByokStep({ provider, onNext }: ByokStepProps) {
+  const hint = hintFor(provider);
+  const [mode, setMode] = useState<Mode>(hint.keyless ? "intro" : "entering");
+  const [value, setValue] = useState<string>("");
+  const [error, setError] = useState<string>("");
+
+  useInput((_input, key) => {
+    if (key.escape && mode !== "saving" && mode !== "saved") {
+      setMode("skipped");
+      onNext({ byokSaved: false });
+    }
+  });
+
+  // No provider selected (the user skipped ProviderStep) — pass through.
+  if (!provider) {
+    onNext({ byokSaved: false });
+    return null;
+  }
+
+  if (mode === "intro") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>API key for {provider}</Text>
+        <Text dimColor>{hint.placeholder}</Text>
+        <Text> </Text>
+        <SelectInput
+          items={[
+            { label: "I want to enter an API key", value: "enter" },
+            { label: "Skip — I'm using subscription / CLI / local mode", value: "skip" },
+          ]}
+          onSelect={(item) => {
+            if (item.value === "enter") setMode("entering");
+            else {
+              setMode("skipped");
+              onNext({ byokSaved: false });
+            }
+          }}
+        />
+      </Box>
+    );
+  }
+
+  if (mode === "entering") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>API key for {provider}</Text>
+        {hint.dashboardUrl ? (
+          <Text dimColor>Get one at <Text color="cyan">{hint.dashboardUrl}</Text></Text>
+        ) : null}
+        <Text> </Text>
+        <Text>Key: </Text>
+        <TextInput
+          value={value}
+          onChange={setValue}
+          placeholder={hint.placeholder}
+          mask="*"
+          onSubmit={async (submitted) => {
+            const trimmed = submitted.trim();
+            if (trimmed.length < hint.minLength) {
+              setError(
+                hint.minLength === 0
+                  ? "Key cannot be empty."
+                  : `Key looks too short (need at least ${hint.minLength} characters).`,
+              );
+              return;
+            }
+            setError("");
+            setMode("saving");
+            try {
+              await setByokKey(provider, trimmed);
+              setMode("saved");
+              setTimeout(() => onNext({ byokSaved: true }), 500);
+            } catch (e) {
+              setError(`Could not save key: ${e instanceof Error ? e.message : String(e)}`);
+              setMode("failed");
+            }
+          }}
+        />
+        {error ? <Text color="red">{error}</Text> : null}
+        <Text> </Text>
+        <Text dimColor>Enter to save · Esc to skip (use platform key instead)</Text>
+      </Box>
+    );
+  }
+
+  if (mode === "saving") {
+    return (
+      <Box flexDirection="column">
+        <Text>Saving key to ~/.octopus/byok.json …</Text>
+      </Box>
+    );
+  }
+
+  if (mode === "saved") {
+    return (
+      <Box flexDirection="column">
+        <Text color="green">Key saved.</Text>
+      </Box>
+    );
+  }
+
+  if (mode === "failed") {
+    return (
+      <Box flexDirection="column">
+        <Text color="red" bold>Save failed.</Text>
+        <Text color="red">{error}</Text>
+        <Text dimColor>Esc to skip.</Text>
+      </Box>
+    );
+  }
+
+  return null; // skipped — already advanced
+}

--- a/apps/cli/src/steps/DoneStep.tsx
+++ b/apps/cli/src/steps/DoneStep.tsx
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text, useApp } from "ink";
+import { loadConfig, saveConfig, type OctopusConfig } from "../lib/config.js";
+import { loadCredentials } from "../lib/credentials.js";
+import { loadByok } from "../lib/byok.js";
+
+export type DoneStepProps = {
+  answers: Partial<OctopusConfig>;
+};
+
+type Phase = "saving" | "done" | "failed";
+type Summary = {
+  baseUrl?: string;
+  orgName?: string;
+  provider?: string;
+  model?: string;
+  byokSaved?: boolean;
+  ollamaBaseUrl?: string;
+};
+
+/**
+ * Final step: persists the accumulated answers, then renders a per-section
+ * summary of what was configured so the user can see at a glance what's set
+ * up and what was skipped. Save happens in a useEffect on mount; the screen
+ * reflects the phase so a filesystem failure surfaces inline rather than
+ * crashing the wizard.
+ */
+export function DoneStep({ answers }: DoneStepProps) {
+  const { exit } = useApp();
+  const [phase, setPhase] = useState<Phase>("saving");
+  const [error, setError] = useState<string>("");
+  const [summary, setSummary] = useState<Summary>({});
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const current = await loadConfig();
+        await saveConfig({ ...current, ...answers });
+
+        // Build the summary from the persisted state — covers fields filled by
+        // earlier steps (auth wrote credentials; byok wrote keys; etc.).
+        const [creds, byok] = await Promise.all([loadCredentials(), loadByok()]);
+        setSummary({
+          baseUrl: creds?.baseUrl,
+          orgName: creds?.orgName,
+          provider: answers.provider,
+          model: answers.model,
+          byokSaved: answers.provider ? Boolean(byok.keys[answers.provider]) : false,
+          ollamaBaseUrl: answers.ollamaBaseUrl,
+        });
+
+        setPhase("done");
+        // Give the user a beat to see the success line before exiting.
+        setTimeout(exit, 1500);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        setPhase("failed");
+      }
+    })();
+  }, [answers, exit]);
+
+  if (phase === "saving") {
+    return (
+      <Box flexDirection="column">
+        <Text>Saving preferences…</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "failed") {
+    return (
+      <Box flexDirection="column">
+        <Text color="red" bold>Could not save preferences:</Text>
+        <Text color="red">{error}</Text>
+        <Text> </Text>
+        <Text dimColor>Check that ~/.octopus is writable, then re-run the wizard.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text color="green" bold>You're set 🐙</Text>
+      <Text> </Text>
+      <Text bold>Summary</Text>
+      <Text>  Server:   {summary.baseUrl ? <Text color="cyan">{summary.baseUrl}</Text> : <Text dimColor>not signed in</Text>}</Text>
+      <Text>  Org:      {summary.orgName ?? <Text dimColor>—</Text>}</Text>
+      <Text>  Provider: {summary.provider ?? <Text dimColor>not chosen</Text>}</Text>
+      {summary.provider === "ollama" && !summary.model ? (
+        <Text>  Model:    <Text dimColor>configure per-repo (no default picked)</Text></Text>
+      ) : (
+        <Text>  Model:    {summary.model ?? <Text dimColor>not chosen</Text>}</Text>
+      )}
+      <Text>  BYOK key: {summary.byokSaved ? <Text color="green">saved</Text> : <Text dimColor>none</Text>}</Text>
+      {summary.provider === "ollama" ? (
+        <Text>  Ollama URL: <Text color="cyan">{summary.ollamaBaseUrl ?? "http://localhost:11434 (default)"}</Text></Text>
+      ) : null}
+      <Text> </Text>
+      <Text bold>Next steps</Text>
+      <Text>  • Run <Text color="cyan">octp review</Text> in any git repo to review your local changes before committing.</Text>
+      <Text>  • Connect a repo at <Text color="cyan">/settings/integrations</Text> for cloud reviews on every PR — and for richer context-aware <Text color="cyan">octp review</Text> output.</Text>
+      <Text>  • Re-run this wizard any time with <Text color="cyan">octp onboard --reset</Text>.</Text>
+    </Box>
+  );
+}

--- a/apps/cli/src/steps/ModelStep.tsx
+++ b/apps/cli/src/steps/ModelStep.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import { defaultModelFor, formatPrice, modelsFor } from "../lib/models.js";
+
+export type ModelStepProps = {
+  provider: string;
+  onNext: (patch: { model: string }) => void;
+};
+
+/**
+ * Pick a model from the chosen provider. The catalogue lives in
+ * apps/cli/src/lib/models.ts and is hardcoded today (see note there
+ * about the future /api/cli/models endpoint).
+ *
+ * Empty provider catalogues (the coming-soon ones) render a friendly
+ * "no models yet" panel and allow the user to skip or proceed with an
+ * empty model — DoneStep handles the unset case downstream.
+ */
+export function ModelStep({ provider, onNext }: ModelStepProps) {
+  // The no-provider panel below tells the user "Press Enter to continue",
+  // so handle Enter (in addition to Esc) when there's no provider. Without
+  // this, Enter does nothing on that screen and the user is soft-locked
+  // on a step whose own instructions are wrong.
+  useInput((_input, key) => {
+    if (key.escape) onNext({ model: "" });
+    if (key.return && !provider) onNext({ model: "" });
+  });
+
+  const models = modelsFor(provider);
+
+  if (!provider) {
+    return (
+      <Box flexDirection="column">
+        <Text>No provider selected — nothing to pick.</Text>
+        <Text dimColor>Press Enter to continue.</Text>
+      </Box>
+    );
+  }
+
+  if (models.length === 0) {
+    return (
+      <Box flexDirection="column">
+        <Text bold>No models seeded for "{provider}" yet</Text>
+        <Text> </Text>
+        <Text>This provider is coming soon. You can finish onboarding now;</Text>
+        <Text>the model picker will populate once the backend ships.</Text>
+        <Text> </Text>
+        <SelectInput
+          items={[
+            { label: "Continue without a model", value: "skip" },
+            { label: "Go back to provider picker", value: "back" },
+          ]}
+          onSelect={(item) => {
+            if (item.value === "skip") onNext({ model: "" });
+            // "back" is handled by the wizard's Esc/back arrow — for now treat as skip.
+            else onNext({ model: "" });
+          }}
+        />
+      </Box>
+    );
+  }
+
+  const def = defaultModelFor(provider);
+  const items = models.map((m) => {
+    const suffix = m.isDefault ? "  (recommended)" : "";
+    return {
+      label: `${m.displayName.padEnd(28, " ")}  ${formatPrice(m)}${suffix}`,
+      value: m.modelId,
+    };
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Pick a model for {provider}</Text>
+      {def ? (
+        <Text dimColor>
+          Recommended: {def.displayName} ({formatPrice(def)})
+        </Text>
+      ) : null}
+      <Text> </Text>
+      <SelectInput items={items} onSelect={(item) => onNext({ model: item.value })} />
+      <Text> </Text>
+      <Text dimColor>Use ↑/↓ to move, Enter to select · Esc to skip</Text>
+    </Box>
+  );
+}

--- a/apps/cli/src/steps/OllamaSetupStep.tsx
+++ b/apps/cli/src/steps/OllamaSetupStep.tsx
@@ -1,0 +1,353 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import TextInput from "ink-text-input";
+import {
+  CURATED_MODELS,
+  installInstructionFor,
+  isLocalhostUrl,
+  isOllamaInstalledLocally,
+  listOllamaModels,
+  pullOllamaModel,
+  type OllamaModel,
+  type PullProgress,
+} from "../lib/ollama.js";
+import { DEFAULT_OLLAMA_BASE_URL } from "../lib/config.js";
+
+export type OllamaSetupStepProps = {
+  ollamaBaseUrl?: string;
+  onNext: (patch: { model?: string; ollamaBaseUrl?: string }) => void;
+};
+
+type Phase =
+  | "url-input" // first: ask for the URL, pre-filled to localhost:11434
+  | "probing" // checking install + querying /api/tags
+  | "remote-empty" // remote URL, no models — can't pull for them
+  | "remote-pick" // remote URL, models exist
+  | "local-not-installed" // localhost URL, ollama not on PATH
+  | "local-not-running" // localhost URL, installed but daemon down
+  | "local-empty" // localhost URL, running, no models — offer curated picks
+  | "local-pick" // localhost URL, running, models exist
+  | "pulling" // pulling a curated model
+  | "done"; // emit to onNext
+
+/**
+ * Ollama-specific setup phase. Runs only when provider === "ollama"
+ * (gated in OnboardWizard's sequence).
+ *
+ * Detection matrix:
+ *
+ *                    | reachable + models  | reachable + empty | unreachable
+ *   ----------------- + ------------------- + ----------------- + -----------
+ *   localhost URL    | pick from existing  | offer top-5 pull  | install/start
+ *   remote URL       | pick from existing  | "no models there" | "unreachable"
+ *
+ * We never install Ollama for the user — that needs sudo on Linux and
+ * is invasive — but we DO offer to `ollama pull <model>` via the HTTP
+ * API when the daemon is up locally, since that's a download into
+ * user-owned space.
+ *
+ * The user can Esc to skip at any time. If skipped, the wizard proceeds
+ * without a model preference — they can configure it later via the web
+ * UI at /settings/models.
+ */
+export function OllamaSetupStep({ ollamaBaseUrl, onNext }: OllamaSetupStepProps) {
+  // baseUrl is now mutable state: starts at the wizard-prop / default, the
+  // user can edit it in `url-input`, and edits also bring us back to this
+  // phase from any of the not-reachable terminals (so they can fix a typo
+  // without restarting onboarding).
+  const [baseUrl, setBaseUrl] = useState<string>(ollamaBaseUrl ?? DEFAULT_OLLAMA_BASE_URL);
+  const [urlInputValue, setUrlInputValue] = useState<string>(
+    ollamaBaseUrl ?? DEFAULT_OLLAMA_BASE_URL,
+  );
+  const isLocal = isLocalhostUrl(baseUrl);
+
+  const [phase, setPhase] = useState<Phase>("url-input");
+  const [installedModels, setInstalledModels] = useState<OllamaModel[]>([]);
+  const [pullingModel, setPullingModel] = useState<string>("");
+  const [pullStatus, setPullStatus] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const [urlInputError, setUrlInputError] = useState<string>("");
+
+  // Esc → skip at any non-pulling phase. We don't allow interrupting a
+  // pull mid-stream because the partial layers stay on disk and re-runs
+  // resume cleanly anyway — no destructive state.
+  // From any of the "not reachable" / "not installed" phases, `b`/backspace
+  // jumps back to the URL input so the user can fix a typo without restarting.
+  useInput((input, key) => {
+    if (key.escape && phase !== "pulling" && phase !== "done") {
+      // Still emit the URL on skip if the user explicitly changed it from
+      // the default — losing their typing would be surprising. emitPatch
+      // suppresses it for the default case so the config file stays clean.
+      emitPatch({});
+    }
+    if (
+      (phase === "local-not-installed" ||
+        phase === "local-not-running" ||
+        phase === "remote-empty") &&
+      (input === "b" || input === "B" || key.backspace || key.delete)
+    ) {
+      setError("");
+      setUrlInputError("");
+      setPhase("url-input");
+    }
+  });
+
+  // Probe whenever we (re-)enter "probing". List models, derive phase.
+  useEffect(() => {
+    if (phase !== "probing") return;
+    let cancelled = false;
+    (async () => {
+      const models = await listOllamaModels(baseUrl);
+      if (cancelled) return;
+      if (models === null) {
+        if (isLocal) {
+          const installed = await isOllamaInstalledLocally();
+          if (cancelled) return;
+          setPhase(installed ? "local-not-running" : "local-not-installed");
+        } else {
+          setPhase("remote-empty");
+          setError(`Couldn't reach Ollama at ${baseUrl}.`);
+        }
+        return;
+      }
+      setInstalledModels(models);
+      if (models.length === 0) {
+        setPhase(isLocal ? "local-empty" : "remote-empty");
+      } else {
+        setPhase(isLocal ? "local-pick" : "remote-pick");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [phase, baseUrl, isLocal]);
+
+  function submitUrl(submitted: string) {
+    const url = submitted.trim() || DEFAULT_OLLAMA_BASE_URL;
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        setUrlInputError(`URL must be http(s); got ${parsed.protocol}`);
+        return;
+      }
+    } catch {
+      setUrlInputError(`Not a parseable URL: ${url.slice(0, 60)}`);
+      return;
+    }
+    setUrlInputError("");
+    setBaseUrl(url);
+    setUrlInputValue(url);
+    setPhase("probing");
+  }
+
+  // Emit the URL on patch when (and only when) it differs from the default,
+  // so the saved config stays minimal for the common case.
+  function emitPatch(patch: { model?: string }) {
+    const ollamaPatch =
+      baseUrl !== DEFAULT_OLLAMA_BASE_URL ? { ollamaBaseUrl: baseUrl } : {};
+    onNext({ ...patch, ...ollamaPatch });
+  }
+
+  // ── Render phases ──────────────────────────────────────────────────────────
+
+  if (phase === "url-input") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Ollama base URL</Text>
+        <Text dimColor>
+          Default is <Text color="cyan">{DEFAULT_OLLAMA_BASE_URL}</Text>. Change
+          only if your Ollama daemon runs on a different host or port.
+        </Text>
+        <Text> </Text>
+        <Text>URL: </Text>
+        <TextInput
+          value={urlInputValue}
+          onChange={setUrlInputValue}
+          onSubmit={submitUrl}
+        />
+        {urlInputError ? <Text color="red">{urlInputError}</Text> : null}
+        <Text> </Text>
+        <Text dimColor>Enter: continue · Esc: skip</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "probing") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Checking Ollama at <Text color="cyan">{baseUrl}</Text>…</Text>
+        <Text dimColor>Listing installed models. This should take a second.</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "local-not-installed") {
+    const inst = installInstructionFor();
+    return (
+      <Box flexDirection="column">
+        <Text bold>Ollama isn&apos;t installed on this machine.</Text>
+        <Text> </Text>
+        <Text>Install it ({inst.platform}):</Text>
+        <Text color="cyan">  {inst.command}</Text>
+        <Text dimColor>Or download: <Text color="cyan">{inst.alternativeUrl}</Text></Text>
+        <Text> </Text>
+        <Text>
+          Once installed, start the daemon with <Text color="cyan">ollama serve</Text>.
+        </Text>
+        <Text> </Text>
+        <Text dimColor>B: edit URL · Esc: skip — configure later from /settings/models</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "local-not-running") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Ollama is installed but not running.</Text>
+        <Text> </Text>
+        <Text>Start the daemon in another terminal:</Text>
+        <Text color="cyan">  ollama serve</Text>
+        <Text> </Text>
+        <Text dimColor>B: edit URL · Esc: skip — configure later</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "remote-empty") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>
+          {error
+            ? `Ollama is unreachable at ${baseUrl}.`
+            : `No models installed on the Ollama at ${baseUrl}.`}
+        </Text>
+        <Text> </Text>
+        <Text dimColor>
+          That host is remote — we can&apos;t install or pull models on
+          your behalf. Pull a model there with{" "}
+          <Text color="cyan">ollama pull qwen2.5-coder:32b</Text> (or similar).
+        </Text>
+        <Text> </Text>
+        <Text dimColor>B: edit URL · Esc: skip — configure later</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "local-empty") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Ollama is running but you don&apos;t have any models yet.</Text>
+        <Text dimColor>Pick one to download. Sizes are approximate.</Text>
+        {error ? (
+          <>
+            <Text> </Text>
+            <Text color="red">{error}</Text>
+          </>
+        ) : null}
+        <Text> </Text>
+        <SelectInput
+          items={[
+            ...CURATED_MODELS.map((m) => ({
+              label: `${m.displayName.padEnd(28)} ~${m.approxSizeGb} GB · ${m.blurb}`,
+              value: m.name,
+            })),
+            { label: "Skip — I'll pull one myself later", value: "__skip__" },
+          ]}
+          onSelect={(item) => {
+            if (item.value === "__skip__") {
+              emitPatch({});
+              return;
+            }
+            void runPull(item.value);
+          }}
+        />
+        <Text> </Text>
+        <Text dimColor>Esc: skip</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "local-pick" || phase === "remote-pick") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>
+          {installedModels.length === 1
+            ? `Found 1 model on ${baseUrl}.`
+            : `Found ${installedModels.length} models on ${baseUrl}.`}
+        </Text>
+        <Text dimColor>Pick the default for new repos. You can change per-repo later.</Text>
+        <Text> </Text>
+        <SelectInput
+          items={[
+            ...installedModels.map((m) => ({
+              label: `${m.name.padEnd(38)} ${m.sizeBytes > 0 ? (m.sizeBytes / 1e9).toFixed(1) + " GB" : ""}`,
+              value: m.name,
+            })),
+            { label: "Skip — pick per-repo later", value: "__skip__" },
+          ]}
+          onSelect={(item) => {
+            if (item.value === "__skip__") {
+              emitPatch({});
+              return;
+            }
+            // model id stored in OctopusConfig is `ollama:<name>` so
+            // ai-router's prefix fallback routes through ollamaProvider.
+            emitPatch({ model: `ollama:${item.value}` });
+          }}
+        />
+        <Text> </Text>
+        <Text dimColor>Esc: skip</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "pulling") {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Pulling <Text color="cyan">{pullingModel}</Text>…</Text>
+        <Text dimColor>{pullStatus || "Starting…"}</Text>
+        <Text> </Text>
+        <Text dimColor>
+          This downloads the model into Ollama&apos;s store. Safe to wait;
+          partial downloads resume on re-run.
+        </Text>
+        {error ? <Text color="red">{error}</Text> : null}
+      </Box>
+    );
+  }
+
+  return null;
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  async function runPull(modelName: string) {
+    setPullingModel(modelName);
+    setPullStatus("");
+    setError("");
+    setPhase("pulling");
+    try {
+      let lastEmittedAt = 0;
+      await pullOllamaModel(baseUrl, modelName, (update: PullProgress) => {
+        // Rate-limit re-renders to ~4/sec — bytes flow much faster than that
+        // and re-rendering ink on every chunk causes flicker.
+        const now = Date.now();
+        if (now - lastEmittedAt < 250 && update.status !== "success") return;
+        lastEmittedAt = now;
+        if (update.total && update.completed != null) {
+          const pct = Math.floor((update.completed / update.total) * 100);
+          setPullStatus(`${update.status ?? "downloading"} — ${pct}%`);
+        } else if (update.status) {
+          setPullStatus(update.status);
+        }
+      });
+      emitPatch({ model: `ollama:${modelName}` });
+    } catch (e) {
+      setError(`Pull failed: ${e instanceof Error ? e.message : String(e)}`);
+      // Drop back to the picker so the user can either pick a different
+      // model or Esc to skip — the previous "stay on pulling" trapped
+      // them because the Esc handler short-circuits while phase==="pulling".
+      setPhase(isLocal ? "local-empty" : "remote-empty");
+    }
+  }
+}

--- a/apps/cli/src/steps/OrgStep.tsx
+++ b/apps/cli/src/steps/OrgStep.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text } from "ink";
+import SelectInput from "ink-select-input";
+import { loadCredentials, type Credentials } from "../lib/credentials.js";
+import { getJson } from "../lib/api.js";
+
+type MeResponse = {
+  user: { id: string; name: string; email: string };
+  organization: {
+    id: string;
+    name: string;
+    slug: string;
+    memberCount: number;
+    repoCount: number;
+  };
+};
+
+export type OrgStepProps = {
+  onNext: () => void;
+  /**
+   * Called when the user wants to switch organizations. The wizard sends them
+   * back to the Auth step where a fresh device-code flow targets a different org.
+   */
+  onSwitchOrg: () => void;
+};
+
+type Mode = "loading" | "no-creds" | "verifying" | "ready" | "failed";
+
+/**
+ * Confirmation step. Per the current API, a CLI token is scoped to one
+ * organization — there is no multi-org switcher. So OrgStep loads the saved
+ * credentials, hits /api/cli/me to verify the token is still valid + show
+ * fresh member/repo counts, then asks "continue with this org or re-sign in
+ * to switch?"
+ *
+ * If the user skipped auth (no credentials file), this step skips itself.
+ */
+export function OrgStep({ onNext, onSwitchOrg }: OrgStepProps) {
+  const [mode, setMode] = useState<Mode>("loading");
+  const [creds, setCreds] = useState<Credentials | null>(null);
+  const [me, setMe] = useState<MeResponse | null>(null);
+  const [error, setError] = useState<string>("");
+
+  useEffect(() => {
+    (async () => {
+      const loaded = await loadCredentials();
+      if (!loaded) {
+        // Auth was skipped — nothing to confirm. Pass through.
+        setMode("no-creds");
+        onNext();
+        return;
+      }
+      setCreds(loaded);
+      setMode("verifying");
+
+      const res = await getJson<MeResponse>(`${loaded.baseUrl}/api/cli/me`, {
+        headers: { authorization: `Bearer ${loaded.token}` },
+      });
+      if (!res.ok) {
+        setError(
+          res.status === 401
+            ? "Saved credentials were rejected. Re-sign in to continue."
+            : `Could not verify session: ${res.error}`,
+        );
+        setMode("failed");
+        return;
+      }
+      setMe(res.data);
+      setMode("ready");
+    })();
+  }, [onNext]);
+
+  if (mode === "loading" || mode === "verifying") {
+    return (
+      <Box flexDirection="column">
+        <Text>Verifying session …</Text>
+      </Box>
+    );
+  }
+
+  if (mode === "no-creds") {
+    return null; // already advanced
+  }
+
+  if (mode === "failed") {
+    return (
+      <Box flexDirection="column">
+        <Text color="red" bold>Session check failed.</Text>
+        <Text color="red">{error}</Text>
+        <Text> </Text>
+        <SelectInput
+          items={[
+            { label: "Re-sign in", value: "switch" },
+            { label: "Continue anyway (skip session check)", value: "skip" },
+          ]}
+          onSelect={(item) => (item.value === "switch" ? onSwitchOrg() : onNext())}
+        />
+      </Box>
+    );
+  }
+
+  // ready — normalise the two sources (live `/api/cli/me` response and the
+  // saved credentials) into the same shape so we don't have to discriminate
+  // the union at every property access.
+  const org = me?.organization
+    ? { name: me.organization.name, slug: me.organization.slug }
+    : { name: creds!.orgName, slug: creds!.orgSlug };
+  const user = me?.user;
+  return (
+    <Box flexDirection="column">
+      <Text bold>Signed in to organization</Text>
+      <Text> </Text>
+      <Text>  Org:   <Text color="cyan">{org.name}</Text> ({org.slug})</Text>
+      {user ? <Text>  User:  {user.name} &lt;{user.email}&gt;</Text> : null}
+      {me ? (
+        <>
+          <Text>  Members: {me.organization.memberCount}</Text>
+          <Text>  Repos:   {me.organization.repoCount}</Text>
+        </>
+      ) : null}
+      <Text> </Text>
+      <SelectInput
+        items={[
+          { label: `Continue with ${org.name}`, value: "continue" },
+          { label: "Switch organization (re-sign in)", value: "switch" },
+        ]}
+        onSelect={(item) => (item.value === "switch" ? onSwitchOrg() : onNext())}
+      />
+    </Box>
+  );
+}

--- a/apps/cli/src/steps/ProviderStep.tsx
+++ b/apps/cli/src/steps/ProviderStep.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import { PROVIDERS, type ProviderInfo } from "../lib/providers.js";
+
+export type ProviderStepProps = {
+  onNext: (patch: { provider: string }) => void;
+};
+
+const TYPE_ORDER: ProviderInfo["type"][] = ["direct", "harness", "gateway", "local"];
+const TYPE_LABEL: Record<ProviderInfo["type"], string> = {
+  direct: "Direct API",
+  harness: "Agent harnesses",
+  gateway: "Gateways",
+  local: "Local",
+};
+
+/**
+ * Render the catalogue as a single SelectInput with type labels as
+ * non-selectable separators. ink-select-input does not support headers,
+ * so we use disabled items with a leading dash convention; the selector
+ * skips them via the `isItemSelectable` we wrap around the items list.
+ *
+ * Coming-soon providers are still shown (so users see what's planned)
+ * but disabled — selecting them moves on with a one-line note that
+ * onboarding completes but reviews won't run until the backend lands.
+ */
+export function ProviderStep({ onNext }: ProviderStepProps) {
+  useInput((_input, key) => {
+    if (key.escape) onNext({ provider: "" }); // skip — onboarding finishes without a provider
+  });
+
+  // Build a flat list with type headings interleaved. Headings are inert
+  // (selecting one is a no-op handled in onSelect).
+  type Item = { label: string; value: string; isHeading?: boolean; disabled?: boolean };
+  const items: Item[] = [];
+  for (const type of TYPE_ORDER) {
+    const inType = PROVIDERS.filter((p) => p.type === type);
+    if (inType.length === 0) continue;
+    items.push({ label: `── ${TYPE_LABEL[type]} ──`, value: `__heading_${type}`, isHeading: true });
+    for (const p of inType) {
+      const suffix = p.status === "coming-soon" ? " (coming soon)" : "";
+      items.push({
+        label: `  ${p.displayName}${suffix}`,
+        value: p.slug,
+        disabled: p.status === "coming-soon",
+      });
+    }
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Pick an AI provider</Text>
+      <Text dimColor>The provider runs your code reviews. You can change this later.</Text>
+      <Text> </Text>
+      <SelectInput
+        items={items}
+        onSelect={(item) => {
+          if (item.value.startsWith("__heading_")) return; // ignore
+          onNext({ provider: item.value });
+        }}
+      />
+      <Text> </Text>
+      <Text dimColor>Use ↑/↓ to move, Enter to select · Esc to skip</Text>
+    </Box>
+  );
+}

--- a/apps/cli/src/steps/RepoStep.tsx
+++ b/apps/cli/src/steps/RepoStep.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import { loadCredentials } from "../lib/credentials.js";
+import { getJson } from "../lib/api.js";
+
+const GITHUB_APP_SLUG = process.env.OCTOPUS_GITHUB_APP_SLUG ?? "octopus-review";
+
+export type RepoStepProps = {
+  onNext: () => void;
+};
+
+type Repo = {
+  id: string;
+  name: string;
+  fullName: string;
+  provider: string;
+  indexStatus: string;
+  indexedAt: string | null;
+  autoReview: boolean;
+};
+
+type Phase = "loading" | "no-creds" | "loaded" | "failed";
+
+/**
+ * Connect a repo to Octopus.
+ *
+ * Today's scope: list the org's already-connected repos (via /api/cli/repos)
+ * with their index/review status. If the user wants to add a new repo we
+ * link them to the GitHub App install page; we don't fetch their GitHub
+ * repo list (that needs a different OAuth scope and is a separate epic).
+ *
+ * Self-hosted: skipped — repos there are added via the web UI's GitHub
+ * integration page, not via this wizard.
+ */
+export function RepoStep({ onNext }: RepoStepProps) {
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [repos, setRepos] = useState<Repo[]>([]);
+  const [error, setError] = useState<string>("");
+  const [installUrl, setInstallUrl] = useState<string>("");
+
+  useInput((_input, key) => {
+    if (key.escape && phase !== "loading") onNext();
+  });
+
+  useEffect(() => {
+    (async () => {
+      const creds = await loadCredentials();
+      if (!creds) {
+        setPhase("no-creds");
+        onNext();
+        return;
+      }
+
+      // Self-hosted users: skip the repo step entirely. The hosted GitHub
+      // App install flow is irrelevant for them.
+      const isHosted = creds.baseUrl === "https://octopus-review.ai";
+      if (!isHosted) {
+        onNext();
+        return;
+      }
+
+      setInstallUrl(`https://github.com/apps/${GITHUB_APP_SLUG}/installations/new`);
+
+      const res = await getJson<{ repos: Repo[] }>(`${creds.baseUrl}/api/cli/repos`, {
+        headers: { authorization: `Bearer ${creds.token}` },
+      });
+      if (!res.ok) {
+        setError(`Could not list repos: ${res.error}`);
+        setPhase("failed");
+        return;
+      }
+      setRepos(res.data.repos);
+      setPhase("loaded");
+    })();
+  }, [onNext]);
+
+  if (phase === "loading") {
+    return (
+      <Box flexDirection="column">
+        <Text>Loading connected repositories …</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "no-creds") return null;
+
+  if (phase === "failed") {
+    return (
+      <Box flexDirection="column">
+        <Text color="red" bold>Could not list repos.</Text>
+        <Text color="red">{error}</Text>
+        <Text> </Text>
+        <Text dimColor>Esc to continue anyway.</Text>
+      </Box>
+    );
+  }
+
+  // loaded
+  if (repos.length === 0) {
+    return (
+      <Box flexDirection="column">
+        <Text bold>No repositories connected yet</Text>
+        <Text> </Text>
+        <Text>Install the Octopus GitHub App to start reviewing PRs:</Text>
+        <Text color="cyan">{installUrl}</Text>
+        <Text> </Text>
+        <Text dimColor>Open the URL in your browser, pick a repo, click Install.</Text>
+        <Text dimColor>You can always do this later from the Octopus web UI.</Text>
+        <Text> </Text>
+        <SelectInput
+          items={[
+            { label: "Continue (I'll install later)", value: "continue" },
+          ]}
+          onSelect={() => onNext()}
+        />
+      </Box>
+    );
+  }
+
+  // Show connected repos as an informational list, then offer continue.
+  return (
+    <Box flexDirection="column">
+      <Text bold>Connected repositories ({repos.length})</Text>
+      <Text> </Text>
+      {repos.slice(0, 8).map((r) => (
+        <Text key={r.id}>
+          {" "}{statusBadge(r.indexStatus)} {r.fullName}{" "}
+          <Text dimColor>· {r.autoReview ? "auto-review on" : "auto-review off"}</Text>
+        </Text>
+      ))}
+      {repos.length > 8 ? <Text dimColor>  …and {repos.length - 8} more</Text> : null}
+      <Text> </Text>
+      <Text dimColor>
+        Add more repos at <Text color="cyan">{installUrl}</Text>
+      </Text>
+      <Text> </Text>
+      <SelectInput
+        items={[{ label: "Continue", value: "continue" }]}
+        onSelect={() => onNext()}
+      />
+    </Box>
+  );
+}
+
+function statusBadge(status: string): string {
+  if (status === "indexed") return "✓";
+  if (status === "indexing") return "↻";
+  if (status === "failed") return "✗";
+  return "·"; // pending or unknown
+}

--- a/apps/cli/src/steps/ValidateStep.tsx
+++ b/apps/cli/src/steps/ValidateStep.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import SelectInput from "ink-select-input";
+import { validateProvider, type ValidateResult } from "../lib/validate.js";
+
+export type ValidateStepProps = {
+  provider: string;
+  onNext: () => void;
+  /** Wizard sends the user back here when they want to edit their key. */
+  onEditKey: () => void;
+};
+
+type Phase = "validating" | "ok" | "failed" | "skipped";
+
+/**
+ * Live API ping to confirm the BYOK key works (or that Ollama is reachable).
+ * Each provider has a cheapest-possible check defined in lib/validate.ts.
+ *
+ * Phases:
+ *   validating → fetch is in flight
+ *   ok         → green check, brief pause, auto-advance
+ *   skipped    → provider has no validator yet; render a note + advance
+ *   failed     → red error + SelectInput: retry / edit-key / skip
+ */
+export function ValidateStep({ provider, onNext, onEditKey }: ValidateStepProps) {
+  const [phase, setPhase] = useState<Phase>("validating");
+  const [result, setResult] = useState<ValidateResult | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  useInput((_input, key) => {
+    if (key.escape && phase !== "validating" && phase !== "ok") onNext();
+  });
+
+  useEffect(() => {
+    if (!provider) {
+      onNext();
+      return;
+    }
+    let cancelled = false;
+    // Track the auto-advance timer so we can clear it on unmount. Without
+    // this, an Esc during the 1.2s "skipped" window (or the 600ms "ok"
+    // window) calls onNext immediately, then the un-cleared timer fires
+    // after unmount and calls onNext a second time — stepIndex advances
+    // twice, jumping past RepoStep to Done without the user seeing it.
+    let autoAdvance: ReturnType<typeof setTimeout> | null = null;
+    (async () => {
+      setPhase("validating");
+      const r = await validateProvider(provider);
+      if (cancelled) return;
+      setResult(r);
+      if (r.ok === true) {
+        setPhase("ok");
+        autoAdvance = setTimeout(onNext, 600);
+      } else if (r.ok === "skipped") {
+        setPhase("skipped");
+        autoAdvance = setTimeout(onNext, 1200);
+      } else {
+        setPhase("failed");
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (autoAdvance !== null) clearTimeout(autoAdvance);
+    };
+  }, [provider, attempt, onNext]);
+
+  if (!provider) return null;
+
+  if (phase === "validating") {
+    return (
+      <Box flexDirection="column">
+        <Text>Validating {provider} credentials …</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "ok" && result?.ok === true) {
+    return (
+      <Box flexDirection="column">
+        <Text color="green">
+          ✓ {provider} reachable
+          {typeof result.modelCount === "number"
+            ? ` — ${result.modelCount} model${result.modelCount === 1 ? "" : "s"} available.`
+            : "."}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (phase === "skipped" && result?.ok === "skipped") {
+    return (
+      <Box flexDirection="column">
+        <Text color="yellow">⚠ Skipping validation</Text>
+        <Text dimColor>{result.reason}</Text>
+      </Box>
+    );
+  }
+
+  if (phase === "failed" && result && result.ok === false) {
+    // Strip ANSI / OSC escapes from `result.message` before rendering —
+    // it can contain raw response bodies from arbitrary remote endpoints
+    // (the user's self-hosted URL or BYOK provider), and a malicious or
+    // misconfigured remote could otherwise inject cursor movement /
+    // terminal-title-rewrite / hyperlink sequences into the wizard's
+    // output. \x1b is the ESC byte; the broad alternation covers CSI,
+    // OSC, and other introducers.
+    const safeMessage = result.message?.replace(
+      // eslint-disable-next-line no-control-regex
+      /\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[A-Za-z=>]/g,
+      "",
+    );
+    return (
+      <Box flexDirection="column">
+        <Text color="red" bold>Validation failed{result.status ? ` (HTTP ${result.status})` : ""}.</Text>
+        <Text color="red">{safeMessage}</Text>
+        <Text> </Text>
+        <SelectInput
+          items={[
+            { label: "Retry", value: "retry" },
+            { label: "Edit the API key", value: "edit" },
+            { label: "Skip — continue anyway", value: "skip" },
+          ]}
+          onSelect={(item) => {
+            if (item.value === "retry") setAttempt((a) => a + 1);
+            else if (item.value === "edit") onEditKey();
+            else onNext();
+          }}
+        />
+      </Box>
+    );
+  }
+
+  return null;
+}

--- a/apps/cli/src/steps/WelcomeStep.tsx
+++ b/apps/cli/src/steps/WelcomeStep.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+
+export type WelcomeStepProps = {
+  onNext: () => void;
+};
+
+export function WelcomeStep({ onNext }: WelcomeStepProps) {
+  useInput((_input, key) => {
+    if (key.return) onNext();
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Welcome to Octopus 🐙</Text>
+      <Text> </Text>
+      <Text>
+        Octopus is an AI code reviewer that runs on every pull request — using the
+      </Text>
+      <Text>AI provider and model you pick. This wizard takes about a minute.</Text>
+      <Text> </Text>
+      <Text dimColor>Press Enter to continue · Ctrl+C to quit</Text>
+    </Box>
+  );
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@octopus/tsconfig/node.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist", "src/__tests__/**"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,23 @@
         "turbo": "^2",
       },
     },
+    "apps/cli": {
+      "name": "@octopus/cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "ink": "^6.8.0",
+        "ink-select-input": "^6.2.0",
+        "ink-text-input": "^6.0.0",
+        "react": "19.2.5",
+        "react-devtools-core": "^7.0.1",
+      },
+      "devDependencies": {
+        "@octopus/tsconfig": "workspace:*",
+        "@types/react": "^19",
+        "bun-types": "^1.3.12",
+        "typescript": "^5",
+      },
+    },
     "apps/web": {
       "name": "@octopus/web",
       "version": "0.1.0",
@@ -114,6 +131,8 @@
     "prisma",
   ],
   "packages": {
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
@@ -539,6 +558,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@octopus/cli": ["@octopus/cli@workspace:apps/cli"],
 
     "@octopus/db": ["@octopus/db@workspace:packages/db"],
 
@@ -1140,9 +1161,11 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "apache-arrow": ["apache-arrow@21.1.0", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^24.0.3", "command-line-args": "^6.0.1", "command-line-usage": "^7.0.1", "flatbuffers": "^25.1.24", "json-bignum": "^0.0.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.js" } }, "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA=="],
 
@@ -1179,6 +1202,8 @@
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "atomically": ["atomically@2.1.1", "", { "dependencies": { "stubborn-fs": "^2.0.0", "when-exit": "^2.1.4" } }, "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
@@ -1246,7 +1271,7 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
-    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "chalk-template": ["chalk-template@0.4.0", "", { "dependencies": { "chalk": "^4.1.2" } }, "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg=="],
 
@@ -1268,9 +1293,13 @@
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
-    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
 
     "cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
+    "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
@@ -1285,6 +1314,8 @@
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 
     "cohere-ai": ["cohere-ai@7.20.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-sdk/client-sagemaker": "^3.583.0", "@aws-sdk/credential-providers": "^3.583.0", "@smithy/protocol-http": "^5.1.2", "@smithy/signature-v4": "^5.1.2", "convict": "^6.2.4", "form-data": "^4.0.4", "form-data-encoder": "^4.1.0", "formdata-node": "^6.0.3", "readable-stream": "^4.7.0" } }, "sha512-h/3h3pcLXRUmkzp/W+/FWViEMcAFtSZ8YayCTFQXpib112uNSj3feApOtJg7v9lreWR1t7gznhE6N9KNCX5FOA=="],
 
@@ -1315,6 +1346,8 @@
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
     "convict": ["convict@6.2.4", "", { "dependencies": { "lodash.clonedeep": "^4.5.0", "yargs-parser": "^20.2.7" } }, "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ=="],
 
@@ -1525,6 +1558,8 @@
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
@@ -1794,9 +1829,17 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
     "index-array-by": ["index-array-by@1.4.2", "", {}, "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ink": ["ink@6.8.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.4", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^8.0.0", "stack-utils": "^2.0.6", "string-width": "^8.1.1", "terminal-size": "^4.0.1", "type-fest": "^5.4.1", "widest-line": "^6.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA=="],
+
+    "ink-select-input": ["ink-select-input@6.2.0", "", { "dependencies": { "figures": "^6.1.0", "to-rotated": "^1.0.0" }, "peerDependencies": { "ink": ">=5.0.0", "react": ">=18.0.0" } }, "sha512-304fZXxkpYxJ9si5lxRCaX01GNlmPBgOZumXXRnPYbHW/iI31cgQynqk2tRypGLOF1cMIwPUzL2LSm6q4I5rQQ=="],
+
+    "ink-text-input": ["ink-text-input@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "type-fest": "^4.18.2" }, "peerDependencies": { "ink": ">=5", "react": ">=18" } }, "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw=="],
 
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
@@ -1842,13 +1885,15 @@
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
 
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
 
     "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
 
@@ -2260,6 +2305,8 @@
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
@@ -2378,6 +2425,8 @@
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
+    "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-email": ["react-email@5.2.10", "", { "dependencies": { "@babel/parser": "7.27.0", "@babel/traverse": "7.27.0", "chokidar": "^4.0.3", "commander": "^13.0.0", "conf": "^15.0.2", "debounce": "^2.0.0", "esbuild": "0.27.3", "glob": "^13.0.6", "jiti": "2.4.2", "log-symbols": "^7.0.0", "mime-types": "^3.0.0", "normalize-path": "^3.0.0", "nypm": "0.6.2", "ora": "^8.0.0", "prompts": "2.4.2", "socket.io": "^4.8.1", "tsconfig-paths": "4.2.0" }, "bin": { "email": "dist/index.mjs" } }, "sha512-Ys8yR5/a0nXf5u2GlT2UV93PJHC3ZnuMnNebEn7I5UE9XfMFPtlpgDs02mPJOJn49fhJjDTWIUlZD1vmQPDgJg=="],
@@ -2389,6 +2438,8 @@
     "react-kapsule": ["react-kapsule@2.5.7", "", { "dependencies": { "jerrypick": "^1.1.1" }, "peerDependencies": { "react": ">=16.13.1" } }, "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
+    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
 
@@ -2446,7 +2497,7 @@
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
-    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
@@ -2514,6 +2565,8 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shell-quote": ["shell-quote@1.9.0", "", {}, "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA=="],
+
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
@@ -2522,9 +2575,11 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
 
     "socket.io": ["socket.io@4.8.3", "", { "dependencies": { "accepts": "~1.3.4", "base64id": "~2.0.0", "cors": "~2.8.5", "debug": "~4.4.1", "engine.io": "~6.6.0", "socket.io-adapter": "~2.5.2", "socket.io-parser": "~4.2.4" } }, "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A=="],
 
@@ -2548,6 +2603,8 @@
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
@@ -2566,7 +2623,7 @@
 
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
 
-    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+    "string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
 
     "string.prototype.includes": ["string.prototype.includes@2.0.1", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-abstract": "^1.23.3" } }, "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg=="],
 
@@ -2630,6 +2687,8 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
+    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
+
     "three": ["three@0.183.2", "", {}, "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="],
 
     "three-mesh-bvh": ["three-mesh-bvh@0.8.3", "", { "peerDependencies": { "three": ">= 0.159.0" } }, "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg=="],
@@ -2649,6 +2708,8 @@
     "tldts-core": ["tldts-core@7.0.25", "", {}, "sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "to-rotated": ["to-rotated@1.0.0", "", {}, "sha512-KsEID8AfgUy+pxVRLsWp0VzCa69wxzUDZnzGbyIST/bcgcrMvTYoFBX/QORH4YApoD89EDuUovx4BTdpOn319Q=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
@@ -2802,11 +2863,13 @@
 
     "which-typed-array": ["which-typed-array@1.1.20", "", { "dependencies": { "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "for-each": "^0.3.5", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2" } }, "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg=="],
 
+    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
+
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wordwrapjs": ["wordwrapjs@5.1.1", "", {}, "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg=="],
 
-    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
@@ -2829,6 +2892,8 @@
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zeptomatch": ["zeptomatch@2.1.0", "", { "dependencies": { "grammex": "^3.1.11", "graphmatch": "^1.1.0" } }, "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA=="],
 
@@ -3162,6 +3227,10 @@
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
     "@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
@@ -3232,6 +3301,8 @@
 
     "canvas-renderer/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
+    "chalk-template/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "chevrotain-allstar/chevrotain": ["chevrotain@11.1.2", "", { "dependencies": { "@chevrotain/cst-dts-gen": "11.1.2", "@chevrotain/gast": "11.1.2", "@chevrotain/regexp-to-ast": "11.1.2", "@chevrotain/types": "11.1.2", "@chevrotain/utils": "11.1.2", "lodash-es": "4.17.23" } }, "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -3264,6 +3335,8 @@
 
     "engine.io/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
+    "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
@@ -3282,17 +3355,23 @@
 
     "eslint-plugin-react-hooks/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
 
+    "execa/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "giget/nypm": ["nypm@0.6.5", "", { "dependencies": { "citty": "^0.2.0", "pathe": "^2.0.3", "tinyexec": "^1.0.2" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ=="],
 
     "glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
@@ -3310,9 +3389,11 @@
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
-    "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+    "ora/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
     "ora/log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
+
+    "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -3320,11 +3401,9 @@
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
-    "proper-lockfile/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+    "react-devtools-core/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
 
     "react-email/jiti": ["jiti@2.4.2", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="],
-
-    "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "router/is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
@@ -3338,9 +3417,9 @@
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "stats-gl/three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
+    "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
-    "string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+    "stats-gl/three": ["three@0.170.0", "", {}, "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ=="],
 
     "svix/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
@@ -3348,9 +3427,7 @@
 
     "tunnel-rat/zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
 
-    "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -3570,11 +3647,15 @@
 
     "@dotenvx/dotenvx/execa/npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
-    "@dotenvx/dotenvx/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
     "@dotenvx/dotenvx/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
     "@dotenvx/dotenvx/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+
+    "@inquirer/core/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@inquirer/core/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -3600,6 +3681,8 @@
 
     "canvas-renderer/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "chalk-template/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "chevrotain-allstar/chevrotain/@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.1.2", "", { "dependencies": { "@chevrotain/gast": "11.1.2", "@chevrotain/types": "11.1.2", "lodash-es": "4.17.23" } }, "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q=="],
 
     "chevrotain-allstar/chevrotain/@chevrotain/gast": ["@chevrotain/gast@11.1.2", "", { "dependencies": { "@chevrotain/types": "11.1.2", "lodash-es": "4.17.23" } }, "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g=="],
@@ -3610,7 +3693,11 @@
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cohere-ai/@smithy/protocol-http/@smithy/types": ["@smithy/types@4.13.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g=="],
 
@@ -3625,6 +3712,8 @@
     "engine.io/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "eslint-plugin-import/tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
+
+    "eslint/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -3644,13 +3733,17 @@
 
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
+    "ora/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
     "ora/log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
-    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -3710,11 +3803,21 @@
 
     "@aws-sdk/nested-clients/@aws-sdk/core/@aws-sdk/xml-builder/fast-xml-parser": ["fast-xml-parser@5.4.1", "", { "dependencies": { "fast-xml-builder": "^1.0.0", "strnum": "^2.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A=="],
 
+    "@inquirer/core/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "@inquirer/core/wrap-ansi/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "ora/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 


### PR DESCRIPTION
## What
The self-contained **octp** CLI (`apps/cli`, ~5.4k LOC, ink TUI, Bun-compiled binary). Subcommands: first-run **onboarding wizard**, **`octp review`** (uses the local-review + index-local backends from Slices 1–2), **`octp agent serve`** (the LLM-agent bridge from Slice 3), **`octp doctor`**. Device-flow auth against existing `/api/cli/auth/*`; credentials in `~/.octopus` (mode 0600). **No `@octopus/*` runtime imports** — only the `@octopus/tsconfig` build dep (already upstream).

## CI / monorepo
- `bun.lock` regenerated (adds ink / ink-select-input / ink-text-input / react-devtools-core); `bun install --frozen-lockfile` passes.
- turbo runs the CLI's typecheck (`tsc --noEmit`) + build (`bun build --target node --minify`) — both green. (`bun test` is local-only; 63/0 here.)
- **Not** added to `.dockerignore`: the web Dockerfile uses `--frozen-lockfile` which references the `@octopus/cli` workspace, so excluding it would break the frozen install. The source in the build context is negligible and never enters the final image (only `apps/web/.next/standalone` is copied).

## Constant sync (CLI hand-duplicates a few server values)
- `MAX_DIFF_BYTES` = 500KB == `cli-limits.ts` `MAX_LOCAL_REVIEW_DIFF_BYTES` ✓
- model list mirrors `cost.ts`/seed; provider slugs mirror `ai-router` `PROVIDER_FALLBACK`.

## Scope
- The `octp-v*` release workflow + web-served installers are **Slice 5** (next). `apps/cli/install/` scripts are included (part of the CLI) but resolve a binary only once a release is cut.

## Test plan
- [x] frozen-lockfile / typecheck / lint / build clean; `cd apps/cli && bun test` = 63/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)