### PR TITLE
feat(telemetry): capture live presence + activity (PR B)

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -18,6 +18,7 @@ import { MAX_OWNED_ORGS_PER_USER } from "@/lib/constants";
 import { encryptString } from "@/lib/crypto";
 import { writeAuditLog } from "@/lib/audit";
 import { canUseLiveTelemetry } from "@/lib/entitlements";
+import { getClientIp } from "@/lib/request-ip";
 
 export async function clearOrgCookie() {
   const cookieStore = await cookies();
@@ -922,7 +923,7 @@ export async function toggleLiveTelemetry(
     metadata: {
       liveTelemetryEnabled: { old: orgBefore?.liveTelemetryEnabled ?? false, new: enabled },
     },
-    ipAddress: reqHeaders.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null,
+    ipAddress: getClientIp(reqHeaders),
     userAgent: reqHeaders.get("user-agent") ?? null,
   });
 

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -11,6 +11,7 @@ import { getOrgSpendLimitStatus } from "@/lib/cost";
 import { canUserCreateOrg } from "@/lib/org-limits";
 import { OrgCookieSync } from "@/components/org-cookie-sync";
 import { DeviceReporter } from "@/components/device-reporter";
+import { PresenceReporter } from "@/components/presence-reporter";
 import { createOrgForUser } from "@/lib/org-create";
 
 /**
@@ -185,6 +186,7 @@ export default async function AppLayout({
     <ChatWrapper orgId={currentOrg.id} userId={session.user.id} userName={session.user.name}>
       <OrgCookieSync orgId={currentOrg.id} />
       <DeviceReporter />
+      <PresenceReporter orgId={currentOrg.id} />
       <div className="flex h-screen flex-col">
         {orgsNeedingPermission.length > 0 && (
           <PermissionBanner

--- a/apps/web/app/api/presence/heartbeat/route.ts
+++ b/apps/web/app/api/presence/heartbeat/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { headers, cookies } from "next/headers";
+import { prisma } from "@octopus/db";
+import { auth } from "@/lib/auth";
+import { liveTelemetryActive } from "@/lib/entitlements";
+import { recordPresence } from "@/lib/presence";
+import { isValidActivity } from "@/lib/activity-category";
+
+/**
+ * POST /api/presence/heartbeat — the web client pings this every ~30s to record
+ * the member's live presence + coarse current activity. Session-authenticated;
+ * the org comes from the current_org_id cookie and is RE-VALIDATED against
+ * membership (the cookie is never trusted as proof). Collection is gated on the
+ * org being entitled + having live telemetry enabled — when it isn't, we return
+ * { telemetry: false } so the client stops heartbeating.
+ */
+export async function POST(request: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const cookieStore = await cookies();
+  const orgId = cookieStore.get("current_org_id")?.value;
+  if (!orgId) {
+    return NextResponse.json({ ok: true, telemetry: false });
+  }
+
+  // Re-validate membership server-side — never trust the cookie alone.
+  const membership = await prisma.organizationMember.findFirst({
+    where: { organizationId: orgId, userId: session.user.id, deletedAt: null },
+    select: { id: true },
+  });
+  if (!membership) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Gate collection on entitlement + the org toggle. Tell the client to stop
+  // when inactive so a free/disabled org doesn't keep heartbeating.
+  if (!(await liveTelemetryActive(orgId))) {
+    return NextResponse.json({ ok: true, telemetry: false });
+  }
+
+  const body = (await request.json().catch(() => null)) as { activity?: unknown } | null;
+  // Only accept a known coarse category from the client — anything else is
+  // dropped to null so a crafted body can't store arbitrary text.
+  const activity = isValidActivity(body?.activity) ? body.activity : null;
+
+  await recordPresence(orgId, session.user.id, activity);
+
+  return NextResponse.json({ ok: true, telemetry: true });
+}

--- a/apps/web/app/api/pubby/auth/route.ts
+++ b/apps/web/app/api/pubby/auth/route.ts
@@ -3,6 +3,7 @@ import { pubby } from "@/lib/pubby";
 import { authenticateApiToken } from "@/lib/api-auth";
 import { prisma } from "@octopus/db";
 import { headers } from "next/headers";
