### PR TITLE
feat(cli): octp release workflow + installer sync (distribution)

### DIFF
--- a/.github/workflows/octp-release.yml
+++ b/.github/workflows/octp-release.yml
@@ -1,0 +1,67 @@
+name: Release octp CLI binaries
+
+# Cross-compiles the apps/cli package to five native binaries and attaches
+# them to a GitHub Release. Triggered by pushing a tag whose name starts
+# with `octp-v` (e.g. `octp-v0.1.0`).
+#
+# The install scripts (install.sh / install.ps1) look up the latest such
+# tag and download the matching asset for the user's platform.
+
+on:
+  push:
+    tags:
+      - "octp-v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build + publish
+    runs-on: ubuntu-latest
+    steps:
+      # Third-party actions pinned to full commit SHAs (the standard
+      # supply-chain mitigation for workflows with contents:write — see
+      # https://docs.github.com/en/actions/security-guides). Floating @v*
+      # tags can be re-pointed by the action owner (or anyone who compromises
+      # it), and this workflow publishes binaries that install.sh /
+      # install.ps1 then pipe directly onto user machines. The trailing
+      # comment is the tag the SHA was resolved from at pin time.
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: 1.3.4
+
+      - name: Install dependencies (root workspace)
+        run: bun install --frozen-lockfile
+
+      - name: Cross-compile all targets
+        working-directory: apps/cli
+        run: bun run build:compile
+
+      - name: List built binaries
+        run: ls -la apps/cli/dist
+
+      - name: Generate SHA256 checksums
+        working-directory: apps/cli/dist
+        run: |
+          shasum -a 256 octp-* > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
+        with:
+          # Auto-generate release notes from PRs/commits since the previous tag.
+          generate_release_notes: true
+          # The trigger tag controls which assets to publish.
+          fail_on_unmatched_files: true
+          files: |
+            apps/cli/dist/octp-linux-x64
+            apps/cli/dist/octp-linux-arm64
+            apps/cli/dist/octp-darwin-x64
+            apps/cli/dist/octp-darwin-arm64
+            apps/cli/dist/octp-windows-x64.exe
+            apps/cli/dist/SHA256SUMS.txt

--- a/.github/workflows/sync-installers-check.yml
+++ b/.github/workflows/sync-installers-check.yml
@@ -1,0 +1,19 @@
+name: sync-installers-check
+
+on:
+  pull_request:
+    paths:
+      - "apps/cli/install/install.sh"
+      - "apps/cli/install/install.ps1"
+      - "apps/web/public/install.sh"
+      - "apps/web/public/install.ps1"
+      - "scripts/sync-installers.sh"
+      - ".github/workflows/sync-installers-check.yml"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify installer sync
+        run: scripts/sync-installers.sh --check

--- a/.github/workflows/sync-installers-check.yml
+++ b/.github/workflows/sync-installers-check.yml
@@ -14,6 +14,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Verify installer sync
         run: scripts/sync-installers.sh --check

--- a/apps/web/public/install.ps1
+++ b/apps/web/public/install.ps1
@@ -1,146 +1,131 @@
-#Requires -Version 6.0
-# Octopus CLI installer for Windows (requires PowerShell 6+ / PowerShell Core)
-# Usage: irm https://octopus-review.ai/install.ps1 | iex
+# AUTO-SYNCED COPY — DO NOT EDIT DIRECTLY.
+# Canonical source: apps/cli/install/install.ps1. To update this file, edit
+# the canonical source and run `scripts/sync-installers.sh` (or copy by
+# hand). A diff against the canonical version fails the CI check in
+# .github/workflows/sync-installers-check.yml.
+#
+# Octopus CLI installer (Windows / PowerShell).
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/octopusreview/octopus/master/apps/cli/install/install.ps1 | iex
+#
+# What it does:
+#   1. Detects your CPU architecture
+#   2. Fetches the latest `octp-v*` release from GitHub
+#   3. Downloads the matching native .exe
+#   4. Installs it to $env:USERPROFILE\.octopus\bin\octp.exe (or $env:OCTOPUS_INSTALL_DIR)
+#   5. Adds the install directory to your user PATH (idempotent)
+#
+# After install, run `octp` to launch the first-run onboarding wizard.
+#
+# Environment variables:
+#   $env:OCTOPUS_INSTALL_DIR   Override install directory
+#   $env:OCTOPUS_INSTALL_REPO  Override the GitHub repo (default: octopusreview/octopus)
+#   $env:OCTOPUS_INSTALL_TAG   Install a specific tag instead of latest
+
 $ErrorActionPreference = "Stop"
 
