### PR TITLE
feat(self-host): optional Ollama compose overlay for all-local deployments

### DIFF
--- a/apps/web/app/(landing)/docs/self-hosting/page.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/page.tsx
@@ -128,6 +128,32 @@ volumes:
         </Step>
       </Section>
 
+      <Section title="All-local with Ollama (optional)">
+        <Paragraph>
+          To run Octopus with no cloud API keys — both the review LLM and code
+          embeddings served on your own hardware — start the optional Ollama
+          overlay alongside the base compose file. It adds an{" "}
+          <Mono>ollama</Mono> service and points the app at it.
+        </Paragraph>
+        <CodeBlock>{`docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d`}</CodeBlock>
+        <Paragraph>
+          Then pull at least one chat model and the embedding model — from the
+          UI (Settings → Models → Local models) or the shell:
+        </Paragraph>
+        <CodeBlock>{`docker compose exec ollama ollama pull qwen2.5-coder:7b
+docker compose exec ollama ollama pull nomic-embed-text`}</CodeBlock>
+        <Paragraph>
+          To also use Ollama for embeddings, set{" "}
+          <Mono>OCTOPUS_EMBED_PROVIDER=ollama</Mono>,{" "}
+          <Mono>OCTOPUS_EMBED_MODEL=nomic-embed-text</Mono>, and{" "}
+          <Mono>OCTOPUS_EMBED_DIM=768</Mono> in your <Mono>.env</Mono> before
+          first indexing — switching providers afterward requires a re-index
+          since different models produce non-comparable vectors. Ollama runs
+          CPU-only by default; see the overlay file for enabling NVIDIA GPU
+          acceleration.
+        </Paragraph>
+      </Section>
+
       {/* Environment variables */}
       <Section id="environment-variables" title="Environment Variables">
         <Paragraph>

--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -1,0 +1,66 @@
+# Optional Ollama overlay — run Octopus fully local (review LLM + embeddings)
+# with no cloud API keys. Compose it ON TOP of the base file:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d
+#
+# This adds an `ollama` service and points the web app at it over the compose
+# network. Pull at least one chat model and the embedding model before
+# reviewing — from the UI (Settings -> Models -> Local models) or the shell:
+#
+#   docker compose exec ollama ollama pull qwen2.5-coder:7b
+#   docker compose exec ollama ollama pull nomic-embed-text
+#
+# To use Ollama for embeddings too (not just the review LLM), also set in .env
+# BEFORE first indexing — switching providers later needs a re-index because
+# different models produce non-comparable vectors:
+#   OCTOPUS_EMBED_PROVIDER=ollama
+#   OCTOPUS_EMBED_MODEL=nomic-embed-text
+#   OCTOPUS_EMBED_DIM=768
+services:
+  ollama:
+    image: ollama/ollama:latest
+    # Same loopback-by-default rationale as postgres/qdrant in the base file:
+    # Ollama ships with no authentication, so publishing it on 0.0.0.0 exposes
+    # model inference (and the prompt/response data flowing through it) to
+    # anyone who can reach the host. The web service reaches Ollama over the
+    # compose network regardless of this mapping — the host port is only for
+    # direct access (e.g. `ollama pull` from the host). Override with
+    # OCTOPUS_OLLAMA_BIND=0.0.0.0 in `.env` only if you genuinely need remote
+    # access AND have auth / a proxy in front.
+    ports:
+      - "${OCTOPUS_OLLAMA_BIND:-127.0.0.1}:43311:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      # `ollama list` talks to the local server; it exits non-zero until
+      # `ollama serve` is accepting connections, which is what `web` waits on.
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    restart: unless-stopped
+    # NVIDIA GPU acceleration (optional). Ollama runs CPU-only by default;
+    # uncomment after installing the nvidia-container-toolkit on the host.
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+
+  web:
+    # Point the app at the in-cluster Ollama. These override .env so the
+    # service hostname resolves on the compose network. OLLAMA_SERVER_URL is
+    # the review-LLM provider base; OCTOPUS_OLLAMA_BASE_URL is the embeddings
+    # base — set both so either use works without further config.
+    environment:
+      - OLLAMA_SERVER_URL=http://ollama:11434
+      - OCTOPUS_OLLAMA_BASE_URL=http://ollama:11434
+    depends_on:
+      ollama:
+        condition: service_healthy
+
+volumes:
+  ollama_data:


### PR DESCRIPTION
## What
Adds **`docker-compose.ollama.yml`**, an opt-in overlay composed on top of the base file. It bundles an Ollama service and points the web app at it, so a self-hosted instance can run the review LLM (and optionally embeddings) with **no cloud API keys**.

- **`ollama` service** — loopback-bound by default (`${OCTOPUS_OLLAMA_BIND:-127.0.0.1}`), healthchecked via `ollama list`, NVIDIA GPU `deploy:` block documented-but-commented.
- **`web` overrides** — `OLLAMA_SERVER_URL` + `OCTOPUS_OLLAMA_BASE_URL` resolve to the in-cluster `ollama`; `depends_on` waits for it to be healthy.
- **Self-hosting docs** gain an "All-local with Ollama" section.

## Why
Self-hosters who can't/won't use cloud providers previously had to hand-wire an Ollama container + env. This makes it one extra `-f` flag. The base compose file is **unchanged** — purely additive opt-in.

## How it's used
```
docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d
docker compose exec ollama ollama pull qwen2.5-coder:7b
docker compose exec ollama ollama pull nomic-embed-text
```

## Test plan
- `docker compose -f docker-compose.yml -f docker-compose.ollama.yml config` merges cleanly: `ollama` service present, `web` gains both env vars + `depends_on: ollama (service_healthy)`, `ollama_data` volume registered.
- `bun run typecheck` + `bun run lint` clean (docs page).

## Risk
🟢 **Low** — additive opt-in overlay + a docs section. No change to the base compose file, app code, or schema.

Notes for review:
- **Loopback bind by default** — mirrors the existing postgres/qdrant no-public-bind security rationale (Ollama ships with no auth); override via `OCTOPUS_OLLAMA_BIND`. No new public exposure.
- The overlay deliberately does **not** flip `OCTOPUS_EMBED_PROVIDER` — doing so would invalidate existing Qdrant collections (non-comparable vectors). Ollama embeddings stay a documented opt-in.
- `docker-compose.ollama.yml` matches the repo's `docker-compose.*.yml` gitignore pattern (local-override convention), so it's force-added in a second commit — intentional, the file must ship.
- The "Settings → Models → Local models" UI referenced in the comments/docs lands in a **follow-up PR**; the shell `ollama pull` path works today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1