+import { liveTelemetryActive } from "@/lib/entitlements";
 
 export async function POST(req: Request) {
   // Clone request body since we may need to read it in both auth paths
@@ -98,6 +99,28 @@ export async function POST(req: Request) {
 
     // Deny unrecognized presence channel patterns
     return new Response("Channel not allowed", { status: 403 });
+  }
+
+  // private-telemetry-org-{orgId}: the owner/admin-only live-activity channel.
+  // This is a PRIVATE (not presence) channel so member identities aren't
+  // broadcast in a roster. Owner/admin-only AND only when live telemetry is
+  // actually active for the org (entitled + enabled) — a free org can't even
+  // subscribe.
+  const telemetryMatch = channel_name.match(/^private-telemetry-org-(.+)$/);
+  if (telemetryMatch) {
+    const orgId = telemetryMatch[1];
+    const membership = await prisma.organizationMember.findFirst({
+      where: { organizationId: orgId, userId: session.user.id, deletedAt: null },
+      select: { role: true },
+    });
+    if (!membership || (membership.role !== "owner" && membership.role !== "admin")) {
+      return new Response("Channel not allowed", { status: 403 });
+    }
+    if (!(await liveTelemetryActive(orgId))) {
+      return new Response("Live telemetry not active", { status: 403 });
+    }
+    const authResponse = pubby.authenticatePrivateChannel(socket_id, channel_name);
+    return Response.json(authResponse);
   }
 
   // Deny all other channels for session users

--- a/apps/web/components/presence-reporter.tsx
+++ b/apps/web/components/presence-reporter.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import { categorizePath } from "@/lib/activity-category";
+
+const HEARTBEAT_MS = 30_000;
+
+/**
+ * Mounted once in the authenticated app layout. Pings /api/presence/heartbeat
+ * every ~30s with the COARSE current area (route category only). The server
+ * gates collection; if it reports telemetry inactive (free/disabled org), this
+ * stops heartbeating for the session. Renders nothing.
+ */
+export function PresenceReporter({ orgId }: { orgId: string }) {
+  const pathname = usePathname();
+  const pathnameRef = useRef(pathname);
+
+  // Keep the ref current without touching it during render (the interval reads
+  // the latest path at beat time without restarting on every navigation).
+  useEffect(() => {
+    pathnameRef.current = pathname;
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!orgId) return;
+    let stopped = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const beat = async () => {
+      if (stopped) return;
+      try {
+        const res = await fetch("/api/presence/heartbeat", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ activity: categorizePath(pathnameRef.current) }),
+          keepalive: true,
+        });
+        // Auth-terminal: session expired or membership revoked — stop polling
+        // for the life of the tab rather than hammering an endpoint that will
+        // never succeed. (5xx is transient → keep retrying on the next tick.)
+        if (res.status === 401 || res.status === 403) {
+          stopped = true;
+          if (timer) clearInterval(timer);
+          return;
+        }
+        if (res.ok) {
+          const data = (await res.json().catch(() => null)) as { telemetry?: boolean } | null;
+          if (data && data.telemetry === false) {
+            stopped = true;
+            if (timer) clearInterval(timer);
+          }
+        }
+      } catch {
+        // Network blip — retry on the next tick.
+      }
+    };
+
+    void beat();
+    timer = setInterval(() => void beat(), HEARTBEAT_MS);
+    return () => {
+      if (timer) clearInterval(timer);
+    };
+  }, [orgId]);
+
+  return null;
+}

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -36,6 +36,11 @@ export async function register() {
       // schedule across instances; the worker in queue-workers.ts runs the
       // deletion. Self-hosters tune the window via AUDIT_LOG_RETENTION_DAYS.
       await boss.schedule("enforce-audit-retention", "0 3 * * *");
+
+      // Daily ActivityEvent (live-telemetry) retention (04:00 UTC — offset from
+      // the audit job to avoid simultaneous deleteMany load). Window tunable via
+      // ACTIVITY_RETENTION_DAYS (default 30).
+      await boss.schedule("enforce-activity-retention", "0 4 * * *");
     }
 
     // Graceful shutdown: wait for active jobs (e.g. in-progress reviews) to finish

