### PR TITLE
feat(cli): operational-parity commands for octp (+ 3 server fixes)

### DIFF
--- a/apps/cli/src/__tests__/args.test.ts
+++ b/apps/cli/src/__tests__/args.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "bun:test";
+import { flagValue, hasFlag, positionals } from "../lib/args.js";
+
+describe("flagValue", () => {
+  it("returns the token after a flag", () => {
+    expect(flagValue(["--format", "json"], "--format")).toBe("json");
+  });
+  it("returns undefined when absent or when the next token is a flag", () => {
+    expect(flagValue(["--staged"], "--format")).toBeUndefined();
+    expect(flagValue(["--format", "--strict"], "--format")).toBeUndefined();
+    expect(flagValue(["--format"], "--format")).toBeUndefined();
+  });
+});
+
+describe("hasFlag", () => {
+  it("matches any of the given flags", () => {
+    expect(hasFlag(["--verbose", "-x"], "-v", "--verbose")).toBe(true);
+    expect(hasFlag(["--staged"], "-h", "--help")).toBe(false);
+  });
+});
+
+describe("positionals", () => {
+  it("returns non-flag tokens", () => {
+    expect(positionals(["set", "model", "gpt-4o"])).toEqual(["set", "model", "gpt-4o"]);
+  });
+  it("skips flags and the values they consume", () => {
+    expect(positionals(["--format", "json", "status", "repo"], ["--format"])).toEqual([
+      "status",
+      "repo",
+    ]);
+    expect(positionals(["-g", "chat", "x"])).toEqual(["chat", "x"]);
+  });
+});

--- a/apps/cli/src/__tests__/auth.test.ts
+++ b/apps/cli/src/__tests__/auth.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "bun:test";
+import { isValidTokenFormat, TOKEN_PREFIX } from "../lib/auth.js";
+
+describe("isValidTokenFormat", () => {
+  it("accepts oct_-prefixed tokens with a body", () => {
+    expect(isValidTokenFormat("oct_abc123")).toBe(true);
+    expect(TOKEN_PREFIX).toBe("oct_");
+  });
+
+  it("rejects wrong prefix or empty body", () => {
+    expect(isValidTokenFormat("abc123")).toBe(false);
+    expect(isValidTokenFormat("oct_")).toBe(false);
+    expect(isValidTokenFormat("")).toBe(false);
+    expect(isValidTokenFormat("OCT_abc")).toBe(false);
+  });
+});

--- a/apps/cli/src/__tests__/output.test.ts
+++ b/apps/cli/src/__tests__/output.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "bun:test";
+import { sanitizeTerminal } from "../lib/output.js";
+
+describe("sanitizeTerminal", () => {
+  it("passes plain text through unchanged", () => {
+    expect(sanitizeTerminal("hello world")).toBe("hello world");
+  });
+
+  it("strips CSI color escapes", () => {
+    expect(sanitizeTerminal("a\x1b[31mred\x1b[0mb")).toBe("aredb");
+  });
+
+  it("strips OSC sequences (title / clipboard injection)", () => {
+    expect(sanitizeTerminal("x\x1b]0;pwned\x07y")).toBe("xy");
+    expect(sanitizeTerminal("x\x1b]52;c;abc\x1b\\y")).toBe("xy");
+  });
+
+  it("strips bare C0 control chars but keeps newline / tab / return", () => {
+    expect(sanitizeTerminal("a\x07b")).toBe("ab");
+    expect(sanitizeTerminal("a\nb\tc\rd")).toBe("a\nb\tc\rd");
+  });
+});

--- a/apps/cli/src/__tests__/pr-url.test.ts
+++ b/apps/cli/src/__tests__/pr-url.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "bun:test";
+import { parsePrArg, prTerms, localizeMessage } from "../lib/pr-url.js";
+
+describe("parsePrArg", () => {
+  it("parses a bare PR number", () => {
+    expect(parsePrArg("123")).toEqual({ ok: true, prNumber: 123 });
+    expect(parsePrArg("  7 ")).toEqual({ ok: true, prNumber: 7 });
+  });
+
+  it("parses GitHub / Bitbucket / GitLab URLs", () => {
+    expect(parsePrArg("https://github.com/owner/repo/pull/45")).toEqual({
+      ok: true,
+      prNumber: 45,
+      repoFullName: "owner/repo",
+    });
+    expect(parsePrArg("https://bitbucket.org/o/r/pull-requests/7")).toEqual({
+      ok: true,
+      prNumber: 7,
+      repoFullName: "o/r",
+    });
+    expect(parsePrArg("https://gitlab.example.com/g/sub/r/-/merge_requests/9")).toEqual({
+      ok: true,
+      prNumber: 9,
+      repoFullName: "g/sub/r",
+    });
+  });
+
+  it("rejects non-numeric, non-URL, and partial-number inputs", () => {
+    expect(parsePrArg("abc").ok).toBe(false);
+    expect(parsePrArg("123abc").ok).toBe(false); // not all digits, no URL match
+    expect(parsePrArg("").ok).toBe(false);
+  });
+});
+
+describe("prTerms / localizeMessage", () => {
+  it("uses MR wording for gitlab, PR otherwise", () => {
+    expect(prTerms("gitlab")).toEqual({ full: "merge request", short: "MR" });
+    expect(prTerms("github")).toEqual({ full: "pull request", short: "PR" });
+  });
+
+  it("localizes server wording only for gitlab", () => {
+    expect(localizeMessage("Pull request not found", "gitlab")).toBe("Merge request not found");
+    expect(localizeMessage("PR opened", "gitlab")).toBe("MR opened");
+    expect(localizeMessage("Pull request not found", "github")).toBe("Pull request not found");
+  });
+});

--- a/apps/cli/src/__tests__/repo-resolver.test.ts
+++ b/apps/cli/src/__tests__/repo-resolver.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "bun:test";
+import { parseGitRemote } from "../lib/repo-resolver.js";
+
+describe("parseGitRemote", () => {
+  it("parses SSH scp-like remotes", () => {
+    expect(parseGitRemote("git@github.com:owner/repo.git")).toBe("owner/repo");
+    expect(parseGitRemote("git@bitbucket.org:owner/repo.git")).toBe("owner/repo");
+    expect(parseGitRemote("git@github.com:owner/repo")).toBe("owner/repo");
+  });
+
+  it("parses HTTPS remotes, with and without .git / port", () => {
+    expect(parseGitRemote("https://github.com/owner/repo.git")).toBe("owner/repo");
+    expect(parseGitRemote("https://github.com/owner/repo")).toBe("owner/repo");
+    expect(parseGitRemote("https://gitlab.example.com:8443/group/subgroup/repo.git")).toBe(
+      "group/subgroup/repo",
+    );
+  });
+
+  it("parses SSH URL form with custom port + subgroups", () => {
+    expect(parseGitRemote("ssh://git@gitlab.example.com:2222/group/subgroup/repo.git")).toBe(
+      "group/subgroup/repo",
+    );
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(parseGitRemote("not a remote")).toBeNull();
+    expect(parseGitRemote("")).toBeNull();
+  });
+});

--- a/apps/cli/src/commands/agent-serve.ts
+++ b/apps/cli/src/commands/agent-serve.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import { loadCredentials, type Credentials } from "../lib/credentials.js";
 import { loadConfig, DEFAULT_OLLAMA_BASE_URL } from "../lib/config.js";
 import { getJson, postJson } from "../lib/api.js";
+import { sanitizeTerminal } from "../lib/output.js";
 
 /**
  * `octp agent serve` — register this machine as a local agent for the
@@ -109,7 +110,9 @@ export async function agentServeCommand(argv: string[]): Promise<number> {
   const ollamaBaseUrl =
     process.env.OLLAMA_BASE_URL ?? config.ollamaBaseUrl ?? DEFAULT_OLLAMA_BASE_URL;
 
-  console.log(`octp agent serve — connecting to ${creds.baseUrl} as ${creds.orgName} / ${agentName}`);
+  console.log(
+    `octp agent serve — connecting to ${sanitizeTerminal(creds.baseUrl)} as ${sanitizeTerminal(creds.orgName)} / ${sanitizeTerminal(agentName)}`,
+  );
 
   // Quick Ollama health-check so the user finds out about a stopped daemon
   // before tasks start landing.

--- a/apps/cli/src/commands/analyze-deps.ts
+++ b/apps/cli/src/commands/analyze-deps.ts
@@ -1,0 +1,262 @@
+import { loadCredentials } from "../lib/credentials.js";
+import { streamSse } from "../lib/api.js";
+import { positionals } from "../lib/args.js";
+import {
+  c,
+  heading,
+  table,
+  info,
+  success,
+  error,
+  sanitizeTerminal,
+} from "../lib/output.js";
+
+/**
+ * `octp analyze-deps <repo-url>` — scan a GitHub repo's npm dependencies for
+ * supply-chain risk. Ported from the old commander-based CLI; same server
+ * endpoint (`/api/analyze-deps`), same SSE event names, same CI exit-code
+ * contract:
+ *   - any CRITICAL advisory → exit 2
+ *   - else any HIGH advisory → exit 1
+ *   - else                   → exit 0
+ *   - stream/transport error → exit 1
+ *
+ * Progress + per-finding live lines go to STDERR (so piping stdout stays
+ * machine-clean); the final report + summary go to STDOUT.
+ */
+
+type RiskSignal = { source: string; description: string; score: number };
+
+type RiskReport = {
+  package: string;
+  version: string;
+  file: string;
+  isDevDependency: boolean;
+  overallRisk: string;
+  totalScore: number;
+  signals: RiskSignal[];
+  recommendation: string;
+  isSecurityHolding: boolean;
+};
+
+const RISK_LABEL: Record<string, (s: string) => string> = {
+  critical: (s) => c.red(s),
+  // The old CLI used a custom orange hex; the slim output lib only exposes a
+  // fixed palette, so HIGH renders yellow here. Severity is still distinct
+  // (CRITICAL=red, HIGH/MEDIUM=yellow text, LOW=cyan, CLEAN=green).
+  high: (s) => c.yellow(s),
+  medium: (s) => c.yellow(s),
+  low: (s) => c.cyan(s),
+  clean: (s) => c.green(s),
+};
+
+function riskLabel(risk: string): string {
+  const paint = RISK_LABEL[risk];
+  const text = risk.toUpperCase();
+  return paint ? paint(text) : text;
+}
+
+function asString(v: unknown, fallback = ""): string {
+  return typeof v === "string" ? v : fallback;
+}
+
+function asNumber(v: unknown, fallback = 0): number {
+  return typeof v === "number" ? v : fallback;
+}
+
+function asBool(v: unknown): boolean {
+  return v === true;
+}
+
+function toReport(v: unknown): RiskReport {
+  const o = (typeof v === "object" && v !== null ? v : {}) as Record<string, unknown>;
+  const rawSignals = Array.isArray(o.signals) ? o.signals : [];
+  const signals: RiskSignal[] = rawSignals.map((s) => {
+    const so = (typeof s === "object" && s !== null ? s : {}) as Record<string, unknown>;
+    return {
+      source: asString(so.source),
+      description: asString(so.description),
+      score: asNumber(so.score),
+    };
+  });
+  return {
+    package: asString(o.package),
+    version: asString(o.version),
+    file: asString(o.file),
+    isDevDependency: asBool(o.isDevDependency),
+    overallRisk: asString(o.overallRisk, "unknown"),
+    totalScore: asNumber(o.totalScore),
+    signals,
+    recommendation: asString(o.recommendation),
+    isSecurityHolding: asBool(o.isSecurityHolding),
+  };
+}
+
+function printHelp(): void {
+  console.log(`octp analyze-deps — scan a GitHub repo's npm dependencies for supply-chain risk
+
+Usage:
+  octp analyze-deps <repo-url>
+
+Arguments:
+  <repo-url>   GitHub repository URL (e.g. https://github.com/owner/repo)
+
+Exit codes:
+  0   no high/critical advisories
+  1   at least one HIGH advisory (and no critical), or a runtime/stream error
+  2   at least one CRITICAL advisory, or a usage/auth error
+`);
+}
+
+export async function analyzeDepsCommand(argv: string[]): Promise<number> {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    printHelp();
+    return 0;
+  }
+
+  const creds = await loadCredentials();
+  if (!creds) {
+    error("Not signed in. Run `octp login`.");
+    return 2;
+  }
+
+  const repoUrl = positionals(argv)[0];
+  if (!repoUrl || repoUrl.trim().length === 0) {
+    error("Missing <repo-url>.");
+    printHelp();
+    return 2;
+  }
+
+  // State collected from the stream.
+  let reports: RiskReport[] = [];
+  let repoName = "";
+  let cached = false;
+  let analysisId = "";
+  let streamError: string | null = null;
+
+  process.stderr.write("Starting package analysis...\n");
+
+  const result = await streamSse(
+    `${creds.baseUrl}/api/analyze-deps`,
+    { repoUrl: repoUrl.trim() },
+    creds.token,
+    (event, data) => {
+      switch (event) {
+        case "progress": {
+          const message = asString(data.message, "Analyzing...");
+          process.stderr.write(`${c.dim("…")} ${sanitizeTerminal(message)}\n`);
+          break;
+        }
+        case "finding": {
+          // The `finding` event payload is { package, risk, score } — distinct
+          // from the full RiskReport delivered on `complete`. Read those fields
+          // directly (overallRisk/totalScore don't exist on this event).
+          const pkg = asString(data.package);
+          const risk = asString(data.risk, "unknown");
+          const score = asNumber(data.score);
+          process.stderr.write(`${riskLabel(risk)} ${sanitizeTerminal(pkg)} (score: ${score})\n`);
+          break;
+        }
+        case "complete": {
+          reports = Array.isArray(data.reports) ? data.reports.map(toReport) : [];
+          repoName = asString(data.repoName);
+          cached = asBool(data.cached);
+          analysisId = asString(data.analysisId);
+          break;
+        }
+        case "error": {
+          streamError = asString(data.message, "Analysis failed");
+          break;
+        }
+      }
+    },
+  );
+
+  // Transport-level failure (couldn't open or read the stream).
+  if (!result.ok) {
+    error(`Analysis request failed (HTTP ${result.status}): ${result.error}`);
+    return 1;
+  }
+
+  // Server-emitted error event.
+  if (streamError) {
+    error(sanitizeTerminal(streamError));
+    return 1;
+  }
+
+  if (cached) {
+    process.stderr.write(`${c.green("✓")} Found cached analysis (same commit hash)\n`);
+  } else {
+    process.stderr.write(`${c.green("✓")} Analysis complete\n`);
+  }
+
+  if (reports.length === 0) {
+    success(`All dependencies look clean!${repoName ? ` (${repoName})` : ""}`);
+    return 0;
+  }
+
+  // Severity tallies.
+  const critical = reports.filter((r) => r.overallRisk === "critical").length;
+  const high = reports.filter((r) => r.overallRisk === "high").length;
+  const medium = reports.filter((r) => r.overallRisk === "medium").length;
+  const low = reports.filter((r) => r.overallRisk === "low").length;
+  const clean = reports.filter((r) => r.overallRisk === "clean").length;
+
+  const parts: string[] = [];
+  if (critical) parts.push(c.red(`${critical} critical`));
+  if (high) parts.push(c.yellow(`${high} high`));
+  if (medium) parts.push(c.yellow(`${medium} medium`));
+  if (low) parts.push(c.cyan(`${low} low`));
+  if (clean) parts.push(c.green(`${clean} clean`));
+  info(`${reports.length} packages: ${parts.join(", ")}`);
+
+  // Table for risky packages.
+  const risky = reports.filter((r) => r.overallRisk !== "clean");
+  if (risky.length > 0) {
+    console.log("");
+    table(
+      risky.map((r) => [
+        riskLabel(r.overallRisk),
+        sanitizeTerminal(r.package),
+        String(r.totalScore),
+        sanitizeTerminal(r.file),
+        sanitizeTerminal(r.signals.map((s) => s.description).join("; ")).slice(0, 80),
+      ]),
+      ["Risk", "Package", "Score", "File", "Signals"],
+    );
+  }
+
+  // Detailed findings for critical/high.
+  const urgent = reports.filter((r) => r.overallRisk === "critical" || r.overallRisk === "high");
+  if (urgent.length > 0) {
+    heading("Detailed Findings");
+    for (const report of urgent) {
+      console.log("");
+      console.log(
+        `  ${riskLabel(report.overallRisk)} ${c.bold(sanitizeTerminal(report.package))}@${sanitizeTerminal(report.version)} (score: ${report.totalScore})`,
+      );
+      console.log(`  ${c.dim(sanitizeTerminal(report.file))}`);
+      if (report.isSecurityHolding) {
+        console.log(`  ${c.red("⚠ CONFIRMED MALICIOUS — removed by npm security team")}`);
+      }
+      for (const signal of report.signals) {
+        console.log(
+          `    ${c.yellow("⚠")} [${sanitizeTerminal(signal.source)}] ${sanitizeTerminal(signal.description)}`,
+        );
+      }
+      if (report.recommendation) {
+        console.log(`    ${c.dim("→")} ${sanitizeTerminal(report.recommendation)}`);
+      }
+    }
+  }
+
+  if (analysisId) {
+    console.log("");
+    info(`Analysis ID: ${sanitizeTerminal(analysisId)}`);
+  }
+
+  // CI exit-code contract — preserved from the old command.
+  if (critical > 0) return 2;
+  if (high > 0) return 1;
+  return 0;
+}

