### PR TITLE
feat(models): admin Ollama model-download panel (self-hosted)

### DIFF
--- a/apps/web/app/(app)/settings/models/models-settings.tsx
+++ b/apps/web/app/(app)/settings/models/models-settings.tsx
@@ -17,6 +17,7 @@ import { IconPencil, IconCheck, IconX, IconSearch, IconLoader2 } from "@tabler/i
 import { updateDefaultModels } from "../../actions";
 import { updateRepoModels } from "../../repositories/actions";
 import { searchRepoModels, type RepoModelItem } from "./actions";
+import { OllamaModels } from "./ollama-models";
 
 type AvailableModel = {
   modelId: string;
@@ -336,6 +337,7 @@ export function ModelsSettings({
   platformDefaultEmbedName,
   initialRepos,
   totalRepoCount,
+  ollamaEnabled,
 }: {
   isOwner: boolean;
   availableModels: AvailableModel[];
@@ -345,6 +347,7 @@ export function ModelsSettings({
   platformDefaultEmbedName: string | null;
   initialRepos: RepoModelItem[];
   totalRepoCount: number;
+  ollamaEnabled: boolean;
 }) {
   const [selectedModelId, setSelectedModelId] = useState(currentModelId ?? "");
   const [selectedEmbedModelId, setSelectedEmbedModelId] = useState(currentEmbedModelId ?? "");
@@ -472,6 +475,9 @@ export function ModelsSettings({
         orgDefaultLlmName={orgDefaultLlmName}
         orgDefaultEmbedName={orgDefaultEmbedName}
       />
+
+      {/* Local Models (Ollama) — only when a self-hosted Ollama is configured */}
+      {ollamaEnabled && <OllamaModels isOwner={isOwner} />}
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/models/ollama-models.tsx
+++ b/apps/web/app/(app)/settings/models/ollama-models.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  IconLoader2,
+  IconCheck,
+  IconDownload,
+  IconAlertTriangle,
+} from "@tabler/icons-react";
+
+type CatalogEntry = {
+  name: string;
+  displayName: string;
+  category: string;
+  sizeGb: number;
+  ramHint: string;
+  blurb: string;
+};
+
+type Pull = {
+  model: string;
+  status: string;
+  statusText: string | null;
+  progress: number;
+  error: string | null;
+};
+
+type ModelsResponse = {
+  enabled: boolean;
+  reachable: boolean;
+  installed: string[];
+  catalog: CatalogEntry[];
+  pulls: Pull[];
+};
+
+const POLL_MS = 3000;
+
+export function OllamaModels({ isOwner }: { isOwner: boolean }) {
+  const [data, setData] = useState<ModelsResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/ollama/models");
+      if (!res.ok) throw new Error("Failed to load");
+      setData((await res.json()) as ModelsResponse);
+      setError(null);
+    } catch {
+      setError("Could not load local models.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Poll only while a pull is in flight.
+  const active =
+    data?.pulls.some((p) => p.status === "pulling" || p.status === "queued") ?? false;
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => void load(), POLL_MS);
+    return () => clearInterval(id);
+  }, [active, load]);
+
+  const triggerPull = async (model: string) => {
+    try {
+      const res = await fetch("/api/ollama/pull", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model }),
+      });
+      if (!res.ok) {
+        const j = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(j.error ?? "Failed to start download.");
+        return;
+      }
+      setError(null);
+      await load();
+    } catch {
+      setError("Failed to start download.");
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Local Models (Ollama)</CardTitle>
+        <CardDescription>
+          Download models to your self-hosted Ollama server so reviews and
+          embeddings run entirely on your own hardware.
+          {data && data.enabled && !data.reachable && (
+            <span className="mt-1 block text-amber-600 dark:text-amber-500">
+              Ollama is configured but unreachable — start the service, then reload.
+            </span>
+          )}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {!data ? (
+          <div className="flex items-center justify-center py-8">
+            <IconLoader2 className="size-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          (() => {
+            const pullByModel = new Map(data.pulls.map((p) => [p.model, p]));
+            const installed = new Set(data.installed);
+            return data.catalog.map((entry) => {
+              const pull = pullByModel.get(entry.name);
+              // Ollama's /api/tags reports untagged models as "<name>:latest",
+              // so match both forms (a model pulled outside this UI still shows
+              // as installed).
+              const isInstalled =
+                installed.has(entry.name) ||
+                installed.has(`${entry.name}:latest`) ||
+                pull?.status === "completed";
+              const isPulling = pull?.status === "pulling" || pull?.status === "queued";
+              const isFailed = pull?.status === "failed";
+              return (
+                <div key={entry.name} className="rounded-md border p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-sm font-medium">{entry.displayName}</span>
+                        <Badge variant="secondary" className="h-5 text-[10px] font-normal">
+                          {entry.category}
+                        </Badge>
+                      </div>
+                      <p className="mt-0.5 text-xs text-muted-foreground">{entry.blurb}</p>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        ~{entry.sizeGb} GB · {entry.ramHint} ·{" "}
+                        <code className="rounded bg-muted px-1 py-0.5">{entry.name}</code>
+                      </p>
+                    </div>
+                    <div className="shrink-0">
+                      {isInstalled ? (
+                        <Badge className="gap-1">
+                          <IconCheck className="size-3" />
+                          Installed
+                        </Badge>
+                      ) : isPulling ? (
+                        <Button size="sm" variant="outline" disabled>
+                          <IconLoader2 className="mr-1 size-3.5 animate-spin" />
+                          {pull?.progress ?? 0}%
+                        </Button>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant={isFailed ? "outline" : "default"}
+                          disabled={!isOwner}
+                          onClick={() => triggerPull(entry.name)}
+                        >
+                          <IconDownload className="mr-1 size-3.5" />
+                          {isFailed ? "Retry" : "Download"}
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+
+                  {isPulling && (
+                    <div className="mt-2">
+                      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                        <div
+                          className="h-full bg-primary transition-all"
+                          style={{ width: `${pull?.progress ?? 0}%` }}
+                        />
+                      </div>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        {pull?.statusText ?? "starting"}…
+                      </p>
+                    </div>
+                  )}
+
+                  {isFailed && (
+                    <p className="mt-2 flex items-center gap-1 text-[11px] text-destructive">
+                      <IconAlertTriangle className="size-3" />
+                      {pull?.error ?? "Pull failed"}
+                    </p>
+                  )}
+                </div>
+              );
+            });
+          })()
+        )}
+
+        {!isOwner && (
+          <p className="text-center text-xs text-muted-foreground">
+            Only owners and admins can download models.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/(app)/settings/models/page.tsx
+++ b/apps/web/app/(app)/settings/models/page.tsx
@@ -73,6 +73,10 @@ export default async function ModelsPage() {
 
   const canManage = member.role === "owner" || member.role === "admin";
 
+  // Local-model panel only appears when Ollama is actually configured — on the
+  // hosted SaaS OLLAMA_SERVER_URL is unset, so the panel stays hidden.
+  const ollamaEnabled = !!process.env.OLLAMA_SERVER_URL?.trim();
+
   const platformDefaults = await prisma.availableModel.findMany({
     where: { isPlatformDefault: true, isActive: true },
     select: { modelId: true, displayName: true, category: true },
@@ -97,6 +101,7 @@ export default async function ModelsPage() {
       platformDefaultEmbedName={platformDefaultEmbed?.displayName ?? null}
       initialRepos={repos}
       totalRepoCount={totalCount}
+      ollamaEnabled={ollamaEnabled}
     />
   );
 }

--- a/apps/web/app/api/ollama/models/route.ts
+++ b/apps/web/app/api/ollama/models/route.ts
@@ -1,0 +1,60 @@
+import { headers, cookies } from "next/headers";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { OLLAMA_CATALOG } from "@/lib/ollama-catalog";
+import { isOllamaConfigured, listInstalledModels } from "@/lib/ollama-admin";
+
+/**
+ * GET /api/ollama/models
+ *
+ * Returns the local-model panel state for the caller's org: whether Ollama is
+ * configured/reachable, which curated models are installed, the catalog, and
+ * the status of any in-flight or recent pulls. Read-only — any org member may
+ * view; the pull action (POST /api/ollama/pull) is admin-gated.
+ *
+ * Ollama is instance-level, so installed models + pulls are not org-scoped;
+ * org membership only authenticates the viewer.
+ */
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  const cookieStore = await cookies();
+  const currentOrgId = cookieStore.get("current_org_id")?.value;
+  if (!currentOrgId) return Response.json({ error: "No active org" }, { status: 400 });
+
+  const member = await prisma.organizationMember.findFirst({
+    where: { userId: session.user.id, organizationId: currentOrgId, deletedAt: null },
+    select: { id: true },
+  });
+  if (!member) return Response.json({ error: "Forbidden" }, { status: 403 });
+
+  if (!isOllamaConfigured()) {
+    return Response.json({
+      enabled: false,
+      reachable: false,
+      installed: [],
+      catalog: OLLAMA_CATALOG,
+      pulls: [],
+    });
+  }
+
+  const [installed, pulls] = await Promise.all([
+    listInstalledModels(),
+    prisma.ollamaModelPull.findMany({ orderBy: { updatedAt: "desc" } }),
+  ]);
+
+  return Response.json({
+    enabled: true,
+    reachable: installed !== null,
+    installed: installed ?? [],
+    catalog: OLLAMA_CATALOG,
+    pulls: pulls.map((p) => ({
+      model: p.model,
+      status: p.status,
+      statusText: p.statusText,
+      progress: p.progress,
+      error: p.error,
+    })),
+  });
+}

--- a/apps/web/app/api/ollama/pull/route.ts
+++ b/apps/web/app/api/ollama/pull/route.ts
@@ -1,0 +1,78 @@
+import { headers, cookies } from "next/headers";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { enqueue } from "@/lib/queue";
+import { findCatalogEntry } from "@/lib/ollama-catalog";
+import { isOllamaConfigured } from "@/lib/ollama-admin";
+
+// A pull row that's "pulling"/"queued" but hasn't been touched within this
+// window is treated as orphaned (worker died mid-download) and may be
+// re-triggered. Otherwise an active pull is left alone (idempotent re-clicks).
+const ACTIVE_PULL_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * POST /api/ollama/pull  { model }
+ *
+ * Admin-only. Enqueues a background pull of a curated Ollama model. `model`
+ * must be one of the catalog entries — this both keeps the feature curated and
+ * bounds what the server will fetch. Returns the pull row's current state; the
+ * client polls GET /api/ollama/models for progress.
+ */
+export async function POST(request: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return Response.json({ error: "Unauthorized" }, { status: 401 });
+
+  const cookieStore = await cookies();
+  const currentOrgId = cookieStore.get("current_org_id")?.value;
+  if (!currentOrgId) return Response.json({ error: "No active org" }, { status: 400 });
+
+  const member = await prisma.organizationMember.findFirst({
+    where: { userId: session.user.id, organizationId: currentOrgId, deletedAt: null },
+    select: { role: true },
+  });
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return Response.json({ error: "Admin role required" }, { status: 403 });
+  }
+
+  if (!isOllamaConfigured()) {
+    return Response.json(
+      { error: "Ollama is not configured (set OLLAMA_SERVER_URL)" },
+      { status: 400 },
+    );
+  }
+
+  let body: { model?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const model = typeof body.model === "string" ? body.model : "";
+  if (!findCatalogEntry(model)) {
+    return Response.json({ error: "Unknown model" }, { status: 400 });
+  }
+
+  // Don't double-enqueue an actively-running pull; do allow re-triggering a
+  // completed, failed, or stale (orphaned) one.
+  const existing = await prisma.ollamaModelPull.findUnique({ where: { model } });
+  if (
+    existing &&
+    (existing.status === "pulling" || existing.status === "queued") &&
+    Date.now() - existing.updatedAt.getTime() < ACTIVE_PULL_TTL_MS
+  ) {
+    return Response.json({
+      model: existing.model,
+      status: existing.status,
+      progress: existing.progress,
+    });
+  }
+
+  const row = await prisma.ollamaModelPull.upsert({
+    where: { model },
+    create: { model, status: "queued", progress: 0 },
+    update: { status: "queued", statusText: null, progress: 0, error: null },
+  });
+  await enqueue("pull-ollama-model", { model });
+
+  return Response.json({ model: row.model, status: row.status, progress: row.progress });
+}

--- a/apps/web/lib/__tests__/ollama-catalog.test.ts
+++ b/apps/web/lib/__tests__/ollama-catalog.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "bun:test";
+import { OLLAMA_CATALOG, findCatalogEntry } from "../ollama-catalog";
+
+describe("ollama catalog", () => {
+  it("is non-empty and has unique model names", () => {
+    expect(OLLAMA_CATALOG.length).toBeGreaterThan(0);
+    const names = OLLAMA_CATALOG.map((e) => e.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("every entry is well-formed", () => {
+    for (const e of OLLAMA_CATALOG) {
+      expect(e.name).toBeTruthy();
+      expect(e.displayName).toBeTruthy();
+      expect(["llm", "embedding"]).toContain(e.category);
+      expect(e.sizeGb).toBeGreaterThan(0);
+      expect(e.ramHint).toBeTruthy();
+    }
+  });
+
+  it("offers at least one llm and one embedding model", () => {
+    expect(OLLAMA_CATALOG.some((e) => e.category === "llm")).toBe(true);
+    expect(OLLAMA_CATALOG.some((e) => e.category === "embedding")).toBe(true);
+  });
+
+  it("findCatalogEntry resolves known names and rejects unknown ones", () => {
+    const first = OLLAMA_CATALOG[0];
+    expect(findCatalogEntry(first.name)?.name).toBe(first.name);
+    expect(findCatalogEntry("definitely-not-a-real-model")).toBeUndefined();
+    expect(findCatalogEntry("")).toBeUndefined();
+  });
+});

--- a/apps/web/lib/ollama-admin.ts
+++ b/apps/web/lib/ollama-admin.ts
@@ -1,0 +1,165 @@
+import "server-only";
+import { prisma } from "@octopus/db";
+import { normalizeServerUrl } from "./providers/ollama";
+import { findCatalogEntry } from "./ollama-catalog";
+
+/**
+ * Admin-side Ollama model management: list installed models, stream a pull and
+ * record its progress, register a completed model. Instance-level — Ollama is
+ * one server per deployment (see the OllamaModelPull schema note).
+ *
+ * Unlike the review provider (which defaults to localhost), the management UI
+ * requires OLLAMA_SERVER_URL to be *explicitly set*: the panel is meaningless
+ * without a real server, and on the hosted SaaS the var is unset so the whole
+ * feature stays hidden.
+ */
+export function isOllamaConfigured(): boolean {
+  return !!process.env.OLLAMA_SERVER_URL?.trim();
+}
+
+/** Normalized origin of the configured server. Only call when isOllamaConfigured(). */
+export function getOllamaBaseUrl(): string {
+  const raw = process.env.OLLAMA_SERVER_URL?.trim();
+  if (!raw) throw new Error("OLLAMA_SERVER_URL is not set");
+  return normalizeServerUrl(raw);
+}
+
+function authHeaders(): Record<string, string> {
+  const username = process.env.OLLAMA_USERNAME;
+  if (!username) return {};
+  const password = process.env.OLLAMA_PASSWORD ?? "";
+  return {
+    Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`,
+  };
+}
+
+/**
+ * Models already present on the server (`GET /api/tags`). Returns null when the
+ * server is unreachable, so the UI can tell "none installed" apart from
+ * "can't reach Ollama".
+ */
+export async function listInstalledModels(): Promise<string[] | null> {
+  try {
+    const res = await fetch(`${getOllamaBaseUrl()}/api/tags`, {
+      headers: authHeaders(),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { models?: Array<{ name?: string }> };
+    return (data.models ?? []).map((m) => m.name).filter((n): n is string => !!n);
+  } catch {
+    return null;
+  }
+}
+
+// The pull stream emits many progress lines per second; persist at most this
+// often so a download doesn't hammer the DB with thousands of writes.
+const PROGRESS_WRITE_INTERVAL_MS = 1500;
+
+/**
+ * Stream `POST /api/pull` and record progress into the OllamaModelPull row.
+ *
+ * Error handling is self-contained: on failure it writes status="failed" with
+ * the message and returns (it does NOT throw), so the pg-boss worker never
+ * retries a multi-GB download and the row stays the single source of truth the
+ * UI polls. On success it registers the model in AvailableModel so it appears
+ * in the model pickers right away.
+ */
+export async function runOllamaPull(model: string): Promise<void> {
+  try {
+    await prisma.ollamaModelPull.update({
+      where: { model },
+      data: { status: "pulling", statusText: "starting", progress: 0, error: null },
+    });
+
+    const res = await fetch(`${getOllamaBaseUrl()}/api/pull`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({ model, stream: true }),
+    });
+    if (!res.ok || !res.body) {
+      throw new Error(`Ollama /api/pull returned ${res.status}`);
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let lastWrite = 0;
+    let lastStatus = "";
+    let lastProgress = 0;
+    let success = false;
+
+    const flush = async () => {
+      const now = Date.now();
+      if (now - lastWrite < PROGRESS_WRITE_INTERVAL_MS) return;
+      lastWrite = now;
+      await prisma.ollamaModelPull.update({
+        where: { model },
+        data: { status: "pulling", statusText: lastStatus || null, progress: lastProgress },
+      });
+    };
+
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        let evt: { status?: string; error?: string; total?: number; completed?: number };
+        try {
+          evt = JSON.parse(trimmed);
+        } catch {
+          continue;
+        }
+        if (evt.error) throw new Error(evt.error);
+        if (evt.status) {
+          lastStatus = evt.status;
+          if (evt.status === "success") success = true;
+        }
+        if (typeof evt.total === "number" && evt.total > 0 && typeof evt.completed === "number") {
+          lastProgress = Math.min(100, Math.round((evt.completed / evt.total) * 100));
+        }
+        await flush();
+      }
+    }
+
+    // Ollama ends a successful pull with {"status":"success"}. If the stream
+    // closed without it (e.g. the connection dropped mid-download), treat it as
+    // a failure rather than silently marking a partial model "completed".
+    if (!success) throw new Error("pull ended before completion");
+
+    await registerPulledModel(model);
+    await prisma.ollamaModelPull.update({
+      where: { model },
+      data: { status: "completed", statusText: "ready", progress: 100, error: null },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await prisma.ollamaModelPull
+      .update({ where: { model }, data: { status: "failed", error: message.slice(0, 500) } })
+      .catch(() => {});
+  }
+}
+
+/** Add a successfully-pulled curated model to AvailableModel (free, active). */
+async function registerPulledModel(model: string): Promise<void> {
+  const entry = findCatalogEntry(model);
+  if (!entry) return; // only curated models are registered — stay defensive
+  const modelId = `ollama:${entry.name}`;
+  await prisma.availableModel.upsert({
+    where: { modelId },
+    create: {
+      modelId,
+      displayName: entry.displayName,
+      provider: "ollama",
+      category: entry.category,
+      inputPrice: 0,
+      outputPrice: 0,
+      isActive: true,
+    },
+    update: { isActive: true, displayName: entry.displayName, category: entry.category },
+  });
+}

--- a/apps/web/lib/ollama-catalog.ts
+++ b/apps/web/lib/ollama-catalog.ts
@@ -1,0 +1,59 @@
+/**
+ * Curated list of Ollama models offered in Settings → Models → Local models.
+ *
+ * Admins pick from this list rather than typing arbitrary tags: it keeps the
+ * download UX to a few vetted, code-review-suitable models with honest size /
+ * RAM expectations, and bounds what the pull endpoint will fetch (the POST
+ * route validates the requested model against these names).
+ *
+ * `name` is the exact Ollama tag (also the suffix of the `ollama:<name>` model
+ * id registered in AvailableModel on a successful pull). `sizeGb` is the
+ * approximate download size; `ramHint` is rough guidance for running it.
+ */
+export interface OllamaCatalogEntry {
+  name: string;
+  displayName: string;
+  category: "llm" | "embedding";
+  sizeGb: number;
+  ramHint: string;
+  blurb: string;
+}
+
+export const OLLAMA_CATALOG: OllamaCatalogEntry[] = [
+  {
+    name: "qwen2.5-coder:7b",
+    displayName: "Qwen2.5 Coder 7B",
+    category: "llm",
+    sizeGb: 4.7,
+    ramHint: "8 GB RAM",
+    blurb: "Fast code-focused reviews. Good default for a laptop or small VM.",
+  },
+  {
+    name: "qwen2.5-coder:14b",
+    displayName: "Qwen2.5 Coder 14B",
+    category: "llm",
+    sizeGb: 9,
+    ramHint: "16 GB RAM",
+    blurb: "Stronger reasoning with a balanced quality/speed trade-off.",
+  },
+  {
+    name: "qwen2.5-coder:32b",
+    displayName: "Qwen2.5 Coder 32B",
+    category: "llm",
+    sizeGb: 20,
+    ramHint: "32 GB RAM or a GPU",
+    blurb: "Highest review quality. Needs a workstation or GPU to be usable.",
+  },
+  {
+    name: "nomic-embed-text",
+    displayName: "Nomic Embed Text",
+    category: "embedding",
+    sizeGb: 0.28,
+    ramHint: "2 GB RAM",
+    blurb: "768-dimension code/text embeddings for retrieval (OCTOPUS_EMBED_DIM=768).",
+  },
+];
+
+export function findCatalogEntry(name: string): OllamaCatalogEntry | undefined {
+  return OLLAMA_CATALOG.find((e) => e.name === name);
+}

--- a/apps/web/lib/providers/ollama.ts
+++ b/apps/web/lib/providers/ollama.ts
@@ -27,7 +27,7 @@ const DEFAULT_BASE_URL = "http://localhost:11434";
  * Ollama is normally reached at localhost or an internal host (no SSRF surface:
  * the value is not user-supplied).
  */
-function normalizeServerUrl(raw: string): string {
+export function normalizeServerUrl(raw: string): string {
   let parsed: URL;
   try {
     parsed = new URL(raw);

--- a/apps/web/lib/queue-workers.ts
+++ b/apps/web/lib/queue-workers.ts
@@ -7,6 +7,7 @@ import {
 } from "./large-review-result";
 import { processCommunityReview, type CommunityReviewJobData } from "./community-review";
 import { enforceAuditLogRetention } from "./audit";
+import { runOllamaPull } from "./ollama-admin";
 import type { QueueConfig } from "./queue";
 
 export interface WelcomeEmailJob {
@@ -91,5 +92,15 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     }
   });
 
-  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review, enforce-audit-retention");
+  // Admin-triggered Ollama model download (self-hosted). runOllamaPull is
+  // self-contained: it records progress/failure in the OllamaModelPull row and
+  // never throws, so a failed download doesn't trip pg-boss retries.
+  await boss.work<{ model: string }>("pull-ollama-model", async (jobs) => {
+    for (const job of jobs) {
+      console.log(`[queue] pull-ollama-model ${job.id}: ${job.data.model}`);
+      await runOllamaPull(job.data.model);
+    }
+  });
+
+  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review, enforce-audit-retention, pull-ollama-model");
 }

--- a/apps/web/lib/queue.ts
+++ b/apps/web/lib/queue.ts
@@ -107,6 +107,14 @@ export async function startQueue(): Promise<PgBoss> {
     expireInSeconds: 600, // 10 min — a deleteMany shouldn't take long
   }).catch(() => {});
 
+  // Admin-triggered Ollama model downloads (self-hosted). Long expiry — a
+  // large model is many GB. No auto-retry: runOllamaPull records failures in
+  // the OllamaModelPull row itself and re-pulls are admin-driven from the UI.
+  await boss.createQueue("pull-ollama-model", {
+    retryLimit: 0,
+    expireInSeconds: 7200, // 2 h hard cap per attempt
+  }).catch(() => {});
+
   // Only review-engine containers should register workers. Web containers
   // still need pg-boss started so they can enqueue jobs, but must not consume.
   // The flag must be set explicitly: a missing value is a misconfiguration,

--- a/packages/db/prisma/migrations/20260629120000_add_ollama_model_pulls/migration.sql
+++ b/packages/db/prisma/migrations/20260629120000_add_ollama_model_pulls/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "public"."ollama_model_pulls" (
+    "id" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'queued',
+    "statusText" TEXT,
+    "progress" INTEGER NOT NULL DEFAULT 0,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ollama_model_pulls_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ollama_model_pulls_model_key" ON "public"."ollama_model_pulls"("model");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -754,6 +754,23 @@ model AvailableModel {
   @@map("available_models")
 }
 
+/// Tracks `ollama pull` model downloads triggered from Settings → Models.
+/// Instance-level: Ollama is one server per deployment, shared across all
+/// orgs, so this is intentionally NOT org-scoped. `model` is unique — a
+/// re-pull updates the same row rather than creating a duplicate.
+model OllamaModelPull {
+  id         String   @id @default(cuid())
+  model      String   @unique // ollama tag, e.g. "qwen2.5-coder:7b"
+  status     String   @default("queued") // queued | pulling | completed | failed
+  statusText String? // latest ollama status line, e.g. "pulling manifest"
+  progress   Int      @default(0) // 0-100, current layer
+  error      String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@map("ollama_model_pulls")
+}
+
 model SystemConfig {
   id        String   @id @default("singleton")
   defaultReviewConfig Json @default("{}")


### PR DESCRIPTION
## What
Adds a **"Local Models (Ollama)"** panel to **Settings → Models** so self-hosted admins can download curated Ollama models from the UI instead of shelling into the container. A completed model is registered in `AvailableModel`, so it's immediately selectable as a review/embedding model.

Follow-up to the Ollama compose overlay (#561) — this is the in-app management layer the overlay's comments referenced.

## How it works
- **Curated catalog** (`lib/ollama-catalog.ts`) — a few vetted code-review models (Qwen2.5-Coder 7B/14B/32B) + the embedding model (`nomic-embed-text`), each with size / RAM hints. The pull endpoint **only accepts catalog entries**, which keeps the feature curated and bounds what the server will fetch.
- **pg-boss pull job** (`lib/ollama-admin.ts` + queue wiring) — streams Ollama's `/api/pull` NDJSON, throttles progress writes (≤1 every 1.5 s) into a new `OllamaModelPull` row, and registers the model only on a **confirmed** `{"status":"success"}`. Error handling is self-contained: failures are written to the row and the worker never throws, so pg-boss doesn't retry a multi-GB download.
- **API** — `GET /api/ollama/models` (any org member; returns enabled/reachable + installed + catalog + pull status) and `POST /api/ollama/pull` (**admin-only**; validates the model against the catalog and enqueues).
- **UI** (`ollama-models.tsx`) — non-blocking panel with per-model Download buttons, live progress bars (polls **only while a pull is active**), and Retry on failure.

## Gating / safety
- Panel **and** routes are inert unless `OLLAMA_SERVER_URL` is set → hidden on the hosted SaaS, visible only on self-hosted instances.
- No SSRF surface: the fetch target is the operator-set `OLLAMA_SERVER_URL` (normalized via the provider's `normalizeServerUrl`), and the only user-influenced value (`model`) is allow-listed against the catalog.
- `POST` requires `owner`/`admin`; orphaned pulls (worker died mid-download) can be re-triggered after a 10-min TTL — no separate reaper needed.
- New `pull-ollama-model` queue is `createQueue`'d before `work()`/`send()` (pg-boss v12 requirement).

## Schema
New `OllamaModelPull` table (instance-level — Ollama is one server per deployment, so it's intentionally not org-scoped). `progress` is a 0–100 `Int` (no `BigInt`, so JSON-safe). Migration `20260629120000_add_ollama_model_pulls`.

## Test plan
- `bun run db:generate` ✓ · `bun run typecheck` ✓ · `bun run lint` ✓ · `bun run build` ✓
- `cd apps/web && bun test` → **452 pass / 0 fail** (incl. new `ollama-catalog.test.ts`, 4 tests).

## Risk
🟡 **Low–Medium** — net-new, fully behind the `OLLAMA_SERVER_URL` gate (no SaaS impact); one additive table + one queue; no change to existing review/embedding paths beyond exporting `normalizeServerUrl` for reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1