### PR TITLE
feat(telemetry): live-usage telemetry foundation (schema + entitlements + toggle)

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -16,6 +16,8 @@ import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
 import { canUserCreateOrg } from "@/lib/org-limits";
 import { MAX_OWNED_ORGS_PER_USER } from "@/lib/constants";
 import { encryptString } from "@/lib/crypto";
+import { writeAuditLog } from "@/lib/audit";
+import { canUseLiveTelemetry } from "@/lib/entitlements";
 
 export async function clearOrgCookie() {
   const cookieStore = await cookies();
@@ -857,6 +859,74 @@ export async function toggleReviewsPaused(
   });
 
   revalidatePath("/settings/reviews");
+  return { success: true };
+}
+
+/**
+ * Enable/disable live telemetry (real-time presence + activity) for the org.
+ * Owner/admin only. Paid-only: a free org cannot enable it (entitlement is
+ * re-checked server-side, never trusting the client). Audited under the
+ * "admin" category since it controls member-activity monitoring.
+ */
+export async function toggleLiveTelemetry(
+  _prevState: { error?: string; success?: boolean },
+  formData: FormData,
+): Promise<{ error?: string; success?: boolean }> {
+  const user = await getUser();
+  const reqHeaders = await headers();
+  const cookieStore = await cookies();
+  const orgId = cookieStore.get("current_org_id")?.value;
+
+  if (!orgId) return { error: "No organization selected." };
+
+  const member = await prisma.organizationMember.findFirst({
+    where: { organizationId: orgId, userId: user.id, deletedAt: null },
+    select: { role: true },
+  });
+
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return { error: "Only organization owners and admins can change live telemetry." };
+  }
+
+  const enabled = formData.get("enabled") === "true";
+
+  // Force-off for unpaid orgs: a free org may never enable telemetry, even if a
+  // crafted form tries to. (Disabling is always allowed.)
+  if (enabled && !(await canUseLiveTelemetry(orgId))) {
+    return { error: "Live telemetry is a paid feature. Upgrade your plan to enable it." };
+  }
+
+  const orgBefore = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { liveTelemetryEnabled: true },
+  });
+
+  // No-op if unchanged — don't write a misleading audit entry.
+  if (orgBefore && orgBefore.liveTelemetryEnabled === enabled) {
+    return { success: true };
+  }
+
+  await prisma.organization.update({
+    where: { id: orgId },
+    data: { liveTelemetryEnabled: enabled },
+  });
+
+  await writeAuditLog({
+    action: enabled ? "telemetry.enabled" : "telemetry.disabled",
+    category: "admin",
+    actorId: user.id,
+    actorEmail: user.email,
+    targetType: "organization",
+    targetId: orgId,
+    organizationId: orgId,
+    metadata: {
+      liveTelemetryEnabled: { old: orgBefore?.liveTelemetryEnabled ?? false, new: enabled },
+    },
+    ipAddress: reqHeaders.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null,
+    userAgent: reqHeaders.get("user-agent") ?? null,
+  });
+
+  revalidatePath("/settings/telemetry");
   return { success: true };
 }
 

--- a/apps/web/app/(app)/settings/settings-nav.tsx
+++ b/apps/web/app/(app)/settings/settings-nav.tsx
@@ -17,6 +17,7 @@ import {
   IconDevices,
   IconArrowUp,
   IconHistory,
+  IconActivity,
 } from "@tabler/icons-react";
 
 // Self-hosted-only nav items are filtered out at render time when