--- a/apps/cli/src/commands/chat.ts
+++ b/apps/cli/src/commands/chat.ts
@@ -1,0 +1,152 @@
+import { createInterface } from "node:readline";
+import { loadCredentials } from "../lib/credentials.js";
+import { streamData } from "../lib/api.js";
+import { hasFlag, flagValue, positionals } from "../lib/args.js";
+import { resolveRepo } from "../lib/repo-resolver.js";
+import { error, info, c, sanitizeTerminal } from "../lib/output.js";
+
+const USAGE = `octp chat — chat with Octopus about a repository
+
+Usage:
+  octp chat [repo] [-p|--print <message>] [-g|--global]
+
+Arguments:
+  repo                 Repository name or full name (auto-detects from git remote)
+
+Options:
+  -p, --print <msg>    Pipeline mode: ask a single question, print the answer, exit
+  -g, --global         Ask across all repos in your organization (no repo resolution)
+  -h, --help           Show this help
+
+Pipeline mode is also used automatically when stdin is not a TTY (piped input).`;
+
+const CHAT_TIMEOUT_MS = (() => {
+  const v = Number(process.env.OCTP_CHAT_TIMEOUT_MS ?? 5 * 60_000);
+  return Number.isNaN(v) ? 5 * 60_000 : v;
+})();
+
+/** Read all of stdin to a trimmed string. */
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8").trim();
+}
+
+/** `octp chat` — interactive or pipeline chat backed by /api/cli/chat. */
+export async function chatCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    console.log(USAGE);
+    return 0;
+  }
+
+  const creds = await loadCredentials();
+  if (!creds) {
+    error("Not signed in. Run `octp login`.");
+    return 2;
+  }
+
+  const printMsg = flagValue(argv, "-p") ?? flagValue(argv, "--print");
+  const isPrintFlag = hasFlag(argv, "-p", "--print");
+  const isGlobal = hasFlag(argv, "-g", "--global");
+  const isPipeline = isPrintFlag || !process.stdin.isTTY;
+
+  const repoArg = positionals(argv, ["-p", "--print"])[0];
+
+  let repoId: string | null = null;
+  let label = "your organization";
+  if (!isGlobal) {
+    const resolved = await resolveRepo(creds, repoArg);
+    if (!resolved.ok) {
+      error(resolved.error);
+      return 1;
+    }
+    repoId = resolved.repo.id;
+    label = resolved.repo.fullName;
+  }
+
+  const url = `${creds.baseUrl}/api/cli/chat`;
+
+  // Pipeline mode: single question -> stream answer -> exit.
+  if (isPipeline) {
+    const message = printMsg ?? (await readStdin());
+    if (!message) {
+      error("No message provided. Use -p <message> or pipe via stdin.");
+      return 1;
+    }
+
+    let hadError = false;
+    const result = await streamData(url, { message, conversationId: null, repoId }, creds.token, (data) => {
+      if (data.type === "delta" && typeof data.text === "string") {
+        process.stdout.write(sanitizeTerminal(data.text));
+      } else if (data.type === "error") {
+        hadError = true;
+        const m = typeof data.message === "string" ? data.message : "chat failed";
+        process.stderr.write(`\n${sanitizeTerminal(m)}\n`);
+      }
+    }, CHAT_TIMEOUT_MS);
+
+    process.stdout.write("\n");
+    if (!result.ok) {
+      error(`Chat request failed (HTTP ${result.status}: ${result.error})`);
+      return 1;
+    }
+    return hadError ? 1 : 0;
+  }
+
+  // Interactive REPL.
+  info(`Chatting about ${c.bold(label)}. Type 'exit' or Ctrl+C to quit.\n`);
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  let conversationId: string | null = null;
+  let exitCode = 0;
+
+  return await new Promise<number>((resolve) => {
+    let closed = false;
+    const finish = (code: number) => {
+      if (closed) return;
+      closed = true;
+      exitCode = code;
+      rl.close();
+    };
+
+    rl.on("close", () => resolve(exitCode));
+    rl.on("SIGINT", () => finish(0));
+
+    const ask = () => {
+      rl.question(c.cyan("you> "), (raw) => {
+        const message = raw.trim();
+        if (!message) {
+          ask();
+          return;
+        }
+        if (message.toLowerCase() === "exit") {
+          finish(0);
+          return;
+        }
+
+        process.stdout.write(c.green("octopus> "));
+        streamData(url, { message, conversationId, repoId }, creds.token, (data) => {
+          if (data.type === "conversation_id" && typeof data.id === "string") {
+            conversationId = data.id;
+          } else if (data.type === "delta" && typeof data.text === "string") {
+            process.stdout.write(sanitizeTerminal(data.text));
+          } else if (data.type === "error") {
+            const m = typeof data.message === "string" ? data.message : "chat failed";
+            process.stdout.write(c.red(`\n${sanitizeTerminal(m)}`));
+          }
+        }, CHAT_TIMEOUT_MS)
+          .then((result) => {
+            if (!result.ok) {
+              process.stdout.write(c.red(`\nChat request failed (HTTP ${result.status}: ${result.error})`));
+            }
+            process.stdout.write("\n\n");
+            if (!closed) ask();
+          });
+      });
+    };
+
+    ask();
+  });
+}

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -1,0 +1,126 @@
+import { loadConfig, saveConfig } from "../lib/config.js";
+import { loadCredentials } from "../lib/credentials.js";
+import { normalizeBaseUrl } from "../lib/api.js";
+import { positionals, hasFlag } from "../lib/args.js";
+import { success, error, info, heading, table, c } from "../lib/output.js";
+
+/**
+ * `octp config` — read/write ~/.octopus/config.json prefs non-interactively.
+ * Replaces the previous stub. Writable keys are the OctopusConfig prefs;
+ * baseUrl/org are read-only here (managed by `octp login`).
+ */
+
+const WRITABLE = ["provider", "model", "ollamaBaseUrl", "selfHostedBaseUrl"] as const;
+const URL_KEYS = new Set(["ollamaBaseUrl", "selfHostedBaseUrl"]);
+
+export async function configCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    printHelp();
+    return 0;
+  }
+  const [sub, key, value] = positionals(argv);
+  if (!sub || sub === "list") return listConfig();
+  if (sub === "get") return getConfig(key);
+  if (sub === "set") return setConfig(key, value);
+  error(`Unknown config subcommand: ${sub}. Use get | set | list.`);
+  return 2;
+}
+
+async function listConfig(): Promise<number> {
+  const cfg = await loadConfig();
+  const creds = await loadCredentials();
+  heading("Config (~/.octopus/config.json)");
+  table([
+    ["provider", cfg.provider ?? c.dim("(unset)")],
+    ["model", cfg.model ?? c.dim("(unset)")],
+    ["ollamaBaseUrl", cfg.ollamaBaseUrl ?? c.dim("(default)")],
+    ["selfHostedBaseUrl", cfg.selfHostedBaseUrl ?? c.dim("(unset)")],
+  ]);
+  if (creds) {
+    heading("Session (~/.octopus/credentials)");
+    table([
+      ["baseUrl", creds.baseUrl],
+      ["org", `${creds.orgName} (${creds.orgSlug})`],
+      [
+        "user",
+        creds.userName
+          ? `${creds.userName}${creds.userEmail ? ` <${creds.userEmail}>` : ""}`
+          : c.dim("(unknown)"),
+      ],
+    ]);
+  } else {
+    info(c.dim("\nNot signed in. Run `octp login`."));
+  }
+  return 0;
+}
+
+async function getConfig(key?: string): Promise<number> {
+  if (!key) {
+    error("Usage: octp config get <key>");
+    return 2;
+  }
+  const cfg = await loadConfig();
+  const creds = await loadCredentials();
+  switch (key) {
+    case "provider":
+    case "model":
+    case "ollamaBaseUrl":
+    case "selfHostedBaseUrl":
+      console.log(cfg[key] ?? "not set");
+      return 0;
+    case "baseUrl":
+      console.log(creds?.baseUrl ?? "not set");
+      return 0;
+    case "orgSlug":
+      console.log(creds?.orgSlug ?? "not set");
+      return 0;
+    case "orgId":
+      console.log(creds?.orgId ?? "not set");
+      return 0;
+    default:
+      error(
+        `Unknown config key: ${key}. Readable: provider, model, ollamaBaseUrl, selfHostedBaseUrl, baseUrl, orgSlug, orgId`,
+      );
+      return 2;
+  }
+}
+
+async function setConfig(key?: string, value?: string): Promise<number> {
+  if (!key || value === undefined || value === "") {
+    error("Usage: octp config set <key> <value>");
+    return 2;
+  }
+  if (!(WRITABLE as readonly string[]).includes(key)) {
+    error(
+      `Cannot set "${key}". Writable keys: ${WRITABLE.join(", ")}. (baseUrl/org are managed by \`octp login\`.)`,
+    );
+    return 2;
+  }
+  let finalValue = value;
+  if (URL_KEYS.has(key)) {
+    const n = normalizeBaseUrl(value);
+    if (!n) {
+      error(`Invalid URL for ${key}: ${value}`);
+      return 2;
+    }
+    finalValue = n;
+  }
+  const cfg = await loadConfig();
+  (cfg as Record<string, unknown>)[key] = finalValue;
+  await saveConfig(cfg);
+  success(`Set ${key} = ${finalValue}`);
+  return 0;
+}
+
+function printHelp(): void {
+  console.log(`octp config — read/write CLI configuration
+
+Usage:
+  octp config list                 Show config + current session
+  octp config get <key>            Print a single value
+  octp config set <key> <value>    Set a writable pref
+
+Writable keys:  provider, model, ollamaBaseUrl, selfHostedBaseUrl
+Readable keys:  + baseUrl, orgSlug, orgId  (managed by \`octp login\`)
+`);
+}

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -2,7 +2,7 @@ import { loadConfig, saveConfig } from "../lib/config.js";
 import { loadCredentials } from "../lib/credentials.js";
 import { normalizeBaseUrl } from "../lib/api.js";
 import { positionals, hasFlag } from "../lib/args.js";