-$GITHUB_REPO = "octopusreview/octopus-cli"
-$BINARY_NAME = "octopus"
-$INSTALL_DIR = "$env:USERPROFILE\.octopus\bin"
+$Repo        = if ($env:OCTOPUS_INSTALL_REPO) { $env:OCTOPUS_INSTALL_REPO } else { "octopusreview/octopus" }
+$InstallDir  = if ($env:OCTOPUS_INSTALL_DIR)  { $env:OCTOPUS_INSTALL_DIR }  else { Join-Path $env:USERPROFILE ".octopus\bin" }
+$BinaryName  = "octp.exe"
 
-# ─── Helpers ────────────────────────────────────────────────────────────────
+# ── Step 1: arch ─────────────────────────────────────────────────────────────
 
-function Write-Info    { param($msg) Write-Host $msg -ForegroundColor Cyan }
-function Write-Success { param($msg) Write-Host $msg -ForegroundColor Green }
-function Write-Warn    { param($msg) Write-Host $msg -ForegroundColor Yellow }
-function Write-Err     { param($msg) Write-Host "error: $msg" -ForegroundColor Red; exit 1 }
+# We only ship x64 today. ARM64 Windows can fall back to x64 emulation; if a
+# native ARM64 build is added later, expand this map.
+$arch = "x64"
+$asset = "octp-windows-${arch}.exe"
 
-# ─── Detect Architecture ───────────────────────────────────────────────────
+# ── Step 2: resolve release tag ──────────────────────────────────────────────
 
-function Get-Arch {
-    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-    switch ($arch) {
-        "X64"   { return "x64" }
-        "Arm64" { return "arm64" }
-        default { Write-Err "Unsupported architecture: $arch" }
-    }
+if ($env:OCTOPUS_INSTALL_TAG) {
+  $tag = $env:OCTOPUS_INSTALL_TAG
+  Write-Host "Installing pinned version: $tag"
+} else {
+  Write-Host "Looking up latest octp release on $Repo ..."
+  # Find the most recent NON-DRAFT, NON-PRERELEASE octp-v* tag.
+  # Users testing prerelease tags can override via $env:OCTOPUS_INSTALL_TAG.
+  $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=30" -Headers @{ "User-Agent" = "octp-installer" }
+  $tag = (
+    $releases |
+      Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name -like "octp-v*" } |
+      Select-Object -First 1
+  ).tag_name
+  if (-not $tag) {
+    Write-Error "Could not find any non-prerelease octp-v* on $Repo. Pin a tag with `$env:OCTOPUS_INSTALL_TAG = 'octp-v0.X.Y'`."
+    exit 1
+  }
+  Write-Host "Latest release: $tag"
 }
 
-# ─── Get Latest Release ────────────────────────────────────────────────────
+# ── Step 3: download ─────────────────────────────────────────────────────────
 