--- a/apps/web/lib/__tests__/activity-projection.test.ts
+++ b/apps/web/lib/__tests__/activity-projection.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "bun:test";
+import { projectActivity } from "../activity";
+
+describe("projectActivity — privacy allowlist", () => {
+  it("never leaks PR title / URL from a review event", () => {
+    const p = projectActivity({
+      type: "review-completed",
+      orgId: "o1",
+      prNumber: 42,
+      prTitle: "SECRET_TITLE_should_not_leak",
+      prUrl: "https://secret.example/pulls/42",
+      findingsCount: 3,
+      filesChanged: 7,
+    });
+    expect(p).not.toBeNull();
+    const dump = JSON.stringify(p);
+    expect(dump).not.toContain("SECRET_TITLE_should_not_leak");
+    expect(dump).not.toContain("secret.example");
+    expect(p!.action).toBe("review.completed");
+    expect(p!.target).toBe("PR #42");
+    expect(p!.actorType).toBe("system");
+    expect(p!.metadata).toEqual({ prNumber: 42, findingsCount: 3, filesChanged: 7 });
+  });
+
+  it("never leaks the prTitle on review-requested / review-failed", () => {
+    const req = projectActivity({
+      type: "review-requested",
+      orgId: "o1",
+      prNumber: 9,
+      prTitle: "LEAKY_TITLE",
+      prAuthor: "alice",
+      prUrl: "https://x/9",
+    });
+    const fail = projectActivity({
+      type: "review-failed",
+      orgId: "o1",
+      prNumber: 9,
+      prTitle: "LEAKY_TITLE",
+      error: "boom at /Users/secret/path.ts",
+    });
+    expect(JSON.stringify(req)).not.toContain("LEAKY_TITLE");
+    expect(JSON.stringify(req)).not.toContain("alice");
+    expect(JSON.stringify(fail)).not.toContain("LEAKY_TITLE");
+    expect(JSON.stringify(fail)).not.toContain("/Users/secret");
+  });
+
+  it("never leaks knowledge document titles", () => {
+    const p = projectActivity({
+      type: "knowledge-ready",
+      orgId: "o1",
+      documentTitle: "SECRET_DOC_NAME",
+      action: "created",
+      totalChunks: 5,
+      totalVectors: 50,
+    });
+    expect(JSON.stringify(p)).not.toContain("SECRET_DOC_NAME");
+    expect(p!.action).toBe("knowledge.created");
+    expect(p!.target).toBeNull();
+  });
+
+  it("includes the org's own repo name for repo / community events", () => {
+    const indexed = projectActivity({
+      type: "repo-indexed",
+      orgId: "o1",
+      repoFullName: "acme/widgets",
+      success: true,
+      indexedFiles: 10,
+    });
+    expect(indexed!.action).toBe("repo.indexed");
+    expect(indexed!.target).toBe("acme/widgets");
+
+    const community = projectActivity({
+      type: "community-review",
+      orgId: "o1",
+      repoFullName: "acme/oss",
+      prNumber: 3,
+      findingsCount: 1,
+    });
+    expect(community!.target).toBe("acme/oss");
+  });
+
+  it("drops billing and admin events from the feed", () => {
+    expect(
+      projectActivity({ type: "credit-low", orgId: "o1", remainingBalance: 1 }),
+    ).toBeNull();
+    expect(
+      projectActivity({
+        type: "org-type-changed",
+        orgId: "o1",
+        orgName: "Acme",
+        fromType: 1,
+        toType: 3,
+        changedById: "u1",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/lib/activity-category.ts
+++ b/apps/web/lib/activity-category.ts
@@ -1,0 +1,56 @@
+/**
+ * Coarse activity categories for live presence. This module is intentionally
+ * dependency-free so BOTH the client reporter and the server ingest route can
+ * import it. Presence only ever records WHICH AREA of the app a member is in —
+ * never the full path, query string, ids, or any resource name — so no
+ * sensitive data (repo names, PR titles, doc titles) can leak via presence.
+ */
+
+export const ACTIVITY_CATEGORIES = [
+  "Dashboard",
+  "Repositories",
+  "Reviews",
+  "Chat",
+  "Knowledge",
+  "Usage",
+  "Settings",
+  "Other",
+] as const;
+
+export type ActivityCategory = (typeof ACTIVITY_CATEGORIES)[number];
+
+const CATEGORY_SET = new Set<string>(ACTIVITY_CATEGORIES);
+
+/** Server-side guard: only accept a known coarse category from the client. */
+export function isValidActivity(value: unknown): value is ActivityCategory {
+  return typeof value === "string" && CATEGORY_SET.has(value);
+}
+
+/**
+ * Map a pathname to a coarse category using ONLY its first path segment —
+ * deeper segments (ids, repo names, query strings) are deliberately ignored.
+ */
+export function categorizePath(pathname: string): ActivityCategory {
+  const seg = pathname.split("/").filter(Boolean)[0]?.toLowerCase() ?? "";
+  switch (seg) {
+    case "":
+    case "dashboard":
+      return "Dashboard";
+    case "repositories":
+    case "repos":
+      return "Repositories";
+    case "reviews":
+    case "review":
+      return "Reviews";
+    case "chat":
+      return "Chat";
+    case "knowledge":
+      return "Knowledge";
+    case "usage":
+      return "Usage";
+    case "settings":
+      return "Settings";
+    default:
+      return "Other";
+  }
+}

--- a/apps/web/lib/activity.ts
+++ b/apps/web/lib/activity.ts
@@ -1,0 +1,69 @@
+import type { AppEvent } from "@/lib/events/types";
+
+/**
+ * Privacy-safe projection of internal AppEvents into the live activity feed.
+ *
+ * ALLOWLIST BY CONSTRUCTION: each case copies ONLY the explicitly named fields.
+ * Free-text content that could carry anything sensitive — PR titles, PR URLs,
+ * knowledge document titles, file paths, message bodies — is NEVER included.
+ * A repository's full name IS included as the target for repo/community events:
+ * it is the org's own resource and the feed is shown to that org's own admins.
+ *
+ * Returns null for events that are not surfaced in the activity feed (billing
+ * alerts, admin/type changes). A leak test asserts no sensitive field escapes.
+ */
+
+export type ActorType = "user" | "agent" | "system";
+
+export type ProjectedActivity = {
+  action: string;
+  target: string | null;
+  actorType: ActorType;
+  actorId: string | null;
+  actorLabel: string | null;
+  metadata: Record<string, unknown>;
+};
+
+function system(
+  action: string,
+  target: string | null,
+  metadata: Record<string, unknown>,
+): ProjectedActivity {
+  return { action, target, actorType: "system", actorId: null, actorLabel: null, metadata };
+}
+
+export function projectActivity(event: AppEvent): ProjectedActivity | null {
+  switch (event.type) {
+    case "repo-indexed":
+      return event.success
+        ? system("repo.indexed", event.repoFullName, { indexedFiles: event.indexedFiles ?? null })
+        : system("repo.index_failed", event.repoFullName, {});
+    case "repo-analyzed":
+      return system("repo.analyzed", event.repoFullName, {});
+    case "review-requested":
+      // target is the PR NUMBER only — never prTitle/prUrl/prAuthor.
+      return system("review.requested", `PR #${event.prNumber}`, { prNumber: event.prNumber });
+    case "review-completed":
+      return system("review.completed", `PR #${event.prNumber}`, {
+        prNumber: event.prNumber,
+        findingsCount: event.findingsCount,
+        filesChanged: event.filesChanged,
+      });
+    case "review-failed":
+      return system("review.failed", `PR #${event.prNumber}`, { prNumber: event.prNumber });
+    case "knowledge-ready":
+      // documentTitle is sensitive → excluded entirely; no target.
+      return system(`knowledge.${event.action}`, null, { totalChunks: event.totalChunks });
+    case "community-review":
+      return system("community-review", event.repoFullName, {
+        prNumber: event.prNumber ?? null,
+        findingsCount: event.findingsCount,
+      });
+    // Not surfaced in the activity feed:
+    case "credit-low": // billing alert
+    case "org-type-changed": // admin/audit concern
+      return null;
+    default:
+      return null;
+  }
+}

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -62,6 +62,37 @@ export async function enforceAuditLogRetention(retentionDays?: number): Promise<
   return count;
 }
 
+/**
+ * Default retention window for ActivityEvent rows (the live-telemetry feed).
+ * Much shorter than the audit log (365d) — this is high-volume, identified
+ * member activity, kept only long enough to back the live feed. Overridable
+ * via ACTIVITY_RETENTION_DAYS.
+ */
+export const ACTIVITY_EVENT_DEFAULT_RETENTION_DAYS = 30;
+
+/**
+ * Delete ActivityEvent rows older than the configured retention window.
+ * Idempotent — only rows past the cutoff are removed. Returns the deleted count.
+ * Scheduled daily (see queue-workers.ts + the boss.schedule in instrumentation.ts).
+ */
+export async function enforceActivityEventRetention(retentionDays?: number): Promise<number> {
+  const envOverride = process.env.ACTIVITY_RETENTION_DAYS;
+  const days =
+    retentionDays ?? (envOverride ? parseInt(envOverride, 10) : ACTIVITY_EVENT_DEFAULT_RETENTION_DAYS);
+  if (!Number.isFinite(days) || days <= 0) {
+    console.warn(`[activity] enforceActivityEventRetention: invalid days=${days}, skipping`);
+    return 0;
+  }
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  const { count } = await prisma.activityEvent.deleteMany({
+    where: { createdAt: { lt: cutoff } },
+  });
+  if (count > 0) {
+    console.log(`[activity] enforceActivityEventRetention: deleted ${count} rows older than ${days} days`);
+  }
+  return count;
+}
+
 export type AuditCategory =
   | "auth"
   | "email"

--- a/apps/web/lib/events/observers/activity.observer.ts
+++ b/apps/web/lib/events/observers/activity.observer.ts
@@ -1,0 +1,83 @@
+import { prisma, type Prisma } from "@octopus/db";
+import { pubby, PUBBY_ENABLED } from "@/lib/pubby";
+import { liveTelemetryActive } from "@/lib/entitlements";
+import { projectActivity } from "@/lib/activity";
+import { eventBus } from "../bus";
+import type {
+  AppEvent,
+  RepoIndexedEvent,
+  RepoAnalyzedEvent,
+  ReviewRequestedEvent,
+  ReviewCompletedEvent,
+  ReviewFailedEvent,
+  KnowledgeReadyEvent,
+  CommunityReviewEvent,
+} from "../types";
+
+/**
+ * Bridges internal AppEvents into the live activity feed: writes a privacy-safe
+ * ActivityEvent row (always, for durable history + polling reconcile) and pushes
+ * a throttled real-time event to the org's admin-only telemetry channel.
+ *
+ * The throttle is PER-ORG (the stats observer uses one global window). Every
+ * event is still persisted; only the external Pubby fan-out is rate-limited, so
+ * a dropped best-effort push self-heals when the dashboard polls the DB.
+ */
+
+const THROTTLE_MS = 5_000;
+const lastBroadcast = new Map<string, number>();
+
+const telemetryChannel = (orgId: string) => `private-telemetry-org-${orgId}`;
+
+async function handle(event: AppEvent): Promise<void> {
+  const orgId = (event as { orgId?: string }).orgId;
+  if (!orgId) return;
+
+  // Pure, cheap projection first — skips billing/admin events before any DB hit.
+  const projected = projectActivity(event);
+  if (!projected) return;
+
+  // Only collect for orgs that are entitled AND have telemetry enabled.
+  if (!(await liveTelemetryActive(orgId))) return;
+
+  await prisma.activityEvent.create({
+    data: {
+      organizationId: orgId,
+      actorType: projected.actorType,
+      actorId: projected.actorId,
+      actorLabel: projected.actorLabel,
+      action: projected.action,
+      target: projected.target,
+      metadata: projected.metadata as Prisma.InputJsonValue,
+    },
+  });
+
+  if (PUBBY_ENABLED) {
+    const now = Date.now();
+    if (now - (lastBroadcast.get(orgId) ?? 0) >= THROTTLE_MS) {
+      lastBroadcast.set(orgId, now);
+      pubby
+        .trigger(telemetryChannel(orgId), "activity", {
+          action: projected.action,
+          target: projected.target,
+          actorType: projected.actorType,
+          actorLabel: projected.actorLabel,
+          at: now,
+        })
+        .catch((err) =>
+          console.error("[activity-observer] pubby trigger failed:", err instanceof Error ? err.message : err),
+        );
+    }
+  }
+}
+
+export function registerActivityObserver(): void {
+  console.log("[activity-observer] Registering Activity observer");
+  eventBus.on<RepoIndexedEvent>("repo-indexed", handle);
+  eventBus.on<RepoAnalyzedEvent>("repo-analyzed", handle);
+  eventBus.on<ReviewRequestedEvent>("review-requested", handle);
+  eventBus.on<ReviewCompletedEvent>("review-completed", handle);
+  eventBus.on<ReviewFailedEvent>("review-failed", handle);
+  eventBus.on<KnowledgeReadyEvent>("knowledge-ready", handle);
+  eventBus.on<CommunityReviewEvent>("community-review", handle);
+}

--- a/apps/web/lib/events/observers/index.ts
+++ b/apps/web/lib/events/observers/index.ts
@@ -2,6 +2,7 @@ import { registerSlackObserver } from "./slack.observer";
 import { registerEmailObserver } from "./email.observer";
 import { registerAuditObserver } from "./audit.observer";
 import { registerStatsObserver } from "./stats.observer";
+import { registerActivityObserver } from "./activity.observer";
 
 // Use globalThis so the flag survives Next.js HMR (module re-evaluation resets module-level vars,
 // but globalThis persists — same as the EventBus instance in bus.ts).
@@ -16,4 +17,5 @@ export function initializeObservers(): void {
   registerEmailObserver();
   registerAuditObserver();
   registerStatsObserver();
+  registerActivityObserver();
 }

--- a/apps/web/lib/presence.ts
+++ b/apps/web/lib/presence.ts
@@ -1,0 +1,51 @@
+import { prisma } from "@octopus/db";
+import { getRedis } from "@/lib/redis";
+
+/**
+ * Human-user live presence. Redis-primary (key-per-user with TTL, so "online"
+ * is exactly "key still exists" and stale members self-expire), with a Postgres
+ * fallback when Redis is not configured (e.g. self-host without REDIS_URL).
+ *
+ * Only a coarse activity category and a last-seen timestamp are stored — never
+ * IP, full path, or any resource name. The roster READ lives with the dashboard
+ * (a later slice); this module is the write path used by the heartbeat ingest.
+ */
+
+// TTL slightly above the 30s client heartbeat so one missed beat doesn't flap.
+export const PRESENCE_TTL_SECONDS = 60;
+// Postgres-fallback staleness window (mirrors the TTL): online := lastSeenAt
+// within this window.
+export const PRESENCE_STALE_MS = PRESENCE_TTL_SECONDS * 1000;
+
+export function presenceKey(orgId: string, userId: string): string {
+  return `presence:${orgId}:${userId}`;
+}
+
+export async function recordPresence(
+  orgId: string,
+  userId: string,
+  currentActivity: string | null,
+): Promise<void> {
+  const redis = getRedis();
+  if (redis) {
+    const value = JSON.stringify({ userId, currentActivity, lastSeenAt: Date.now() });
+    // Fire-and-forget: the client (enableOfflineQueue:false) rejects awaited
+    // commands during a Redis blip, so a heartbeat must never 500 on Redis.
+    redis
+      .set(presenceKey(orgId, userId), value, "EX", PRESENCE_TTL_SECONDS)
+      .catch((err) => console.error("[presence] redis set failed:", err instanceof Error ? err.message : err));
+    return;
+  }
+
+  // Degraded fallback (no Redis): persist to Postgres. The roster read derives
+  // "online" as lastSeenAt >= now - PRESENCE_STALE_MS.
+  try {
+    await prisma.userPresence.upsert({
+      where: { userId_organizationId: { userId, organizationId: orgId } },
+      create: { userId, organizationId: orgId, currentActivity, lastSeenAt: new Date() },
+      update: { currentActivity, lastSeenAt: new Date() },
+    });
+  } catch (err) {
+    console.error("[presence] db upsert failed:", err instanceof Error ? err.message : err);
+  }
+}

--- a/apps/web/lib/pubby.ts
+++ b/apps/web/lib/pubby.ts
@@ -6,3 +6,16 @@ export const pubby = new PubbyServer({
   secret: process.env.PUBBY_APP_SECRET!,
   apiHost: "https://api.pubby.dev",
 });
+
+/**
+ * Whether Pubby is configured. The client above is constructed unconditionally
+ * (the `!` assertions don't throw at construction), so on self-hosted / no-Pubby
+ * installs `pubby.trigger()` would fail at call time. New code should early-return
+ * when this is false; the browser likewise switches to polling when
+ * NEXT_PUBLIC_PUBBY_KEY is absent.
+ */
+export const PUBBY_ENABLED = !!(
+  process.env.PUBBY_APP_ID &&
+  process.env.PUBBY_APP_KEY &&
+  process.env.PUBBY_APP_SECRET
+);

--- a/apps/web/lib/queue-workers.ts
+++ b/apps/web/lib/queue-workers.ts
@@ -6,7 +6,7 @@ import {
   type LargeReviewResultJob,
 } from "./large-review-result";
 import { processCommunityReview, type CommunityReviewJobData } from "./community-review";
-import { enforceAuditLogRetention } from "./audit";
+import { enforceAuditLogRetention, enforceActivityEventRetention } from "./audit";
 import { runOllamaPull } from "./ollama-admin";
 import type { QueueConfig } from "./queue";
 
@@ -92,6 +92,20 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     }
   });
 
+  // Daily ActivityEvent retention job — scheduled in instrumentation.ts via
+  // boss.schedule(); idempotent deleteMany makes concurrent instances harmless.
+  await boss.work("enforce-activity-retention", async (jobs) => {
+    for (const job of jobs) {
+      try {
+        const deleted = await enforceActivityEventRetention();
+        console.log(`[queue] enforce-activity-retention ${job.id}: deleted ${deleted} rows`);
+      } catch (err) {
+        console.error(`[queue] enforce-activity-retention failed (job ${job.id}):`, err);
+        throw err;
+      }
+    }
+  });
+
   // Admin-triggered Ollama model download (self-hosted). runOllamaPull is
   // self-contained: it records progress/failure in the OllamaModelPull row and
   // never throws, so a failed download doesn't trip pg-boss retries.
@@ -102,5 +116,5 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     }
   });
 