-import { success, error, info, heading, table, c } from "../lib/output.js";
+import { success, error, info, heading, table, c, sanitizeTerminal } from "../lib/output.js";
 
 /**
  * `octp config` — read/write ~/.octopus/config.json prefs non-interactively.
@@ -39,12 +39,12 @@ async function listConfig(): Promise<number> {
   if (creds) {
     heading("Session (~/.octopus/credentials)");
     table([
-      ["baseUrl", creds.baseUrl],
-      ["org", `${creds.orgName} (${creds.orgSlug})`],
+      ["baseUrl", sanitizeTerminal(creds.baseUrl)],
+      ["org", `${sanitizeTerminal(creds.orgName)} (${sanitizeTerminal(creds.orgSlug)})`],
       [
         "user",
         creds.userName
-          ? `${creds.userName}${creds.userEmail ? ` <${creds.userEmail}>` : ""}`
+          ? `${sanitizeTerminal(creds.userName)}${creds.userEmail ? ` <${sanitizeTerminal(creds.userEmail)}>` : ""}`
           : c.dim("(unknown)"),
       ],
     ]);
@@ -69,13 +69,13 @@ async function getConfig(key?: string): Promise<number> {
       console.log(cfg[key] ?? "not set");
       return 0;
     case "baseUrl":
-      console.log(creds?.baseUrl ?? "not set");
+      console.log(creds ? sanitizeTerminal(creds.baseUrl) : "not set");
       return 0;
     case "orgSlug":
-      console.log(creds?.orgSlug ?? "not set");
+      console.log(creds ? sanitizeTerminal(creds.orgSlug) : "not set");
       return 0;
     case "orgId":
-      console.log(creds?.orgId ?? "not set");
+      console.log(creds ? sanitizeTerminal(creds.orgId) : "not set");
       return 0;
     default:
       error(

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -3,6 +3,7 @@ import { loadCredentials } from "../lib/credentials.js";
 import { loadByok } from "../lib/byok.js";
 import { getJson } from "../lib/api.js";
 import { getOctopusHome } from "../lib/paths.js";
+import { sanitizeTerminal } from "../lib/output.js";
 
 /**
  * `octp doctor` — environment + auth health check. Prints one line per
@@ -46,7 +47,11 @@ export async function doctorCommand(_argv: string[]): Promise<number> {
   if (!creds) {
     line("warn", "credentials", "no ~/.octopus/credentials — run `octp` to sign in");
   } else {
-    line("ok", "credentials", `${creds.orgName} (${creds.orgSlug}) on ${creds.baseUrl}`);
+    line(
+      "ok",
+      "credentials",
+      `${sanitizeTerminal(creds.orgName)} (${sanitizeTerminal(creds.orgSlug)}) on ${sanitizeTerminal(creds.baseUrl)}`,
+    );
 
     // Live token check — hits /api/cli/me with the saved bearer.
     const res = await getJson(`${creds.baseUrl}/api/cli/me`, {

--- a/apps/cli/src/commands/knowledge.ts
+++ b/apps/cli/src/commands/knowledge.ts
@@ -1,0 +1,154 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { loadCredentials } from "../lib/credentials.js";
+import { getJson, postJson, del } from "../lib/api.js";
+import { positionals, flagValue, hasFlag } from "../lib/args.js";
+import { error, success, info, table, c, sanitizeTerminal } from "../lib/output.js";
+import type { KnowledgeDocument } from "../lib/types.js";
+
+const USAGE = `octp knowledge — manage knowledge base documents
+
+Usage:
+  octp knowledge list                      List knowledge base documents
+  octp knowledge add <file> [--title <t>]  Add a file (title defaults to filename)
+  octp knowledge remove <id>               Remove a knowledge document`;
+
+// Sent as a JSON string in the request body, so cap the content size to keep
+// the payload sane and give a clear error instead of a vague server reject.
+const MAX_CONTENT_BYTES = 1024 * 1024; // 1 MB
+
+export async function knowledgeCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    console.log(USAGE);
+    return 0;
+  }
+
+  const creds = await loadCredentials();
+  if (!creds) {
+    error("Not signed in. Run `octp login`.");
+    return 2;
+  }
+
+  const pos = positionals(argv, ["--title"]);
+  const sub = pos[0];
+
+  switch (sub) {
+    case "list":
+      return await listKnowledge(creds.baseUrl, creds.token);
+    case "add":
+      return await addKnowledge(creds.baseUrl, creds.token, pos[1], flagValue(argv, "--title"));
+    case "remove":
+      return await removeKnowledge(creds.baseUrl, creds.token, pos[1]);
+    default:
+      if (sub) error(`Unknown subcommand: ${sub}`);
+      else error("Missing subcommand.");
+      console.error(USAGE);
+      return 2;
+  }
+}
+
+async function listKnowledge(baseUrl: string, token: string): Promise<number> {
+  const res = await getJson<{ documents: KnowledgeDocument[] }>(`${baseUrl}/api/cli/knowledge`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    if (res.status === 401) {
+      error("Session expired or token revoked. Run `octp login` again.");
+      return 1;
+    }
+    error(`Could not list documents (HTTP ${res.status}: ${res.error})`);
+    return 1;
+  }
+
+  const { documents } = res.data;
+  if (documents.length === 0) {
+    info("No knowledge documents found. Use `octp knowledge add <file>` to add one.");
+    return 0;
+  }
+
+  const rows = documents.map((d) => [
+    d.id.slice(0, 8),
+    sanitizeTerminal(d.title),
+    sanitizeTerminal(d.sourceType),
+    sanitizeTerminal(d.status),
+    String(d.totalChunks),
+    sanitizeTerminal(d.createdAt),
+  ]);
+  table(rows, ["ID", "Title", "Type", "Status", "Chunks", "Created"]);
+  info(c.dim(`\n${documents.length} document${documents.length === 1 ? "" : "s"} total`));
+  return 0;
+}
+
+async function addKnowledge(
+  baseUrl: string,
+  token: string,
+  file: string | undefined,
+  title: string | undefined,
+): Promise<number> {
+  if (!file) {
+    error("Missing <file> argument.");
+    console.error(USAGE);
+    return 2;
+  }
+
+  let content: string;
+  try {
+    content = await readFile(file, "utf8");
+  } catch {
+    error(`Could not read file: ${file}`);
+    return 1;
+  }
+
+  const bytes = Buffer.byteLength(content, "utf8");
+  if (bytes > MAX_CONTENT_BYTES) {
+    error(
+      `File too large: ${(bytes / 1024 / 1024).toFixed(2)} MB exceeds the 1 MB limit for knowledge uploads.`,
+    );
+    return 1;
+  }
+
+  const fileName = basename(file);
+  const docTitle = title ?? fileName;
+
+  const res = await postJson<{ document: { id: string; title: string } }>(
+    `${baseUrl}/api/cli/knowledge`,
+    { title: docTitle, content, fileName },
+    token,
+  );
+  if (!res.ok) {
+    if (res.status === 401) {
+      error("Session expired or token revoked. Run `octp login` again.");
+      return 1;
+    }
+    error(`Could not add document (HTTP ${res.status}: ${res.error})`);
+    return 1;
+  }
+
+  success(`Added "${res.data.document.title}" (${res.data.document.id})`);
+  return 0;
+}
+
+async function removeKnowledge(
+  baseUrl: string,
+  token: string,
+  id: string | undefined,
+): Promise<number> {
+  if (!id) {
+    error("Missing <id> argument.");
+    console.error(USAGE);
+    return 2;
+  }
+
+  const res = await del<unknown>(`${baseUrl}/api/cli/knowledge/${encodeURIComponent(id)}`, token);
+  if (!res.ok) {
+    if (res.status === 401) {
+      error("Session expired or token revoked. Run `octp login` again.");
+      return 1;
+    }
+    error(`Could not remove document (HTTP ${res.status}: ${res.error})`);
+    return 1;
+  }
+
+  success(`Document ${id} removed.`);
+  return 0;
+}

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -1,0 +1,88 @@
+import { loadConfig } from "../lib/config.js";
+import { loadCredentials, saveCredentials } from "../lib/credentials.js";
+import {
+  runDeviceFlow,
+  verifyToken,
+  isValidTokenFormat,
+  buildCredentials,
+  type AuthIdentity,
+} from "../lib/auth.js";
+import { normalizeBaseUrl, isTransportSafe } from "../lib/api.js";
+import { flagValue, hasFlag } from "../lib/args.js";
+import { success, error, info, c } from "../lib/output.js";
+
+const DEFAULT_BASE_URL = "https://octopus-review.ai";
+
+/**
+ * `octp login` — standalone, scriptable auth. Browser device-flow by default,
+ * or `--token oct_…` for headless/CI. Writes ~/.octopus/credentials.
+ *
+ * Base URL precedence: --api-url > existing creds > config.selfHostedBaseUrl >
+ * hosted default. We refuse to send the token over cleartext HTTP to a
+ * non-local host unless --insecure is passed (a token leak to any on-path
+ * observer otherwise).
+ */
+export async function loginCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    printHelp();
+    return 0;
+  }
+
+  const token = flagValue(argv, "--token");
+  const apiUrlFlag = flagValue(argv, "--api-url");
+  const insecure = hasFlag(argv, "--insecure");
+
+  const fallback =
+    (await loadCredentials())?.baseUrl ?? (await loadConfig()).selfHostedBaseUrl ?? DEFAULT_BASE_URL;
+  const normalized = normalizeBaseUrl(apiUrlFlag ?? fallback);
+  if (!normalized) {
+    error(`Invalid API URL: ${apiUrlFlag ?? fallback}`);
+    return 2;
+  }
+  const baseUrl = normalized;
+
+  if (!isTransportSafe(baseUrl) && !insecure) {
+    error(
+      `Refusing to send credentials over insecure transport: ${baseUrl}\n` +
+        `Use an https URL (or a loopback / private-LAN host), or pass --insecure to override.`,
+    );
+    return 2;
+  }
+
+  try {
+    let identity: AuthIdentity;
+    if (token) {
+      if (!isValidTokenFormat(token)) {
+        error("Invalid token format. Tokens start with 'oct_'.");
+        return 2;
+      }
+      const verified = await verifyToken(baseUrl, token);
+      identity = { token, organization: verified.organization, user: verified.user };
+    } else {
+      identity = await runDeviceFlow(baseUrl, { onAuthorizeUrl: (url) => info(c.dim(url)) });
+    }
+    await saveCredentials(buildCredentials(baseUrl, identity));
+    const email = identity.user.email ? ` (${identity.user.email})` : "";
+    success(`Logged in as ${identity.user.name}${email} — org: ${identity.organization.name}`);
+    return 0;
+  } catch (err) {
+    error(err instanceof Error ? err.message : "Login failed");
+    return 1;
+  }
+}
+
+function printHelp(): void {
+  console.log(`octp login — authenticate with Octopus
+
+Usage:
+  octp login                     Browser device-flow sign-in
+  octp login --token oct_...      Sign in with a token (headless / CI)
+
+Flags:
+  --token <oct_...>              API token; skips the browser
+                                 (exposes the token via process args (ps) and shell history; for CI prefer 'octp setup-token')
+  --api-url <url>                Server base URL (default: hosted, or your saved server)
+  --insecure                     Allow sending the token over cleartext HTTP (not recommended)
+  --help, -h                     This help
+`);
+}

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -9,7 +9,7 @@ import {
 } from "../lib/auth.js";
 import { normalizeBaseUrl, isTransportSafe } from "../lib/api.js";
 import { flagValue, hasFlag } from "../lib/args.js";
-import { success, error, info, c } from "../lib/output.js";
+import { success, error, info, c, sanitizeTerminal } from "../lib/output.js";
 
 const DEFAULT_BASE_URL = "https://octopus-review.ai";
 
@@ -62,8 +62,10 @@ export async function loginCommand(argv: string[]): Promise<number> {
       identity = await runDeviceFlow(baseUrl, { onAuthorizeUrl: (url) => info(c.dim(url)) });
     }
     await saveCredentials(buildCredentials(baseUrl, identity));
-    const email = identity.user.email ? ` (${identity.user.email})` : "";
-    success(`Logged in as ${identity.user.name}${email} — org: ${identity.organization.name}`);
+    const email = identity.user.email ? ` (${sanitizeTerminal(identity.user.email)})` : "";
+    success(
+      `Logged in as ${sanitizeTerminal(identity.user.name)}${email} — org: ${sanitizeTerminal(identity.organization.name)}`,
+    );
     return 0;
   } catch (err) {
     error(err instanceof Error ? err.message : "Login failed");

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -1,0 +1,25 @@
+import { loadCredentials, clearCredentials } from "../lib/credentials.js";
+import { hasFlag } from "../lib/args.js";
+import { success, error, info } from "../lib/output.js";
+
+/** `octp logout` — remove saved credentials (~/.octopus/credentials). */
+export async function logoutCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    console.log("octp logout — remove saved credentials (~/.octopus/credentials)");
+    return 0;
+  }
+  const creds = await loadCredentials();
+  if (!creds) {
+    info("Not signed in — nothing to do.");
+    return 0;
+  }
+  try {
+    await clearCredentials();
+    success(`Signed out of ${creds.orgName}.`);
+    return 0;
+  } catch (e) {
+    // clearCredentials re-throws non-ENOENT — the token is still on disk.
+    error(`Could not remove credentials: ${e instanceof Error ? e.message : String(e)}`);
+    return 1;
+  }
+}

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -1,6 +1,6 @@
 import { loadCredentials, clearCredentials } from "../lib/credentials.js";
 import { hasFlag } from "../lib/args.js";