@@ -33,6 +34,7 @@ const sections = [
       { href: "/settings/billing", label: "Billing", icon: IconCreditCard },
       { href: "/settings/notifications", label: "Notifications", icon: IconBell },
       { href: "/settings/audit-log", label: "Audit Log", icon: IconHistory },
+      { href: "/settings/telemetry", label: "Live Activity", icon: IconActivity },
     ],
   },
   {

--- a/apps/web/app/(app)/settings/telemetry/live-telemetry-switch.tsx
+++ b/apps/web/app/(app)/settings/telemetry/live-telemetry-switch.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useActionState, useRef } from "react";
+import Link from "@/components/link";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { toggleLiveTelemetry } from "../../actions";
+
+export function LiveTelemetrySwitch({
+  canManage,
+  enabled,
+  paid,
+}: {
+  canManage: boolean;
+  enabled: boolean;
+  paid: boolean;
+}) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const [state, formAction, pending] = useActionState(toggleLiveTelemetry, {});
+
+  // Unpaid orgs can never enable it; the control is locked with an upsell.
+  const switchDisabled = !paid || !canManage || pending;
+  const checked = paid && enabled;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Live Activity</CardTitle>
+        <CardDescription>
+          When enabled, your organization&apos;s admins can see a real-time view
+          of which members and agents are connected and what they&apos;re doing.
+          Members are shown a notice and can opt out of being tracked. Only
+          coarse activity (e.g. which area of the app) is recorded — never file
+          contents, PR titles, or message text.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form ref={formRef} action={formAction}>
+          <input type="hidden" name="enabled" value={checked ? "false" : "true"} />
+          <div className="flex items-center justify-between">
+            <Label htmlFor="live-telemetry" className="flex flex-col gap-1">
+              <span className="font-medium">
+                {checked ? "Live activity is on" : "Live activity is off"}
+              </span>
+              <span className="text-xs text-muted-foreground font-normal">
+                {checked
+                  ? "Presence and activity are being collected for this organization."
+                  : "No presence or activity is collected."}
+              </span>
+            </Label>
+            <Switch
+              id="live-telemetry"
+              checked={checked}
+              disabled={switchDisabled}
+              onCheckedChange={() => formRef.current?.requestSubmit()}
+            />
+          </div>
+
+          {state.error && (
+            <p className="text-sm text-destructive mt-3">{state.error}</p>
+          )}
+
+          {!paid && (
+            <p className="text-muted-foreground text-xs mt-3">
+              Live activity is a paid feature.{" "}
+              <Link href="/settings/billing" className="underline hover:text-foreground">
+                Upgrade your plan
+              </Link>{" "}
+              to enable it.
+            </p>
+          )}
+
+          {paid && !canManage && (
+            <p className="text-muted-foreground text-xs mt-3">
+              Only organization owners and admins can change this setting.
+            </p>
+          )}
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/(app)/settings/telemetry/page.tsx
+++ b/apps/web/app/(app)/settings/telemetry/page.tsx
@@ -1,0 +1,48 @@
+import { headers, cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { canUseLiveTelemetry } from "@/lib/entitlements";
+import { LiveTelemetrySwitch } from "./live-telemetry-switch";
+
+export default async function TelemetrySettingsPage() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+  if (!session) redirect("/login");
+
+  const cookieStore = await cookies();
+  const currentOrgId = cookieStore.get("current_org_id")?.value;
+
+  const member = await prisma.organizationMember.findFirst({
+    where: {
+      userId: session.user.id,
+      ...(currentOrgId ? { organizationId: currentOrgId } : {}),
+      deletedAt: null,
+    },
+    select: {
+      role: true,
+      organization: {
+        select: {
+          id: true,
+          liveTelemetryEnabled: true,
+        },
+      },
+    },
+  });
+
+  if (!member) redirect("/dashboard");
+
+  const canManage = member.role === "owner" || member.role === "admin";
+  const paid = await canUseLiveTelemetry(member.organization.id);
+
+  return (
+    <div key={member.organization.id} className="space-y-6">
+      <LiveTelemetrySwitch
+        canManage={canManage}
+        enabled={member.organization.liveTelemetryEnabled}
+        paid={paid}
+      />
+    </div>
+  );
+}

