### PR TITLE
feat(cli): multi-account (profile) support for octp

### DIFF
--- a/apps/cli/src/__tests__/paths.test.ts
+++ b/apps/cli/src/__tests__/paths.test.ts
@@ -37,10 +37,11 @@ describe("getOctopusHome", () => {
 });
 
 describe("path helpers", () => {
-  it("places config, byok, and credentials inside OCTOPUS_HOME", () => {
+  it("keeps config global; puts byok + credentials under the active profile dir", () => {
+    // No profiles.json yet → active profile resolves to "default".
     expect(getConfigPath()).toBe(join(tmpHome, "config.json"));
-    expect(getByokPath()).toBe(join(tmpHome, "byok.json"));
-    expect(getCredentialsPath()).toBe(join(tmpHome, "credentials"));
+    expect(getByokPath()).toBe(join(tmpHome, "profiles", "default", "byok.json"));
+    expect(getCredentialsPath()).toBe(join(tmpHome, "profiles", "default", "credentials"));
   });
 });
 

--- a/apps/cli/src/__tests__/profile.test.ts
+++ b/apps/cli/src/__tests__/profile.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, readFile, stat, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isValidProfileName,
+  ensureProfilesMigrated,
+  ensureProfile,
+  setActiveProfile,
+  removeProfile,
+  loadProfilesIndex,
+  loadCredentialsForProfile,
+} from "../lib/profile";
+import { setActiveProfileOverride, getProfileDir, getProfilesIndexPath } from "../lib/paths";
+
+let tmpHome: string;
+
+beforeEach(async () => {
+  tmpHome = await mkdtemp(join(tmpdir(), "octp-profile-"));
+  process.env.OCTOPUS_HOME = tmpHome;
+  setActiveProfileOverride(null);
+});
+
+afterEach(async () => {
+  delete process.env.OCTOPUS_HOME;
+  setActiveProfileOverride(null);
+  await rm(tmpHome, { recursive: true, force: true });
+});
+
+describe("isValidProfileName (path-traversal guard)", () => {
+  it("accepts safe names", () => {
+    for (const n of ["work", "default", "a.b-c_1", "Personal"]) {
+      expect(isValidProfileName(n)).toBe(true);
+    }
+  });
+  it("rejects empty, dot-entries, and path separators", () => {
+    for (const n of ["", ".", "..", "../x", "a/b", "a\\b", "a b", "x/../y"]) {
+      expect(isValidProfileName(n)).toBe(false);
+    }
+  });
+});
+
+describe("ensureProfilesMigrated", () => {
+  it("on a fresh home creates the index with an active default and no creds", async () => {
+    await ensureProfilesMigrated();
+    const idx = await loadProfilesIndex();
+    expect(idx.active).toBe("default");
+    expect(Object.keys(idx.profiles)).toEqual(["default"]);
+    expect(await loadCredentialsForProfile("default")).toBeNull();
+  });
+
+  it("moves a legacy credentials file into profiles/default (no logout)", async () => {
+    const creds = {
+      baseUrl: "https://x",
+      token: "oct_abc",
+      orgId: "o",
+      orgSlug: "s",
+      orgName: "Org",
+      approvedAt: "2026-01-01T00:00:00Z",
+    };
+    await writeFile(join(tmpHome, "credentials"), JSON.stringify(creds), { mode: 0o600 });
+
+    await ensureProfilesMigrated();
+
+    await expect(stat(join(tmpHome, "credentials"))).rejects.toThrow(); // legacy gone
+    const moved = await loadCredentialsForProfile("default");
+    expect(moved?.token).toBe("oct_abc");
+    expect((await loadProfilesIndex()).active).toBe("default");
+  });
+
+  it("is idempotent — a second run doesn't clobber state", async () => {
+    await ensureProfilesMigrated();
+    await ensureProfile("work");
+    await setActiveProfile("work");
+    await ensureProfilesMigrated(); // index already exists → no-op
+    const idx = await loadProfilesIndex();
+    expect(idx.active).toBe("work");
+    expect(Object.keys(idx.profiles).sort()).toEqual(["default", "work"]);
+  });
+});
+
+describe("profile ops", () => {
+  beforeEach(async () => {
+    await ensureProfilesMigrated();
+  });
+
+  it("ensureProfile registers a new profile + creates its dir", async () => {
+    await ensureProfile("work");
+    expect((await loadProfilesIndex()).profiles.work).toBeDefined();
+    expect((await stat(getProfileDir("work"))).isDirectory()).toBe(true);
+  });
+
+  it("setActiveProfile switches active; rejects unknown", async () => {
+    await ensureProfile("work");
+    await setActiveProfile("work");
+    expect((await loadProfilesIndex()).active).toBe("work");
+    await expect(setActiveProfile("nope")).rejects.toThrow();
+  });
+
+  it("removeProfile of the active one auto-repoints to a remaining profile", async () => {
+    await ensureProfile("work");
+    await setActiveProfile("work");
+    const { newActive } = await removeProfile("work");
+    expect(newActive).toBe("default");
+    expect((await loadProfilesIndex()).active).toBe("default");
+    await expect(stat(getProfileDir("work"))).rejects.toThrow();
+  });
+
+  it("removeProfile unsets active when none remain", async () => {
+    const { newActive } = await removeProfile("default");
+    expect(newActive).toBeNull();
+    expect((await loadProfilesIndex()).active).toBeNull();
+  });
+
+  it("rejects invalid names everywhere (traversal guard)", async () => {
+    await expect(ensureProfile("..")).rejects.toThrow();
+    await expect(setActiveProfile("../x")).rejects.toThrow();
+    await expect(removeProfile("a/b")).rejects.toThrow();
+  });
+});
+
+describe("loadProfilesIndex hardening", () => {
+  it("returns an empty index for an array `profiles` or non-JSON", async () => {
+    await mkdir(tmpHome, { recursive: true });
+    await writeFile(getProfilesIndexPath(), JSON.stringify({ active: "x", profiles: ["a", "b"] }));
+    let idx = await loadProfilesIndex();
+    expect(idx.profiles).toEqual({});
+    expect(idx.active).toBeNull();
+    await writeFile(getProfilesIndexPath(), "not json");
+    idx = await loadProfilesIndex();
+    expect(idx.profiles).toEqual({});
+  });
+
+  it("drops traversal/invalid profile keys and an invalid active pointer", async () => {
+    await mkdir(tmpHome, { recursive: true });
+    await writeFile(
+      getProfilesIndexPath(),
+      JSON.stringify({
+        active: "../evil",
+        profiles: { "../evil": { createdAt: "x" }, work: { createdAt: "y" } },
+      }),
+    );
+    const idx = await loadProfilesIndex();
+    expect(Object.keys(idx.profiles)).toEqual(["work"]);
+    expect(idx.active).toBeNull();
+  });
+});
+
+describe("migration perms + byok", () => {
+  it("writes profiles.json with 0600 perms", async () => {
+    await ensureProfilesMigrated();
+    const st = await stat(getProfilesIndexPath());
+    expect(st.mode & 0o777).toBe(0o600);
+  });
+
+  it("migrates a legacy byok.json into profiles/default", async () => {
+    await writeFile(join(tmpHome, "byok.json"), JSON.stringify({ keys: { openai: "sk-x" } }), {
+      mode: 0o600,
+    });
+    await ensureProfilesMigrated();
+    await expect(stat(join(tmpHome, "byok.json"))).rejects.toThrow();
+    const moved = await readFile(join(getProfileDir("default"), "byok.json"), "utf8");
+    expect(moved).toContain("sk-x");
+  });
+});

--- a/apps/cli/src/commands/account.ts
+++ b/apps/cli/src/commands/account.ts
@@ -1,0 +1,163 @@
+import { createInterface } from "node:readline";
+import {
+  listProfiles,
+  setActiveProfile,
+  removeProfile,
+  type ProfileSummary,
+} from "../lib/profile.js";
+import { getActiveProfileName } from "../lib/paths.js";
+import { loadCredentials } from "../lib/credentials.js";
+import { positionals, hasFlag } from "../lib/args.js";
+import { success, error, info, heading, table, c, sanitizeTerminal } from "../lib/output.js";
+
+/**
+ * `octp account` — manage signed-in profiles (Azure-CLI `az account` style).
+ *   list           Table of all accounts (* marks active)
+ *   set [name]     Switch active; no name → list, then pick interactively
+ *   show           Show the active account
+ *   remove <name>  Delete an account (auto-repoints active)
+ * A global `--account <name>` flag overrides the active account for one command.
+ */
+export async function accountCommand(argv: string[]): Promise<number> {
+  if (hasFlag(argv, "--help", "-h")) {
+    printHelp();
+    return 0;
+  }
+  const [sub, name] = positionals(argv);
+  if (!sub || sub === "list") return listAccounts();
+  if (sub === "show") return showAccount();
+  if (sub === "set" || sub === "use") return setAccount(name);
+  if (sub === "remove" || sub === "rm") return removeAccount(name);
+  error(`Unknown account subcommand: ${sub}. Use list | set | show | remove.`);
+  return 2;
+}
+
+async function listAccounts(): Promise<number> {
+  const profiles = await listProfiles();
+  if (profiles.length === 0) {
+    info("No accounts yet. Run `octp login` to add one.");
+    return 0;
+  }
+  heading("Accounts");
+  table(
+    profiles.map((p) => [
+      p.active ? c.green(`* ${sanitizeTerminal(p.name)}`) : `  ${sanitizeTerminal(p.name)}`,
+      p.creds ? sanitizeTerminal(p.creds.orgName) : c.dim("(not signed in)"),
+      p.creds?.userName ? sanitizeTerminal(p.creds.userName) : c.dim("—"),
+      p.creds ? sanitizeTerminal(p.creds.baseUrl) : c.dim("—"),
+    ]),
+    ["Account", "Org", "User", "Server"],
+  );
+  return 0;
+}
+
+async function showAccount(): Promise<number> {
+  // getActiveProfileName() honors the --account override, so the header matches
+  // the profile loadCredentials() actually resolves (no display/data mismatch).
+  const active = getActiveProfileName();
+  const creds = await loadCredentials();
+  info(c.bold(sanitizeTerminal(active)));
+  if (creds) {
+    info(`org:    ${sanitizeTerminal(creds.orgName)} (${sanitizeTerminal(creds.orgSlug)})`);
+    if (creds.userName) {
+      info(
+        `user:   ${sanitizeTerminal(creds.userName)}${creds.userEmail ? ` <${sanitizeTerminal(creds.userEmail)}>` : ""}`,
+      );
+    }
+    info(`server: ${sanitizeTerminal(creds.baseUrl)}`);
+  } else {
+    info(c.dim("(active account has no saved credentials — run `octp login`)"));
+  }
+  return 0;
+}
+
+async function setAccount(name?: string): Promise<number> {
+  const profiles = await listProfiles();
+  if (profiles.length === 0) {
+    error("No accounts yet. Run `octp login` to add one.");
+    return 2;
+  }
+
+  let target = name;
+  if (!target) {
+    // "List before you switch": show the numbered list, then prompt.
+    if (!process.stdin.isTTY) {
+      error("Specify an account name (no TTY for interactive selection). `octp account list` to see them.");
+      return 2;
+    }
+    printNumbered(profiles);
+    const picked = await promptSelect(profiles.map((p) => p.name));
+    if (!picked) {
+      info("No selection — active account unchanged.");
+      return 0;
+    }
+    target = picked;
+  }
+
+  try {
+    await setActiveProfile(target);
+    success(`Active account → ${sanitizeTerminal(target)}`);
+    return 0;
+  } catch (e) {
+    error(e instanceof Error ? e.message : String(e));
+    return 2;
+  }
+}
+
+async function removeAccount(name?: string): Promise<number> {
+  if (!name) {
+    error("Usage: octp account remove <name>");
+    return 2;
+  }
+  try {
+    const { newActive } = await removeProfile(name);
+    success(`Removed account ${sanitizeTerminal(name)}.`);
+    if (newActive) info(`Active account → ${sanitizeTerminal(newActive)}`);
+    else info("No accounts remain. Run `octp login` to add one.");
+    return 0;
+  } catch (e) {
+    error(e instanceof Error ? e.message : String(e));
+    return 2;
+  }
+}
+
+function printNumbered(profiles: ProfileSummary[]): void {
+  info("Accounts:");
+  profiles.forEach((p, i) => {
+    const mark = p.active ? c.green("*") : " ";
+    const org = p.creds ? ` — ${sanitizeTerminal(p.creds.orgName)}` : c.dim(" (not signed in)");
+    info(`  ${i + 1}) ${mark} ${sanitizeTerminal(p.name)}${org}`);
+  });
+}
+
+function promptSelect(names: string[]): Promise<string | null> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stderr });
+    rl.question("\nSelect account (number or name): ", (raw) => {
+      rl.close();
+      const t = raw.trim();
+      if (!t) return resolve(null);
+      const n = Number(t);
+      if (Number.isInteger(n) && n >= 1 && n <= names.length) return resolve(names[n - 1]);
+      if (names.includes(t)) return resolve(t);
+      resolve(null);
+    });
+  });
+}
+
+function printHelp(): void {
+  console.log(`octp account — manage signed-in profiles
+
+Usage:
+  octp account list              List all accounts (* = active)
+  octp account set [name]        Switch active account (no name → pick from a list)
+  octp account show              Show the active account
+  octp account remove <name>     Delete an account
+
+Global:
+  --account <name>               Use a specific account for one command
+                                 (e.g. octp whoami --account work)
+
+Add an account with: octp login --account <name>
+`);
+}

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -3,6 +3,7 @@ import { loadCredentials } from "../lib/credentials.js";
 import { loadByok } from "../lib/byok.js";
 import { getJson } from "../lib/api.js";
 import { getOctopusHome } from "../lib/paths.js";