-  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review, enforce-audit-retention, pull-ollama-model");
+  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review, enforce-audit-retention, enforce-activity-retention, pull-ollama-model");
 }

--- a/apps/web/lib/queue.ts
+++ b/apps/web/lib/queue.ts
@@ -107,6 +107,14 @@ export async function startQueue(): Promise<PgBoss> {
     expireInSeconds: 600, // 10 min — a deleteMany shouldn't take long
   }).catch(() => {});
 
+  // Daily ActivityEvent (live-telemetry) retention (scheduled in
+  // instrumentation.ts, worked in queue-workers.ts). Same v12 requirement —
+  // the queue must exist before schedule()/work() or the cron silently no-ops.
+  await boss.createQueue("enforce-activity-retention", {
+    retryLimit: 1,
+    expireInSeconds: 600, // 10 min — a deleteMany shouldn't take long
+  }).catch(() => {});
+
   // Admin-triggered Ollama model downloads (self-hosted). Long expiry — a
   // large model is many GB. No auto-retry: runOllamaPull records failures in
   // the OllamaModelPull row itself and re-pulls are admin-driven from the UI.

--- a/apps/web/lib/request-ip.ts
+++ b/apps/web/lib/request-ip.ts
@@ -1,0 +1,20 @@
+/**
+ * Extract the client IP from request headers, preferring server-set headers
+ * that a client cannot spoof, and falling back to the LAST hop of
+ * x-forwarded-for (the nearest proxy) — never the first (client-controlled)
+ * entry. Returns null when no usable header is present; callers that need a
+ * non-null key append their own fallback (e.g. `getClientIp(h) ?? "unknown"`).
+ *
+ * TODO(proxy-trust): this trusts whatever the edge / reverse proxy sets. A full
+ * trusted-hop-count / TRUSTED_PROXY configuration is out of scope; self-hosted
+ * operators must ensure their reverse proxy overwrites these headers rather than
+ * passing client-supplied values through.
+ */
+export function getClientIp(headers: Headers): string | null {
+  return (
+    headers.get("cf-connecting-ip") ||
+    headers.get("x-real-ip") ||
+    headers.get("x-forwarded-for")?.split(",").pop()?.trim() ||
+    null
+  );
+}