-function Get-LatestVersion {
-    $url = "https://api.github.com/repos/$GITHUB_REPO/releases/latest"
+$downloadUrl = "https://github.com/$Repo/releases/download/$tag/$asset"
+$sumsUrl = "https://github.com/$Repo/releases/download/$tag/SHA256SUMS.txt"
+Write-Host "Downloading $downloadUrl ..."
+
+New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+$target = Join-Path $InstallDir $BinaryName
+
+try {
+  Invoke-WebRequest -Uri $downloadUrl -OutFile $target -UseBasicParsing
+} catch {
+  Write-Error "Failed to download $asset from $tag. The release might not have a Windows binary."
+  exit 1
+}
+
+# ── Step 3b: verify SHA256 checksum ──────────────────────────────────────────
+# octp-release.yml generates SHA256SUMS.txt and attaches it to every release.
+# Verifying the binary against the published sum protects against in-flight
+# tampering and truncated downloads. Set $env:OCTOPUS_INSTALL_SKIP_VERIFY="1"
+# to bypass (only do this when pinning a tag pre-dating the sums workflow).
+
+if ($env:OCTOPUS_INSTALL_SKIP_VERIFY -eq "1") {
+  Write-Host "SKIPPING SHA256 verification (OCTOPUS_INSTALL_SKIP_VERIFY=1)."
+} else {
+  $sumsTmp = New-TemporaryFile
+  try {
     try {
-        $release = Invoke-RestMethod -Uri $url -Headers @{ "User-Agent" = "octopus-installer" }
-        $version = $release.tag_name
-        if (-not $version) { Write-Err "Could not determine latest version." }
-        Write-Info "Latest version: $version"
-        return $version
+      Invoke-WebRequest -Uri $sumsUrl -OutFile $sumsTmp -UseBasicParsing
     } catch {
-        Write-Err "Failed to fetch latest release: $_"
+      Remove-Item $target -Force -ErrorAction SilentlyContinue
+      Write-Error "Could not download SHA256SUMS.txt from $tag. Older releases pre-date the sums workflow — set `$env:OCTOPUS_INSTALL_SKIP_VERIFY='1' if you accept that risk."
+      exit 1
     }
+    $expectedLine = Get-Content $sumsTmp | Where-Object { $_ -match "  $([Regex]::Escape($asset))$" } | Select-Object -First 1
+    if (-not $expectedLine) {
+      Remove-Item $target -Force -ErrorAction SilentlyContinue
+      Write-Error "No SHA256SUMS.txt entry for $asset on $tag. Set `$env:OCTOPUS_INSTALL_SKIP_VERIFY='1' to bypass (NOT recommended)."
+      exit 1
+    }
+    $expected = ($expectedLine -split "\s+")[0]
+    $actual = (Get-FileHash -Algorithm SHA256 -Path $target).Hash.ToLower()
+    if ($expected -ne $actual) {
+      Remove-Item $target -Force -ErrorAction SilentlyContinue
+      Write-Error "SHA256 mismatch for $asset. expected=$expected actual=$actual. The download may be corrupt or tampered. Aborting."
+      exit 1
+    }
+    Write-Host "Verified SHA256 ($expected)"
+  } finally {
+    Remove-Item $sumsTmp -Force -ErrorAction SilentlyContinue
+  }
 }
 
-# ─── Download & Install ────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "Installed octp → $target"
 
-function Install-Octopus {
-    param($arch)
-    $version = Get-LatestVersion
+# ── Step 4: PATH ─────────────────────────────────────────────────────────────
 
-    $artifactBase = "$BINARY_NAME-windows-$arch"
-    $archive = "$artifactBase.tar.gz"
-    $downloadUrl = "https://github.com/$GITHUB_REPO/releases/download/$version/$archive"
-
-    Write-Info "Downloading $archive..."
-
-    # Ensure install directory exists
-    if (-not (Test-Path $INSTALL_DIR)) {
-        New-Item -ItemType Directory -Path $INSTALL_DIR -Force | Out-Null
-    }
-
-    $tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) "octopus-install-$([System.Guid]::NewGuid().ToString('N'))"
-    New-Item -ItemType Directory -Path $tmpDir -Force | Out-Null
-
-    $archivePath = Join-Path $tmpDir $archive
-
-    try {
-        Invoke-WebRequest -Uri $downloadUrl -OutFile $archivePath -UseBasicParsing
-    } catch {
-        Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
-        Write-Err "Download failed. Check if a release exists for windows-$arch. Error: $_"
-    }
-
-    # Verify SHA256 checksum if checksums.txt is available
-    $checksumsUrl = "https://github.com/$GITHUB_REPO/releases/download/$version/checksums.txt"
-    try {
-        $checksums = Invoke-RestMethod -Uri $checksumsUrl -Headers @{ "User-Agent" = "octopus-installer" }
-        $expectedLine = $checksums -split "`n" | Where-Object { $_ -match [regex]::Escape($archive) }
-        if ($expectedLine) {
-            $expectedSha = ($expectedLine -split "\s+")[0]
-            $actualSha = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLower()
-            if ($expectedSha -ne $actualSha) {
-                Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
-                Write-Err "Checksum mismatch! Expected $expectedSha, got $actualSha. Aborting."
-            }
-            Write-Info "Checksum verified."
-        }
-    } catch {
-        Write-Warn "No checksums.txt found for this release -- skipping integrity check."
-    }
-
-    # Extract binary from archive
-    tar -xzf $archivePath -C $tmpDir
-    $extractedBinary = Join-Path $tmpDir "$BINARY_NAME.exe"
-    if (-not (Test-Path $extractedBinary)) {
-        Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
-        Write-Err "Expected binary '$BINARY_NAME.exe' not found in archive."
-    }
-
-    $destination = Join-Path $INSTALL_DIR "$BINARY_NAME.exe"
-    Copy-Item $extractedBinary $destination -Force
-    Remove-Item $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
-
-    Write-Success "Installed $BINARY_NAME to $destination"
-
-    # Add to PATH if not already there
-    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
-    if ($userPath -notlike "*$INSTALL_DIR*") {
-        [Environment]::SetEnvironmentVariable("Path", "$userPath;$INSTALL_DIR", "User")
-        $env:Path = "$env:Path;$INSTALL_DIR"
-        Write-Info "Added $INSTALL_DIR to your PATH."
-    }
+$userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+$pathEntries = $userPath -split ";" | Where-Object { $_ -ne "" }
+if ($pathEntries -notcontains $InstallDir) {
+  $newPath = ($pathEntries + $InstallDir) -join ";"
+  [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+  Write-Host "Added $InstallDir to your user PATH."
+  Write-Host ""
+  Write-Host "Open a new PowerShell window, then run: octp"
+} else {
+  Write-Host "$InstallDir is already on your PATH."
+  Write-Host ""
+  Write-Host "Get started: octp"
 }
-
-# ─── Skills Prompt ──────────────────────────────────────────────────────────
-
-function Prompt-InstallSkills {
-    Write-Host ""
-    $answer = Read-Host "Would you like to install Octopus skills for Claude Code? (y/N)"
-    if ($answer -match "^[yY]") {
-        Write-Info "Installing skills..."
-        try {
-            & (Join-Path $INSTALL_DIR "$BINARY_NAME.exe") skills install --all
-        } catch {
-            Write-Warn "Could not install skills automatically. Run 'octopus skills install --all' after logging in."
-        }
-    } else {
-        Write-Info "Skipped. You can install skills later with: octopus skills install --all"
-    }
-}
-
-# ─── Main ───────────────────────────────────────────────────────────────────
-
-Write-Host ""
-Write-Info "  Octopus CLI Installer"
-Write-Info "  ====================="
-Write-Host ""
-
-$arch = Get-Arch
-Write-Info "Detected platform: windows-$arch"
-
-Install-Octopus -arch $arch
-Prompt-InstallSkills
-
-Write-Host ""
-Write-Success "Done! Get started with:"
-Write-Success "  octopus login"
-Write-Host ""

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -1,197 +1,205 @@
 #!/usr/bin/env bash
-# Octopus CLI installer
-# Usage: curl -fsSL https://octopus-review.ai/install.sh | bash
+# AUTO-SYNCED COPY — DO NOT EDIT DIRECTLY.
+# Canonical source: apps/cli/install/install.sh. To update this file, edit
+# the canonical source and run `scripts/sync-installers.sh` (or copy by
+# hand). A diff against the canonical version fails the CI check in
+# .github/workflows/sync-installers-check.yml.
+#
+#
+# Octopus CLI installer (Linux / macOS).
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/octopusreview/octopus/master/apps/cli/install/install.sh | bash
+#
+# The script's shebang is /usr/bin/env bash and it uses bash-isms
+# (set -o pipefail, `[[...]]` would-be patterns) — piping into `sh`
+# can break on dash/ash. Documented `| bash` accordingly.
+#
+# What it does:
+#   1. Detects your OS + CPU architecture
+#   2. Fetches the latest `octp-v*` release from GitHub
+#   3. Downloads the matching native binary
+#   4. Installs it to ~/.octopus/bin/octp (or $OCTOPUS_INSTALL_DIR)
+#   5. Prints a one-line instruction to add ~/.octopus/bin to your PATH (if not already there)
+#
+# After install, run `octp` to launch the first-run onboarding wizard.
+#
+# Environment variables:
+#   OCTOPUS_INSTALL_DIR  Override install directory (default: $HOME/.octopus/bin)
+#   OCTOPUS_INSTALL_REPO Override the GitHub repo (default: octopusreview/octopus)
+#   OCTOPUS_INSTALL_TAG  Install a specific tag instead of latest (e.g. octp-v0.2.0)
+#
+# Exit codes:
+#   0 success
+#   1 unsupported OS/arch, network failure, or write failure
+
 set -euo pipefail
 
-GITHUB_REPO="octopusreview/octopus-cli"
-BINARY_NAME="octopus"
-INSTALL_DIR="$HOME/.local/bin"
-FALLBACK_DIR="/usr/local/bin"
-TMPDIR_CLEANUP=""
+REPO="${OCTOPUS_INSTALL_REPO:-octopusreview/octopus}"
+INSTALL_DIR="${OCTOPUS_INSTALL_DIR:-$HOME/.octopus/bin}"
+BINARY_NAME="octp"
 
-# ─── Helpers ────────────────────────────────────────────────────────────────
+# ── Step 1: detect platform ──────────────────────────────────────────────────
 
-info()    { printf '\033[1;34m%s\033[0m\n' "$*"; }
-success() { printf '\033[1;32m%s\033[0m\n' "$*"; }
-warn()    { printf '\033[1;33m%s\033[0m\n' "$*"; }
-error()   { printf '\033[1;31merror: %s\033[0m\n' "$*" >&2; exit 1; }
+uname_s=$(uname -s 2>/dev/null || echo "")
+uname_m=$(uname -m 2>/dev/null || echo "")
 
-need_cmd() {
-  command -v "$1" > /dev/null 2>&1 || error "Required command '$1' not found. Please install it and retry."
-}
+case "$uname_s" in
+  Linux)  os="linux"  ;;
+  Darwin) os="darwin" ;;
+  *)
+    echo "Error: unsupported OS: $uname_s" >&2
+    echo "Supported: Linux, macOS. On Windows, use install.ps1 (PowerShell)." >&2
+    exit 1
+    ;;
+esac
 