-import { success, error, info } from "../lib/output.js";
+import { success, error, info, sanitizeTerminal } from "../lib/output.js";
 
 /** `octp logout` — remove saved credentials (~/.octopus/credentials). */
 export async function logoutCommand(argv: string[]): Promise<number> {
@@ -15,7 +15,7 @@ export async function logoutCommand(argv: string[]): Promise<number> {
   }
   try {
     await clearCredentials();
-    success(`Signed out of ${creds.orgName}.`);
+    success(`Signed out of ${sanitizeTerminal(creds.orgName)}.`);
     return 0;
   } catch (e) {
     // clearCredentials re-throws non-ENOENT — the token is still on disk.

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -1,0 +1,289 @@
+/**
+ * `octp repo` — list / status / index / analyze connected repositories.
+ *
+ * Ported from the standalone @octp/cli (commands/repo/*). The old CLI used
+ * commander + ora spinners and threw ApiError; here each subcommand is a plain
+ * async branch that returns an exit code and reads the ApiResult discriminated
+ * union from the foundation api helpers (never try/catch around them).
+ *
+ * Progress while polling goes to STDERR so STDOUT stays clean for piping.
+ */
+
+import { loadCredentials, type Credentials } from "../lib/credentials.js";
+import { getJson, postJson } from "../lib/api.js";
+import { resolveRepo } from "../lib/repo-resolver.js";
+import { c, success, error, info, heading, table, sanitizeTerminal } from "../lib/output.js";
+import { positionals } from "../lib/args.js";
+import type { ApiRepo } from "../lib/types.js";
+
+const POLL_INTERVAL_MS = 3000;
+const MAX_ATTEMPTS = 200;
+
+const USAGE = `Usage: octp repo <command> [repo]
+
+Commands:
+  list                 List all connected repositories (default)
+  status [repo]        Show detailed status for a repository
+  index [repo]         Index a repository for code search, then wait
+  analyze [repo]       Run AI analysis on a repository, then wait
+
+[repo] is a repository name or full name. When omitted, it is auto-detected
+from the current git remote.
+
+Options:
+  -h, --help           Show this help`;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** STDERR progress — keeps STDOUT clean for piping. */
+function progress(msg: string): void {
+  process.stderr.write(`${msg}\n`);
+}
+
+function colorStatus(status: string): string {
+  switch (status) {
+    case "indexed":
+    case "analyzed":
+    case "done":
+    case "completed":
+      return c.green(status);
+    case "indexing":
+    case "analyzing":
+    case "pending":
+      return c.yellow(status);
+    case "failed":
+      return c.red(status);
+    case "none":
+      return c.dim(status);
+    default:
+      return c.dim(sanitizeTerminal(status));
+  }
+}
+
+function formatDate(d: string | null): string {
+  if (!d) return "never";
+  const date = new Date(d);
+  if (Number.isNaN(date.getTime())) return "never";
+  return date.toLocaleString();
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+function formatDuration(ms: number | undefined): string {
+  if (!ms || ms <= 0) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m ${rem}s`;
+}
+
+export async function repoCommand(argv: string[]): Promise<number> {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    info(USAGE);
+    return 0;
+  }
+
+  const creds = await loadCredentials();
+  if (!creds) {
+    error("Not signed in. Run `octp login`.");
+    return 2;
+  }
+
+  const [sub, repoArg] = positionals(argv);
+
+  switch (sub ?? "list") {
+    case "list":
+      return await listRepos(creds.baseUrl, creds.token);
+    case "status":
+      return await statusRepo(creds, repoArg);
+    case "index":
+      return await indexRepo(creds, repoArg);
+    case "analyze":
+      return await analyzeRepo(creds, repoArg);
+    case "chat":
+      info("`octp repo chat` moved to `octp chat`");
+      return 2;
+    default:
+      error(`Unknown subcommand: ${sub}`);
+      info(USAGE);
+      return 2;
+  }
+}
+
+async function listRepos(baseUrl: string, token: string): Promise<number> {
+  const res = await getJson<{ repos: ApiRepo[] }>(`${baseUrl}/api/cli/repos`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    error(`Failed to list repositories (HTTP ${res.status}: ${res.error})`);
+    return 1;
+  }
+
+  const repos = res.data.repos ?? [];
+  if (repos.length === 0) {
+    info("No repositories found. Connect repos in the Octopus dashboard.");
+    return 0;
+  }
+
+  const rows = repos.map((r) => [
+    sanitizeTerminal(r.fullName),
+    sanitizeTerminal(r.provider),
+    colorStatus(r.indexStatus),
+    colorStatus(r.analysisStatus),
+    String(r._count.pullRequests),
+    formatDate(r.indexedAt),
+  ]);
+  table(rows, ["Repository", "Provider", "Index", "Analysis", "PRs", "Last Indexed"]);
+  info(`\n${repos.length} repositories total`);
+  return 0;
+}
+
+async function statusRepo(creds: Credentials, repoArg?: string): Promise<number> {
+  const resolved = await resolveRepo(creds, repoArg);
+  if (!resolved.ok) {
+    error(resolved.error);
+    return 1;
+  }
+
+  const res = await getJson<{ repo: ApiRepo }>(
+    `${creds.baseUrl}/api/cli/repos/${encodeURIComponent(resolved.repo.id)}/status`,
+    { headers: { authorization: `Bearer ${creds.token}` } },
+  );
+  if (!res.ok) {
+    error(`Failed to get repo status (HTTP ${res.status}: ${res.error})`);
+    return 1;
+  }
+  const repo = res.data.repo;
+
+  heading(sanitizeTerminal(repo.fullName));
+  info(`  Provider:       ${sanitizeTerminal(repo.provider)}`);
+  info(`  Default Branch: ${sanitizeTerminal(repo.defaultBranch)}`);
+  info(`  Auto Review:    ${repo.autoReview ? "enabled" : "disabled"}`);
+
+  heading("Indexing");
+  info(`  Status:     ${colorStatus(repo.indexStatus)}`);
+  info(`  Last Index: ${formatDate(repo.indexedAt)}`);
+  info(`  Files:      ${repo.indexedFiles}/${repo.totalFiles}`);
+  info(`  Chunks:     ${formatNumber(repo.totalChunks)}`);
+  info(`  Vectors:    ${formatNumber(repo.totalVectors ?? 0)}`);
+  info(`  Duration:   ${formatDuration(repo.indexDurationMs)}`);
+
+  heading("Analysis");
+  info(`  Status:        ${colorStatus(repo.analysisStatus)}`);
+  info(`  Last Analyzed: ${formatDate(repo.analyzedAt)}`);
+  if (repo.purpose) info(`  Purpose:       ${sanitizeTerminal(repo.purpose)}`);
+  if (repo.summary) info(`  Summary:       ${sanitizeTerminal(repo.summary)}`);
+
+  heading("Stats");
+  info(`  Pull Requests: ${repo._count.pullRequests}`);
+  info(`  Contributors:  ${repo.contributorCount ?? 0}`);
+  info("");
+  return 0;
+}
+
+async function indexRepo(creds: Credentials, repoArg?: string): Promise<number> {
+  const resolved = await resolveRepo(creds, repoArg);
+  if (!resolved.ok) {
+    error(resolved.error);
+    return 1;
+  }
+  const repo = resolved.repo;
+
+  progress(`Starting index for ${repo.fullName}...`);
+  const start = await postJson(`${creds.baseUrl}/api/cli/repos/${encodeURIComponent(repo.id)}/index`, {}, creds.token);
+  if (!start.ok) {
+    error(`Failed to start indexing (HTTP ${start.status}: ${start.error})`);
+    return 1;
+  }
+
+  progress(`Indexing ${repo.fullName}...`);
+  let status = "indexing";
+  let attempts = 0;
+  while (status === "indexing" && attempts < MAX_ATTEMPTS) {
+    attempts++;
+    await sleep(POLL_INTERVAL_MS);
+    const res = await getJson<{ repo: ApiRepo }>(
+      `${creds.baseUrl}/api/cli/repos/${encodeURIComponent(repo.id)}/status`,
+      { headers: { authorization: `Bearer ${creds.token}` } },
+    );
+    if (!res.ok) {
+      error(`Failed to poll index status (HTTP ${res.status}: ${res.error})`);
+      return 1;
+    }
+    const updated = res.data.repo;
+    status = updated.indexStatus;
+
+    if (status === "indexed") {
+      success(`Indexed ${repo.fullName}`);
+      info(`Files: ${updated.indexedFiles}/${updated.totalFiles}`);
+      info(`Chunks: ${formatNumber(updated.totalChunks)}`);
+      info(`Duration: ${formatDuration(updated.indexDurationMs)}`);
+      return 0;
+    }
+    if (status === "failed") {
+      error(`Indexing failed for ${repo.fullName}`);
+      return 1;
+    }
+  }
+
+  error(`Indexing timed out for ${repo.fullName} after ${MAX_ATTEMPTS * (POLL_INTERVAL_MS / 1000)}s`);
+  return 1;
+}
+
+async function analyzeRepo(creds: Credentials, repoArg?: string): Promise<number> {
+  const resolved = await resolveRepo(creds, repoArg);
+  if (!resolved.ok) {
+    error(resolved.error);
+    return 1;
+  }
+  const repo = resolved.repo;
+
+  progress(`Starting analysis for ${repo.fullName}...`);
+  const start = await postJson(`${creds.baseUrl}/api/cli/repos/${encodeURIComponent(repo.id)}/analyze`, {}, creds.token);
+  if (!start.ok) {
+    error(`Failed to start analysis (HTTP ${start.status}: ${start.error})`);
+    return 1;
+  }
+
+  progress(`Analyzing ${repo.fullName}...`);
+  let analysisStatus = "analyzing";
+  let attempts = 0;
+  while (analysisStatus === "analyzing" && attempts < MAX_ATTEMPTS) {
+    attempts++;
+    await sleep(POLL_INTERVAL_MS);
+    const res = await getJson<{ repo: ApiRepo }>(
+      `${creds.baseUrl}/api/cli/repos/${encodeURIComponent(repo.id)}/status`,
+      { headers: { authorization: `Bearer ${creds.token}` } },
+    );
+    if (!res.ok) {
+      error(`Failed to poll analysis status (HTTP ${res.status}: ${res.error})`);
+      return 1;
+    }
+    const updated = res.data.repo;
+    analysisStatus = updated.analysisStatus;
+
+    if (
+      analysisStatus === "analyzed" ||
+      analysisStatus === "done" ||
+      analysisStatus === "completed"
+    ) {
+      success(`Analysis complete for ${repo.fullName}`);
+      if (updated.purpose) info(`Purpose: ${sanitizeTerminal(updated.purpose)}`);
+      if (updated.summary) info(`Summary: ${sanitizeTerminal(updated.summary)}`);
+      return 0;
+    }
+    if (analysisStatus === "failed") {
+      error(`Analysis failed for ${repo.fullName}`);
+      return 1;
+    }
+  }
+
+  error(`Analysis timed out for ${repo.fullName} after ${MAX_ATTEMPTS * (POLL_INTERVAL_MS / 1000)}s`);
+  return 1;
+}

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -1,9 +1,13 @@
 import { spawnSync } from "node:child_process";
 import { createInterface } from "node:readline";
-import { loadCredentials } from "../lib/credentials.js";
+import { loadCredentials, type Credentials } from "../lib/credentials.js";
 import { loadConfig } from "../lib/config.js";
 import { getJson, postJson } from "../lib/api.js";
 import { ensureRepoIndexed } from "../lib/local-index.js";
+import { parsePrArg, prTerms, localizeMessage } from "../lib/pr-url.js";
+import { resolveRepo } from "../lib/repo-resolver.js";
+import { positionals } from "../lib/args.js";
+import { sanitizeTerminal } from "../lib/output.js";
 
 /**
  * `octp review` — pre-PR review of local changes.
@@ -80,6 +84,15 @@ export async function reviewCommand(argv: string[]): Promise<number> {
   if (argv.includes("--help") || argv.includes("-h")) {
     printHelp();
     return 0;
+  }
+
+  // PR-review path: `octp review --pr <n>` or `octp review <n|url>` triggers a
+  // server-side review of an existing PR (posted as comments) — distinct from
+  // the local working-tree diff review below. A positional arg (one that isn't
+  // a flag value) signals PR intent.
+  const prArg = flagValue(argv, "--pr") ?? positionals(argv, ["--since", "--format", "--pr"])[0];
+  if (prArg) {
+    return await reviewPr(creds, prArg);
   }
 
   const mode = parseMode(argv);
@@ -271,6 +284,48 @@ export async function reviewCommand(argv: string[]): Promise<number> {
     const criticalCount = data.findings.filter((f) => isCritical(f.severity)).length;
     if (criticalCount > 0) return 1;
   }
+  return 0;
+}
+
+// ── PR review (server-side, posts comments) ──────────────────────────────────
+
+/**
+ * Trigger a review of an existing PR/MR via the platform pipeline (the result
+ * is posted as comments on the PR, same as the cloud auto-review). Resolves the
+ * repo from the PR URL's owner/repo when present, otherwise the current git
+ * remote.
+ */
+async function reviewPr(creds: Credentials, prArg: string): Promise<number> {
+  const parsed = parsePrArg(prArg);
+  if (!parsed.ok) {
+    console.error(parsed.error);
+    return 2;
+  }
+  const resolved = await resolveRepo(creds, parsed.repoFullName);
+  if (!resolved.ok) {
+    console.error(resolved.error);
+    return 1;
+  }
+  const repo = resolved.repo;
+  const terms = prTerms(repo.provider);
+  const res = await postJson<{ ok?: boolean }>(
+    `${creds.baseUrl}/api/cli/repos/${encodeURIComponent(repo.id)}/review`,
+    { prNumber: parsed.prNumber },
+    creds.token,
+    { timeoutMs: 60_000 },
+  );
+  if (!res.ok) {
+    console.error(
+      localizeMessage(`Failed to trigger review (HTTP ${res.status}): ${res.error}`, repo.provider),
+    );
+    return 1;
+  }
+  console.log(
+    `${COLOR.green}✓${COLOR.reset} Review triggered for ${repo.fullName} ${terms.short} #${parsed.prNumber}`,
+  );
+  console.log(
+    `${COLOR.dim}The review will be posted as a comment on the ${terms.full} when complete.${COLOR.reset}`,
+  );
   return 0;
 }
 
@@ -523,7 +578,7 @@ type RenderedData = ReviewResponse & { truncated?: boolean };
 function renderHuman(data: RenderedData, repoFullName: string): void {
   const { findings, model, usage } = data;
   console.log(
-    `${COLOR.bold}🐙 octp review${COLOR.reset}  ${COLOR.dim}${repoFullName} · ${model} · ${usage.inputTokens}→${usage.outputTokens} tokens${COLOR.reset}`,
+    `${COLOR.bold}🐙 octp review${COLOR.reset}  ${COLOR.dim}${sanitizeTerminal(repoFullName)} · ${sanitizeTerminal(model)} · ${usage.inputTokens}→${usage.outputTokens} tokens${COLOR.reset}`,
   );
   if (data.bareMode) {
     console.log(
@@ -542,13 +597,16 @@ function renderHuman(data: RenderedData, repoFullName: string): void {
   console.log("");
   for (const f of findings) {
     console.log(
-      `${severityGlyph(f.severity)} ${COLOR.bold}${f.severity}${COLOR.reset}  ${COLOR.cyan}${f.filePath}:${f.startLine}${COLOR.reset}`,
+      `${severityGlyph(f.severity)} ${COLOR.bold}${sanitizeTerminal(f.severity)}${COLOR.reset}  ${COLOR.cyan}${sanitizeTerminal(f.filePath)}:${f.startLine}${COLOR.reset}`,
     );
-    console.log(`  ${COLOR.bold}${f.title}${COLOR.reset}`);
-    console.log(`  ${f.description}`);
-    if (f.suggestion) console.log(`  ${COLOR.dim}suggestion:${COLOR.reset} ${f.suggestion}`);
+    console.log(`  ${COLOR.bold}${sanitizeTerminal(f.title)}${COLOR.reset}`);
+    console.log(`  ${sanitizeTerminal(f.description)}`);
+    if (f.suggestion)
+      console.log(`  ${COLOR.dim}suggestion:${COLOR.reset} ${sanitizeTerminal(f.suggestion)}`);
     if (f.suggestedRegressionTest)
-      console.log(`  ${COLOR.dim}test:${COLOR.reset} ${f.suggestedRegressionTest}`);
+      console.log(
+        `  ${COLOR.dim}test:${COLOR.reset} ${sanitizeTerminal(f.suggestedRegressionTest)}`,
+      );
     console.log("");
   }
   const buckets: Record<string, number> = {};
@@ -568,11 +626,11 @@ function renderMarkdown(data: RenderedData): string {
   const lines: string[] = [];
   lines.push(`# octp review`);
   lines.push("");
-  lines.push(`Model: \`${data.model}\``);
+  lines.push(`Model: \`${sanitizeTerminal(data.model)}\``);
   if (data.truncated) lines.push(`> ⚠ diff was truncated — findings may be incomplete`);
   if (data.summary) {
     lines.push("");
-    lines.push(data.summary);
+    lines.push(sanitizeTerminal(data.summary));
   }
   lines.push("");
   if (data.findings.length === 0) {
@@ -580,20 +638,20 @@ function renderMarkdown(data: RenderedData): string {
     return lines.join("\n");
   }
   for (const f of data.findings) {
-    lines.push(`## ${severityGlyph(f.severity)} ${f.title}`);
+    lines.push(`## ${severityGlyph(f.severity)} ${sanitizeTerminal(f.title)}`);
     lines.push("");
-    lines.push(`**File:** \`${f.filePath}:${f.startLine}\`  `);
-    lines.push(`**Severity:** ${f.severity}  `);
-    if (f.category) lines.push(`**Category:** ${f.category}  `);
+    lines.push(`**File:** \`${sanitizeTerminal(f.filePath)}:${f.startLine}\`  `);
+    lines.push(`**Severity:** ${sanitizeTerminal(f.severity)}  `);
+    if (f.category) lines.push(`**Category:** ${sanitizeTerminal(f.category)}  `);
     lines.push("");
-    lines.push(f.description);
+    lines.push(sanitizeTerminal(f.description));
     if (f.suggestion) {
       lines.push("");
-      lines.push(`**Suggestion:** ${f.suggestion}`);
+      lines.push(`**Suggestion:** ${sanitizeTerminal(f.suggestion)}`);
     }
     if (f.suggestedRegressionTest) {
       lines.push("");
-      lines.push(`**Test idea:** ${f.suggestedRegressionTest}`);
+      lines.push(`**Test idea:** ${sanitizeTerminal(f.suggestedRegressionTest)}`);
     }
     lines.push("");
   }
@@ -609,6 +667,7 @@ Usage:
   octp review                        Review upstream..HEAD plus uncommitted changes
   octp review --staged               Review only \`git diff --staged\` output
   octp review --since <ref>          Review since a given ref (eg. HEAD~3, main)
+  octp review --pr <n|url>           Review an existing PR/MR — posts comments (123 or a GH/GL/BB URL)
 
 Flags:
   --strict                           Exit 1 if any critical (🔴) findings — for pre-commit hooks

--- a/apps/cli/src/commands/setup-token.ts
+++ b/apps/cli/src/commands/setup-token.ts
@@ -1,0 +1,73 @@
+import { loadCredentials, saveCredentials } from "../lib/credentials.js";
+import { loadConfig } from "../lib/config.js";
+import { runDeviceFlow, buildCredentials } from "../lib/auth.js";
+import { normalizeBaseUrl, isTransportSafe } from "../lib/api.js";
+import { flagValue, hasFlag } from "../lib/args.js";
+import { error } from "../lib/output.js";
+
+const DEFAULT_BASE_URL = "https://octopus-review.ai";
+
+/**
+ * `octp setup-token` — browser auth that prints the raw token to STDOUT for
+ * CI/CD capture. The authorize URL + all status text go to STDERR so
+ * `TOKEN=$(octp setup-token)` captures only the token. `--save` also persists
+ * a local session.
+ */
+export async function setupTokenCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    printHelp();
+    return 0;
+  }
+  const apiUrlFlag = flagValue(argv, "--api-url");
+  const noOpen = hasFlag(argv, "--no-open");
+  const save = hasFlag(argv, "--save");
+  const insecure = hasFlag(argv, "--insecure");
+
+  const fallback =
+    (await loadCredentials())?.baseUrl ?? (await loadConfig()).selfHostedBaseUrl ?? DEFAULT_BASE_URL;
+  const normalized = normalizeBaseUrl(apiUrlFlag ?? fallback);
+  if (!normalized) {
+    error(`Invalid API URL: ${apiUrlFlag ?? fallback}`);
+    return 2;
+  }
+  const baseUrl = normalized;
+
+  if (!isTransportSafe(baseUrl) && !insecure) {
+    error(`Refusing to authenticate over insecure transport: ${baseUrl}. Use https, or pass --insecure.`);
+    return 2;
+  }
+
+  try {
+    const identity = await runDeviceFlow(baseUrl, {
+      noOpen,
+      onAuthorizeUrl: (url) =>
+        process.stderr.write(
+          noOpen ? `Open this URL to authorize:\n${url}\n` : `Opening browser to authorize: ${url}\n`,
+        ),
+    });
+    if (save) await saveCredentials(buildCredentials(baseUrl, identity));
+    // Token → stdout (the one capturable line). Everything else went to stderr.
+    process.stdout.write(identity.token + "\n");
+    return 0;
+  } catch (err) {
+    error(err instanceof Error ? err.message : "Failed to obtain token");
+    return 1;
+  }
+}
+
+function printHelp(): void {
+  console.log(`octp setup-token — print an API token to stdout (for CI/CD)
+
+Usage:
+  TOKEN=$(octp setup-token)        Authenticate, capture the token
+  octp setup-token --no-open       Don't auto-open the browser (print the URL)
+  octp setup-token --save          Also save a local session (~/.octopus/credentials)
+
+Flags:
+  --api-url <url>                  Server base URL
+  --no-open                        Don't open the browser automatically
+  --save                           Persist the token as a local session too
+  --insecure                       Allow cleartext HTTP transport
+  --help, -h                       This help
+`);
+}

--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -1,0 +1,364 @@
+import { mkdir, writeFile, readFile, unlink } from "node:fs/promises";
+import { join, basename } from "node:path";
+import { createHash } from "node:crypto";
+import { loadCredentials } from "../lib/credentials.js";
+import { getJson } from "../lib/api.js";
+import { positionals, hasFlag } from "../lib/args.js";
+import { success, error, info, warn, table, c, sanitizeTerminal } from "../lib/output.js";
+import { getOctopusHome, ensureOctopusHome } from "../lib/paths.js";
+
+/**
+ * `octp skills` — manage Octopus skills (slash-command markdown files) for AI
+ * coding agents. Ported from the old commander-based CLI to the plain
+ * async-function convention. The skill registry lives under the API base URL
+ * (`creds.baseUrl`); the manifest + content endpoints need no auth, but we
+ * still require sign-in so the base URL is known.
+ */
+
+interface SkillEntry {
+  name: string;
+  title: string;
+  description: string;
+  filename: string;
+  hash: string;
+}
+
+interface SkillsManifest {
+  version: number;
+  skills: SkillEntry[];
+}
+
+interface InstalledSkillState {
+  hash: string;
+  installedAt: string;
+}
+
+interface SkillsState {
+  lastKnownVersion: number;
+  lastCheckedAt: string;
+  installed: Record<string, InstalledSkillState>;
+}
+
+const COMMANDS_DIR = join(process.cwd(), ".claude", "commands");
+
+function stateFile(): string {
+  return join(getOctopusHome(), "skills-state.json");
+}
+
+// --- State persistence (tolerant load; ensure-home before save) ---
+
+async function loadState(): Promise<SkillsState> {
+  try {
+    const data = await readFile(stateFile(), "utf8");
+    const parsed = JSON.parse(data) as Partial<SkillsState>;
+    return {
+      lastKnownVersion:
+        typeof parsed.lastKnownVersion === "number" ? parsed.lastKnownVersion : 0,
+      lastCheckedAt: typeof parsed.lastCheckedAt === "string" ? parsed.lastCheckedAt : "",
+      installed:
+        parsed.installed && typeof parsed.installed === "object" ? parsed.installed : {},
+    };
+  } catch {
+    return { lastKnownVersion: 0, lastCheckedAt: "", installed: {} };
+  }
+}
+
+async function saveState(state: SkillsState): Promise<void> {
+  await ensureOctopusHome();
+  await writeFile(stateFile(), JSON.stringify(state, null, 2), "utf8");
+}
+
+// --- Helpers ---
+
+async function fetchManifest(baseUrl: string): Promise<SkillsManifest | null> {
+  const res = await getJson<SkillsManifest>(`${baseUrl}/skills/skills.json`);
+  if (!res.ok) {
+    error(`Failed to fetch skills list: ${res.error}`);
+    return null;
+  }
+  return res.data;
+}
+
+/**
+ * Download skill content as plain text. api.js has no text helper (getJson
+ * parses JSON), so this uses a direct fetch — the one foundation gap here.
+ */
+async function fetchSkillContent(baseUrl: string, filename: string): Promise<string> {
+  const res = await fetch(`${baseUrl}/skills/${filename}`, {
+    headers: { "user-agent": "octp-cli/0.1" },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to download skill file: ${res.status} ${res.statusText}`);
+  }
+  return res.text();
+}
+
+function computeHash(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+/** Reject path traversal — filename must be a bare `*.md` basename. */
+function validateFilename(filename: string): string {
+  const safe = basename(filename);
+  if (!safe.endsWith(".md") || safe !== filename) {
+    throw new Error(`Invalid skill filename: ${filename}`);
+  }
+  return safe;
+}
+
+// --- Subcommands ---
+
+async function listSkills(baseUrl: string): Promise<number> {
+  const manifest = await fetchManifest(baseUrl);
+  if (!manifest) return 1;
+
+  const state = await loadState();
+
+  if (manifest.version > state.lastKnownVersion && state.lastKnownVersion > 0) {
+    info(c.cyan("New skills available!"));
+  }
+
+  state.lastKnownVersion = manifest.version;
+  state.lastCheckedAt = new Date().toISOString();
+  await saveState(state);
+
+  if (manifest.skills.length === 0) {
+    info("No skills available.");
+    return 0;
+  }
+
+  const rows: string[][] = [];
+  for (const skill of manifest.skills) {
+    const installed = state.installed[skill.name];
+    let status: string;
+    if (installed) {
+      status =
+        installed.hash !== skill.hash
+          ? `${c.green("installed")} ${c.yellow("(update available)")}`
+          : c.green("installed");
+    } else {
+      status = c.dim("not installed");
+    }
+    rows.push([
+      c.bold(sanitizeTerminal(skill.name)),
+      skill.description ? sanitizeTerminal(skill.description) : c.dim("—"),
+      status,
+    ]);
+  }
+  table(rows, ["Name", "Description", "Status"]);
+  return 0;
+}
+
+async function installSkills(
+  baseUrl: string,
+  name: string | undefined,
+  all: boolean,
+): Promise<number> {
+  if (!name && !all) {
+    error("Provide a skill name or use --all to install all skills.");
+    return 2;
+  }
+
+  const manifest = await fetchManifest(baseUrl);
+  if (!manifest) return 1;
+
+  const toInstall = all
+    ? manifest.skills
+    : manifest.skills.filter((s) => s.name === name);
+
+  if (toInstall.length === 0) {
+    error(`Skill "${name}" not found. Run \`octp skills list\` to see available skills.`);
+    return 1;
+  }
+
+  await mkdir(COMMANDS_DIR, { recursive: true });
+  const state = await loadState();
+  let failed = false;
+
+  for (const skill of toInstall) {
+    const installed = state.installed[skill.name];
+
+    if (installed && installed.hash === skill.hash) {
+      info(`${c.bold(skill.name)} is already up to date.`);
+      continue;
+    }
+
+    try {
+      const safeFilename = validateFilename(skill.filename);
+      const content = await fetchSkillContent(baseUrl, safeFilename);
+
+      const downloadedHash = computeHash(content);
+      if (downloadedHash !== skill.hash) {
+        error(
+          `Hash mismatch for ${c.bold(skill.name)}: expected ${skill.hash.slice(0, 12)}… got ${downloadedHash.slice(0, 12)}…. Aborting.`,
+        );
+        failed = true;
+        continue;
+      }
+
+      await writeFile(join(COMMANDS_DIR, safeFilename), content, "utf8");
+      state.installed[skill.name] = {
+        hash: skill.hash,
+        installedAt: new Date().toISOString(),
+      };
+
+      if (installed) {
+        success(`Updated ${c.bold(skill.name)}.`);
+      } else {
+        success(`Installed ${c.bold(skill.name)}. Use it with: ${c.cyan(`/${skill.name}`)}`);
+      }
+    } catch (e) {
+      error(`Failed to install ${skill.name}: ${e instanceof Error ? e.message : String(e)}`);
+      failed = true;
+    }
+  }
+
+  state.lastKnownVersion = manifest.version;
+  state.lastCheckedAt = new Date().toISOString();
+  await saveState(state);
+  return failed ? 1 : 0;
+}
+
+async function updateSkills(baseUrl: string): Promise<number> {
+  const manifest = await fetchManifest(baseUrl);
+  if (!manifest) return 1;
+
+  const state = await loadState();
+  const installedNames = Object.keys(state.installed);
+
+  if (installedNames.length === 0) {
+    info(`No skills installed. Run ${c.cyan("octp skills install <name>")} first.`);
+    return 0;
+  }
+
+  let updated = 0;
+  let upToDate = 0;
+  let failed = false;
+
+  for (const name of installedNames) {
+    const skill = manifest.skills.find((s) => s.name === name);
+    if (!skill) {
+      warn(`Skill "${name}" no longer exists in registry, skipping.`);
+      continue;
+    }
+
+    if (state.installed[name].hash === skill.hash) {
+      upToDate++;
+      continue;
+    }
+
+    try {
+      const safeFilename = validateFilename(skill.filename);
+      const content = await fetchSkillContent(baseUrl, safeFilename);
+
+      const downloadedHash = computeHash(content);
+      if (downloadedHash !== skill.hash) {
+        error(
+          `Hash mismatch for ${c.bold(skill.name)}: expected ${skill.hash.slice(0, 12)}… got ${downloadedHash.slice(0, 12)}…. Aborting.`,
+        );
+        failed = true;
+        continue;
+      }
+
+      await mkdir(COMMANDS_DIR, { recursive: true });
+      await writeFile(join(COMMANDS_DIR, safeFilename), content, "utf8");
+      state.installed[name] = {
+        hash: skill.hash,
+        installedAt: new Date().toISOString(),
+      };
+      updated++;
+    } catch (e) {
+      error(`Failed to update ${name}: ${e instanceof Error ? e.message : String(e)}`);
+      failed = true;
+    }
+  }
+
+  state.lastKnownVersion = manifest.version;
+  state.lastCheckedAt = new Date().toISOString();
+  await saveState(state);
+
+  const parts: string[] = [];
+  if (updated > 0) parts.push(`Updated ${updated} skill(s)`);
+  if (upToDate > 0) parts.push(`${upToDate} already up to date`);
+  success(parts.join(", ") || "Nothing to update.");
+  return failed ? 1 : 0;
+}
+
+async function removeSkill(baseUrl: string, name: string | undefined): Promise<number> {
+  if (!name) {
+    error("Usage: octp skills remove <name>");
+    return 2;
+  }
+
+  const state = await loadState();
+  if (!state.installed[name]) {
+    error(`Skill "${name}" is not installed.`);
+    return 1;
+  }
+
+  // Prefer the manifest's filename; fall back to the name-based convention.
+  let filename = `${name}.md`;
+  const res = await getJson<SkillsManifest>(`${baseUrl}/skills/skills.json`);
+  if (res.ok) {
+    const skill = res.data.skills.find((s) => s.name === name);
+    if (skill) filename = skill.filename;
+  }
+
+  const safeFilename = basename(filename);
+  try {
+    await unlink(join(COMMANDS_DIR, safeFilename));
+  } catch (e) {
+    if (!(e instanceof Error && "code" in e && (e as { code: string }).code === "ENOENT")) {
+      error(`Failed to remove file: ${e instanceof Error ? e.message : String(e)}`);
+      return 1;
+    }
+  }
+
+  delete state.installed[name];
+  await saveState(state);
+  success(`Removed ${c.bold(name)}.`);
+  return 0;
+}
+
+function printHelp(): void {
+  console.log(`octp skills — manage Octopus skills for AI coding agents
+
+Usage:
+  octp skills list                     List available skills + install status
+  octp skills install <name>           Install a skill into .claude/commands
+  octp skills install --all            Install all available skills
+  octp skills update                   Update all installed skills
+  octp skills remove <name>            Remove an installed skill
+`);
+}
+
+export async function skillsCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    printHelp();
+    return 0;
+  }
+
+  const creds = await loadCredentials();
+  if (!creds) {
+    error("Not signed in. Run `octp login`.");
+    return 2;
+  }
+
+  const [sub, name] = positionals(argv);
+  const baseUrl = creds.baseUrl;
+
+  switch (sub) {
+    case undefined:
+    case "list":
+      return listSkills(baseUrl);
+    case "install":
+      return installSkills(baseUrl, name, hasFlag(argv, "--all"));
+    case "update":
+      return updateSkills(baseUrl);
+    case "remove":
+      return removeSkill(baseUrl, name);
+    default:
+      error(`Unknown skills subcommand: ${sub}. Use list | install | update | remove.`);
+      return 2;
+  }
+}

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -1,0 +1,98 @@
+import { loadCredentials } from "../lib/credentials.js";
+import { getJson } from "../lib/api.js";
+import { hasFlag } from "../lib/args.js";
+import { error, info, success, c } from "../lib/output.js";
+
+// Must track VERSION in index.tsx. The compiled binary has no package.json to
+// read from at runtime, so the current version is hardcoded here.
+const CURRENT = "0.1.0";
+
+const RELEASES_URL = "https://api.github.com/repos/octopusreview/octopus/releases";
+const TAG_PREFIX = "octp-v";
+const DEFAULT_SERVER = "https://octopus-review.ai";
+
+type GithubRelease = { tag_name?: unknown };
+
+/**
+ * Compare two semver-ish strings (e.g. "0.2.0" vs "0.1.0"). Returns >0 if a>b,
+ * <0 if a<b, 0 if equal. Missing/non-numeric segments are treated as 0.
+ */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".");
+  const pb = b.split(".");
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = parseInt(pa[i] ?? "0", 10) || 0;
+    const nb = parseInt(pb[i] ?? "0", 10) || 0;
+    if (na !== nb) return na - nb;
+  }
+  return 0;
+}
+
+function printHelp(): void {
+  console.log(`octp update — check for a newer octp CLI release
+
+Usage:
+  octp update [--check]
+
+This command only CHECKS GitHub for the latest published CLI release and prints
+the upgrade instruction. It does NOT download or replace the binary in-process.
+
+Flags:
+  --check       Check for a newer version (default behavior)
+  -h, --help    Show this help`);
+}
+
+/** `octp update` — check GitHub for a newer octp CLI release and instruct how to upgrade. */
+export async function updateCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    printHelp();
+    return 0;
+  }
+
+  // creds are optional here — only used to point the install URL at the
+  // configured server (self-host friendly). No auth required.
+  const creds = await loadCredentials();
+  const server = creds?.baseUrl || DEFAULT_SERVER;
+
+  const res = await getJson<GithubRelease[]>(RELEASES_URL);
+  if (!res.ok) {
+    if (res.status === 403) {
+      error("GitHub API rate limit reached. Try again later.");
+      return 1;
+    }
+    if (res.status === 0) {
+      error(`Could not reach GitHub: ${res.error}`);
+      return 1;
+    }
+    error(`Could not fetch releases (HTTP ${res.status}: ${res.error})`);
+    return 1;
+  }
+
+  if (!Array.isArray(res.data)) {
+    error("Unexpected response from GitHub releases API.");
+    return 1;
+  }
+
+  let latest: string | undefined;
+  for (const rel of res.data) {
+    const tag = rel?.tag_name;
+    if (typeof tag !== "string" || !tag.startsWith(TAG_PREFIX)) continue;
+    const version = tag.slice(TAG_PREFIX.length);
+    if (!latest || compareSemver(version, latest) > 0) latest = version;
+  }
+
+  if (!latest) {
+    info("No published CLI release found yet.");
+    return 0;
+  }
+
+  if (compareSemver(latest, CURRENT) > 0) {
+    info(`A new version of octp is available: ${c.green(latest)} (you have ${CURRENT})`);
+    info("Upgrade with:");
+    info(`  ${c.cyan(`curl -fsSL ${server}/install.sh | sh`)}`);
+    return 0;
+  }
+
+  success(`octp is up to date (${CURRENT}).`);
+  return 0;
+}

