### PR TITLE
feat(telemetry): per-org live-activity dashboard + member privacy surface (PR C)

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -19,6 +19,7 @@ import { encryptString } from "@/lib/crypto";
 import { writeAuditLog } from "@/lib/audit";
 import { canUseLiveTelemetry } from "@/lib/entitlements";
 import { getClientIp } from "@/lib/request-ip";
+import { clearPresence } from "@/lib/presence";
 
 export async function clearOrgCookie() {
   const cookieStore = await cookies();
@@ -929,6 +930,38 @@ export async function toggleLiveTelemetry(
 
   revalidatePath("/settings/telemetry");
   return { success: true };
+}
+
+/**
+ * Per-member opt-out from live telemetry. When opted out, no presence/activity
+ * is collected for this member in the current org. Any member may set their own
+ * preference (no role gate — it's the member's own privacy choice).
+ */
+export async function toggleTelemetryOptOut(optedOut: boolean): Promise<{ error?: string }> {
+  const user = await getUser();
+  const cookieStore = await cookies();
+  const orgId = cookieStore.get("current_org_id")?.value;
+  if (!orgId) return { error: "No organization selected." };
+
+  const member = await prisma.organizationMember.findFirst({
+    where: { organizationId: orgId, userId: user.id, deletedAt: null },
+    select: { id: true },
+  });
+  if (!member) return { error: "Not a member of this organization." };
+
+  await prisma.organizationMember.update({
+    where: { id: member.id },
+    data: { telemetryOptedOut: optedOut },
+  });
+
+  // Opting out should take effect immediately — drop any live presence so the
+  // member disappears from the roster at once (rather than after the TTL).
+  if (optedOut) {
+    await clearPresence(orgId, user.id);
+  }
+
+  revalidatePath("/settings/telemetry");
+  return {};
 }
 
 export async function updateOrgDefaultReviewConfig(

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -8,10 +8,12 @@ import { PermissionBanner } from "@/components/permission-banner";
 import { SpendLimitBanner } from "@/components/spend-limit-banner";
 import { getInstallationPermissions } from "@/lib/github";
 import { getOrgSpendLimitStatus } from "@/lib/cost";
+import { getOrgEntitlements } from "@/lib/entitlements";
 import { canUserCreateOrg } from "@/lib/org-limits";
 import { OrgCookieSync } from "@/components/org-cookie-sync";
 import { DeviceReporter } from "@/components/device-reporter";
 import { PresenceReporter } from "@/components/presence-reporter";
+import { TelemetryNotice } from "@/components/telemetry-notice";
 import { createOrgForUser } from "@/lib/org-create";
 
 /**
@@ -55,6 +57,7 @@ export default async function AppLayout({
       organizationMembers: {
         where: { deletedAt: null, organization: { deletedAt: null } },
         select: {
+          telemetryOptedOut: true,
           organization: {
             select: {
               id: true,
@@ -146,6 +149,19 @@ export default async function AppLayout({
   const currentOrg =
     orgs.find((o) => o.id === currentOrgId) ?? orgs[0] ?? { id: "", name: "Octopus", avatarUrl: null };
 
+  // Per-user telemetry notice: show when the active org is actually COLLECTING
+  // (entitled AND enabled — not just the raw liveTelemetryEnabled flag, which
+  // can linger true after an org loses paid status) and this member hasn't
+  // opted out. Gated on the same liveTelemetryActive signal as the settings
+  // opt-out control so the banner and that control never disagree.
+  const currentMember = user.organizationMembers.find(
+    (m) => m.organization.id === currentOrg.id,
+  );
+  const telemetryActive =
+    !!currentMember && (await getOrgEntitlements(currentOrg.id)).liveTelemetryActive;
+  const showTelemetryNotice =
+    !!currentMember && telemetryActive && !currentMember.telemetryOptedOut;
+
   const canCreateOrg = await canUserCreateOrg(session.user.id);
 
   const sidebarProps = {
@@ -194,6 +210,7 @@ export default async function AppLayout({
           />
         )}
         <SpendLimitBanner spendStatus={spendStatus} />
+        {showTelemetryNotice && <TelemetryNotice orgId={currentOrg.id} />}
         <div className="flex min-h-0 flex-1 flex-col md:flex-row">
           <AppSidebar {...sidebarProps} />
           <div className="flex min-h-0 flex-1 flex-col">

--- a/apps/web/app/(app)/monitor/monitor-client.tsx
+++ b/apps/web/app/(app)/monitor/monitor-client.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { getPubbyClient } from "@/lib/pubby-client";
+
+const POLL_MS = 10_000;
+const MAX_FEED = 200;
+
+type FeedEvent = {
+  id: string;
+  action: string;
+  target: string | null;
+  actorType: string;
+  actorId: string | null;
+  actorLabel: string | null;
+  createdAt: string;
+};
+
+type Member = {
+  userId: string;
+  name: string;
+  image: string | null;
+  currentActivity: string | null;
+  lastSeenAt: number;
+};
+
+type Agent = { id: string; name: string; capabilities: unknown; lastSeenAt: number | null };
+
+export function MonitorClient({
+  orgId,
+  pubbyEnabled,
+  initialEvents,
+}: {
+  orgId: string;
+  pubbyEnabled: boolean;
+  initialEvents: FeedEvent[];
+}) {
+  const [events, setEvents] = useState<FeedEvent[]>(initialEvents);
+  const [members, setMembers] = useState<Member[]>([]);
+  const [agents, setAgents] = useState<Agent[]>([]);
+
+  // Merge incoming events by id, newest-first, capped.
+  const mergeEvents = useCallback((incoming: FeedEvent[]) => {
+    setEvents((prev) => {
+      const byId = new Map(prev.map((e) => [e.id, e]));
+      for (const e of incoming) byId.set(e.id, e);
+      return [...byId.values()]
+        .sort((a, b) =>
+          a.createdAt === b.createdAt ? (a.id < b.id ? 1 : -1) : a.createdAt < b.createdAt ? 1 : -1,
+        )
+        .slice(0, MAX_FEED);
+    });
+  }, []);
+
+  const pollFeed = useCallback(async () => {
+    try {
+      const res = await fetch("/api/activity", { cache: "no-store" });
+      if (!res.ok) return;
+      const data = (await res.json()) as { events?: FeedEvent[]; active?: boolean };
+      // Telemetry disabled mid-session → clear the feed (don't show stale events).
+      if (data.active === false) {
+        setEvents([]);
+        return;
+      }
+      if (data.events) mergeEvents(data.events);
+    } catch {
+      /* transient — next tick retries */
+    }
+  }, [mergeEvents]);
+
+  const pollRoster = useCallback(async () => {
+    try {
+      const res = await fetch("/api/presence", { cache: "no-store" });
+      if (!res.ok) return;
+      const data = (await res.json()) as { members?: Member[]; agents?: Agent[] };
+      setMembers(data.members ?? []);
+      setAgents(data.agents ?? []);
+    } catch {
+      /* transient */
+    }
+  }, []);
+
+  // Poll roster + feed on an interval (presence is never pushed; the feed poll
+  // also reconciles any dropped real-time pushes).
+  useEffect(() => {
+    void pollRoster();
+    void pollFeed();
+    const t = setInterval(() => {
+      void pollRoster();
+      void pollFeed();
+    }, POLL_MS);
+    return () => clearInterval(t);
+  }, [pollRoster, pollFeed]);
+
+  // Live feed via Pubby (when configured): a push just nudges a feed re-fetch so
+  // the DB stays the source of truth (ids/dedup/ordering are authoritative).
+  // pollFeed is a stable useCallback, so this subscribes once per org.
+  useEffect(() => {
+    if (!pubbyEnabled) return;
+    const pubby = getPubbyClient();
+    const channelName = `private-telemetry-org-${orgId}`;
+    const channel = pubby.subscribe(channelName);
+    const onActivity = () => void pollFeed();
+    channel.bind("activity", onActivity);
+    return () => {
+      channel.unbind("activity", onActivity);
+      pubby.unsubscribe(channelName);
+    };
+  }, [orgId, pubbyEnabled, pollFeed]);
+
+  return (
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <Panel title={`Online now (${members.length + agents.length})`}>
+        {members.length === 0 && agents.length === 0 ? (
+          <Empty>No one is online right now.</Empty>
+        ) : (
+          <ul className="divide-y divide-border">
+            {members.map((m) => (
+              <li key={`u-${m.userId}`} className="flex items-center justify-between gap-3 py-2">
+                <span className="flex items-center gap-2 overflow-hidden">
+                  <Dot online />
+                  <span className="truncate text-sm">{m.name}</span>
+                </span>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {m.currentActivity ?? "—"}
+                </span>
+              </li>
+            ))}
+            {agents.map((a) => (
+              <li key={`a-${a.id}`} className="flex items-center justify-between gap-3 py-2">
+                <span className="flex items-center gap-2 overflow-hidden">
+                  <Dot online />
+                  <span className="truncate text-sm">{a.name}</span>
+                </span>
+                <span className="shrink-0 text-xs text-muted-foreground">agent</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Panel>
+
+      <Panel title="Activity">
+        {events.length === 0 ? (
+          <Empty>No recent activity.</Empty>
+        ) : (
+          <ul className="divide-y divide-border">
+            {events.map((e) => (
+              <li key={e.id} className="flex items-center justify-between gap-3 py-2">
+                <span className="flex items-center gap-2 overflow-hidden">
+                  <ActorBadge type={e.actorType} />
+                  <span className="truncate text-sm">
+                    <span className="font-medium">{e.action}</span>
+                    {e.target ? <span className="text-muted-foreground"> · {e.target}</span> : null}
+                  </span>
+                </span>
+                <time className="shrink-0 text-xs text-muted-foreground">
+                  {new Date(e.createdAt).toLocaleTimeString()}
+                </time>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Panel>
+    </div>
+  );
+}
+
+function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-lg border border-border bg-card">
+      <header className="border-b border-border px-4 py-2 text-sm font-medium">{title}</header>
+      <div className="max-h-[28rem] overflow-y-auto px-4 py-2">{children}</div>
+    </section>
+  );
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return <p className="py-8 text-center text-sm text-muted-foreground">{children}</p>;
+}
+
+function Dot({ online }: { online: boolean }) {
+  return (
+    <span
+      className={`size-2 shrink-0 rounded-full ${online ? "bg-green-500" : "bg-muted-foreground/40"}`}
+      aria-hidden
+    />
+  );
+}
+
+function ActorBadge({ type }: { type: string }) {
+  const label = type === "user" ? "user" : type === "agent" ? "agent" : "system";
+  return (
+    <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">
+      {label}
+    </span>
+  );
+}

--- a/apps/web/app/(app)/monitor/page.tsx
+++ b/apps/web/app/(app)/monitor/page.tsx
@@ -1,0 +1,122 @@
+import { headers, cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import Link from "@/components/link";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { getOrgEntitlements } from "@/lib/entitlements";
+import { MonitorClient } from "./monitor-client";
+
+/**
+ * /monitor — the per-org live-activity dashboard. Owner/admin only. Shows a live
+ * roster (online members + agents) and an activity feed. Free orgs see an
+ * upgrade upsell; paid-but-disabled orgs see a prompt to enable it in settings.
+ */
+export default async function MonitorPage() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) redirect("/login");
+
+  const cookieStore = await cookies();
+  const currentOrgId = cookieStore.get("current_org_id")?.value;
+  // Require an explicit active org so the page gates the SAME org the polling
+  // APIs (/api/presence, /api/activity) resolve from the cookie.
+  if (!currentOrgId) redirect("/dashboard");
+
+  const member = await prisma.organizationMember.findFirst({
+    where: {
+      userId: session.user.id,
+      organizationId: currentOrgId,
+      deletedAt: null,
+    },
+    select: { role: true, organizationId: true },
+  });
+  if (!member) redirect("/dashboard");
+  if (member.role !== "owner" && member.role !== "admin") redirect("/settings");
+
+  const orgId = member.organizationId;
+  const ent = await getOrgEntitlements(orgId);
+
+  if (!ent.paid) {
+    return (
+      <Shell>
+        <LockedCard
+          title="Live Activity is a paid feature"
+          body="See who on your team is active and what they're doing in real time. Upgrade your plan to unlock the live monitor."
+          cta={{ href: "/settings/billing", label: "Upgrade plan" }}
+        />
+      </Shell>
+    );
+  }
+
+  if (!ent.liveTelemetryActive) {
+    return (
+      <Shell>
+        <LockedCard
+          title="Live Activity is off"
+          body="Turn on live activity monitoring for your organization to see who's online and what they're doing here."
+          cta={{ href: "/settings/telemetry", label: "Enable in settings" }}
+        />
+      </Shell>
+    );
+  }
+
+  const initialEvents = await prisma.activityEvent.findMany({
+    where: { organizationId: orgId },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: 50,
+  });
+
+  return (
+    <Shell>
+      <MonitorClient
+        orgId={orgId}
+        pubbyEnabled={!!process.env.NEXT_PUBLIC_PUBBY_KEY}
+        initialEvents={initialEvents.map((e) => ({
+          id: e.id,
+          action: e.action,
+          target: e.target,
+          actorType: e.actorType,
+          actorId: e.actorId,
+          actorLabel: e.actorLabel,
+          createdAt: e.createdAt.toISOString(),
+        }))}
+      />
+    </Shell>
+  );
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 p-6 md:p-10">
+      <div>
+        <h1 className="text-xl font-semibold">Live Activity</h1>
+        <p className="text-sm text-muted-foreground">
+          Who&apos;s online and what&apos;s happening in your organization right now.
+        </p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function LockedCard({
+  title,
+  body,
+  cta,
+}: {
+  title: string;
+  body: string;
+  cta: { href: string; label: string };
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-8 text-center">
+      <h2 className="text-base font-medium">{title}</h2>
+      <p className="mx-auto mt-2 max-w-md text-sm text-muted-foreground">{body}</p>
+      <Link
+        href={cta.href}
+        className="mt-4 inline-block rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+      >
+        {cta.label}
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/settings/telemetry/page.tsx
+++ b/apps/web/app/(app)/settings/telemetry/page.tsx
@@ -2,8 +2,9 @@ import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
-import { canUseLiveTelemetry } from "@/lib/entitlements";
+import { getOrgEntitlements } from "@/lib/entitlements";
 import { LiveTelemetrySwitch } from "./live-telemetry-switch";
+import { TelemetryOptOutSwitch } from "./telemetry-opt-out-switch";
 
 export default async function TelemetrySettingsPage() {
   const session = await auth.api.getSession({
@@ -22,6 +23,7 @@ export default async function TelemetrySettingsPage() {
     },
     select: {
       role: true,
+      telemetryOptedOut: true,
       organization: {
         select: {
           id: true,
@@ -34,7 +36,10 @@ export default async function TelemetrySettingsPage() {
   if (!member) redirect("/dashboard");
 
   const canManage = member.role === "owner" || member.role === "admin";
-  const paid = await canUseLiveTelemetry(member.organization.id);
+  const ent = await getOrgEntitlements(member.organization.id);
+  const paid = ent.paid;
+  // Show the per-member opt-out only when telemetry is actually collecting.
+  const active = ent.liveTelemetryActive;
 
   return (
     <div key={member.organization.id} className="space-y-6">
@@ -43,6 +48,7 @@ export default async function TelemetrySettingsPage() {
         enabled={member.organization.liveTelemetryEnabled}
         paid={paid}
       />
+      {active && <TelemetryOptOutSwitch optedOut={member.telemetryOptedOut} />}
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/telemetry/telemetry-opt-out-switch.tsx
+++ b/apps/web/app/(app)/settings/telemetry/telemetry-opt-out-switch.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { toggleTelemetryOptOut } from "../../actions";
+
+/**
+ * Per-member opt-out from live telemetry. Available to every member (it's their
+ * own privacy choice). Shown only when the org has live telemetry active.
+ */
+export function TelemetryOptOutSwitch({ optedOut }: { optedOut: boolean }) {
+  const [isPending, startTransition] = useTransition();
+  const [checked, setChecked] = useState(!optedOut); // "Include me" = NOT opted out
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Your visibility</CardTitle>
+        <CardDescription>
+          Your organization has live activity monitoring enabled. While it&apos;s
+          on, your admins can see when you&apos;re online and a coarse view of
+          which area of the app you&apos;re in (never file contents, PR titles,
+          or message text). You can opt out of being included at any time.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="telemetry-opt-in" className="flex flex-col gap-1">
+            <span className="font-medium">
+              {checked ? "You're included" : "You've opted out"}
+            </span>
+            <span className="text-xs text-muted-foreground font-normal">
+              {checked
+                ? "Your presence and activity are visible to your org's admins."
+                : "No presence or activity is collected for or attributed to you."}
+            </span>
+          </Label>
+          <Switch
+            id="telemetry-opt-in"
+            checked={checked}
+            disabled={isPending}
+            onCheckedChange={(next) => {
+              setChecked(next);
+              setError(null);
+              startTransition(async () => {
+                const res = await toggleTelemetryOptOut(!next);
+                if (res?.error) {
+                  setChecked(!next); // revert on failure
+                  setError(res.error);
+                }
+              });
+            }}
+          />
+        </div>
+        {error && <p className="text-sm text-destructive mt-3">{error}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/app/(landing)/docs/data-retention/page.tsx
+++ b/apps/web/app/(landing)/docs/data-retention/page.tsx
@@ -74,6 +74,18 @@ const RETENTION: RetentionRow[] = [
     what: "Encrypted DB snapshots",
     retention: "30 days for hosted; self-hosters control their own",
   },
+  {
+    category: "Activity events",
+    what: "Live team-telemetry feed rows (coarse actions only — no content)",
+    retention: "30 days (hosted default)",
+    notes: "Only when an org enables Live Activity. Tunable via ACTIVITY_RETENTION_DAYS; pruned daily.",
+  },
+  {
+    category: "Presence",
+    what: "Whether a member/agent is currently online + coarse current area",
+    retention: "Ephemeral — expires ~60s after going offline",
+    notes: "Held in Redis with a TTL (or a short-lived DB row); never archived.",
+  },
 ];
 
 export default function DataRetentionPage() {

--- a/apps/web/app/(landing)/docs/dpa/page.tsx
+++ b/apps/web/app/(landing)/docs/dpa/page.tsx
@@ -40,7 +40,7 @@ export default function DpaPage() {
       <Section title="What it covers">
         <UL>
           <li>Subject matter, duration, nature, and purpose of processing</li>
-          <li>The types of personal data processed (account identifiers, repository content references, audit metadata)</li>
+          <li>The types of personal data processed (account identifiers, repository content references, audit metadata, and — for orgs that enable Live Activity — coarse presence and activity telemetry, never content)</li>
           <li>Octopus&apos;s technical and organisational security measures (see <a href="/docs/security-overview" className="text-cyan-400 underline">Security Overview</a>)</li>
           <li>Sub-processor authorisation and notification of changes</li>
           <li>International transfer safeguards (Standard Contractual Clauses)</li>

--- a/apps/web/app/(landing)/docs/privacy/page.tsx
+++ b/apps/web/app/(landing)/docs/privacy/page.tsx
@@ -20,7 +20,7 @@ export default function PrivacyPage() {
         <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">
           Privacy Policy
         </h1>
-        <p className="mt-3 text-sm text-[#555]">Last updated: March 2026</p>
+        <p className="mt-3 text-sm text-[#555]">Last updated: June 2026</p>
       </div>
 
       <Section title="1. Introduction">
@@ -143,6 +143,7 @@ export default function PrivacyPage() {
           <li>Request deletion of your account and associated data</li>
           <li>Disconnect repositories at any time</li>
           <li>Opt out of analytics tracking</li>
+          <li>Opt out of live team-telemetry visibility (from member settings)</li>
         </UL>
         <P>
           For any privacy-related requests, open an issue on our GitHub
@@ -150,7 +151,34 @@ export default function PrivacyPage() {
         </P>
       </Section>
 
-      <Section title="9. Self-Hosting">
+      <Section title="9. Live Telemetry (Team Monitoring)">
+        <P>
+          For organizations on a paid plan, owners and admins may enable a live
+          team-monitoring dashboard. When enabled, we collect coarse presence
+          (whether a member or agent is currently online) and high-level activity
+          events (e.g. &quot;a review completed&quot;, &quot;a repository was
+          indexed&quot;) — we do not collect the content of what you view, type,
+          or review.
+        </P>
+        <P>
+          The lawful basis for this processing is the organization&apos;s
+          legitimate interest in operational visibility into its own workspace;
+          it is not based on your consent. Activity events are retained for 30
+          days (see{" "}
+          <a href="/docs/data-retention" className="text-cyan-400 underline">
+            Data Retention
+          </a>
+          ); presence is ephemeral and expires within about 60 seconds of going
+          offline.
+        </P>
+        <P>
+          Any member can opt out at any time from their member settings; opting
+          out stops presence and activity from being collected for or attributed
+          to them.
+        </P>
+      </Section>
+
+      <Section title="10. Self-Hosting">
         <P>
           Octopus is fully open source. If you self-host Octopus on your own
           infrastructure, your code never touches our servers. You are
@@ -158,7 +186,7 @@ export default function PrivacyPage() {
         </P>
       </Section>
 
-      <Section title="10. Changes to This Policy">
+      <Section title="11. Changes to This Policy">
         <P>
           We may update this policy from time to time. Changes will be posted
           on this page with an updated revision date. Continued use of the

--- a/apps/web/app/(landing)/docs/sub-processors/page.tsx
+++ b/apps/web/app/(landing)/docs/sub-processors/page.tsx
@@ -124,6 +124,14 @@ const SUBPROCESSORS: Subprocessor[] = [
     url: "https://linear.app/legal/privacy",
   },
   {
+    name: "Pubby",
+    purpose: "Real-time messaging (WebSocket pub/sub) for live chat streaming and the Live Activity dashboard",
+    dataAccessed: "Coarse real-time events only (e.g. \"a review completed\") for orgs that enable Live Activity — never file contents, PR titles, or message text; durable activity is stored in our own DB, not Pubby",
+    location: "United States",
+    required: "conditional",
+    url: "https://pubby.dev",
+  },
+  {
     name: "Atlassian (Jira)",
     purpose: "Create issues from review findings",
     dataAccessed: "Finding title + description + reference URL",

--- a/apps/web/app/api/activity/route.ts
+++ b/apps/web/app/api/activity/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import { headers, cookies } from "next/headers";
+import { prisma } from "@octopus/db";
+import { auth } from "@/lib/auth";
+import { liveTelemetryActive } from "@/lib/entitlements";
+
+const PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 200;
+
+/**
+ * GET /api/activity — the activity feed for the org's monitor dashboard.
+ * Owner/admin only, org-scoped, and only when live telemetry is active. Rows are
+ * already privacy-safe (the activity.observer allowlist). Descending, cursor-
+ * paginated for "load more"; the dashboard polls page 1 (no cursor) and merges
+ * by id to pick up new events / reconcile dropped real-time pushes.
+ */
+export async function GET(request: Request) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const cookieStore = await cookies();
+  const orgId = cookieStore.get("current_org_id")?.value;
+  if (!orgId) return NextResponse.json({ error: "No active org" }, { status: 400 });
+
+  const member = await prisma.organizationMember.findFirst({
+    where: { userId: session.user.id, organizationId: orgId, deletedAt: null },
+    select: { role: true },
+  });
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return NextResponse.json({ error: "Admin role required" }, { status: 403 });
+  }
+
+  if (!(await liveTelemetryActive(orgId))) {
+    return NextResponse.json({ events: [], nextCursor: null, active: false });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const rawLimit = parseInt(searchParams.get("limit") ?? "", 10);
+  const limit = Number.isFinite(rawLimit) ? Math.min(MAX_PAGE_SIZE, Math.max(1, rawLimit)) : PAGE_SIZE;
+  const cursor = searchParams.get("cursor") ?? undefined;
+
+  const rows = await prisma.activityEvent.findMany({
+    where: { organizationId: orgId },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    take: limit + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+  });
+
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const nextCursor = hasMore ? page[page.length - 1].id : null;
+
+  return NextResponse.json({
+    events: page.map((e) => ({
+      id: e.id,
+      action: e.action,
+      target: e.target,
+      actorType: e.actorType,
+      actorId: e.actorId,
+      actorLabel: e.actorLabel,
+      metadata: e.metadata,
+      createdAt: e.createdAt.toISOString(),
+    })),
+    nextCursor,
+    active: true,
+  });
+}

--- a/apps/web/app/api/presence/heartbeat/route.ts
+++ b/apps/web/app/api/presence/heartbeat/route.ts
@@ -5,17 +5,27 @@ import { auth } from "@/lib/auth";
 import { liveTelemetryActive } from "@/lib/entitlements";
 import { recordPresence } from "@/lib/presence";
 import { isValidActivity } from "@/lib/activity-category";
+import { isSameOrigin } from "@/lib/same-origin";
 
 /**
  * POST /api/presence/heartbeat — the web client pings this every ~30s to record
  * the member's live presence + coarse current activity. Session-authenticated;
  * the org comes from the current_org_id cookie and is RE-VALIDATED against
  * membership (the cookie is never trusted as proof). Collection is gated on the
- * org being entitled + having live telemetry enabled — when it isn't, we return
- * { telemetry: false } so the client stops heartbeating.
+ * org being entitled + telemetry-enabled AND the member not having opted out —
+ * when inactive we return { telemetry: false } so the client stops heartbeating.
  */
 export async function POST(request: Request) {
-  const session = await auth.api.getSession({ headers: await headers() });
+  const reqHeaders = await headers();
+
+  // CSRF defence-in-depth: this is a state-changing POST driven by the browser.
+  // Use 400 (not 401/403) so the client's auth-terminal handling doesn't treat a
+  // cross-origin reject as "logged out" and stop heartbeating for the session.
+  if (!isSameOrigin(reqHeaders.get("host"), reqHeaders.get("origin"), reqHeaders.get("referer"))) {
+    return NextResponse.json({ error: "Cross-origin request rejected" }, { status: 400 });
+  }
+
+  const session = await auth.api.getSession({ headers: reqHeaders });
   if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -26,18 +36,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: true, telemetry: false });
   }
 
-  // Re-validate membership server-side — never trust the cookie alone.
+  // Re-validate membership server-side — never trust the cookie alone. Also read
+  // the per-member opt-out so an opted-out member is never recorded.
   const membership = await prisma.organizationMember.findFirst({
     where: { organizationId: orgId, userId: session.user.id, deletedAt: null },
-    select: { id: true },
+    select: { telemetryOptedOut: true },
   });
   if (!membership) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  // Gate collection on entitlement + the org toggle. Tell the client to stop
-  // when inactive so a free/disabled org doesn't keep heartbeating.
-  if (!(await liveTelemetryActive(orgId))) {
+  // Gate collection on entitlement + the org toggle + the member opt-out. Tell
+  // the client to stop when inactive so a free/disabled org — or an opted-out
+  // member — doesn't keep heartbeating.
+  if (membership.telemetryOptedOut || !(await liveTelemetryActive(orgId))) {
     return NextResponse.json({ ok: true, telemetry: false });
   }
 

--- a/apps/web/app/api/presence/route.ts
+++ b/apps/web/app/api/presence/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { headers, cookies } from "next/headers";
+import { prisma } from "@octopus/db";
+import { auth } from "@/lib/auth";
+import { liveTelemetryActive } from "@/lib/entitlements";
+import { getOnlinePresence } from "@/lib/presence";
+import { AGENT_STALE_THRESHOLD_MS } from "@/lib/agent-constants";
+
+/**
+ * GET /api/presence — the live roster for the org's monitor dashboard: currently
+ * online members (human presence) + online local agents. Owner/admin only, and
+ * only when live telemetry is active; otherwise returns empty + active:false.
+ * Polled by the dashboard (presence changes aren't pushed over Pubby).
+ */
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const cookieStore = await cookies();
+  const orgId = cookieStore.get("current_org_id")?.value;
+  if (!orgId) return NextResponse.json({ error: "No active org" }, { status: 400 });
+
+  const member = await prisma.organizationMember.findFirst({
+    where: { userId: session.user.id, organizationId: orgId, deletedAt: null },
+    select: { role: true },
+  });
+  if (!member || (member.role !== "owner" && member.role !== "admin")) {
+    return NextResponse.json({ error: "Admin role required" }, { status: 403 });
+  }
+
+  if (!(await liveTelemetryActive(orgId))) {
+    return NextResponse.json({ members: [], agents: [], active: false });
+  }
+
+  // Online members (presence rows) joined with display info.
+  const presence = await getOnlinePresence(orgId);
+  const userIds = [...new Set(presence.map((p) => p.userId))];
+  const users = userIds.length
+    ? await prisma.user.findMany({
+        where: { id: { in: userIds } },
+        select: { id: true, name: true, image: true },
+      })
+    : [];
+  const userMap = new Map(users.map((u) => [u.id, u]));
+  const members = presence.map((p) => ({
+    userId: p.userId,
+    name: userMap.get(p.userId)?.name ?? "Unknown",
+    image: userMap.get(p.userId)?.image ?? null,
+    currentActivity: p.currentActivity,
+    lastSeenAt: p.lastSeenAt,
+  }));
+
+  // Online local agents (same staleness window as the agent-status endpoint).
+  const agentRows = await prisma.localAgent.findMany({
+    where: {
+      organizationId: orgId,
+      status: "online",
+      lastSeenAt: { gte: new Date(Date.now() - AGENT_STALE_THRESHOLD_MS) },
+    },
+    select: { id: true, name: true, capabilities: true, lastSeenAt: true },
+  });
+  const agents = agentRows.map((a) => ({
+    id: a.id,
+    name: a.name,
+    capabilities: a.capabilities,
+    lastSeenAt: a.lastSeenAt?.getTime() ?? null,
+  }));
+
+  return NextResponse.json({ members, agents, active: true });
+}

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -37,6 +37,7 @@ import {
   IconHelpCircle,
   IconExternalLink,
   IconSparkles,
+  IconBroadcast,
 } from "@tabler/icons-react";
 import {
   DropdownMenu,
@@ -59,6 +60,7 @@ const mainNavItems = [
 ];
 
 const bottomNavItems = [
+  { href: "/monitor", label: "Live Monitor", icon: IconBroadcast },
   { href: "/usage", label: "Usage", icon: IconChartBar },
 ];
 

--- a/apps/web/components/telemetry-notice.tsx
+++ b/apps/web/components/telemetry-notice.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "@/components/link";
+import { IconBroadcast } from "@tabler/icons-react";
+
+/**
+ * Per-user notice shown app-wide when the member's current org has live activity
+ * monitoring enabled (and the member hasn't opted out — computed server-side in
+ * the layout). Informs the member they may be visible and links to the opt-out.
+ * Dismissal is client-side (localStorage, keyed by org) — no schema needed; it
+ * reappears for a different org so each workspace is disclosed once.
+ */
+export function TelemetryNotice({ orgId }: { orgId: string }) {
+  const storageKey = `octopus.telemetryNoticeDismissed.${orgId}`;
+  // Start hidden until mounted to avoid an SSR/client flash and to read storage.
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    try {
+      setShow(localStorage.getItem(storageKey) !== "1");
+    } catch {
+      setShow(true);
+    }
+  }, [storageKey]);
+
+  if (!show) return null;
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(storageKey, "1");
+    } catch {
+      // ignore — worst case the notice shows again next load
+    }
+    setShow(false);
+  };
+
+  return (
+    <div className="sticky top-0 z-50">
+      <div className="flex items-center justify-between gap-3 bg-sky-950 px-4 py-1.5">
+        <div className="flex items-center gap-2 overflow-hidden">
+          <IconBroadcast className="size-3.5 shrink-0 text-sky-400" />
+          <p className="truncate text-xs text-sky-200">
+            Live activity monitoring is{" "}
+            <span className="font-medium">on</span> for this organization — your
+            admins can see when you&apos;re online and which area you&apos;re in
+            (never content).
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Link
+            href="/settings/telemetry"
+            className="rounded bg-sky-500/20 px-2 py-0.5 text-[11px] font-medium text-sky-200 hover:bg-sky-500/30"
+          >
+            Manage
+          </Link>
+          <button
+            type="button"
+            onClick={dismiss}
+            className="rounded px-2 py-0.5 text-[11px] font-medium text-sky-300/70 hover:text-sky-200"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/presence.ts
+++ b/apps/web/lib/presence.ts
@@ -7,9 +7,14 @@ import { getRedis } from "@/lib/redis";
  * fallback when Redis is not configured (e.g. self-host without REDIS_URL).
  *
  * Only a coarse activity category and a last-seen timestamp are stored — never
- * IP, full path, or any resource name. The roster READ lives with the dashboard
- * (a later slice); this module is the write path used by the heartbeat ingest.
+ * IP, full path, or any resource name.
  */
+
+export type PresenceEntry = {
+  userId: string;
+  currentActivity: string | null;
+  lastSeenAt: number; // epoch ms
+};
 
 // TTL slightly above the 30s client heartbeat so one missed beat doesn't flap.
 export const PRESENCE_TTL_SECONDS = 60;
@@ -47,5 +52,79 @@ export async function recordPresence(
     });
   } catch (err) {
     console.error("[presence] db upsert failed:", err instanceof Error ? err.message : err);
+  }
+}
+
+/**
+ * Remove a member's presence immediately (e.g. when they opt out), so they
+ * disappear from the roster at once rather than after the TTL. Best-effort and
+ * null-safe — clears both the Redis key and any Postgres fallback row.
+ */
+export async function clearPresence(orgId: string, userId: string): Promise<void> {
+  const redis = getRedis();
+  if (redis) {
+    redis
+      .del(presenceKey(orgId, userId))
+      .catch((err) => console.error("[presence] redis del failed:", err instanceof Error ? err.message : err));
+  }
+  try {
+    await prisma.userPresence.deleteMany({ where: { organizationId: orgId, userId } });
+  } catch (err) {
+    console.error("[presence] db delete failed:", err instanceof Error ? err.message : err);
+  }
+}
+
+/**
+ * Read the currently-online members for an org. Redis-primary (SCAN — never
+ * KEYS, which blocks the server — then MGET); Postgres fallback derives online
+ * from lastSeenAt within the staleness window. Returns presence entries WITHOUT
+ * display info; callers join user name/image. Never throws — returns [] on any
+ * backend error so the dashboard degrades gracefully.
+ */
+export async function getOnlinePresence(orgId: string): Promise<PresenceEntry[]> {
+  const redis = getRedis();
+  if (redis) {
+    try {
+      const pattern = `presence:${orgId}:*`;
+      const keys: string[] = [];
+      let cursor = "0";
+      do {
+        const [next, batch] = await redis.scan(cursor, "MATCH", pattern, "COUNT", 200);
+        cursor = next;
+        keys.push(...batch);
+      } while (cursor !== "0");
+      if (keys.length === 0) return [];
+      const values = await redis.mget(...keys);
+      return values
+        .filter((v): v is string => v !== null)
+        .map((v) => {
+          try {
+            return JSON.parse(v) as PresenceEntry;
+          } catch {
+            return null;
+          }
+        })
+        .filter((e): e is PresenceEntry => e !== null && typeof e.userId === "string");
+    } catch (err) {
+      console.error("[presence] redis read failed:", err instanceof Error ? err.message : err);
+      return [];
+    }
+  }
+
+  // Postgres fallback.
+  try {
+    const since = new Date(Date.now() - PRESENCE_STALE_MS);
+    const rows = await prisma.userPresence.findMany({
+      where: { organizationId: orgId, lastSeenAt: { gte: since } },
+      select: { userId: true, currentActivity: true, lastSeenAt: true },
+    });
+    return rows.map((r) => ({
+      userId: r.userId,
+      currentActivity: r.currentActivity,
+      lastSeenAt: r.lastSeenAt.getTime(),
+    }));
+  } catch (err) {
+    console.error("[presence] db read failed:", err instanceof Error ? err.message : err);
+    return [];
   }
 }

--- a/apps/web/lib/same-origin.ts
+++ b/apps/web/lib/same-origin.ts
@@ -1,0 +1,33 @@
+/**
+ * Same-origin check for state-changing browser POSTs (CSRF defence-in-depth).
+ * Better Auth session cookies are SameSite=Lax (so a cross-site POST already
+ * carries no cookie → 401), but an explicit Origin/Referer host check guards
+ * against a future cookie-policy change and hostile-extension script POSTs.
+ *
+ * (The agent-revoke route has an equivalent local copy; this is the shared
+ * version for new endpoints.)
+ */
+export function isSameOrigin(
+  host: string | null,
+  origin: string | null,
+  referer: string | null,
+): boolean {
+  if (!host) return false;
+  const expected = host.toLowerCase();
+  if (origin) {
+    try {
+      return new URL(origin).host.toLowerCase() === expected;
+    } catch {
+      return false;
+    }
+  }
+  // No Origin — fall back to Referer for the small legacy-client window.
+  if (referer) {
+    try {
+      return new URL(referer).host.toLowerCase() === expected;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}

--- a/packages/db/prisma/migrations/20260701120000_add_member_telemetry_opt_out/migration.sql
+++ b/packages/db/prisma/migrations/20260701120000_add_member_telemetry_opt_out/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "organization_members" ADD COLUMN     "telemetryOptedOut" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -182,6 +182,11 @@ model OrganizationMember {
   role      String    @default("member")
   createdAt DateTime  @default(now())
   deletedAt DateTime?
+  // Per-member opt-out from live telemetry: when true, no presence/activity is
+  // collected for or attributed to this member (privacy surface for the
+  // live-monitoring feature). Default false = tracked-by-default, mirroring
+  // User.marketingEmailsEnabled.
+  telemetryOptedOut Boolean @default(false)
 
   organizationId String
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## What

**PR C of 4** — the first **member-visible** slice. Builds the per-org `/monitor` dashboard on PR A (#569) + PR B (#570), and ships the **member privacy surface** alongside it (per the plan: privacy must land with the first visible telemetry, not later).

## Dashboard — `/monitor` (owner/admin)
- **Live roster** (online members + agents) + **activity feed**. The roster is polled (presence isn't pushed); the feed is live via the dedicated `private-telemetry-org-{orgId}` channel when Pubby is configured, with a **polling-reconcile fallback** (merge-by-id) so self-host installs and dropped best-effort pushes still converge. Free orgs see an **upgrade upsell**; paid-but-disabled orgs see an **enable prompt**.
- `GET /api/presence` (roster) + `GET /api/activity` (cursor feed) — owner/admin, org re-validated from the cookie, gated on `liveTelemetryActive`; the feed returns only the privacy-safe `ActivityEvent` fields. `lib/presence.ts` gains `getOnlinePresence` (Redis `SCAN`+`MGET` / Postgres fallback).

## Member privacy surface
- `OrganizationMember.telemetryOptedOut` (+ migration). The heartbeat **skips opted-out members**, and opting out **clears any live presence immediately** (not just after the TTL).
- **Per-user opt-out toggle** on `/settings/telemetry` (shown only while telemetry is active) + a **dismissible in-app notice**, gated on the entitlement-aware `liveTelemetryActive` (not the raw flag) so it can never over-disclose.
- **Legal docs updated**: privacy (lawful basis = legitimate interest + opt-out), data-retention (ActivityEvent 30d, presence ephemeral), dpa + sub-processors (Pubby as the real-time transport; coarse events only).

## Hardening / folded in
- **CSRF same-origin check** on the heartbeat POST (shared `lib/same-origin.ts`), returning **400** (not 403/401) so the reporter's auth-terminal handling doesn't misfire and stop heartbeating.
- Single `getOrgEntitlements` per render (settings + monitor pages).
- Pubby channel **unsubscribed** on unmount; feed **clears** if telemetry is disabled mid-session; `/monitor` requires an explicit active org so the page and the polling APIs resolve the **same** org.

## Notes for review (pre-emptions)
- **Migration is `git add -f`'d** (the `packages/db/prisma/migrations/` dir is gitignored) — confirmed tracked. It's a metadata-only `ADD COLUMN ... NOT NULL DEFAULT false` (no table rewrite).
- Untrusted strings (member name, `currentActivity`, activity `action`/`target`) are rendered as React text nodes (auto-escaped); `currentActivity` is server-validated to a coarse allowlist (PR B).
- A removed/just-opted-out member can linger on the roster for up to the ~60s presence TTL — bounded by design (opt-out clears immediately; the TTL covers removals).
- Human/agent-*attributed* feed events remain deferred (PR B note); the feed is engine/system-attributed, members are shown via presence.
- Vendor cross-org console is PR D.

## Test plan
- `bun run typecheck` ✓ (3/3) · `eslint` ✓ (0 errors) · `bun run build` ✓ (`/monitor`, `/api/presence`, `/api/activity` registered)
- `bun test` ✓ **457 pass / 0 fail** (incl. the PR B privacy leak test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1