--- a/apps/web/lib/entitlements.ts
+++ b/apps/web/lib/entitlements.ts
@@ -1,0 +1,135 @@
+import { prisma } from "@octopus/db";
+import { ORG_TYPE } from "@/lib/org-types";
+
+/**
+ * Feature entitlements for paid-only features (currently: live telemetry).
+ *
+ * There is no subscription/plan model — billing is credit-based (one-time
+ * Stripe top-ups). "Paid" is therefore defined monotonically so it can't
+ * flicker as credits are spent, and so it doesn't wrongly lock the feature
+ * for legitimate non-credit payers. An org is paid when ANY of:
+ *   1. self-hosted install (no billing path at all);
+ *   2. FRIENDLY org type (comped / relationship tier);
+ *   3. BYOK — the org runs on its own provider key(s);
+ *   4. it has ever made a real purchase (purchase / auto_reload txn).
+ *
+ * COMMUNITY orgs are intentionally excluded — that tier is rate-limited, not
+ * credit-based, and live telemetry is a paid perk.
+ *
+ * Mirrors the spirit of lib/cost.ts:getOrgSpendLimitStatus but is purchase-
+ * history based rather than current-balance based.
+ */
+
+const IS_SELF_HOSTED = process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true";
+
+/** CreditTransaction.type values that represent a real (paid) purchase. */
+const PURCHASE_TXN_TYPES = ["purchase", "auto_reload"];
+
+/** True when the deployment is a self-hosted install (no billing path). */
+export function isSelfHosted(): boolean {
+  return IS_SELF_HOSTED;
+}
+
+type ProviderKeyFields = {
+  anthropicApiKey: string | null;
+  openaiApiKey: string | null;
+  googleApiKey: string | null;
+  cohereApiKey: string | null;
+  grokApiKey: string | null;
+  openrouterApiKey: string | null;
+  claudeCodeApiKey: string | null;
+};
+
+function hasOwnProviderKey(org: ProviderKeyFields): boolean {
+  return Boolean(
+    org.anthropicApiKey ||
+      org.openaiApiKey ||
+      org.googleApiKey ||
+      org.cohereApiKey ||
+      org.grokApiKey ||
+      org.openrouterApiKey ||
+      org.claudeCodeApiKey,
+  );
+}
+
+export type OrgEntitlements = {
+  /** Entitled to paid-only features. */
+  paid: boolean;
+  /** Live telemetry is entitled AND the org owner has enabled it. */
+  liveTelemetryActive: boolean;
+  /** Org has opted in to letting vendor staff see member-level detail. */
+  allowVendorMemberVisibility: boolean;
+};
+
+/**
+ * Resolve all telemetry-relevant entitlements for an org in as few queries as
+ * possible. Returns conservative defaults (everything false) for a missing org.
+ */
+export async function getOrgEntitlements(orgId: string): Promise<OrgEntitlements> {
+  if (IS_SELF_HOSTED) {
+    // Self-hosted: always entitled; the only thing that matters is whether the
+    // owner enabled it. Still respects the vendor-visibility opt-in (unused on
+    // self-host, where there is no vendor console — but kept consistent).
+    const org = await prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { liveTelemetryEnabled: true, allowVendorMemberVisibility: true },
+    });
+    return {
+      paid: true,
+      liveTelemetryActive: Boolean(org?.liveTelemetryEnabled),
+      allowVendorMemberVisibility: Boolean(org?.allowVendorMemberVisibility),
+    };
+  }
+
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: {
+      type: true,
+      anthropicApiKey: true,
+      openaiApiKey: true,
+      googleApiKey: true,
+      cohereApiKey: true,
+      grokApiKey: true,
+      openrouterApiKey: true,
+      claudeCodeApiKey: true,
+      liveTelemetryEnabled: true,
+      allowVendorMemberVisibility: true,
+    },
+  });
+  if (!org) {
+    return { paid: false, liveTelemetryActive: false, allowVendorMemberVisibility: false };
+  }
+
+  let paid = org.type === ORG_TYPE.FRIENDLY || hasOwnProviderKey(org);
+  if (!paid) {
+    const purchase = await prisma.creditTransaction.findFirst({
+      where: { organizationId: orgId, type: { in: PURCHASE_TXN_TYPES } },
+      select: { id: true },
+    });
+    paid = purchase !== null;
+  }
+
+  return {
+    paid,
+    liveTelemetryActive: paid && Boolean(org.liveTelemetryEnabled),
+    allowVendorMemberVisibility: Boolean(org.allowVendorMemberVisibility),
+  };
+}
+
+/** Whether an org is entitled to paid-only features. */
+export async function isOrgPaid(orgId: string): Promise<boolean> {
+  return (await getOrgEntitlements(orgId)).paid;
+}
+
+/** Whether an org may use the live-telemetry feature (entitlement only — does
+ *  NOT require the toggle to be on). Use to decide whether to show the feature
+ *  vs. an upgrade upsell. */
+export async function canUseLiveTelemetry(orgId: string): Promise<boolean> {
+  return isOrgPaid(orgId);
+}
+
+/** Whether live telemetry is actively collecting for this org: entitled AND
+ *  enabled by the owner. Use to gate collection, broadcast, and subscription. */
+export async function liveTelemetryActive(orgId: string): Promise<boolean> {
+  return (await getOrgEntitlements(orgId)).liveTelemetryActive;
+}