--- a/apps/cli/src/commands/usage.ts
+++ b/apps/cli/src/commands/usage.ts
@@ -1,0 +1,77 @@
+import { loadCredentials } from "../lib/credentials.js";
+import { getJson } from "../lib/api.js";
+import { hasFlag } from "../lib/args.js";
+import { c, error, info, heading, table, sanitizeTerminal } from "../lib/output.js";
+import type { UsageBreakdown } from "../lib/types.js";
+
+type UsageResponse = {
+  period: { start: string; end: string };
+  totalSpend: number;
+  spendLimit: number | null;
+  creditBalance: number;
+  freeCreditBalance: number;
+  breakdown: UsageBreakdown[];
+};
+
+function usd(n: number): string {
+  const decimals = n > 0 && n < 0.01 ? 4 : 2;
+  return `$${n.toFixed(decimals)}`;
+}
+
+function num(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+/** `octp usage` — show monthly spend, credit balances, and a per-model breakdown. */
+export async function usageCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    console.log("octp usage — show monthly usage, credit balance, and a per-model cost breakdown");
+    return 0;
+  }
+
+  const creds = await loadCredentials();
+  if (!creds) {
+    error("Not signed in. Run `octp login`.");
+    return 2;
+  }
+
+  const res = await getJson<UsageResponse>(`${creds.baseUrl}/api/cli/usage`, {
+    headers: { authorization: `Bearer ${creds.token}` },
+  });
+  if (!res.ok) {
+    if (res.status === 401) {
+      error("Session expired or token revoked. Run `octp login` again.");
+      return 1;
+    }
+    error(`Could not fetch usage (HTTP ${res.status}: ${res.error})`);
+    return 1;
+  }
+
+  const data = res.data;
+
+  heading("Monthly Usage");
+  info(`  Period:         ${new Date(data.period.start).toLocaleDateString()} — now`);
+  info(`  Total Spend:    ${c.bold(usd(data.totalSpend))}`);
+  if (data.spendLimit !== null) {
+    info(`  Spend Limit:    ${usd(data.spendLimit)}`);
+  }
+  info(`  Credit Balance: ${usd(data.creditBalance)} (+ ${usd(data.freeCreditBalance)} free)`);
+
+  if (data.breakdown.length > 0) {
+    heading("Breakdown");
+    const rows = [...data.breakdown]
+      .sort((a, b) => b.cost - a.cost)
+      .map((row) => [
+        sanitizeTerminal(row.model),
+        sanitizeTerminal(row.operation),
+        num(row.count),
+        num(row.inputTokens),
+        num(row.outputTokens),
+        usd(row.cost),
+      ]);
+    table(rows, ["Model", "Operation", "Calls", "Input", "Output", "Cost"]);
+    console.log();
+  }
+
+  return 0;
+}

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -1,0 +1,54 @@
+import { loadCredentials } from "../lib/credentials.js";
+import { getJson } from "../lib/api.js";
+import { hasFlag } from "../lib/args.js";
+import { error, info, c, sanitizeTerminal } from "../lib/output.js";
+
+type Me = {
+  user: { name: string; email: string };
+  organization: { name: string; slug: string; memberCount?: number; repoCount?: number };
+};
+
+/** `octp whoami` — show the signed-in user + org (live check via /api/cli/me). */
+export async function whoamiCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    console.log("octp whoami — show the signed-in user and organization");
+    return 0;
+  }
+  const creds = await loadCredentials();
+  if (!creds) {
+    error("Not signed in. Run `octp login`.");
+    return 2;
+  }
+  const res = await getJson<Me>(`${creds.baseUrl}/api/cli/me`, {
+    headers: { authorization: `Bearer ${creds.token}` },
+  });
+  if (!res.ok) {
+    if (res.status === 401) {
+      error("Session expired or token revoked. Run `octp login` again.");
+      return 1;
+    }
+    if (res.status === 0) {
+      error(res.error);
+      return 1;
+    }
+    error(`Could not fetch identity (HTTP ${res.status}: ${res.error})`);
+    return 1;
+  }
+  const { user, organization } = res.data;
+  const name = sanitizeTerminal(user.name);
+  const email = sanitizeTerminal(user.email);
+  const orgName = sanitizeTerminal(organization.name);
+  const orgSlug = sanitizeTerminal(organization.slug);
+  info(`${c.bold(name)}${email ? ` <${email}>` : ""}`);
+  info(`org: ${orgName} (${orgSlug})`);
+  const bits: string[] = [];
+  if (typeof organization.memberCount === "number") {
+    bits.push(`${organization.memberCount} member${organization.memberCount === 1 ? "" : "s"}`);
+  }
+  if (typeof organization.repoCount === "number") {
+    bits.push(`${organization.repoCount} repo${organization.repoCount === 1 ? "" : "s"}`);
+  }
+  if (bits.length) info(c.dim(bits.join(" · ")));
+  info(c.dim(`server: ${creds.baseUrl}`));
+  return 0;
+}

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -6,6 +6,18 @@ import { isOnboarded, loadConfig } from "./lib/config.js";
 import { agentServeCommand } from "./commands/agent-serve.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { reviewCommand } from "./commands/review.js";