-# ─── Detect OS & Arch ──────────────────────────────────────────────────────
+case "$uname_m" in
+  x86_64|amd64) arch="x64"   ;;
+  arm64|aarch64) arch="arm64" ;;
+  *)
+    echo "Error: unsupported CPU architecture: $uname_m" >&2
+    echo "Supported: x86_64, arm64." >&2
+    exit 1
+    ;;
+esac
 
-detect_platform() {
-  local os arch
+asset="${BINARY_NAME}-${os}-${arch}"
 
-  case "$(uname -s)" in
-    Linux*)  os="linux" ;;
-    Darwin*) os="darwin" ;;
-    MINGW*|MSYS*|CYGWIN*) os="windows" ;;
-    *) error "Unsupported operating system: $(uname -s)" ;;
-  esac
+# ── Step 2: resolve the release tag ──────────────────────────────────────────
 
-  case "$(uname -m)" in
-    x86_64|amd64)  arch="x64" ;;
-    arm64|aarch64) arch="arm64" ;;
-    *) error "Unsupported architecture: $(uname -m)" ;;
-  esac
-
-  PLATFORM="${os}"
-  ARCH="${arch}"
-}
-
-# ─── Fetch latest release tag from GitHub ───────────────────────────────────
-
-get_latest_version() {
-  need_cmd curl
-
-  local url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
-  local response
-  response=$(curl -fsSL "$url") || error "Failed to fetch release info from GitHub. You may be rate-limited."
-
-  if command -v jq > /dev/null 2>&1; then
-    VERSION=$(echo "$response" | jq -r '.tag_name // empty')
-  else
-    VERSION=$(echo "$response" | grep '"tag_name"' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')
+if [ -n "${OCTOPUS_INSTALL_TAG:-}" ]; then
+  tag="$OCTOPUS_INSTALL_TAG"
+  echo "Installing pinned version: $tag"
+else
+  echo "Looking up latest octp release on $REPO ..."
+  # Find the most recent NON-DRAFT, NON-PRERELEASE octp-v* tag.
+  # `jq` is not assumed (some minimal install targets — alpine, distroless,
+  # CI runners — don't have it), so parse with sed/grep. GitHub returns
+  # `/releases` as a JSON ARRAY where each release is one object on the
+  # same line. We split objects by inserting a real newline at every
+  # `},{` boundary so line-oriented grep can filter by draft/prerelease
+  # siblings without false-matching across objects.
+  #
+  # macOS portability: BSD sed treats `\n` in the REPLACEMENT as a
+  # literal `n` (only the recognise-`\n`-in-pattern semantics is shared
+  # with GNU sed). Use the portable form — a backslash immediately
+  # followed by a real newline character inside the s/// replacement,
+  # which both GNU and BSD sed interpret as a newline. The `[[:space:]]`
+  # POSIX class is used everywhere else for the same portability reason
+  # (GNU `\s` would silently match "s" on busybox grep / BSD sed).
+  # Users testing prerelease tags can still override via OCTOPUS_INSTALL_TAG.
+  api_url="https://api.github.com/repos/${REPO}/releases?per_page=30"
+  tag=$(
+    curl -fsSL "$api_url" \
+      | sed 's/},{/}\
+{/g' \
+      | grep -v '"draft"[[:space:]]*:[[:space:]]*true' \
+      | grep -v '"prerelease"[[:space:]]*:[[:space:]]*true' \
+      | grep -E '"tag_name"[[:space:]]*:[[:space:]]*"octp-v' \
+      | head -1 \
+      | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+  )
+  if [ -z "$tag" ]; then
+    echo "Error: could not find any non-prerelease octp-v* on $REPO." >&2
+    echo "If you are testing a prerelease, pin a tag with OCTOPUS_INSTALL_TAG=octp-v0.X.Y" >&2
+    exit 1
   fi
+  echo "Latest release: $tag"
+fi
 
-  if [ -z "$VERSION" ]; then
-    error "Could not determine the latest release version. You may be rate-limited by GitHub API."
-  fi
+# ── Step 3: download ─────────────────────────────────────────────────────────
 
-  info "Latest version: ${VERSION}"
-}
+download_url="https://github.com/${REPO}/releases/download/${tag}/${asset}"
+sums_url="https://github.com/${REPO}/releases/download/${tag}/SHA256SUMS.txt"
+echo "Downloading $download_url ..."
 
-# ─── Download & Install ────────────────────────────────────────────────────
+mkdir -p "$INSTALL_DIR"
+tmp_file="$(mktemp)"
+sums_file="$(mktemp)"
+trap 'rm -f "$tmp_file" "$sums_file"' EXIT
 
-download_and_install() {
-  local bin_ext=""
-  if [ "$PLATFORM" = "windows" ]; then
-    bin_ext=".exe"
-  fi
+if ! curl -fL --progress-bar -o "$tmp_file" "$download_url"; then
+  echo "Error: failed to download $asset from $tag." >&2
+  echo "The release might not have a binary for ${os}-${arch}." >&2
+  exit 1
+fi
 
-  local artifact="${BINARY_NAME}-${PLATFORM}-${ARCH}"
-  local archive="${artifact}.tar.gz"
-  local download_url="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/${archive}"
+# ── Step 3b: verify SHA256 checksum ──────────────────────────────────────────
+# octp-release.yml generates SHA256SUMS.txt and attaches it to every release.
+# Verifying the binary against the published sum protects against:
+#   - In-flight tampering on a compromised mirror (GitHub itself signs the
+#     download but the asset chain is still worth re-checking).
+#   - Truncated downloads (curl exit code is the only signal otherwise).
+# If sums file is missing on a release (older builds), we abort with a clear
+# message — passing OCTOPUS_INSTALL_SKIP_VERIFY=1 documents the trade-off
+# explicitly when the user knowingly accepts the risk (e.g. CI pinning a tag
+# pre-dating the sums-generation workflow).
 
-  info "Downloading ${archive}..."
-  local tmpdir
-  tmpdir=$(mktemp -d)
-  TMPDIR_CLEANUP="$tmpdir"
-  trap 'rm -rf "$TMPDIR_CLEANUP"' EXIT
-
-  local tmparchive="${tmpdir}/${archive}"
-  curl -fsSL -o "$tmparchive" "$download_url" || error "Download failed. Check if a release exists for your platform: ${PLATFORM}-${ARCH}"
-
-  # Verify SHA256 checksum if checksums.txt is available
-  local checksums_url="https://github.com/${GITHUB_REPO}/releases/download/${VERSION}/checksums.txt"
-  local expected_sha
-  expected_sha=$(curl -fsSL "$checksums_url" 2>/dev/null | grep "${archive}" | awk '{print $1}') || true
-  if [ -n "$expected_sha" ]; then
-    local actual_sha
-    if command -v sha256sum > /dev/null 2>&1; then
-      actual_sha=$(sha256sum "$tmparchive" | awk '{print $1}')
-    elif command -v shasum > /dev/null 2>&1; then
-      actual_sha=$(shasum -a 256 "$tmparchive" | awk '{print $1}')
+if [ "${OCTOPUS_INSTALL_SKIP_VERIFY:-0}" = "1" ]; then
+  echo "SKIPPING SHA256 verification (OCTOPUS_INSTALL_SKIP_VERIFY=1)."
+else
+  if curl -fsSL -o "$sums_file" "$sums_url"; then
+    expected=$(grep -F "  $asset" "$sums_file" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')
+    if [ -z "$expected" ]; then
+      echo "Error: no SHA256SUMS.txt entry for $asset on $tag." >&2
+      echo "Run with OCTOPUS_INSTALL_SKIP_VERIFY=1 to bypass (NOT recommended)." >&2
+      exit 1
     fi
-    if [ -n "$actual_sha" ] && [ "$expected_sha" != "$actual_sha" ]; then
-      error "Checksum mismatch! Expected ${expected_sha}, got ${actual_sha}. Aborting."
+    if command -v sha256sum >/dev/null 2>&1; then
+      actual=$(sha256sum "$tmp_file" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')
+    elif command -v shasum >/dev/null 2>&1; then
+      actual=$(shasum -a 256 "$tmp_file" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')
+    else
+      echo "Error: neither sha256sum nor shasum found; cannot verify the download." >&2
+      echo "Run with OCTOPUS_INSTALL_SKIP_VERIFY=1 to bypass (NOT recommended)." >&2
+      exit 1
     fi
-    info "Checksum verified."
+    if [ "$expected" != "$actual" ]; then
+      echo "Error: SHA256 mismatch for $asset." >&2
+      echo "  expected: $expected" >&2
+      echo "  actual:   $actual" >&2
+      echo "The download may be corrupt or tampered. Aborting." >&2
+      exit 1
+    fi
+    echo "✓ Verified SHA256 ($expected)"
   else
-    warn "No checksums.txt found for this release -- skipping integrity check."
+    echo "Error: could not download SHA256SUMS.txt from $tag." >&2
+    echo "Older releases pre-date the sums workflow — re-run with" >&2
+    echo "OCTOPUS_INSTALL_SKIP_VERIFY=1 if you accept that risk." >&2
+    exit 1
   fi
+fi
 
-  # Extract binary from archive
-  tar -xzf "$tmparchive" -C "$tmpdir"
-  local tmpfile="${tmpdir}/${BINARY_NAME}${bin_ext}"
-  [ -f "$tmpfile" ] || error "Expected binary '${BINARY_NAME}${bin_ext}' not found in archive."
-  chmod +x "$tmpfile"
+# ── Step 4: install ──────────────────────────────────────────────────────────
 
-  # Try user-local dir first (no sudo needed), fall back to system dir
-  local target_dir="$INSTALL_DIR"
-  mkdir -p "$target_dir"
-  if ! install_binary "$tmpfile" "$target_dir" 2>/dev/null; then
-    target_dir="$FALLBACK_DIR"
-    install_binary "$tmpfile" "$target_dir"
-  fi
-  ensure_in_path "$target_dir"
+target="${INSTALL_DIR}/${BINARY_NAME}"
+# Keep the EXIT trap active across the move so a failed mv (bad perms / missing
+# INSTALL_DIR) still cleans up $tmp_file instead of leaking it.
+if ! mv "$tmp_file" "$target"; then
+  echo "Error: failed to install to $target (check permissions / INSTALL_DIR)." >&2
+  exit 1
+fi
+chmod +x "$target"
+trap - EXIT
 
-  INSTALLED_DIR="$target_dir"
-  success "Installed ${BINARY_NAME} to ${target_dir}/${BINARY_NAME}${bin_ext}"
-}
+echo ""
+echo "Installed $BINARY_NAME → $target"
 
-install_binary() {
-  local src="$1" dir="$2"
-  local ext=""
-  if [ "$PLATFORM" = "windows" ]; then ext=".exe"; fi
+# ── Step 5: PATH hint ────────────────────────────────────────────────────────
 
-  if [ -w "$dir" ]; then
-    cp "$src" "${dir}/${BINARY_NAME}${ext}"
-  else
-    info "Writing to ${dir} requires elevated permissions..."
-    sudo cp "$src" "${dir}/${BINARY_NAME}${ext}"
-  fi
-}
-
-ensure_in_path() {
-  local dir="$1"
-  case ":$PATH:" in
-    *":${dir}:"*) ;;
-    *)
-      warn "${dir} is not in your PATH."
-      warn "Add this to your shell profile:"
-      warn "  export PATH=\"${dir}:\$PATH\""
-      ;;
-  esac
-}
-
-# ─── Skills prompt ──────────────────────────────────────────────────────────
-
-prompt_install_skills() {
-  # If no terminal available at all, skip prompt
-  if [ ! -e /dev/tty ]; then
-    info ""
-    info "To install skills later, run: octopus skills install --all"
-    return
-  fi
-
-  echo ""
-  printf 'Would you like to install Octopus skills for Claude Code? (y/N) '
-  read -r answer < /dev/tty
-  case "$answer" in
-    [yY]|[yY][eE][sS])
-      info "Installing skills..."
-      "${INSTALLED_DIR}/${BINARY_NAME}" skills install --all \
-        || warn "Could not install skills automatically. Run 'octopus skills install --all' after logging in."
-      ;;
-    *)
-      info "Skipped. You can install skills later with: octopus skills install --all"
-      ;;
-  esac
-}
-
-# ─── Main ───────────────────────────────────────────────────────────────────
-
-main() {
-  echo ""
-  info "  Octopus CLI Installer"
-  info "  ====================="
-  echo ""
-
-  detect_platform
-  info "Detected platform: ${PLATFORM}-${ARCH}"
-
-  get_latest_version
-  download_and_install
-  prompt_install_skills
-
-  echo ""
-  success "Done! Get started with:"
-  success "  octopus login"
-  echo ""
-}
-
-main
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*)
+    echo "$INSTALL_DIR is already on your PATH."
+    echo ""
+    echo "Get started: $BINARY_NAME"
+    ;;
+  *)
+    echo ""
+    echo "Add this line to your shell rc (~/.zshrc, ~/.bashrc, etc.):"
+    echo ""
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo ""
+    echo "Then restart your shell and run: $BINARY_NAME"
+    ;;
+esac

