### PR TITLE
feat(deploy): blue-green readiness — health probe, Cloudflare cutover workflow, runbook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,181 @@
+name: deploy (blue-green cutover)
+
+# Manual, automated blue-green cutover for a Cloudflare Load Balancer fronting
+# two legs (e.g. datacenter + AWS), both stateless app containers pulling the
+# same GHCR image and sharing ONE database. Flow:
+#   1. (optional) deploy the chosen image tag to the TARGET leg over SSH
+#   2. health-gate: poll the target leg's /api/health directly until ready
+#   3. cutover: point the Cloudflare LB's default pool at the target leg
+#   4. verify the public hostname, then print rollback instructions
+#
+# The previous leg is left running, so rollback = re-run this with the other
+# target (instant traffic flip back). This assumes additive (expand-only)
+# migrations so both legs can serve one shared DB during cutover — enforced by
+# the migrate-check workflow.
+#
+# ── Required configuration (set in repo Settings) ───────────────────────────
+#   Secrets:
+#     CLOUDFLARE_API_TOKEN   - token with "Load Balancers: Edit" on the zone
+#     DEPLOY_SSH_KEY         - (optional) private key for the SSH deploy step
+#   Variables:
+#     CLOUDFLARE_ZONE_ID, CLOUDFLARE_LB_ID
+#     CF_POOL_DATACENTER, CF_POOL_AWS          - Cloudflare LB pool IDs per leg
+#     HEALTH_URL_DATACENTER, HEALTH_URL_AWS    - each leg's DIRECT origin /api/health (bypassing the LB)
+#     PUBLIC_HEALTH_URL                        - the LB hostname's /api/health (post-cutover verify)
+#     SSH_HOST_DATACENTER, SSH_HOST_AWS, DEPLOY_SSH_USER, DEPLOY_REMOTE_CMD  - (optional) SSH deploy
+# If the SSH_* vars / DEPLOY_SSH_KEY are unset, the deploy step is skipped and
+# the workflow assumes the target leg already runs the desired tag (e.g. it
+# auto-pulls), doing only the health-gate + cutover.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Leg to deploy to and cut traffic over to"
+        type: choice
+        options: [datacenter, aws]
+        required: true
+      tag:
+        description: "Image tag to deploy (e.g. 0.3.0). Used by the optional SSH deploy step."
+        type: string
+        required: true
+
+concurrency:
+  group: deploy-cutover
+  cancel-in-progress: false
+
+jobs:
+  cutover:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve target leg
+        id: t
+        # Pass config via env (not inline ${{ }} into the script) so a malformed
+        # repo Variable can't break out of / corrupt the shell.
+        env:
+          TARGET: ${{ inputs.target }}
+          POOL_DC: ${{ vars.CF_POOL_DATACENTER }}
+          POOL_AWS: ${{ vars.CF_POOL_AWS }}
+          HEALTH_DC: ${{ vars.HEALTH_URL_DATACENTER }}
+          HEALTH_AWS: ${{ vars.HEALTH_URL_AWS }}
+          SSH_DC: ${{ vars.SSH_HOST_DATACENTER }}
+          SSH_AWS: ${{ vars.SSH_HOST_AWS }}
+        run: |
+          set -euo pipefail
+          if [ "$TARGET" = "datacenter" ]; then
+            pool="$POOL_DC"; health="$HEALTH_DC"; ssh_host="$SSH_DC"
+          else
+            pool="$POOL_AWS"; health="$HEALTH_AWS"; ssh_host="$SSH_AWS"
+          fi
+          printf '%s\n' "pool=$pool" "health=$health" "ssh_host=$ssh_host" >> "$GITHUB_OUTPUT"
+
+      - name: Preflight — validate inputs + required configuration
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          TARGET: ${{ inputs.target }}
+          ZONE: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          LB: ${{ vars.CLOUDFLARE_LB_ID }}
+          POOL: ${{ steps.t.outputs.pool }}
+          HEALTH: ${{ steps.t.outputs.health }}
+        run: |
+          set -uo pipefail
+          # The tag flows into the SSH deploy command — constrain it to a safe
+          # image-tag charset so it can't smuggle shell metacharacters.
+          if ! printf '%s' "$TAG" | grep -qE '^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$'; then
+            echo "::error::Invalid tag '$TAG' — allowed: letters, digits, dot, dash, underscore."
+            exit 1
+          fi
+          missing=""
+          [ -n "$CF_TOKEN" ] || missing="$missing CLOUDFLARE_API_TOKEN(secret)"
+          [ -n "$ZONE" ]   || missing="$missing CLOUDFLARE_ZONE_ID"
+          [ -n "$LB" ]     || missing="$missing CLOUDFLARE_LB_ID"
+          [ -n "$POOL" ]   || missing="$missing CF_POOL_$TARGET"
+          [ -n "$HEALTH" ] || missing="$missing HEALTH_URL_$TARGET"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing required config:$missing — see the header of this workflow."
+            exit 1
+          fi
+
+      - name: Deploy image to target leg (optional SSH)
+        if: ${{ vars.DEPLOY_SSH_USER != '' && steps.t.outputs.ssh_host != '' }}
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          SSH_USER: ${{ vars.DEPLOY_SSH_USER }}
+          SSH_HOST: ${{ steps.t.outputs.ssh_host }}
+          # Customise per your compose layout; IMAGE_TAG is exported for it.
+          REMOTE_CMD: ${{ vars.DEPLOY_REMOTE_CMD }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "$SSH_KEY" ]; then
+            echo "::error::DEPLOY_SSH_USER is set but DEPLOY_SSH_KEY secret is missing."; exit 1
+          fi
+          key=$(mktemp); trap 'rm -f "$key"' EXIT  # remove the key on any exit path
+          printf '%s' "$SSH_KEY" > "$key"; chmod 600 "$key"
+          cmd="${REMOTE_CMD:-cd /opt/octopus && docker compose pull && docker compose up -d}"
+          echo "Deploying tag '$TAG' to $SSH_HOST"
+          IMAGE_TAG="$TAG" ssh -i "$key" -o StrictHostKeyChecking=accept-new \
+            "$SSH_USER@$SSH_HOST" "export IMAGE_TAG='$TAG'; $cmd"
+
+      - name: Health-gate the target leg
+        env:
+          HEALTH: ${{ steps.t.outputs.health }}
+        run: |
+          set -uo pipefail
+          echo "Waiting for $HEALTH to report ready..."
+          for i in $(seq 1 30); do
+            code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 5 "$HEALTH" || echo 000)
+            if [ "$code" = "200" ]; then echo "✓ target healthy"; exit 0; fi
+            echo "  attempt $i: HTTP $code — retrying"; sleep 5
+          done
+          echo "::error::Target leg never became healthy — NOT cutting over."
+          exit 1
+
+      - name: Cut traffic over to target (Cloudflare LB)
+        env:
+          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          ZONE: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          LB: ${{ vars.CLOUDFLARE_LB_ID }}
+          POOL: ${{ steps.t.outputs.pool }}
+        run: |
+          set -euo pipefail
+          # Make the target pool the LB's sole default pool — all traffic routes
+          # to it. The other leg stays up for an instant rollback (re-run with
+          # the other target).
+          resp=$(curl -fsS -X PATCH \
+            "https://api.cloudflare.com/client/v4/zones/$ZONE/load_balancers/$LB" \
+            -H "Authorization: Bearer $CF_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data "{\"default_pools\":[\"$POOL\"]}")
+          ok=$(echo "$resp" | jq -r '.success')
+          if [ "$ok" != "true" ]; then
+            echo "::error::Cloudflare cutover failed: $(echo "$resp" | jq -c '.errors')"; exit 1
+          fi
+          echo "✓ traffic now routes to ${{ inputs.target }} (pool $POOL)"
+
+      - name: Verify public hostname
+        if: ${{ vars.PUBLIC_HEALTH_URL != '' }}
+        env:
+          PUB: ${{ vars.PUBLIC_HEALTH_URL }}
+        run: |
+          set -uo pipefail
+          ok=0
+          for i in $(seq 1 12); do
+            code=$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 5 "$PUB" || echo 000)
+            [ "$code" = "200" ] && { echo "✓ public hostname healthy"; ok=1; break; }
+            echo "  attempt $i: HTTP $code"; sleep 5
+          done
+          # Post-cutover: don't hard-fail (traffic is already switched and we
+          # don't auto-rollback), but make an unconfirmed cutover visible.
+          [ "$ok" = 1 ] || echo "::warning::public hostname never returned 200 after cutover — verify manually (rollback = re-run with the other target)."
+
+      - name: Summary
+        run: |
+          {
+            echo "### Blue-green cutover → ${{ inputs.target }}"
+            echo ""
+            echo "- Image tag: \`${{ inputs.tag }}\`"
+            echo "- Traffic now on pool: \`${{ steps.t.outputs.pool }}\`"
+            echo "- **Rollback:** re-run this workflow with the *other* target — the previous leg is still running, so it's an instant flip back."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ name: deploy (blue-green cutover)
 #     CF_POOL_DATACENTER, CF_POOL_AWS          - Cloudflare LB pool IDs per leg
 #     HEALTH_URL_DATACENTER, HEALTH_URL_AWS    - each leg's DIRECT origin /api/health (bypassing the LB)
 #     PUBLIC_HEALTH_URL                        - the LB hostname's /api/health (post-cutover verify)
-#     SSH_HOST_DATACENTER, SSH_HOST_AWS, DEPLOY_SSH_USER, DEPLOY_REMOTE_CMD  - (optional) SSH deploy
+#     SSH_HOST_DATACENTER, SSH_HOST_AWS, DEPLOY_SSH_USER, DEPLOY_DIR  - (optional) SSH deploy (DEPLOY_DIR = compose dir, default /opt/octopus)
 # If the SSH_* vars / DEPLOY_SSH_KEY are unset, the deploy step is skipped and
 # the workflow assumes the target leg already runs the desired tag (e.g. it
 # auto-pulls), doing only the health-gate + cutover.
@@ -103,20 +103,30 @@ jobs:
           SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
           SSH_USER: ${{ vars.DEPLOY_SSH_USER }}
           SSH_HOST: ${{ steps.t.outputs.ssh_host }}
-          # Customise per your compose layout; IMAGE_TAG is exported for it.
-          REMOTE_CMD: ${{ vars.DEPLOY_REMOTE_CMD }}
+          # The compose directory on the leg (default /opt/octopus). A PATH, not
+          # an arbitrary command — the deploy command itself is fixed below.
+          DEPLOY_DIR: ${{ vars.DEPLOY_DIR }}
           TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
           if [ -z "$SSH_KEY" ]; then
             echo "::error::DEPLOY_SSH_USER is set but DEPLOY_SSH_KEY secret is missing."; exit 1
           fi
+          dir="${DEPLOY_DIR:-/opt/octopus}"
+          # Validate the dir as a plain path so it can't smuggle shell into the
+          # remote command (the deploy command is otherwise fixed — no free-form
+          # remote command is accepted).
+          if ! printf '%s' "$dir" | grep -qE '^/[A-Za-z0-9._/-]*$'; then
+            echo "::error::Invalid DEPLOY_DIR '$dir' — must be an absolute path of [A-Za-z0-9._/-]."; exit 1
+          fi
           key=$(mktemp); trap 'rm -f "$key"' EXIT  # remove the key on any exit path
           printf '%s' "$SSH_KEY" > "$key"; chmod 600 "$key"
-          cmd="${REMOTE_CMD:-cd /opt/octopus && docker compose pull && docker compose up -d}"
-          echo "Deploying tag '$TAG' to $SSH_HOST"
+          echo "Deploying tag '$TAG' to $SSH_HOST ($dir)"
+          # Fixed remote command; $TAG (charset-validated in preflight) and $dir
+          # (validated above) are the only interpolated values.
           IMAGE_TAG="$TAG" ssh -i "$key" -o StrictHostKeyChecking=accept-new \
-            "$SSH_USER@$SSH_HOST" "export IMAGE_TAG='$TAG'; $cmd"
+            "$SSH_USER@$SSH_HOST" \
+            "export IMAGE_TAG='$TAG'; cd '$dir' && docker compose pull && docker compose up -d"
 
       - name: Health-gate the target leg
         env:

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -58,4 +58,11 @@ USER nextjs
 EXPOSE 3000
 ENV HOSTNAME=0.0.0.0
 ENV NODE_OPTIONS="--max-old-space-size=4096"
+
+# Container-level readiness for orchestrators / compose. Hits the same
+# /api/health probe the Cloudflare LB monitors. Node 22 ships a global fetch, so
+# no curl is needed in the alpine runner. start-period covers app boot.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=45s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:3000/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 CMD ["node", "apps/web/server.js"]

--- a/apps/web/app/(landing)/docs/self-hosting/page.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/page.tsx
@@ -320,6 +320,45 @@ docker compose up -d`}</CodeBlock>
           database during cutover.
         </Paragraph>
       </Section>
+
+      {/* Blue-green with a Cloudflare load balancer */}
+      <Section title="Zero-downtime cutover (Cloudflare LB)">
+        <Paragraph>
+          For zero-downtime deploys, front two legs (e.g. your datacenter and a
+          cloud VM) with a Cloudflare Load Balancer. Both legs are{" "}
+          <strong>stateless app containers</strong> pulling the same image and
+          pointing at <strong>one shared database</strong> (and Qdrant/Redis) —
+          Octopus is safe to run as multiple app instances on one DB, since
+          pg-boss coordinates workers and dedupes the scheduled jobs across them.
+        </Paragraph>
+        <ul className="mb-3 list-inside list-disc space-y-1.5 text-sm text-[#888]">
+          <li>
+            Create a Cloudflare LB with one <Mono>pool</Mono> per leg and a{" "}
+            <Mono>monitor</Mono> that probes <Mono>/api/health</Mono> (it returns{" "}
+            <Mono>200</Mono> only when the leg can reach the database, else{" "}
+            <Mono>503</Mono>). Cloudflare drops an unhealthy leg from rotation
+            automatically.
+          </li>
+          <li>
+            Deploy the new tag to the <strong>idle</strong> leg, let its{" "}
+            <Mono>/api/health</Mono> go green, then point the LB&apos;s default
+            pool at it. Keep the previous leg running — rollback is an instant
+            flip back.
+          </li>
+          <li>
+            The included <Mono>deploy</Mono> workflow automates this
+            (deploy &rarr; health-gate &rarr; Cloudflare cutover &rarr; verify);
+            set the documented Cloudflare token / LB &amp; pool IDs as repo
+            secrets and variables.
+          </li>
+        </ul>
+        <Paragraph>
+          Note: this is zero-downtime <em>deploys</em> against one shared DB. True
+          survive-a-whole-site-outage HA additionally needs that database
+          (and Qdrant) replicated across both legs with failover — a separate,
+          larger piece of work.
+        </Paragraph>
+      </Section>
     </article>
   );
 }

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,5 +1,39 @@
-export function GET() {
-  return Response.json({
-    status: "ok",
-  });
+import { prisma } from "@octopus/db";
+
+// Never cache a readiness probe — it must reflect the instance's live state.
+export const dynamic = "force-dynamic";
+
+// Bound the DB check so a hung/unresponsive database fails the probe fast
+// (returns 503) rather than letting the request hang.
+const DB_CHECK_TIMEOUT_MS = 2000;
+
+/**
+ * GET /api/health — unauthenticated readiness probe for the Cloudflare load
+ * balancer (per-origin monitor) and the blue-green deploy gate. Returns 200 when
+ * this instance can reach its primary database (the dependency every request
+ * needs), else 503 so the LB stops routing to it / the deploy doesn't promote a
+ * not-ready leg. Intentionally does NOT gate on Qdrant/Redis — those degrade
+ * search/reviews but the app still serves, so they shouldn't pull a leg out of
+ * rotation. No data is returned beyond a coarse status.
+ */
+export async function GET() {
+  try {
+    // Bound the probe at the DRIVER level: `SET LOCAL statement_timeout` makes
+    // Postgres abort the query and RELEASE the pooled connection if the DB is
+    // slow/hung. (A raced, uncancellable promise would 503 fast but leave the
+    // query — and its checked-out connection — pending, so repeated probes
+    // against a degraded DB could exhaust the pool and starve real traffic.)
+    // The $transaction timeout is a belt-and-suspenders overall bound. The
+    // interpolated value is a hardcoded constant, so $executeRawUnsafe is safe.
+    await prisma.$transaction(
+      async (tx) => {
+        await tx.$executeRawUnsafe(`SET LOCAL statement_timeout = ${DB_CHECK_TIMEOUT_MS}`);
+        await tx.$queryRaw`SELECT 1`;
+      },
+      { timeout: DB_CHECK_TIMEOUT_MS + 1000 },
+    );
+    return Response.json({ status: "ok" });
+  } catch {
+    return Response.json({ status: "degraded", db: "down" }, { status: 503 });
+  }
 }


### PR DESCRIPTION
## What

In-repo foundation for **zero-downtime blue-green deploys** behind a Cloudflare Load Balancer with two legs (e.g. datacenter + a cloud VM) — both **stateless app containers sharing one database** and pulling the same GHCR image. (The LB itself + where the shared DB lives are infra-side; this PR is the part the repo owns.)

## Changes
- **`/api/health` → real readiness probe.** Was `{status:"ok"}` (always 200, even with the DB down — would route traffic to a broken leg). Now does `SELECT 1` bounded by a **DB-level `statement_timeout`** inside a short `$transaction`, so a slow/hung DB **aborts the query and releases the pooled connection** (a raced, uncancellable promise would 503 fast but leak the connection — repeated probes could then exhaust the pool). Returns 200 ready / 503 degraded; unauthenticated, no sensitive data, `force-dynamic`. Gates on the DB only (not Qdrant/Redis — those degrade features but the app still serves, so they shouldn't pull a leg out of rotation).
- **Dockerfile `HEALTHCHECK`** hitting `/api/health` (node `fetch`; alpine runner has no curl) for orchestrator/compose readiness.
- **`.github/workflows/deploy.yml`** — manual (`workflow_dispatch`) blue-green cutover: *(optional)* SSH-deploy the tag to the target leg → **health-gate** its `/api/health` (won't cut over to a dead leg) → **PATCH the Cloudflare LB default pool** to flip traffic → verify. The previous leg stays warm, so **rollback = re-run with the other target** (instant flip). Hardened: preflight validates required secrets/vars, the `tag` input is charset-checked before reaching SSH, config is passed via `env` (not inline `${{ }}`) to prevent injection, and the SSH key is `trap`-cleaned on any exit path.
- **Self-hosting docs** — a "Zero-downtime cutover (Cloudflare LB)" runbook.

## Notes for review
- **Shared-DB requirement** is documented: blue and green run against one DB during cutover — safe because migrations are additive (the `migrate-check` gate, #573, enforces this). Octopus runs fine as multiple app instances on one DB (pg-boss coordinates workers + dedupes schedules).
- This is zero-downtime **deploys**, *not* survive-a-whole-site-outage HA — that additionally needs the DB/Qdrant replicated across legs with failover (called out in the docs as a separate, larger effort).
- The deploy workflow is `workflow_dispatch` (doesn't run on PR) and inert until its Cloudflare/SSH secrets+vars are configured — the required set is documented in the workflow header.
- Pre-push adversarial review (workflow secret/injection + health-probe DoS lenses): 6 raised, 5 fixed here — incl. the connection-leak (now `statement_timeout`-bounded), the SSH-key cleanup trap, the silent verify step (now warns), and `GITHUB_OUTPUT` injection hardening.

## Test plan
- `bun run typecheck` ✓ (3/3) · `eslint` ✓ · `bun run build` ✓ (`/api/health` dynamic) · `deploy.yml` valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1