### PR TITLE
fix(cli): pass ripgrep `--no-follow` so grep can't read through symlinks

### DIFF
--- a/apps/cli/src/__tests__/code-search.test.ts
+++ b/apps/cli/src/__tests__/code-search.test.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { containedPath, extractKeywords, fileReadSearch } from "../lib/code-search";
+import { containedPath, extractKeywords, fileReadSearch, grepSearch } from "../lib/code-search";
 
 describe("containedPath (path-traversal guard, lexical)", () => {
   const root = "/tmp/repo";
@@ -33,6 +33,9 @@ describe("containedPath (symlink-escape guard)", () => {
     const secret = join(base, "secret");
     mkdirSync(secret);
     writeFileSync(join(secret, "id_rsa"), "TOPSECRET-KEY-MATERIAL");
+    // A searchable-extension file outside the repo, so grepSearch WOULD match it
+    // if a symlink were followed — gives the --no-follow / lstat-skip test teeth.
+    writeFileSync(join(secret, "out.ts"), "const x = 'LEAKTOKEN_8123';\n");
     writeFileSync(join(repo, "real.ts"), "const ok = true;\n");
     // An in-repo file symlink and dir symlink that point OUTSIDE the repo.
     symlinkSync(join(secret, "id_rsa"), join(repo, "leak")); // repo/leak -> ../secret/id_rsa
@@ -56,6 +59,16 @@ describe("containedPath (symlink-escape guard)", () => {
     const res = await fileReadSearch(["leak", "dirlink/id_rsa"], repo);
     expect(res.results).toHaveLength(0);
     expect(res.summary).not.toContain("TOPSECRET");
+  });
+
+  it("grepSearch does not match through an escaping symlink (rg --no-follow / node lstat-skip)", async () => {
+    // The out-of-repo file contains a unique token; a grep for it from inside the
+    // repo must NOT find it via the dirlink symlink, whether the backend is
+    // ripgrep (invoked with --no-follow) or the pure-Node walker (lstat-skip).
+    // A leak would surface as a hit + an "out.ts" header in the summary.
+    const res = await grepSearch("LEAKTOKEN_8123", repo);
+    expect(res.results).toHaveLength(0);
+    expect(res.summary).not.toContain("out.ts");
   });
 });
 

--- a/apps/cli/src/lib/code-search.ts
+++ b/apps/cli/src/lib/code-search.ts
@@ -148,6 +148,13 @@ async function ripgrep(pattern: string, dir: string, maxResults = 20): Promise<S
     const args = [
       "--no-heading",
       "--line-number",
+      // Never follow symlinks — the security boundary is "read only files
+      // physically inside the watched repo". This is ripgrep's DEFAULT, but we
+      // pass it explicitly so a user's $RIPGREP_CONFIG_PATH that enables
+      // `--follow` can't silently turn the grep path into an out-of-repo read
+      // (a CLI flag overrides config-file flags). Mirrors the pure-Node walker,
+      // which lstat-skips symlinks for the same reason.
+      "--no-follow",
       // Match literally (not as a regex), so behaviour matches the pure-Node
       // fallback (which escapeRegex()es the pattern) and a cloud-supplied
       // keyword with regex metacharacters can't silently fail or mis-match.


### PR DESCRIPTION
## What

Follow-up to #567. Pass `--no-follow` explicitly when invoking ripgrep in the code-search grep path.

## Why

The #567 review left one security checklist item open:

> `containedPath` grep path does not re-resolve symlinks — verify intent

The node-fallback walker (`lstat`-skip) and the `file-read` path (realpath-aware `containedPath`) are symlink-safe. The **ripgrep** grep path, however, relied on ripgrep's *default* no-follow behavior. A developer's `$RIPGREP_CONFIG_PATH` containing `--follow` would silently re-enable symlink following, so an in-repo symlink (`link -> /etc`) could leak out-of-repo file contents straight into the matched lines — `containedPath` only guards the context re-read, not ripgrep's own match output.

Passing `--no-follow` on the command line overrides any config-file flag, making the grep path's symlink containment independent of the environment. This matches the pure-Node walker's `lstat`-skip.

## Test plan

- New `grepSearch` regression test: a searchable-extension file placed **outside** the repo, reachable only through an in-repo directory symlink, must not be matched (verified with ripgrep 15.1.0 present — exercises the real rg path; also holds for the node fallback).
- `bun run typecheck` ✓ · `eslint` ✓ (0 errors) · `bun run build` ✓ · `bun test` ✓ **106 pass / 0 fail**.

## Risk

🟢 Low. Additive flag that makes ripgrep's existing default explicit; no behavior change for repos without out-of-tree symlinks or a `--follow` config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1