--- a/packages/db/prisma/migrations/20260630120000_add_live_telemetry/migration.sql
+++ b/packages/db/prisma/migrations/20260630120000_add_live_telemetry/migration.sql
@@ -1,0 +1,52 @@
+-- AlterTable
+ALTER TABLE "organizations" ADD COLUMN     "allowVendorMemberVisibility" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "liveTelemetryEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "user_presences" (
+    "id" TEXT NOT NULL,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL,
+    "currentActivity" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+
+    CONSTRAINT "user_presences_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "activity_events" (
+    "id" TEXT NOT NULL,
+    "actorType" TEXT NOT NULL,
+    "actorId" TEXT,
+    "actorLabel" TEXT,
+    "action" TEXT NOT NULL,
+    "target" TEXT,
+    "metadata" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "organizationId" TEXT NOT NULL,
+
+    CONSTRAINT "activity_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_presences_organizationId_lastSeenAt_idx" ON "user_presences"("organizationId", "lastSeenAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_presences_userId_organizationId_key" ON "user_presences"("userId", "organizationId");
+
+-- CreateIndex
+CREATE INDEX "activity_events_organizationId_createdAt_idx" ON "activity_events"("organizationId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "activity_events_createdAt_idx" ON "activity_events"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "user_presences" ADD CONSTRAINT "user_presences_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_presences" ADD CONSTRAINT "user_presences_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "activity_events" ADD CONSTRAINT "activity_events_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   packageAnalyses       PackageAnalysis[]
   safePackageRequests   SafePackageRequest[]
   packageDeepDives      PackageDeepDive[]
+  presences             UserPresence[]
 
   @@map("users")
 }
@@ -118,6 +119,13 @@ model Organization {
   monthlySpendLimitUsd    Float?
   checkFailureThreshold   String   @default("critical") // "critical" | "high" | "medium" | "none"
   reviewsPaused           Boolean  @default(false)
+  // Live telemetry (real-time presence + activity). Opt-in, paid-only.
+  // liveTelemetryEnabled: org owner surfaces members'/agents' live presence +
+  // activity to the org's own admins. allowVendorMemberVisibility: a SEPARATE
+  // opt-in letting Octopus staff see member-level detail in the vendor console
+  // (otherwise that console sees org-level aggregates only).
+  liveTelemetryEnabled        Boolean  @default(false)
+  allowVendorMemberVisibility Boolean  @default(false)
   blockedAuthors          Json     @default("[]") // string[] of PR author usernames to skip review
   defaultReviewConfig     Json     @default("{}")
   reviewLanguage          String   @default("en") // BCP-47 code; review prose output language
@@ -163,6 +171,8 @@ model Organization {
   safePackageRequests   SafePackageRequest[]
   packageDeepDives      PackageDeepDive[]
   couponRedemptions     CouponRedemption[]
+  userPresences         UserPresence[]
+  activityEvents        ActivityEvent[]
 
   @@map("organizations")
 }
@@ -1126,6 +1136,49 @@ model AuditLog {
   @@index([action, createdAt])
   @@index([createdAt])
   @@map("audit_logs")
+}
+
+// ── Live Telemetry (real-time presence + activity) ───────────────────────────
+// Powers the per-org live-activity dashboard and the vendor cross-org console.
+// Collection is gated on a paid org with liveTelemetryEnabled (+ per-user
+// opt-out); see lib/entitlements.ts. Both tables cascade-delete with the org
+// (hard delete); soft-delete + member-removal purge is handled explicitly in
+// the deletion flows.
+
+model UserPresence {
+  id              String   @id @default(cuid())
+  lastSeenAt      DateTime // last heartbeat; "online" := lastSeenAt >= now - PRESENCE_STALE_MS
+  currentActivity String?  // COARSE route category only (e.g. "Repositories") — never URLs/content
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  userId         String
+  user           User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, organizationId])
+  @@index([organizationId, lastSeenAt])
+  @@map("user_presences")
+}
+
+model ActivityEvent {
+  id         String   @id @default(cuid())
+  actorType  String   // "user" | "agent" | "system"
+  actorId    String?  // userId or agentId (null for system); denormalized like AuditLog.actorId
+  actorLabel String?  // denormalized display name (coarse)
+  action     String   // e.g. "review.completed", "repo.indexed", "chat.message"
+  target     String?  // COARSE target label only (repo display name) — never PR titles/URLs/file names
+  metadata   Json     @default("{}")
+  createdAt  DateTime @default(now())
+
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId, createdAt])
+  @@index([createdAt])
+  @@map("activity_events")
 }
 
 // ── Organization Type History ────────────────────────────────────────────────