+import { loginCommand } from "./commands/login.js";
+import { logoutCommand } from "./commands/logout.js";
+import { whoamiCommand } from "./commands/whoami.js";
+import { setupTokenCommand } from "./commands/setup-token.js";
+import { configCommand } from "./commands/config.js";
+import { repoCommand } from "./commands/repo.js";
+import { knowledgeCommand } from "./commands/knowledge.js";
+import { usageCommand } from "./commands/usage.js";
+import { analyzeDepsCommand } from "./commands/analyze-deps.js";
+import { skillsCommand } from "./commands/skills.js";
+import { updateCommand } from "./commands/update.js";
+import { chatCommand } from "./commands/chat.js";
 
 const VERSION = "0.1.0";
 
@@ -27,34 +39,41 @@ const VERSION = "0.1.0";
  * Unknown subcommands and flags fail fast with a help hint — the WS6.6 pattern.
  */
 
-const KNOWN_SUBCOMMANDS = new Set([
-  "onboard",
-  "review",
-  "agent",
-  "config",
-  "doctor",
-]);
-
 function printHelp(): void {
   console.log(`octp ${VERSION} — Octopus CLI
 
 Usage:
-  octp                       Launch the onboarding wizard (first run) or dashboard
-  octp onboard [--reset]     Run the onboarding wizard explicitly
-  octp review [--staged]     Review local changes pre-PR (see \`octp review --help\`)
-  octp agent serve           Run as a local-agent bridge (poll for tasks, run via Ollama)
-  octp config <get|set>      Manage ~/.octopus/config.json               (coming soon)
-  octp doctor                Environment + auth health check
+  octp                       Onboarding wizard (first run) or status hint
+  octp onboard [--reset]     Run the onboarding wizard
 
-octp agent serve flags:
-  --name <name>              Agent name reported to the server (default: hostname-pid)
-  --verbose, -v              Log every task claim + completion
+Auth:
+  octp login [--token ...]   Sign in (browser device-flow or --token)
+  octp logout                Remove saved credentials
+  octp whoami                Show the signed-in user + org
+  octp setup-token           Print a token to stdout (for CI/CD)
+
+Reviews:
+  octp review [--staged|--since <ref>]   Review local changes pre-PR
+  octp review --pr <n|url>               Review an existing PR/MR (posts comments)
+  octp chat [repo] [-p <msg>] [-g]       Chat with your codebase
+
+Repositories & knowledge:
+  octp repo <list|status|index|analyze> [repo]   Manage connected repos
+  octp knowledge <list|add|remove>               Manage the knowledge base
+  octp analyze-deps <repo-url>                    Scan dependencies for advisories
+  octp usage                                     Show spend + token usage
+
+Agent & ops:
+  octp agent serve           Run as a local-agent bridge (Ollama-backed)
+  octp config <get|set|list> Manage ~/.octopus/config.json
+  octp skills <list|install|update|remove>       Manage AI-agent skills
+  octp doctor                Environment + auth health check
+  octp update [--check]      Update the CLI
 
 Flags:
-  --skip-onboard             Skip the first-run wizard
-  --reset                    Re-run the onboarding wizard, pre-seeding existing config
   --version, -v              Print version
   --help, -h                 Print this help
+  (run \`octp <command> --help\` for command-specific flags)
 
 Environment:
   OCTOPUS_HOME               Override the config/secrets directory (default ~/.octopus)
@@ -96,28 +115,43 @@ async function main(argv: string[]): Promise<number> {
     return await renderWizard(argv.includes("--reset"));
   }
 
-  if (first === "agent") {
-    const sub = argv[1];
-    if (sub === "serve") {
-      return await agentServeCommand(argv.slice(2));
+  const rest = argv.slice(1);
+  switch (first) {
+    case "login":
+      return await loginCommand(rest);
+    case "logout":
+      return await logoutCommand(rest);
+    case "whoami":
+      return await whoamiCommand(rest);
+    case "setup-token":
+      return await setupTokenCommand(rest);
+    case "config":
+      return await configCommand(rest);
+    case "review":
+      return await reviewCommand(rest);
+    case "chat":
+      return await chatCommand(rest);
+    case "repo":
+      return await repoCommand(rest);
+    case "knowledge":
+      return await knowledgeCommand(rest);
+    case "analyze-deps":
+      return await analyzeDepsCommand(rest);
+    case "usage":
+      return await usageCommand(rest);
+    case "skills":
+      return await skillsCommand(rest);
+    case "update":
+      return await updateCommand(rest);
+    case "doctor":
+      return await doctorCommand(rest);
+    case "agent": {
+      const sub = argv[1];
+      if (sub === "serve") return await agentServeCommand(argv.slice(2));
+      console.error(`Unknown agent subcommand: ${sub ?? "(none)"}`);
+      console.error("Try: octp agent serve");
+      return 2;
     }
-    console.error(`Unknown agent subcommand: ${sub ?? "(none)"}`);
-    console.error("Try: octp agent serve");
-    return 2;
-  }
-
-  if (first === "doctor") {
-    return await doctorCommand(argv.slice(1));
-  }
-
-  if (first === "review") {
-    return await reviewCommand(argv.slice(1));
-  }
-
-  if (KNOWN_SUBCOMMANDS.has(first)) {
-    console.error(`octp ${first}: not yet implemented in this build.`);
-    console.error("Tracking: https://github.com/cemoso/octopus/issues?q=workstream%3A");
-    return 2;
   }
 
   console.error(`Unknown command: ${first}`);

--- a/apps/cli/src/lib/api.ts
+++ b/apps/cli/src/lib/api.ts
@@ -91,6 +91,171 @@ async function jsonRequest<T>(url: string, init: RequestInit): Promise<ApiResult
   return { ok: true, data: parsed as T };
 }
 
+export async function del<T>(url: string, bearerToken?: string): Promise<ApiResult<T>> {
+  const headers: Record<string, string> = { "user-agent": USER_AGENT };
+  if (bearerToken) headers.authorization = `Bearer ${bearerToken}`;
+  return await jsonRequest<T>(url, { method: "DELETE", headers });
+}
+
+export type StreamResult = { ok: true } | { ok: false; status: number; error: string };
+
+// Hard cap on the un-flushed stream buffer. A server that streams a large body
+// with no newline would otherwise grow `buffer` without bound (memory DoS).
+const MAX_STREAM_BUFFER = 5 * 1024 * 1024;
+
+function streamErr(e: unknown): string {
+  if (e instanceof Error && (e.name === "AbortError" || e.name === "TimeoutError")) {
+    return "Request timed out";
+  }
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * Open a POST stream. Resolves the non-2xx path the same way jsonRequest does
+ * (parse {error} JSON, else raw text) so streaming callers get a usable error
+ * instead of a half-read body. On success hands back the reader.
+ */
+// Returns the Response on success; each streamer calls getReader() itself so
+// the (overloaded) reader type is inferred at the 0-arg call site — annotating
+// it here resolves to the wrong overload (BYOB) or the wrong DOM generic.
+async function openStream(
+  url: string,
+  body: unknown,
+  bearerToken?: string,
+  timeoutMs?: number,
+): Promise<{ ok: true; response: Response } | ApiErr> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "user-agent": USER_AGENT,
+  };
+  if (bearerToken) headers.authorization = `Bearer ${bearerToken}`;
+
+  const init: RequestInit = { method: "POST", headers, body: JSON.stringify(body) };
+  // Overall per-call timeout — each chat answer / analyze-deps run is a single
+  // request, so an upper bound here keeps the CLI from hanging forever if the
+  // server accepts the connection then stalls mid-stream.
+  if (timeoutMs && timeoutMs > 0) init.signal = AbortSignal.timeout(timeoutMs);
+
+  let res: Response;
+  try {
+    res = await fetch(url, init);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (e instanceof Error && (e.name === "AbortError" || e.name === "TimeoutError")) {
+      return { ok: false, status: 0, error: `Request timed out — ${msg}` };
+    }
+    return { ok: false, status: 0, error: msg };
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    let error = `HTTP ${res.status}`;
+    if (text) {
+      try {
+        const parsed = JSON.parse(text);
+        if (parsed && typeof parsed === "object" && "error" in parsed) {
+          error = String((parsed as { error: unknown }).error);
+        }
+      } catch {
+        error = text.slice(0, 200);
+      }
+    }
+    return { ok: false, status: res.status, error };
+  }
+  return { ok: true, response: res };
+}
+
+/**
+ * Consume a `data: {json}` line stream (NDJSON-style SSE). Ends on a
+ * `data: [DONE]` sentinel or when the stream closes. `onData` is invoked for
+ * each parsed JSON object; malformed lines are skipped.
+ */
+export async function streamData(
+  url: string,
+  body: unknown,
+  bearerToken: string | undefined,
+  onData: (data: Record<string, unknown>) => void,
+  timeoutMs?: number,
+): Promise<StreamResult> {
+  const opened = await openStream(url, body, bearerToken, timeoutMs);
+  if (!opened.ok) return opened;
+  const reader = opened.response.body?.getReader();
+  if (!reader) return { ok: false, status: 0, error: "No response body" };
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.length > MAX_STREAM_BUFFER) {
+        return { ok: false, status: 0, error: "stream exceeded buffer limit without a line break" };
+      }
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        const data = line.slice(6).trim();
+        if (data === "[DONE]") return { ok: true };
+        try {
+          onData(JSON.parse(data) as Record<string, unknown>);
+        } catch {
+          // skip malformed chunk
+        }
+      }
+    }
+  } catch (e) {
+    return { ok: false, status: 0, error: streamErr(e) };
+  }
+  return { ok: true };
+}
+
+/**
+ * Consume an `event: X\ndata: {json}` SSE stream. `onEvent` receives the event
+ * name + parsed data object per record.
+ */
+export async function streamSse(
+  url: string,
+  body: unknown,
+  bearerToken: string | undefined,
+  onEvent: (event: string, data: Record<string, unknown>) => void,
+  timeoutMs?: number,
+): Promise<StreamResult> {
+  const opened = await openStream(url, body, bearerToken, timeoutMs);
+  if (!opened.ok) return opened;
+  const reader = opened.response.body?.getReader();
+  if (!reader) return { ok: false, status: 0, error: "No response body" };
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let currentEvent = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.length > MAX_STREAM_BUFFER) {
+        return { ok: false, status: 0, error: "stream exceeded buffer limit without a line break" };
+      }
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.startsWith("event: ")) {
+          currentEvent = line.slice(7).trim();
+        } else if (line.startsWith("data: ") && currentEvent) {
+          try {
+            onEvent(currentEvent, JSON.parse(line.slice(6)) as Record<string, unknown>);
+          } catch {
+            // skip malformed chunk
+          }
+          currentEvent = "";
+        }
+      }
+    }
+  } catch (e) {
+    return { ok: false, status: 0, error: streamErr(e) };
+  }
+  return { ok: true };
+}
+
 /**
  * Normalise a base URL — strip trailing slashes, ensure scheme. Returns null
  * if the input is not a parseable http/https URL.

--- a/apps/cli/src/lib/args.ts
+++ b/apps/cli/src/lib/args.ts
@@ -1,0 +1,37 @@
+/**
+ * Tiny argv helpers shared by the operational commands. apps/cli parses argv
+ * by hand (no commander) so each command stays a plain async function; these
+ * keep that parsing consistent.
+ */
+
+/** Value following `flag` (e.g. `--format json`). Undefined if absent or if the
+ * next token is itself a flag. */
+export function flagValue(argv: string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  if (i === -1) return undefined;
+  const v = argv[i + 1];
+  if (v === undefined || v.startsWith("-")) return undefined;
+  return v;
+}
+
+export function hasFlag(argv: string[], ...flags: string[]): boolean {
+  return flags.some((f) => argv.includes(f));
+}
+
+/**
+ * Positional args — argv entries that are neither a flag nor the value
+ * consumed by one of `valueFlags`. Lets a command pull `<key> <value>` out of
+ * a mixed argv without a parser library.
+ */
+export function positionals(argv: string[], valueFlags: string[] = []): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("-")) {
+      if (valueFlags.includes(a)) i++; // skip this flag's value
+      continue;
+    }
+    out.push(a);
+  }
+  return out;
+}

--- a/apps/cli/src/lib/auth.ts
+++ b/apps/cli/src/lib/auth.ts
@@ -1,0 +1,183 @@
+import { spawn } from "node:child_process";
+import { postJson } from "./api.js";
+import type { Credentials } from "./credentials.js";
+
+/**
+ * Headless auth for the operational commands. Extracted so `login`,
+ * `setup-token`, and the onboarding wizard share one device-flow
+ * implementation. Endpoints:
+ *   POST /api/cli/auth/device        → { deviceCode, expiresAt }
+ *   GET  /api/cli/auth/poll?...      → { status, token, organization, user }
+ *   POST /api/cli/auth/verify        → { user, organization }   (token paste)
+ */
+
+const MAX_POLL_ATTEMPTS = 200;
+const POLL_INTERVAL_MS = 2000;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export const TOKEN_PREFIX = "oct_";
+
+export function isValidTokenFormat(token: string): boolean {
+  return token.startsWith(TOKEN_PREFIX) && token.length > TOKEN_PREFIX.length;
+}
+
+export interface AuthIdentity {
+  token: string;
+  organization: { id: string; slug: string; name: string };
+  user: { name: string; email: string };
+}
+
+export interface DeviceFlowOptions {
+  /** Don't open the browser automatically (the URL is still surfaced via onAuthorizeUrl). */
+  noOpen?: boolean;
+  /** Receives the authorize URL — callers decide stdout vs stderr vs silent. */
+  onAuthorizeUrl?: (url: string) => void;
+}
+
+/**
+ * Open a URL in the default browser WITHOUT a shell. We spawn with an args
+ * array (shell:false is the spawn default) so a crafted base URL or device
+ * code cannot inject shell commands. The old standalone CLI used
+ * `exec("open \"" + url + "\"")` — string interpolation into a shell, a
+ * command-injection vector. Best-effort: the URL is also printed for manual
+ * open, so a spawn failure is non-fatal.
+ */
+function openBrowser(url: string): void {
+  try {
+    new URL(url);
+  } catch {
+    return;
+  }
+  let cmd: string;
+  let args: string[];
+  if (process.platform === "win32") {
+    // `cmd /c start "" <url>` — url is a discrete argv entry, never spliced
+    // into a shell string. The empty "" is start's window-title placeholder.
+    cmd = "cmd";
+    args = ["/c", "start", "", url];
+  } else if (process.platform === "darwin") {
+    cmd = "open";
+    args = [url];
+  } else {
+    cmd = "xdg-open";
+    args = [url];
+  }
+  try {
+    const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+    child.on("error", () => {}); // ENOENT (no xdg-open) etc. — ignore, URL is printed
+    child.unref();
+  } catch {
+    // ignore — URL was surfaced for manual open
+  }
+}
+
+export async function runDeviceFlow(
+  baseUrl: string,
+  options: DeviceFlowOptions = {},
+): Promise<AuthIdentity> {
+  const { noOpen = false, onAuthorizeUrl } = options;
+
+  let deviceRes: Response;
+  try {
+    deviceRes = await fetch(`${baseUrl}/api/cli/auth/device`, {
+      method: "POST",
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (e) {
+    throw new Error(`Could not reach ${baseUrl} — ${e instanceof Error ? e.message : String(e)}`);
+  }
+  if (!deviceRes.ok) {
+    if (deviceRes.status === 404) {
+      throw new Error("Device authorization endpoint not found. Is the server up to date?");
+    }
+    if (deviceRes.status === 429) {
+      throw new Error("Too many login attempts. Wait a minute and try again.");
+    }
+    throw new Error(`Failed to initiate login (HTTP ${deviceRes.status}).`);
+  }
+
+  const deviceData = (await deviceRes.json()) as Record<string, unknown>;
+  const deviceCode = deviceData.deviceCode;
+  const expiresAt = deviceData.expiresAt;
+  if (typeof deviceCode !== "string" || typeof expiresAt !== "string") {
+    throw new Error("Invalid response from device authorization endpoint.");
+  }
+
+  const authorizeUrl = `${baseUrl}/cli/authorize?code=${encodeURIComponent(deviceCode)}`;
+  onAuthorizeUrl?.(authorizeUrl);
+  if (!noOpen) openBrowser(authorizeUrl);
+
+  const expiry = new Date(expiresAt).getTime();
+  let attempts = 0;
+  let networkErrors = 0;
+  while (attempts < MAX_POLL_ATTEMPTS) {
+    if (Number.isFinite(expiry) && Date.now() > expiry) {
+      throw new Error("Authorization timed out. Please try again.");
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    attempts++;
+
+    let pollRes: Response;
+    try {
+      pollRes = await fetch(
+        `${baseUrl}/api/cli/auth/poll?device_code=${encodeURIComponent(deviceCode)}`,
+        { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) },
+      );
+    } catch (e) {
+      networkErrors++;
+      if (networkErrors > 5) {
+        throw new Error(
+          `Network error during authorization: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+      continue;
+    }
+    if (pollRes.status === 410) throw new Error("Authorization expired. Please try again.");
+    if (!pollRes.ok) continue;
+
+    const data = (await pollRes.json()) as {
+      status?: string;
+      token?: string;
+      organization?: { id: string; slug: string; name: string };
+      user?: { name?: string; email?: string };
+    };
+    if (data.status === "approved" && data.token && data.organization) {
+      return {
+        token: data.token,
+        organization: data.organization,
+        user: { name: data.user?.name ?? "Unknown User", email: data.user?.email ?? "" },
+      };
+    }
+  }
+  throw new Error("Authorization timed out after too many attempts.");
+}
+
+/** Verify a pasted `oct_` token against the server; returns the org/user it maps to. */
+export async function verifyToken(
+  baseUrl: string,
+  token: string,
+): Promise<{ organization: { id: string; slug: string; name: string }; user: { name: string; email: string } }> {
+  const res = await postJson<{
+    user: { id: string; name: string; email: string };
+    organization: { id: string; name: string; slug: string };
+  }>(`${baseUrl}/api/cli/auth/verify`, {}, token, { timeoutMs: REQUEST_TIMEOUT_MS });
+  if (!res.ok) throw new Error(res.error || "Invalid token");
+  return {
+    organization: res.data.organization,
+    user: { name: res.data.user.name, email: res.data.user.email },
+  };
+}
+
+/** Assemble a Credentials record from a completed auth + base URL. */
+export function buildCredentials(baseUrl: string, id: AuthIdentity): Credentials {
+  return {
+    baseUrl,
+    token: id.token,
+    orgId: id.organization.id,
+    orgSlug: id.organization.slug,
+    orgName: id.organization.name,
+    userName: id.user.name || undefined,
+    userEmail: id.user.email || undefined,
+    approvedAt: new Date().toISOString(),
+  };
+}

