### PR TITLE
fix(models): skip Ollama embedding-model registration + dedupe concurrent pulls

### DIFF
--- a/apps/web/app/api/ollama/pull/route.ts
+++ b/apps/web/app/api/ollama/pull/route.ts
@@ -72,7 +72,10 @@ export async function POST(request: Request) {
     create: { model, status: "queued", progress: 0 },
     update: { status: "queued", statusText: null, progress: 0, error: null },
   });
-  await enqueue("pull-ollama-model", { model });
+  // singletonKey collapses concurrent enqueues for the same model into one
+  // job (the TTL check above handles the common case; this closes the
+  // double-click / double-submit race so two workers can't pull in parallel).
+  await enqueue("pull-ollama-model", { model }, { singletonKey: model });
 
   return Response.json({ model: row.model, status: row.status, progress: row.progress });
 }

--- a/apps/web/lib/ollama-admin.ts
+++ b/apps/web/lib/ollama-admin.ts
@@ -148,6 +148,13 @@ export async function runOllamaPull(model: string): Promise<void> {
 async function registerPulledModel(model: string): Promise<void> {
   const entry = findCatalogEntry(model);
   if (!entry) return; // only curated models are registered — stay defensive
+  // Only register chat/LLM models in AvailableModel. Those route through
+  // ai-router via the "ollama:" prefix and belong in the review-model picker.
+  // Embedding models are configured exclusively via OCTOPUS_EMBED_* env, never
+  // the picker — registering one would add a dropdown entry that's silently
+  // ignored in Ollama-embed mode and fails if picked while on OpenAI
+  // embeddings. The pulled model still shows as "Installed" via /api/tags.
+  if (entry.category !== "llm") return;
   const modelId = `ollama:${entry.name}`;
   await prisma.availableModel.upsert({
     where: { modelId },


### PR DESCRIPTION
## What
Two small, self-host-only hardening fixes for the Ollama model-download feature (#562), found by an adversarial production-safety review.

1. **`registerPulledModel` no longer registers embedding-category models in `AvailableModel`.** Embeddings are configured via `OCTOPUS_EMBED_*` env, not the model picker — so registering `nomic-embed-text` created a dropdown option that is silently ignored in Ollama-embed mode and **fails** if a hoster picks it while still on OpenAI embeddings. Only `llm`-category models (which route via the `ollama:` prefix through `ai-router`) belong in the picker. The pulled embedding model still shows as **Installed** in the panel via `/api/tags`, so download UX is unchanged.
2. **`POST /api/ollama/pull` enqueues with a pg-boss `singletonKey`.** The existing 10-min TTL check handles the common case; this closes the double-click / double-submit race where two requests both pass the check and enqueue two jobs pulling the same model concurrently.

## Why
A full validation pass on #561/#562 confirmed **zero production impact** (the feature is gated off when `OLLAMA_SERVER_URL` is unset, as on the hosted SaaS), but flagged these two as real defects for self-hosters who use the feature. Fixing forward.

## Test plan
- `bun run typecheck` ✓ · `bun run lint` ✓ (changed files clean) · `apps/web` catalog test 4/0 ✓
- No schema/migration change; no change to any production-reachable path.

## Risk
🟢 **Low** — two-line behavior changes inside an already-self-host-gated feature. No production code path is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1