+import { loadProfilesIndex } from "../lib/profile.js";
 import { sanitizeTerminal } from "../lib/output.js";
 
 /**
@@ -43,6 +44,17 @@ export async function doctorCommand(_argv: string[]): Promise<number> {
 
   // ── Credentials ────────────────────────────────────────────────────────────
   console.log("\nAuth:");
+  const profilesIndex = await loadProfilesIndex();
+  const profileCount = Object.keys(profilesIndex.profiles).length;
+  if (profilesIndex.active) {
+    line(
+      "ok",
+      "active account",
+      `${sanitizeTerminal(profilesIndex.active)} (${profileCount} account${profileCount === 1 ? "" : "s"} total)`,
+    );
+  } else {
+    line("warn", "active account", "none — run `octp login`");
+  }
   const creds = await loadCredentials();
   if (!creds) {
     line("warn", "credentials", "no ~/.octopus/credentials — run `octp` to sign in");

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -9,6 +9,8 @@ import {
 } from "../lib/auth.js";
 import { normalizeBaseUrl, isTransportSafe } from "../lib/api.js";
 import { flagValue, hasFlag } from "../lib/args.js";
+import { getActiveProfileName } from "../lib/paths.js";
+import { ensureProfile, setActiveProfile } from "../lib/profile.js";
 import { success, error, info, c, sanitizeTerminal } from "../lib/output.js";
 
 const DEFAULT_BASE_URL = "https://octopus-review.ai";
@@ -61,10 +63,16 @@ export async function loginCommand(argv: string[]): Promise<number> {
     } else {
       identity = await runDeviceFlow(baseUrl, { onAuthorizeUrl: (url) => info(c.dim(url)) });
     }
+    // Land the credentials in the active profile (which reflects --account),
+    // registering + activating it so `account list` shows it and later commands
+    // default to it.
+    const profileName = getActiveProfileName();
+    await ensureProfile(profileName);
     await saveCredentials(buildCredentials(baseUrl, identity));
+    await setActiveProfile(profileName);
     const email = identity.user.email ? ` (${sanitizeTerminal(identity.user.email)})` : "";
     success(
-      `Logged in as ${sanitizeTerminal(identity.user.name)}${email} — org: ${sanitizeTerminal(identity.organization.name)}`,
+      `Logged in as ${sanitizeTerminal(identity.user.name)}${email} — org: ${sanitizeTerminal(identity.organization.name)} [account: ${sanitizeTerminal(profileName)}]`,
     );
     return 0;
   } catch (err) {

--- a/apps/cli/src/commands/setup-token.ts
+++ b/apps/cli/src/commands/setup-token.ts
@@ -3,6 +3,8 @@ import { loadConfig } from "../lib/config.js";
 import { runDeviceFlow, buildCredentials } from "../lib/auth.js";
 import { normalizeBaseUrl, isTransportSafe } from "../lib/api.js";
 import { flagValue, hasFlag } from "../lib/args.js";
+import { getActiveProfileName } from "../lib/paths.js";
+import { ensureProfile, setActiveProfile } from "../lib/profile.js";
 import { error } from "../lib/output.js";
 
 const DEFAULT_BASE_URL = "https://octopus-review.ai";
@@ -45,7 +47,14 @@ export async function setupTokenCommand(argv: string[]): Promise<number> {
           noOpen ? `Open this URL to authorize:\n${url}\n` : `Opening browser to authorize: ${url}\n`,
         ),
     });
-    if (save) await saveCredentials(buildCredentials(baseUrl, identity));
+    if (save) {
+      // Persist into the active profile (reflects --account), registering +
+      // activating it so it shows up in `octp account list`.
+      const profileName = getActiveProfileName();
+      await ensureProfile(profileName);
+      await saveCredentials(buildCredentials(baseUrl, identity));
+      await setActiveProfile(profileName);
+    }
     // Token → stdout (the one capturable line). Everything else went to stderr.
     process.stdout.write(identity.token + "\n");
     return 0;

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -18,8 +18,26 @@ import { analyzeDepsCommand } from "./commands/analyze-deps.js";
 import { skillsCommand } from "./commands/skills.js";
 import { updateCommand } from "./commands/update.js";
 import { chatCommand } from "./commands/chat.js";
+import { accountCommand } from "./commands/account.js";
+import { ensureProfilesMigrated, isValidProfileName, ensureProfile, setActiveProfile } from "./lib/profile.js";
+import { setActiveProfileOverride } from "./lib/paths.js";
+import { flagValue } from "./lib/args.js";
 
 const VERSION = "0.1.0";
+
+/** Remove a `--flag <value>` pair from argv (the value is dropped only when the
+ *  next token isn't itself a flag). Used to peel the global --account/--profile
+ *  flag off before a command parses its own positionals. */
+function stripValueFlag(argv: string[], flag: string): string[] {
+  const out = argv.slice();
+  let i = out.indexOf(flag);
+  while (i !== -1) {
+    const hasValue = out[i + 1] !== undefined && !out[i + 1].startsWith("-");
+    out.splice(i, hasValue ? 2 : 1);
+    i = out.indexOf(flag);
+  }
+  return out;
+}
 
 /**
  * Top-level CLI entry. Parses the first arg as a subcommand and dispatches.
@@ -46,11 +64,12 @@ Usage:
   octp                       Onboarding wizard (first run) or status hint
   octp onboard [--reset]     Run the onboarding wizard
 
-Auth:
+Auth & accounts:
   octp login [--token ...]   Sign in (browser device-flow or --token)
-  octp logout                Remove saved credentials
+  octp logout                Remove the active account's credentials
   octp whoami                Show the signed-in user + org
   octp setup-token           Print a token to stdout (for CI/CD)
+  octp account <list|set|show|remove>   Manage signed-in accounts (profiles)
 
 Reviews:
   octp review [--staged|--since <ref>]   Review local changes pre-PR
@@ -71,6 +90,7 @@ Agent & ops:
   octp update [--check]      Update the CLI
 
 Flags:
+  --account <name>           Use a specific account for one command (e.g. --account work)
   --version, -v              Print version
   --help, -h                 Print this help
   (run \`octp <command> --help\` for command-specific flags)
@@ -83,7 +103,26 @@ Docs:  https://github.com/octopusreview/octopus
 `);
 }
 
-async function main(argv: string[]): Promise<number> {
+async function main(rawArgv: string[]): Promise<number> {
+  // Global --account / --profile: select the active profile for this run, then
+  // strip the flag so it doesn't leak into a command's positional parsing.
+  const acctFlag = flagValue(rawArgv, "--account") ?? flagValue(rawArgv, "--profile");
+  if ((rawArgv.includes("--account") || rawArgv.includes("--profile")) && acctFlag === undefined) {
+    console.error("--account requires an account name (e.g. --account work).");
+    return 2;
+  }
+  let argv = rawArgv;
+  if (acctFlag !== undefined) {
+    if (!isValidProfileName(acctFlag)) {
+      console.error(
+        `Invalid account name "${acctFlag}". Use letters, digits, dot, dash, or underscore.`,
+      );
+      return 2;
+    }
+    setActiveProfileOverride(acctFlag);
+    argv = stripValueFlag(stripValueFlag(rawArgv, "--account"), "--profile");
+  }
+
   const first = argv[0];
 
   if (first === "--version" || first === "-v") {
@@ -94,6 +133,10 @@ async function main(argv: string[]): Promise<number> {
     printHelp();
     return 0;
   }
+
+  // Migrate the legacy single-context layout to per-profile dirs (idempotent;
+  // a no-op after the first run). Must precede any credential read/write.
+  await ensureProfilesMigrated();
 
   // No subcommand: gate on first-run + TTY, then render the wizard (or exit cleanly).
   if (first === undefined || first.startsWith("-")) {
@@ -108,11 +151,29 @@ async function main(argv: string[]): Promise<number> {
       console.log("You're set. Try `octp --help` for available commands.");
       return 0;
     }
-    return await renderWizard(argv.includes("--reset"));
+    {
+      const code = await renderWizard(argv.includes("--reset"));
+      // If signing in under a named account (--account), register + activate it
+      // so the wizard's credentials land in a tracked profile (parity with login).
+      if (acctFlag) {
+        await ensureProfile(acctFlag);
+        await setActiveProfile(acctFlag);
+      }
+      return code;
+    }
   }
 
   if (first === "onboard") {
-    return await renderWizard(argv.includes("--reset"));
+    {
+      const code = await renderWizard(argv.includes("--reset"));
+      // If signing in under a named account (--account), register + activate it
+      // so the wizard's credentials land in a tracked profile (parity with login).
+      if (acctFlag) {
+        await ensureProfile(acctFlag);
+        await setActiveProfile(acctFlag);
+      }
+      return code;
+    }
   }
 
   const rest = argv.slice(1);
@@ -145,6 +206,9 @@ async function main(argv: string[]): Promise<number> {
       return await updateCommand(rest);
     case "doctor":
       return await doctorCommand(rest);
+    case "account":
+    case "profile":
+      return await accountCommand(rest);
     case "agent": {
       const sub = argv[1];
       if (sub === "serve") return await agentServeCommand(argv.slice(2));
@@ -172,6 +236,9 @@ export async function ensureOnboardCompleted(argv: string[] = process.argv.slice
   if (argv.includes("--skip-onboard")) return;
   if (process.env.OCTOPUS_NO_ONBOARD === "1") return;
   if (!process.stdin.isTTY) return;
+
+  // Keep the profile layout migrated for embedders that bypass main().
+  await ensureProfilesMigrated();
 
   const config = await loadConfig();
   const reset = argv.includes("--reset") || argv.includes("--reset-onboard");

--- a/apps/cli/src/lib/paths.ts
+++ b/apps/cli/src/lib/paths.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { mkdir } from "node:fs/promises";
+import { readFileSync } from "node:fs";
 
 /**
  * Resolve the Octopus home directory.
@@ -15,22 +16,93 @@ export function getOctopusHome(): string {
   return join(homedir(), ".octopus");
 }
 
+/**
+ * config.json is GLOBAL (machine-level prefs + the first-run onboarding gate),
+ * shared across accounts/profiles. Only credentials + BYOK keys are
+ * per-profile (see getCredentialsPath / getByokPath below).
+ */
 export function getConfigPath(): string {
   return join(getOctopusHome(), "config.json");
 }
 