--- a/apps/cli/src/lib/output.ts
+++ b/apps/cli/src/lib/output.ts
@@ -1,0 +1,91 @@
+/**
+ * Minimal terminal output helpers — no `chalk`/`ora` dependency, keeping the
+ * compiled Bun binary slim (the rest of apps/cli follows the same rule and
+ * inlines ANSI in commands/review.ts). Color is auto-disabled when stdout is
+ * not a TTY or NO_COLOR is set, so piped/CI output stays clean.
+ */
+
+const useColor = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
+
+function paint(code: string, s: string): string {
+  return useColor ? `\x1b[${code}m${s}\x1b[0m` : s;
+}
+
+export const c = {
+  bold: (s: string) => paint("1", s),
+  dim: (s: string) => paint("2", s),
+  red: (s: string) => paint("31", s),
+  green: (s: string) => paint("32", s),
+  yellow: (s: string) => paint("33", s),
+  cyan: (s: string) => paint("36", s),
+};
+
+export function success(msg: string): void {
+  console.log(`${c.green("✓")} ${msg}`);
+}
+
+export function error(msg: string): void {
+  console.error(`${c.red("✗")} ${msg}`);
+}
+
+export function info(msg: string): void {
+  console.log(msg);
+}
+
+export function warn(msg: string): void {
+  console.error(`${c.yellow("⚠")} ${msg}`);
+}
+
+export function heading(title: string): void {
+  console.log(`\n${c.bold(title)}`);
+}
+
+// Strip ANSI so column widths are measured by VISIBLE length, not byte length —
+// otherwise colored cells throw the alignment off.
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+function visibleLen(s: string): number {
+  return s.replace(ANSI_RE, "").length;
+}
+
+/**
+ * Strip terminal control sequences from UNTRUSTED text (e.g. streamed LLM
+ * output in `octp chat`) before printing — defends against terminal-injection
+ * via ANSI/OSC escapes (cursor moves, title rewrites, clipboard writes, etc.).
+ * Preserves the visible characters plus newline / carriage-return / tab.
+ */
+export function sanitizeTerminal(s: string): string {
+  return (
+    s
+      // OSC sequences: ESC ] ... (BEL | ST). These can rewrite the window
+      // title or (on some terminals) the clipboard — strip them entirely.
+      .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, "")
+      // CSI and charset-select sequences: ESC [ … / ESC ( … etc.
+      .replace(/\x1b[[(][0-9;?]*[ -/]*[@-~]/g, "")
+      // Any other ESC-introduced two-char sequence.
+      .replace(/\x1b./g, "")
+      // Remaining C0/C1 controls except \t (09), \n (0a), \r (0d).
+      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+  );
+}
+
+/**
+ * Render a left-aligned text table. `headers` optional; column widths are the
+ * max visible width per column. Cells may contain ANSI color codes.
+ */
+export function table(rows: string[][], headers?: string[]): void {
+  const all = headers ? [headers, ...rows] : rows;
+  if (all.length === 0) return;
+  const cols = Math.max(...all.map((r) => r.length));
+  const widths: number[] = [];
+  for (let i = 0; i < cols; i++) {
+    widths[i] = Math.max(...all.map((r) => visibleLen(r[i] ?? "")));
+  }
+  const pad = (cell: string, i: number): string =>
+    cell + " ".repeat(Math.max(0, widths[i] - visibleLen(cell)));
+  const render = (r: string[]) =>
+    r.map((cell, i) => pad(cell ?? "", i)).join("  ").trimEnd();
+  if (headers) {
+    console.log(c.bold(render(headers)));
+  }
+  for (const r of rows) console.log(render(r));
+}

--- a/apps/cli/src/lib/pr-url.ts
+++ b/apps/cli/src/lib/pr-url.ts
@@ -1,0 +1,49 @@
+/**
+ * Parse a PR/MR identifier for `octp review --pr`. Accepts a bare number or a
+ * GitHub / Bitbucket / GitLab (incl. self-hosted, nested subgroups) URL.
+ * Ported from the standalone CLI; returns a discriminated result instead of
+ * throwing, matching apps/cli's style.
+ */
+
+export type ParsedPr =
+  | { ok: true; prNumber: number; repoFullName?: string }
+  | { ok: false; error: string };
+
+export function parsePrArg(arg: string): ParsedPr {
+  const trimmed = arg.trim();
+
+  // Bare PR number — require the WHOLE token to be digits so "123abc" or a
+  // stray URL fragment doesn't silently parse to a wrong number.
+  if (/^\d+$/.test(trimmed)) {
+    return { ok: true, prNumber: parseInt(trimmed, 10) };
+  }
+
+  const gh = trimmed.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
+  if (gh) return { ok: true, prNumber: parseInt(gh[2], 10), repoFullName: gh[1] };
+
+  const bb = trimmed.match(/bitbucket\.org\/([^/]+\/[^/]+)\/pull-requests\/(\d+)/);
+  if (bb) return { ok: true, prNumber: parseInt(bb[2], 10), repoFullName: bb[1] };
+
+  // GitLab separates the project path from the resource with "/-/". Anchored
+  // to http(s) so only real web URLs match.
+  const gl = trimmed.match(/https?:\/\/[^/]+\/(.+?)\/-\/merge_requests\/(\d+)/);
+  if (gl) return { ok: true, prNumber: parseInt(gl[2], 10), repoFullName: gl[1] };
+
+  return { ok: false, error: `Invalid PR identifier: "${arg}". Use a PR number or URL.` };
+}
+
+/** GitLab calls them merge requests; everyone else pull requests. */
+export function prTerms(provider: string): { full: string; short: string } {
+  return provider.toLowerCase() === "gitlab"
+    ? { full: "merge request", short: "MR" }
+    : { full: "pull request", short: "PR" };
+}
+
+/** Remap a server message's "pull request"/"PR" wording to GitLab terms. */
+export function localizeMessage(message: string, provider: string): string {
+  if (provider.toLowerCase() !== "gitlab") return message;
+  return message
+    .replace(/pull(\s)request/gi, (m, sp) => (m[0] === "P" ? "Merge" : "merge") + sp + "request")
+    .replace(/\bPRs\b/g, "MRs")
+    .replace(/\bPR\b/g, "MR");
+}

--- a/apps/cli/src/lib/repo-resolver.ts
+++ b/apps/cli/src/lib/repo-resolver.ts
@@ -1,0 +1,88 @@
+import { spawnSync } from "node:child_process";
+import { getJson } from "./api.js";
+import type { Credentials } from "./credentials.js";
+import type { ApiRepo } from "./types.js";
+
+/**
+ * Resolve a repo argument (or the current git remote) to a connected Octopus
+ * repository. Returns a discriminated result rather than throwing — matches
+ * the rest of apps/cli (ApiResult-style). Ported from the standalone CLI.
+ */
+
+/**
+ * Extract `owner/repo` (or nested subgroup path) from a git remote URL.
+ * Handles SSH (scp-like + URL form), HTTPS, custom ports, and GitLab
+ * subgroups: git@github.com:o/r.git · https://h:443/g/sub/r.git ·
+ * ssh://git@h:2222/g/sub/r.git
+ */
+export function parseGitRemote(url: string): string | null {
+  const sshUrl = url.match(/^ssh:\/\/[^/]+\/(.+?)(?:\.git)?\/?$/);
+  if (sshUrl && sshUrl[1].length > 0) return sshUrl[1];
+  const ssh = url.match(/git@[^:]+:(.+?)(?:\.git)?\/?$/);
+  if (ssh && ssh[1].length > 0) return ssh[1];
+  const https = url.match(/https?:\/\/[^/]+\/(.+?)(?:\.git)?\/?$/);
+  if (https && https[1].length > 0) return https[1];
+  return null;
+}
+
+function git(args: string[]): string | null {
+  const r = spawnSync("git", args, { encoding: "utf8" });
+  if (r.status !== 0) return null;
+  return r.stdout;
+}
+
+export function getGitRemoteUrl(): string | null {
+  const origin = git(["remote", "get-url", "origin"]);
+  if (origin) return origin.trim();
+  const remotes = git(["remote"]);
+  const first = remotes
+    ?.split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean)[0];
+  if (!first) return null;
+  return git(["remote", "get-url", first])?.trim() ?? null;
+}
+
+export type ResolveResult = { ok: true; repo: ApiRepo } | { ok: false; error: string };
+
+export async function resolveRepo(creds: Credentials, repoArg?: string): Promise<ResolveResult> {
+  const res = await getJson<{ repos: ApiRepo[] }>(`${creds.baseUrl}/api/cli/repos`, {
+    headers: { authorization: `Bearer ${creds.token}` },
+  });
+  if (!res.ok) {
+    return { ok: false, error: `Could not list repositories (HTTP ${res.status}: ${res.error})` };
+  }
+  const repos = res.data.repos ?? [];
+
+  if (repoArg) {
+    const lower = repoArg.toLowerCase();
+    const match = repos.find(
+      (r) =>
+        r.fullName === repoArg ||
+        r.name === repoArg ||
+        r.fullName.toLowerCase() === lower ||
+        r.name.toLowerCase() === lower,
+    );
+    if (!match) {
+      return { ok: false, error: `Repository "${repoArg}" not found. Run \`octp repo list\` to see available repos.` };
+    }
+    return { ok: true, repo: match };
+  }
+
+  const remoteUrl = getGitRemoteUrl();
+  if (!remoteUrl) {
+    return { ok: false, error: "Not in a git repository. Provide a repo name or run from a git directory." };
+  }
+  const fullName = parseGitRemote(remoteUrl);
+  if (!fullName) {
+    return { ok: false, error: `Could not parse git remote URL: ${remoteUrl}` };
+  }
+  const match = repos.find((r) => r.fullName.toLowerCase() === fullName.toLowerCase());
+  if (!match) {
+    return {
+      ok: false,
+      error: `Repository "${fullName}" is not connected to your Octopus organization. Run \`octp repo list\` to see available repos.`,
+    };
+  }
+  return { ok: true, repo: match };
+}

