### PR TITLE
fix(cli): handle rejection in chat interactive REPL loop

### DIFF
--- a/apps/cli/src/commands/chat.ts
+++ b/apps/cli/src/commands/chat.ts
@@ -143,6 +143,17 @@ export async function chatCommand(argv: string[]): Promise<number> {
             }
             process.stdout.write("\n\n");
             if (!closed) ask();
+          })
+          .catch((err) => {
+            // streamData is designed to resolve (never reject), but guard the
+            // REPL regardless: surface the error and keep the prompt alive
+            // rather than leaving an unhandled rejection that silently kills
+            // the loop.
+            process.stdout.write(
+              c.red(`\nChat error: ${sanitizeTerminal(err instanceof Error ? err.message : String(err))}`),
+            );
+            process.stdout.write("\n\n");
+            if (!closed) ask();
           });
       });
     };


### PR DESCRIPTION
## What
Follow-up to #564 addressing its one remaining 4/5 note (Error Handling): the interactive `octp chat` REPL chained `streamData(...).then(...)` with **no `.catch()`**. A rejection would be swallowed — an unhandled promise rejection that silently kills the prompt loop (the next `ask()` never fires).

## Fix
Add a `.catch()` to the REPL's stream chain that surfaces the error (run through `sanitizeTerminal`) and re-prompts, so the loop stays alive. `streamData` is designed to resolve (never reject), so this is defensive — but it removes the unhandled-rejection path the reviewer flagged.

One-file change; pipeline mode and all other behavior unchanged.

## Test plan
`bun run typecheck` ✓ · `bun run lint` ✓ · `bun run build` ✓ · `cd apps/cli && bun test` → 83 pass / 0 fail.

## Risk
🟢 Low — single defensive `.catch` in `octp chat`'s interactive loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1