### PR DESCRIPTION
## What

**PR B of 4** for live usage telemetry. Builds the **capture + transport** layer on PR A's schema/entitlements (#569). Entitlement-gated throughout; **no behavior change** to existing review/index/chat flows. The dashboard that consumes this is PR C.

## Presence (members)
- `lib/presence.ts recordPresence` — **Redis-primary** (key-per-user, `SET EX 60` so "online" == key-exists and stale members self-expire; null-safe fire-and-forget), with a **Postgres `UserPresence` upsert fallback** when `REDIS_URL` is unset (self-host). `ioredis` already a dep.
- `POST /api/presence/heartbeat` — session auth, **re-validates org membership** (never trusts the `current_org_id` cookie), gates on `liveTelemetryActive`, records a **coarse activity category** only. Returns `{telemetry:false}` so the client stops when the org is free/disabled.
- `components/presence-reporter.tsx` — mounted in the app layout; pings ~30s with the route **category only** (never paths/ids/content); stops on telemetry-off **or 401/403** (logged-out / membership revoked).

## Activity feed (engine events)
- `lib/activity.ts projectActivity` — a **privacy allowlist**: each event copies only named fields; **PR titles, PR URLs, knowledge doc titles, error strings, and file paths are never included**. `lib/__tests__/activity-projection.test.ts` proves it (a leak test that fails if a sensitive field escapes).
- `lib/events/observers/activity.observer.ts` — bridges engine `AppEvent`s → durable `ActivityEvent` rows (for history + polling reconcile) **and** a throttled (per-org, 5s) real-time push to a dedicated admin-only channel.