--- a/apps/cli/src/lib/types.ts
+++ b/apps/cli/src/lib/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared API shapes for the operational commands (repo / usage / knowledge).
+ * Mirror of the server's /api/cli/* response payloads. Ported from the
+ * standalone @octp/cli so the command surface matches what the platform
+ * already returns.
+ */
+
+export interface ApiRepo {
+  id: string;
+  name: string;
+  fullName: string;
+  provider: string;
+  defaultBranch: string;
+  indexStatus: string;
+  indexedAt: string | null;
+  indexedFiles: number;
+  totalFiles: number;
+  totalChunks: number;
+  totalVectors?: number;
+  indexDurationMs?: number;
+  analysisStatus: string;
+  analyzedAt: string | null;
+  analysis?: string;
+  summary: string | null;
+  purpose: string | null;
+  autoReview: boolean;
+  contributorCount?: number;
+  _count: { pullRequests: number };
+}
+
+export interface UsageBreakdown {
+  model: string;
+  operation: string;
+  count: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  cost: number;
+}
+
+export interface KnowledgeDocument {
+  id: string;
+  title: string;
+  sourceType: string;
+  fileName: string | null;
+  status: string;
+  totalChunks: number;
+  totalVectors: number;
+  createdAt: string;
+}

--- a/apps/web/app/api/analyze-deps/route.ts
+++ b/apps/web/app/api/analyze-deps/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
+import { authenticateApiToken } from "@/lib/api-auth";
 import { headers, cookies } from "next/headers";
 import { prisma } from "@octopus/db";
 import { analyzeRepositoryDependencies } from "@octopus/package-analyzer";
@@ -22,34 +23,47 @@ function parseGitHubUrl(url: string): { owner: string; repo: string; branch?: st
 }
 
 export async function POST(req: NextRequest) {
-  // Auth check
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    return Response.json({ error: "Authentication required" }, { status: 401 });
+  // Accept either a CLI API token (Authorization: Bearer oct_…) or a browser
+  // session. The token path is additive — `octp analyze-deps` works headlessly
+  // while the web UI keeps using the session path below, unchanged.
+  let orgId: string;
+  let userId: string;
+  let installationId: number | null;
+
+  const tokenAuth = await authenticateApiToken(req);
+  if (tokenAuth) {
+    orgId = tokenAuth.org.id;
+    userId = tokenAuth.user.id;
+    installationId = tokenAuth.org.githubInstallationId;
+  } else {
+    const session = await auth.api.getSession({ headers: await headers() });
+    if (!session) {
+      return Response.json({ error: "Authentication required" }, { status: 401 });
+    }
+
+    const cookieStore = await cookies();
+    const currentOrgId = cookieStore.get("current_org_id")?.value;
+
+    const member = await prisma.organizationMember.findFirst({
+      where: {
+        userId: session.user.id,
+        ...(currentOrgId ? { organizationId: currentOrgId } : {}),
+        deletedAt: null,
+      },
+      select: {
+        organizationId: true,
+        organization: { select: { githubInstallationId: true } },
+      },
+    });
+
+    if (!member) {
+      return Response.json({ error: "No organization found" }, { status: 403 });
+    }
+
+    orgId = member.organizationId;
+    userId = session.user.id;
+    installationId = member.organization.githubInstallationId;
   }
-
-  const cookieStore = await cookies();
-  const currentOrgId = cookieStore.get("current_org_id")?.value;
-
-  const member = await prisma.organizationMember.findFirst({
-    where: {
-      userId: session.user.id,
-      ...(currentOrgId ? { organizationId: currentOrgId } : {}),
-      deletedAt: null,
-    },
-    select: {
-      organizationId: true,
-      organization: { select: { githubInstallationId: true } },
-    },
-  });
-
-  if (!member) {
-    return Response.json({ error: "No organization found" }, { status: 403 });
-  }
-
-  const orgId = member.organizationId;
-  const userId = session.user.id;
-  const installationId = member.organization.githubInstallationId;
 
   // Build auth headers for GitHub API (uses installation token if available)
   async function githubHeaders(): Promise<Record<string, string>> {

--- a/apps/web/app/api/cli/repos/[id]/analyze/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/analyze/route.ts
@@ -34,17 +34,32 @@ export async function POST(
     return Response.json({ error: "Analysis already in progress" }, { status: 409 });
   }
 
-  // Start analysis in the background
+  // Mark analyzing synchronously so the CLI's status poll observes the
+  // transition, then persist the result. analyzeRepository only RETURNS the
+  // analysis text (the status writes live in reviewer.ts) — persist it here so
+  // this CLI route is self-contained.
+  await prisma.repository.update({
+    where: { id: repo.id },
+    data: { analysisStatus: "analyzing" },
+  });
+
   analyzeRepository(repo.id, repo.fullName, result.org.id)
-    .then(() => {
+    .then(async (analysis) => {
+      await prisma.repository.update({
+        where: { id: repo.id },
+        data: { analysis, analysisStatus: "analyzed", analyzedAt: new Date() },
+      });
       eventBus.emit({
         type: "repo-analyzed",
         orgId: result.org.id,
         repoFullName: repo.fullName,
       });
     })
-    .catch((err) => {
+    .catch(async (err) => {
       console.error(`[cli] Analysis failed for ${repo.fullName}:`, err);
+      await prisma.repository
+        .update({ where: { id: repo.id }, data: { analysisStatus: "failed" } })
+        .catch(() => {});
     });
 
   return Response.json({ message: "Analysis started", repoId: repo.id });

--- a/apps/web/app/api/cli/repos/[id]/index/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/index/route.ts
@@ -1,6 +1,6 @@
 import { authenticateApiToken } from "@/lib/api-auth";
 import { prisma } from "@octopus/db";
-import { indexRepository } from "@/lib/indexer";
+import { runIndexingInBackground } from "@/lib/indexing-runner";
 import { NextRequest } from "next/server";
 
 export async function POST(
@@ -30,19 +30,30 @@ export async function POST(
     return Response.json({ error: "Repository has no installation ID" }, { status: 400 });
   }
 
-  // Start indexing in the background
-  indexRepository(
+  // Mark indexing in-progress synchronously so the CLI's status poll observes
+  // the transition, then hand off to the SAME canonical background runner the
+  // web path uses. It persists the terminal status plus all stats (counts,
+  // contributors, duration, resolved default branch) and generates the repo
+  // summary/purpose — so a CLI-triggered index leaves the repo in the exact
+  // same shape as a web-triggered one. A fresh AbortController + a no-op log
+  // sink are fine here: the CLI polls status rather than subscribing to the
+  // pubby channel (its events simply have no listener).
+  await prisma.repository.update({
+    where: { id: repo.id },
+    data: { indexStatus: "indexing" },
+  });
+
+  runIndexingInBackground(
     repo.id,
     repo.fullName,
     repo.defaultBranch,
-    repo.installationId,
-    () => {},
-    undefined,
-    repo.provider,
     result.org.id,
-  ).catch((err) => {
-    console.error(`[cli] Index failed for ${repo.fullName}:`, err);
-  });
+    repo.installationId,
+    `repo-index-${repo.id}`,
+    () => {},
+    new AbortController(),
+    repo.provider,
+  );
 
   return Response.json({ message: "Indexing started", repoId: repo.id });
 }


### PR DESCRIPTION
## What
Brings the **`octp`** CLI (`apps/cli`) to operational parity with the standalone `@octp/cli`, porting the commands it was missing — onto `octp`'s ink/Bun architecture (no commander/chalk/ora), with a security-hardening pass.

**Commands added:** `login` / `logout` / `whoami` / `setup-token` (+ `--token`), `config get/set/list`, `repo list/status/index/analyze`, `knowledge`, `usage`, `analyze-deps`, `skills`, `update`, `chat` (REPL + `-p` pipeline + `-g` global), and `review --pr <n|url>` (server PR review, provider-aware PR/MR wording).

**Foundation:** `lib/auth` (device-flow + token verify; browser open via `spawn(args)`, never `exec(string)`), `lib/api` SSE streamers (`streamData`/`streamSse`, per-call timeout + 5 MB buffer cap), `lib/repo-resolver`, `lib/pr-url`, `lib/output` (color/table/**`sanitizeTerminal`**), `lib/args`. Unit tests for the pure layer (20 new, 83 total).

## Security hardening (from an adversarial PR + security review)
- **Terminal-injection:** `sanitizeTerminal()` on every server/model-supplied string rendered to a TTY (`review`, `repo`, `usage`, `knowledge`, `skills`, `whoami`, `chat`) — strips ANSI/OSC escapes.
- Browser open uses `spawn` with an args array (the old CLI used `exec("open \"" + url + "\"")` — a shell-injection vector); `skills` keeps SHA256 verification + `.md`/basename path-traversal guards; token only ever in the `Authorization` header; `setup-token` → stdout, status → stderr; `login`/`setup-token` refuse cleartext HTTP to non-local hosts unless `--insecure`.
- Stream **timeout + buffer cap** (DoS); `encodeURIComponent` on all path params.

## Server changes (`apps/web`) — make 3 CLI endpoints functional
These were **pre-existing gaps** (they also broke `@octp/cli`), confirmed against the routes:
- **`/api/analyze-deps`** — accept a CLI Bearer token (`authenticateApiToken`) in addition to the browser session. **Additive**: the web session path is byte-for-byte unchanged.
- **`/api/cli/repos/[id]/index`** — persist status via the canonical `runIndexingInBackground` (counts, contributors, duration, default branch, summary/purpose) so the CLI's status poll sees completion.
- **`/api/cli/repos/[id]/analyze`** — persist `analysisStatus` + the analysis text (matches `reviewer.ts`).

## Validation
`bun run typecheck` ✓ · `bun run lint` ✓ (0 errors) · `bun run build` (web + cli) ✓ · `cd apps/cli && bun test` → **83 pass / 0 fail** · runtime smoke of the dispatcher + commands ✓.

Reviewed by a 6-lens adversarial PR+security pass (2 lenses SAFE outright) and a focused server-route review (SAFE; its one finding — index stat-field divergence — fixed by switching to `runIndexingInBackground`).

## Deferred (separate follow-ups)
- The old **code-search agent** (`agent watch/start/stop`) — collides with octp's existing `agent serve` (local-LLM worker); needs a naming/semantics decision.
- **Multi-profile** support (architectural — touches paths/credentials/config).

## Risk
🟡 Low–Medium. Most surface is new `apps/cli` code. The 3 `apps/web` changes are additive (analyze-deps token path) or fix no-op CLI-only routes (index/analyze status). No change to existing web behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1