--- a/scripts/sync-installers.sh
+++ b/scripts/sync-installers.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Sync canonical installer scripts at apps/cli/install/ into
+# apps/web/public/ (which Next.js serves at https://<host>/install.sh
+# and /install.ps1). The public/ copies carry an AUTO-SYNCED header
+# warning humans off direct edits — this script restores the sync.
+#
+# Usage:
+#   scripts/sync-installers.sh
+#
+# CI runs `scripts/sync-installers.sh --check` and fails on drift.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI_DIR="$REPO_ROOT/apps/cli/install"
+PUBLIC_DIR="$REPO_ROOT/apps/web/public"
+
+# Header for the public copy. Lives in a here-doc so multi-line is sane.
+read -r -d '' SH_HEADER <<'EOF' || true
+# AUTO-SYNCED COPY — DO NOT EDIT DIRECTLY.
+# Canonical source: apps/cli/install/install.sh. To update this file, edit
+# the canonical source and run `scripts/sync-installers.sh` (or copy by
+# hand). A diff against the canonical version fails the CI check in
+# .github/workflows/sync-installers-check.yml.
+#
+EOF
+
+read -r -d '' PS1_HEADER <<'EOF' || true
+# AUTO-SYNCED COPY — DO NOT EDIT DIRECTLY.
+# Canonical source: apps/cli/install/install.ps1. To update this file, edit
+# the canonical source and run `scripts/sync-installers.sh` (or copy by
+# hand). A diff against the canonical version fails the CI check in
+# .github/workflows/sync-installers-check.yml.
+#
+EOF
+
+generate_sh() {
+  local src="$CLI_DIR/install.sh"
+  # Shebang must stay first. Read shebang, emit header, emit rest.
+  head -1 "$src"
+  printf '%s\n' "$SH_HEADER"
+  tail -n +2 "$src"
+}
+
+generate_ps1() {
+  # No shebang in PowerShell. Header goes at top.
+  printf '%s\n' "$PS1_HEADER"
+  cat "$CLI_DIR/install.ps1"
+}
+
+if [ "${1:-}" = "--check" ]; then
+  fail=0
+  if ! diff -u <(generate_sh) "$PUBLIC_DIR/install.sh" >/dev/null; then
+    echo "Drift detected in apps/web/public/install.sh." >&2
+    fail=1
+  fi
+  if ! diff -u <(generate_ps1) "$PUBLIC_DIR/install.ps1" >/dev/null; then
+    echo "Drift detected in apps/web/public/install.ps1." >&2
+    fail=1
+  fi
+  if [ "$fail" = 1 ]; then
+    echo "Run scripts/sync-installers.sh to regenerate." >&2
+    exit 1
+  fi
+  echo "Installers in sync."
+  exit 0
+fi
+
+generate_sh > "$PUBLIC_DIR/install.sh"
+generate_ps1 > "$PUBLIC_DIR/install.ps1"
+echo "Synced apps/web/public/install.{sh,ps1} ← apps/cli/install/install.{sh,ps1}"