-export function getByokPath(): string {
-  return join(getOctopusHome(), "byok.json");
+export const DEFAULT_PROFILE = "default";
+
+/** The secret-free index that records the known profiles + the active one. */
+export function getProfilesIndexPath(): string {
+  return join(getOctopusHome(), "profiles.json");
 }
 
-export function getCredentialsPath(): string {
-  return join(getOctopusHome(), "credentials");
+/** Per-profile directory holding that profile's `credentials` + `byok.json`. */
+export function getProfileDir(name: string): string {
+  return join(getOctopusHome(), "profiles", name);
 }
 
 /**
- * Ensure the Octopus home directory exists with restrictive permissions.
- * Idempotent — safe to call on every launch.
+ * Validate a profile name BEFORE it is ever used as a directory component.
+ * Security boundary: the name becomes `profiles/<name>`, so an unguarded
+ * "." / ".." / path separator would escape the profiles dir and let
+ * account create/remove/switch — or a tampered profiles.json read back through
+ * here — touch arbitrary directories. Lives in paths.ts (not profile.ts) so the
+ * sync path resolver below can use it without a circular import; profile.ts
+ * re-exports it.
+ */
+export function isValidProfileName(name: string): boolean {
+  if (!name || name === "." || name === "..") return false;
+  return /^[A-Za-z0-9._-]+$/.test(name);
+}
+
+// Per-invocation active-profile override, set from the global --account/--profile
+// flag in index.tsx. Wins over the persisted active pointer for one process.
+let activeOverride: string | null = null;
+export function setActiveProfileOverride(name: string | null): void {
+  activeOverride = name;
+}
+
+/**
+ * Sync read of the persisted active-profile pointer so path resolution stays
+ * synchronous (getCredentialsPath/getByokPath are consumed all over as plain
+ * strings). Falls back to "default" when the index is missing/unparseable
+ * (pre-migration or a fresh machine).
+ */
+function readActiveProfileSync(): string {
+  try {
+    const raw = readFileSync(getProfilesIndexPath(), "utf8");
+    const parsed = JSON.parse(raw) as { active?: unknown };
+    // Validate the persisted pointer too — a hand-edited/corrupted index must
+    // not drive a traversal through getProfileDir() into a credential read/write.
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.active === "string" &&
+      isValidProfileName(parsed.active)
+    ) {
+      return parsed.active;
+    }
+  } catch {
+    // no index yet → default
+  }
+  return DEFAULT_PROFILE;
+}
+
+export function getActiveProfileName(): string {
+  return activeOverride ?? readActiveProfileSync();
+}
+
+export function getCredentialsPath(): string {
+  return join(getProfileDir(getActiveProfileName()), "credentials");
+}
+
+export function getByokPath(): string {
+  return join(getProfileDir(getActiveProfileName()), "byok.json");
+}
+
+/**
+ * Ensure the Octopus home directory AND the active profile's directory exist
+ * with restrictive permissions. Idempotent — safe to call on every launch.
+ * saveCredentials/setByokKey call this before writing, so the active profile
+ * dir always exists by the time a secret is written into it.
  */
 export async function ensureOctopusHome(): Promise<void> {
   await mkdir(getOctopusHome(), { recursive: true, mode: 0o700 });
+  await mkdir(getProfileDir(getActiveProfileName()), { recursive: true, mode: 0o700 });
 }

--- a/apps/cli/src/lib/profile.ts
+++ b/apps/cli/src/lib/profile.ts
@@ -1,0 +1,196 @@
+import { mkdir, readFile, writeFile, chmod, rename, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  getOctopusHome,
+  getProfilesIndexPath,
+  getProfileDir,
+  DEFAULT_PROFILE,
+  isValidProfileName,
+} from "./paths.js";
+import type { Credentials } from "./credentials.js";
+
+/**
+ * Multi-profile ("account") support. Each profile is a directory under
+ * ~/.octopus/profiles/<name>/ holding that profile's `credentials` + `byok.json`
+ * (per-profile secrets). A small, secret-free index (~/.octopus/profiles.json)
+ * records the known profiles and which one is active.
+ *
+ * Path resolution (which profile dir credentials/byok live in) is in paths.ts
+ * and stays synchronous; this module owns the async index operations +
+ * migration. config.json stays global (machine prefs + onboarding gate).
+ */
+
+export const PROFILES_VERSION = 1;
+
+export type ProfilesIndex = {
+  version: number;
+  active: string | null;
+  profiles: Record<string, { createdAt: string }>;
+};
+
+// The profile-name guard lives in paths.ts (so the sync path resolver can use
+// it without a paths↔profile import cycle); re-exported here for callers that
+// already import from this module.
+export { isValidProfileName };
+
+function assertValidProfileName(name: string): void {
+  if (!isValidProfileName(name)) {
+    throw new Error(
+      `Invalid account name "${name}". Use letters, digits, dot, dash, or underscore (not "." or "..").`,
+    );
+  }
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function loadProfilesIndex(): Promise<ProfilesIndex> {
+  try {
+    const raw = await readFile(getProfilesIndexPath(), "utf8");
+    const parsed = JSON.parse(raw) as Partial<ProfilesIndex>;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.profiles === "object" &&
+      parsed.profiles !== null &&
+      // `typeof [] === "object"` — reject an array so Object.keys doesn't yield
+      // numeric indices as "profile names" (same trap byok.ts guards against).
+      !Array.isArray(parsed.profiles)
+    ) {
+      // Only trust validly-named keys: the name becomes a directory component,
+      // so a tampered/corrupted index must not introduce a traversal name into
+      // listProfiles / loadCredentialsForProfile. Coerce each entry's shape.
+      const profiles: ProfilesIndex["profiles"] = {};
+      for (const [name, entry] of Object.entries(
+        parsed.profiles as Record<string, { createdAt?: unknown }>,
+      )) {
+        if (!isValidProfileName(name)) continue;
+        profiles[name] = {
+          createdAt: typeof entry?.createdAt === "string" ? entry.createdAt : "",
+        };
+      }
+      const active =
+        typeof parsed.active === "string" && isValidProfileName(parsed.active) && profiles[parsed.active]
+          ? parsed.active
+          : null;
+      return { version: PROFILES_VERSION, active, profiles };
+    }
+  } catch {
+    // missing / unparseable → empty index
+  }
+  return { version: PROFILES_VERSION, active: null, profiles: {} };
+}
+
+async function saveProfilesIndex(index: ProfilesIndex): Promise<void> {
+  await mkdir(getOctopusHome(), { recursive: true, mode: 0o700 });
+  const p = getProfilesIndexPath();
+  await writeFile(p, JSON.stringify(index, null, 2), { mode: 0o600 });
+  // mode only applies on creation; force 0600 on pre-existing files too
+  // (matches credentials.ts / byok.ts).
+  await chmod(p, 0o600);
+}
+
+/**
+ * One-time migration from the legacy single-context layout to per-profile dirs.
+ * Idempotent: returns immediately once profiles.json exists. Otherwise moves
+ * any existing ~/.octopus/credentials + byok.json into profiles/default/ via
+ * `rename` (atomic on the same filesystem, preserves the exact 0600 bytes) so
+ * the user is NOT logged out, then writes the index with active="default".
+ *
+ * Wrapped so a migration failure (perms etc.) leaves the legacy files in place
+ * and the index unwritten — the CLI keeps running and retries next launch
+ * rather than crashing or silently logging the user out.
+ */
+export async function ensureProfilesMigrated(): Promise<void> {
+  try {
+    if (await fileExists(getProfilesIndexPath())) return;
+    const home = getOctopusHome();
+    const defaultDir = getProfileDir(DEFAULT_PROFILE);
+    await mkdir(defaultDir, { recursive: true, mode: 0o700 });
+
+    const legacyCreds = join(home, "credentials");
+    if (await fileExists(legacyCreds)) {
+      await rename(legacyCreds, join(defaultDir, "credentials"));
+    }
+    const legacyByok = join(home, "byok.json");
+    if (await fileExists(legacyByok)) {
+      await rename(legacyByok, join(defaultDir, "byok.json"));
+    }
+
+    await saveProfilesIndex({
+      version: PROFILES_VERSION,
+      active: DEFAULT_PROFILE,
+      profiles: { [DEFAULT_PROFILE]: { createdAt: new Date().toISOString() } },
+    });
+  } catch {
+    // leave legacy files untouched; retry on next launch
+  }
+}
+
+/** Create the profile dir + register it in the index (no-op if already present). */
+export async function ensureProfile(name: string): Promise<void> {
+  assertValidProfileName(name);
+  await mkdir(getProfileDir(name), { recursive: true, mode: 0o700 });
+  const index = await loadProfilesIndex();
+  if (!index.profiles[name]) {
+    index.profiles[name] = { createdAt: new Date().toISOString() };
+    await saveProfilesIndex(index);
+  }
+}
+
+export async function setActiveProfile(name: string): Promise<void> {
+  assertValidProfileName(name);
+  const index = await loadProfilesIndex();
+  if (!index.profiles[name]) throw new Error(`No such account: ${name}`);
+  index.active = name;
+  await saveProfilesIndex(index);
+}
+
+/** Remove a profile (dir + index entry). Auto-repoints active to a remaining
+ *  profile when the removed one was active; unsets active only when none remain. */
+export async function removeProfile(name: string): Promise<{ newActive: string | null }> {
+  assertValidProfileName(name);
+  const index = await loadProfilesIndex();
+  if (!index.profiles[name]) throw new Error(`No such account: ${name}`);
+  delete index.profiles[name];
+  if (index.active === name) {
+    const remaining = Object.keys(index.profiles).sort();
+    index.active = remaining.length > 0 ? remaining[0] : null;
+  }
+  await saveProfilesIndex(index);
+  // Best-effort dir removal — the index is the source of truth; a leftover dir
+  // is harmless and gets reused if the name is re-created.
+  await rm(getProfileDir(name), { recursive: true, force: true }).catch(() => {});
+  return { newActive: index.active };
+}
+
+/** Best-effort read of a SPECIFIC profile's credentials (for `account list`). */
+export async function loadCredentialsForProfile(name: string): Promise<Credentials | null> {
+  if (!isValidProfileName(name)) return null; // defense-in-depth: never readFile a traversal name
+  try {
+    const raw = await readFile(join(getProfileDir(name), "credentials"), "utf8");
+    const parsed = JSON.parse(raw) as Credentials;
+    if (parsed && typeof parsed === "object" && typeof parsed.token === "string") return parsed;
+  } catch {
+    // missing / unparseable → not signed in on this profile
+  }
+  return null;
+}
+
+export type ProfileSummary = { name: string; active: boolean; creds: Credentials | null };
+
+export async function listProfiles(): Promise<ProfileSummary[]> {
+  const index = await loadProfilesIndex();
+  const names = Object.keys(index.profiles).sort();
+  const out: ProfileSummary[] = [];
+  for (const name of names) {
+    out.push({ name, active: index.active === name, creds: await loadCredentialsForProfile(name) });
+  }
+  return out;
+}


### PR DESCRIPTION
## What
Lets one `octp` install hold several **accounts** (server + org + token) side by side and switch between them — modeled on `az account list/set/show`.

- `octp account list` — table of accounts (`*` marks active)
- `octp account set [name]` — switch active; **no name → lists them, then prompts** ("list before you switch")
- `octp account show` — show the active account
- `octp account remove <name>` — delete an account (auto-repoints active)
- global `--account <name>` — use a specific account for one command (`octp whoami --account work`)
- `octp login --account <name>` — sign in to a (new) named account

## Architecture
- **Storage:** per-account dirs `~/.octopus/profiles/<name>/{credentials,byok.json}` (0600) + a **secret-free** `profiles.json` index (just names + the active pointer). `config.json` stays global (machine prefs + onboarding gate).
- **Transparent migration:** the legacy single `~/.octopus/credentials` is `rename`d into `profiles/default/` on first run — atomic, same bytes, **no re-login**. Idempotent + self-healing on partial failure.
- **Minimal blast radius:** path resolution (`getCredentialsPath`/`getByokPath`) became account-aware, so the existing `loadCredentials`/`loadConfig` call sites are **unchanged** — they resolve the active account automatically. Per-account BYOK chosen so a work key never reaches a personal org.

## Security (hardened via an adversarial review pass)
Profile names become directory components, so `isValidProfileName` (rejects `""`/`.`/`..`/path separators) is enforced on **both**:
- **writes** — `account create/remove/switch` + the `--account` flag, and
- **reads** — the persisted `active` pointer and the index keys (a shared-box user could hand-edit `profiles.json`), plus `loadProfilesIndex` rejects an array-`profiles` and drops invalid keys/active.

So a tampered `active: "../evil"` falls back to `default` instead of driving a traversal. Tokens stay one-file-per-account at 0600; `profiles.json` is secret-free + 0600.

## Test plan
`typecheck` / `lint` / `build` ✓ · `cd apps/cli && bun test` → **97 pass / 0 fail** (new migration, traversal-guard, index-hardening, 0600-perms, byok-migration cases). Runtime smoke: legacy migration, `account list/show/set`, `--account` override, `show --account`, `--account` no-value error, and the tampered-pointer fallback all verified.

## Reviewed before push
6-lens adversarial security+correctness review; every medium/low finding fixed (read-side name validation, array-`profiles` trap, `--account` strip-all + require-value, wizard `--account` register/activate, `account show` override). Info/cosmetic notes left as-is.

## Risk
🟢 Low — additive, all under `apps/cli`. No server changes. The only behavior change for existing users is the one-time, no-logout migration into `profiles/default/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1