### PR DESCRIPTION
## What

**PR A of 4** for a live "who's connected / what they're doing" feature. This slice is the **foundation only** — data model, a paid-entitlement helper, and an owner/admin org toggle. **No behavior change to existing flows, and no telemetry is collected yet** (capture = PR B, per-org dashboard = PR C, vendor console = PR D).

## Changes

**Schema + migration**
- `Organization.liveTelemetryEnabled` and `allowVendorMemberVisibility` — `Boolean @default(false)`. The second is a *separate* opt-in (PR D) for letting vendor staff see member-level detail; otherwise the vendor console only ever sees org-level aggregates.
- New `UserPresence` (heartbeat presence) and `ActivityEvent` (activity feed) models — cascade FKs to org/user, snake_case `@@map`, indexes. `ActivityEvent.actorId` is denormalized (spans user/agent/system) exactly like `AuditLog.actorId`.
- Migration is **Prisma-generated** (`migrate diff` of `master`'s schema → new schema), validated by applying it to a throwaway DB seeded at the prior schema (clean apply, zero drift).

**Entitlements (`lib/entitlements.ts`)**
- `isOrgPaid` is **purchase-history based (monotonic)** so it can't flicker as credits drain and doesn't wrongly lock legitimate non-credit payers. Paid := self-hosted **OR** `FRIENDLY` org type **OR** any BYOK provider key set **OR** a real purchase (`CreditTransaction` type `purchase`/`auto_reload`). `COMMUNITY` is excluded (rate-limited tier, not credit-based) — consistent with `lib/cost.ts`.
- **Self-hosted installs are always entitled** (no billing path) via `NEXT_PUBLIC_OCTOPUS_SELF_HOSTED`. Using a balance-based `creditBalance > 0` check would have permanently locked the feature on every self-hosted install — deliberately avoided.

**Toggle (`toggleLiveTelemetry` + `settings/telemetry`)**
- Owner/admin only (mirrors `toggleReviewsPaused`); the entitlement is **re-checked server-side** so a free org can never enable it via a crafted request (disabling is always allowed).
- **Audited** under the `admin` category (enable/disable, old→new, ip/ua).
- Paid-gated UI: free orgs see a locked upgrade prompt; the description states members get a notice and can opt out (PR C), and that only coarse activity is recorded.

## Notes for review (pre-emptions)
- **Migration is `git add -f`'d** — `packages/db/prisma/migrations/` is gitignored; every prior feature migration (e.g. the Ollama one) is force-added the same way. Confirmed tracked.
- `liveTelemetryActive` / `isSelfHosted` are **exported for PRs B–D** and intentionally unused in this slice; `getOrgEntitlements`/`isOrgPaid` are reached via `canUseLiveTelemetry`.
- The `/settings/telemetry` toggle is **inert until PR B/C** (nothing reads the flag at runtime yet) — shipped now so the foundation reviews independently.
- Privacy: the model only ever stores **coarse** data (route category, repo display name) — never file contents, PR titles, or message text; enforced in PR B's capture allowlist + a leak test.

## Test plan
- `bun run typecheck` ✓ (3/3) · `eslint` ✓ (0 errors) · `bun run build` ✓ (`/settings/telemetry` route registered)
- Migration applied to a throwaway Postgres seeded at `master`'s schema → clean apply; columns/tables/FKs/indexes verified; `migrate diff` shows zero drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1