## Transport
- `pubby/auth`: new `private-telemetry-org-{orgId}` branch — **owner/admin + `liveTelemetryActive` only**; a **PRIVATE (not presence)** channel so no member roster is broadcast; a free org can't even subscribe.
- `lib/pubby.ts PUBBY_ENABLED` — the telemetry broadcast **no-ops when Pubby isn't configured** (self-host), while the durable `ActivityEvent` row is still written, so the dashboard reconciles via polling.

## Retention + hardening
- `enforceActivityEventRetention` (default 30d, `ACTIVITY_RETENTION_DAYS`) wired as a daily pg-boss job **exactly like the audit job — `createQueue` + `work` + `schedule`** (pg-boss v12 needs the queue created first or the cron silently no-ops).
- `lib/request-ip.ts getClientIp` (server-set headers first, **last** XFF hop — not the spoofable first hop); adopted in `toggleLiveTelemetry`'s audit — **closes the Security note from PR A #569**. Only that one IP site is changed (no repo-wide sweep).

## Notes for review (pre-emptions)
- **Deferred to a follow-up:** human/agent-*attributed* feed events (`chat-message-sent`, agent-task transitions) — they'd touch the high-traffic chat stream + agent routes. Human "what now" is captured via **per-member presence**; the feed is engine events (system-attributed) for now. The actor-attribution gap is intentional and documented.
- The observer calls `liveTelemetryActive` per surfaced event (after a cheap pure projection that skips billing/admin events first) — acceptable given engine-event frequency; can be cached later.
- `PresenceReporter` mounts for all authenticated users and self-stops after one heartbeat for telemetry-off orgs (avoids a per-page-load entitlement query in the layout).
- Per-user opt-out + the dashboard UI land in PR C.

## Test plan
- `bun run typecheck` ✓ (3/3) · `eslint` ✓ (0 errors) · `bun run build` ✓ (`/api/presence/heartbeat` registered)
- `bun test` ✓ **457 pass / 0 fail**, incl. the new 5-case privacy leak test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1