### PR DESCRIPTION
## What
Final slice of Themes 5–6 — distribution for the `octp` CLI.

- **`.github/workflows/octp-release.yml`** — on `octp-v*` tags, cross-compiles the 5 native binaries (linux/darwin × x64/arm64 + windows-x64) via `bun --compile`, generates `SHA256SUMS.txt`, and publishes a GitHub Release. Third-party actions **SHA-pinned** (it's a `contents:write` workflow that produces binaries piped onto user machines).
- **`scripts/sync-installers.sh` + `sync-installers-check.yml`** — the canonical installers live at `apps/cli/install/*`; this syncs them into the web-served `apps/web/public/install.{sh,ps1}` (with an AUTO-SYNCED header) and CI fails on drift.
- **regenerated `apps/web/public/install.{sh,ps1}`** from the canonical native-binary installers (origin's were the old scheme). `--check` passes.

## Activation note
The web-served installer (`curl https://<host>/install.sh | bash`) now fetches the **native binary**, which requires an `octp-v*` GitHub Release to exist. **Cut `octp-v0.1.0`** (push the tag) to trigger the first release; until then the installer reports "no octp-v* release found."

## Test plan
- [x] typecheck / lint clean; `scripts/sync-installers.sh --check` passes; `build:compile` targets match the workflow's published asset list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)