### PR TITLE
ci+docs: migration backward-compat gate + deploy/rollback runbook

### DIFF
--- a/.github/workflows/migrate-check.yml
+++ b/.github/workflows/migrate-check.yml
@@ -1,0 +1,90 @@
+name: migrate-check
+
+# Enforces that new Prisma migrations are BACKWARD-COMPATIBLE (expand-only), so a
+# code rollback never requires a database rollback: the previous app image must
+# be able to run against the newer schema. This is what keeps "roll back the
+# code, leave the DB" a safe one-step recovery (see the self-hosting "Upgrading &
+# rolling back" docs).
+#
+# Fails a PR whose ADDED migration.sql contains destructive / incompatible DDL
+# (drop/rename a table or column, retype or NOT-NULL an existing column, or add a
+# NOT NULL column with no DEFAULT). A deliberate contract-phase migration — one
+# that ships only AFTER the previous version is fully drained — can opt out with
+# an explicit `-- migrate-check: allow-destructive` line in the migration.
+#
+# Only files ADDED in the PR are scanned; historical migrations are exempt.
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "packages/db/prisma/migrations/**/migration.sql"
+      - ".github/workflows/migrate-check.yml"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need the base branch to diff added files
+
+      - name: Scan new migrations for backward-incompatible DDL
+        shell: bash
+        run: |
+          set -uo pipefail
+          # The PR base commit is guaranteed present with fetch-depth: 0; using
+          # the SHA avoids relying on a local origin/<branch> ref. --diff-filter=A
+          # restricts to files ADDED by this PR (historical migrations are exempt).
+          base="${{ github.event.pull_request.base.sha }}"
+
+          files=$(git diff --name-only --diff-filter=A "$base" HEAD -- packages/db/prisma/migrations/ \
+                  | grep '/migration\.sql$' || true)
+          if [ -z "$files" ]; then
+            echo "No new migration files in this PR — nothing to check."
+            exit 0
+          fi
+
+          fail=0
+          while IFS= read -r f; do
+            [ -n "$f" ] && [ -f "$f" ] || continue
+            echo "── checking $f"
+
+            if grep -qiE '^[[:space:]]*--[[:space:]]*migrate-check:[[:space:]]*allow-destructive' "$f"; then
+              echo "  ↳ 'allow-destructive' marker present — exempt"
+              continue
+            fi
+
+            # Drop SQL comments, then neutralise FK referential actions so
+            # 'ON DELETE CASCADE' / 'ON UPDATE ...' aren't mistaken for drops.
+            scan=$(sed -E 's/--.*$//' "$f" \
+                   | sed -E 's/ON[[:space:]]+(DELETE|UPDATE)[[:space:]]+(CASCADE|SET[[:space:]]+NULL|SET[[:space:]]+DEFAULT|RESTRICT|NO[[:space:]]+ACTION)//gI')
+
+            hits=""
+            grep -qiE '\bDROP[[:space:]]+TABLE\b'   <<<"$scan" && hits="$hits DROP_TABLE"
+            grep -qiE '\bDROP[[:space:]]+COLUMN\b'  <<<"$scan" && hits="$hits DROP_COLUMN"
+            grep -qiE '\bRENAME\b'                  <<<"$scan" && hits="$hits RENAME"
+            # Only the dangerous ALTER COLUMN forms (retype / set-not-null);
+            # benign SET/DROP DEFAULT and DROP NOT NULL are backward-compatible.
+            if grep -iE '\bALTER[[:space:]]+COLUMN\b' <<<"$scan" \
+               | grep -qiE '\bSET[[:space:]]+NOT[[:space:]]+NULL\b|\bTYPE\b'; then
+              hits="$hits ALTER_COLUMN"
+            fi
+            # ADD COLUMN ... NOT NULL with no DEFAULT breaks old inserts and fails
+            # on existing rows. Collect the ADD COLUMN ... NOT NULL lines first,
+            # then flag only if a non-empty set of them lacks a DEFAULT (a bare
+            # `grep -v` on empty input must not be treated as a hit).
+            addnn=$(grep -iE '\bADD[[:space:]]+COLUMN\b' <<<"$scan" | grep -iE '\bNOT[[:space:]]+NULL\b' || true)
+            if [ -n "$addnn" ] && grep -viqE '\bDEFAULT\b' <<<"$addnn"; then
+              hits="$hits ADD_NOTNULL_NO_DEFAULT"
+            fi
+
+            if [ -n "$hits" ]; then
+              echo "::error file=$f::Backward-incompatible migration DDL:$hits. A code rollback would then require a DB rollback. Keep the migration expand-only, or add a line '-- migrate-check: allow-destructive' if this is a deliberate contract migration that ships only after the previous version is fully drained."
+              fail=1
+            else
+              echo "  ↳ ok (expand-only)"
+            fi
+          done <<< "$files"
+
+          exit $fail

--- a/apps/web/app/(landing)/docs/self-hosting/page.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/page.tsx
@@ -267,6 +267,59 @@ bun run start`}</CodeBlock>
           directly.
         </Paragraph>
       </Section>
+
+      {/* Upgrading & rolling back */}
+      <Section title="Upgrading & rolling back">
+        <Paragraph>
+          Pin a specific image tag in production rather than{" "}
+          <Mono>latest</Mono> — that is what turns a rollback into a one-line
+          change. Each release is published to GHCR as{" "}
+          <Mono>ghcr.io/octopusreview/octopus:X.Y.Z</Mono>.
+        </Paragraph>
+
+        <Step number={1} title="Upgrade">
+          <Paragraph>
+            Pull the new tag, apply migrations, then restart. Octopus migrations
+            are <strong>additive (expand-only)</strong> and therefore
+            backward-compatible — the previous image keeps working against the
+            new schema, which is exactly what makes the rollback below safe.
+          </Paragraph>
+          <CodeBlock>{`# pin the new X.Y.Z tag in your compose/env first, then:
+docker compose pull
+docker compose exec octopus bun run db:migrate   # prisma migrate deploy
+docker compose up -d`}</CodeBlock>
+        </Step>
+
+        <Step number={2} title="Verify before sending traffic">
+          <Paragraph>
+            Confirm the app is healthy — hit <Mono>/api/status</Mono> and check
+            that a login and a review still work — before pointing users at the
+            new version.
+          </Paragraph>
+        </Step>
+
+        <Step number={3} title="Roll back (if needed)">
+          <Paragraph>
+            Re-pin the <strong>previous</strong> image tag and restart.{" "}
+            <strong>Do not roll back the database.</strong> Because every
+            migration is additive, the older image runs fine against the newer
+            schema, so you keep all data and avoid a risky down-migration.
+          </Paragraph>
+          <CodeBlock>{`# set the previous X.Y.Z tag in your compose/env, then:
+docker compose pull
+docker compose up -d`}</CodeBlock>
+        </Step>
+
+        <Paragraph>
+          This expand-only discipline is enforced in CI: the{" "}
+          <Mono>migrate-check</Mono> workflow fails any change whose migration
+          drops or rewrites a table/column (without an explicit override), so the
+          &quot;roll back the code, keep the database&quot; path stays safe from
+          one release to the next. The same property is what lets a hosted,
+          blue-green / rolling deploy run both versions against a single shared
+          database during cutover.
+        </Paragraph>
+      </Section>
     </article>
   );
 }


### PR DESCRIPTION
## What

Two changes that make rollback after a deploy safe and repeatable — directly motivated by the live-telemetry rollout (#569–#572). The goal: **"roll back the code, keep the database"** as a one-step recovery, which is also the property a hosted **blue-green / rolling** deploy needs to run two app versions against a single shared DB during cutover.

> Context: this repo's CD only **builds + publishes the GHCR image** (`release.yml` on `v*` tags) — there is no in-repo host-deploy/blue-green step (the hosted deploy lives in AWS infra outside this repo). These changes harden the part the repo *does* own: migration safety + a documented rollback path.

## 1. `migrate-check` CI gate (`.github/workflows/migrate-check.yml`)
On PRs that **add** a Prisma migration, scans the added `migration.sql` for backward-incompatible DDL and fails the PR:
- `DROP TABLE` / `DROP COLUMN`, `RENAME`, `ALTER COLUMN` (retype or `SET NOT NULL`), and `ADD COLUMN … NOT NULL` with **no `DEFAULT`**.
- **No false positives** on `ON DELETE/UPDATE CASCADE` FK clauses (stripped before scanning) or on `CREATE TABLE` columns (new table → no existing rows).
- Escape hatch: a deliberate **contract-phase** migration (shipped only after the previous version is fully drained) can opt out with a `-- migrate-check: allow-destructive` line.
- The scan logic was unit-verified against additive **and** destructive fixtures (the telemetry migrations pass; DROP/RENAME/retype/notnull-no-default fail; `allow-destructive` exempts).

This guarantees future migrations stay **expand-only**, so a code rollback never forces a DB rollback.

## 2. Self-hosting docs — "Upgrading & rolling back"
A runbook: pin image tags; **upgrade** = `docker compose pull` + `prisma migrate deploy` + restart; **verify** via `/api/status`; **roll back** = re-pin the previous tag and restart, **leaving the DB as-is** (safe because migrations are additive). Explains why the expand-only discipline (enforced by #1) is what keeps this safe release-to-release.

## Test plan
- `bun run typecheck` ✓ (3/3) · `bun run build` ✓ (`/docs/self-hosting` renders) · workflow is valid YAML.
- `migrate-check` scan logic verified against 10 fixtures (additive/destructive/marked/CREATE TABLE) — all correct verdicts.
- This PR adds no migration, so `migrate-check` runs and reports "nothing to check" (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1