### PR TITLE
feat(stripe): self-healing customer + pinned API version (account-migration prep)

### DIFF
--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -14,21 +14,37 @@ export function getStripe(): Stripe {
   return _stripe;
 }
 
+// Customer IDs already confirmed to resolve in the current Stripe account, so
+// the verify below runs at most ONCE per customer per process (not on every
+// billing op). This holds only opaque, already-public customer IDs — no
+// cross-tenant data — and is correctness-neutral: a hit merely skips a
+// redundant retrieve; if a customer is deleted mid-process the downstream Stripe
+// call fails exactly as it would without the cache. Bounded by active billing
+// orgs per process; resets on deploy (re-verifies once per customer afterward).
+const _verifiedCustomers = new Set<string>();
+
 export async function getOrCreateStripeCustomer(orgId: string): Promise<string> {
   const org = await prisma.organization.findUniqueOrThrow({
     where: { id: orgId },
     select: { stripeCustomerId: true, name: true, billingEmail: true, slug: true },
   });
 
-  if (org.stripeCustomerId) {
+  const priorId = org.stripeCustomerId;
+  if (priorId) {
+    if (_verifiedCustomers.has(priorId)) return priorId;
     // Verify the stored customer still resolves in the CURRENT account. After a
     // Stripe account switch (or a deleted customer) the old `cus_` belongs to a
     // different account and won't resolve — recreate it instead of failing every
-    // checkout / portal / auto-reload call. This makes an account migration
-    // self-healing per org with no destructive prod data wipe.
+    // checkout / portal / auto-reload call. Self-heals an account migration per
+    // org with no destructive prod data wipe; the cache keeps it one-shot.
     try {
-      const existing = await getStripe().customers.retrieve(org.stripeCustomerId);
-      if (!("deleted" in existing && existing.deleted)) return org.stripeCustomerId;
+      const existing = await getStripe().customers.retrieve(priorId);
+      const isDeleted = "deleted" in existing && existing.deleted === true;
+      if (!isDeleted) {
+        _verifiedCustomers.add(priorId);
+        return priorId;
+      }
+      // Deleted in Stripe → fall through and create a fresh customer.
     } catch (err) {
       // Only "no such customer" justifies recreating; rethrow real errors
       // (auth/network) so they aren't masked as a missing customer.
@@ -46,11 +62,37 @@ export async function getOrCreateStripeCustomer(orgId: string): Promise<string> 
     metadata: { orgId, slug: org.slug },
   });
 
-  await prisma.organization.update({
-    where: { id: orgId },
+  // Claim the slot with a compare-and-swap: only the writer whose `priorId` still
+  // matches the column wins. Two concurrent recreations (e.g. checkout +
+  // auto-reload) thus can't both persist — the loser's update matches 0 rows.
+  // We do NOT hold the Stripe calls inside a DB transaction (that would pin a
+  // pooled connection across slow external I/O and trip Prisma's interactive-txn
+  // timeout); the CAS is a single atomic write instead.
+  const claimed = await prisma.organization.updateMany({
+    where: { id: orgId, stripeCustomerId: priorId },
     data: { stripeCustomerId: customer.id },
   });
 
+  if (claimed.count === 0) {
+    // Lost the race: another request already replaced stripeCustomerId. Delete
+    // our just-created duplicate so it doesn't orphan in Stripe, then use the
+    // winner's customer.
+    try {
+      await getStripe().customers.del(customer.id);
+    } catch {
+      // Best-effort cleanup; an undeleted spare customer is harmless.
+    }
+    const winner = await prisma.organization.findUniqueOrThrow({
+      where: { id: orgId },
+      select: { stripeCustomerId: true },
+    });
+    if (winner.stripeCustomerId) {
+      _verifiedCustomers.add(winner.stripeCustomerId);
+      return winner.stripeCustomerId;
+    }
+  }
+
+  _verifiedCustomers.add(customer.id);
   return customer.id;
 }
 

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -4,7 +4,12 @@ import { prisma } from "@octopus/db";
 let _stripe: Stripe | null = null;
 export function getStripe(): Stripe {
   if (!_stripe) {
-    _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+    _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      // Pin the API version so switching Stripe accounts can't silently change
+      // event/object shapes by inheriting a different account default. Matches
+      // the stripe@20.4.1 SDK's generated types.
+      apiVersion: "2026-02-25.clover",
+    });
   }
   return _stripe;
 }
@@ -15,7 +20,25 @@ export async function getOrCreateStripeCustomer(orgId: string): Promise<string> 
     select: { stripeCustomerId: true, name: true, billingEmail: true, slug: true },
   });
 
-  if (org.stripeCustomerId) return org.stripeCustomerId;
+  if (org.stripeCustomerId) {
+    // Verify the stored customer still resolves in the CURRENT account. After a
+    // Stripe account switch (or a deleted customer) the old `cus_` belongs to a
+    // different account and won't resolve — recreate it instead of failing every
+    // checkout / portal / auto-reload call. This makes an account migration
+    // self-healing per org with no destructive prod data wipe.
+    try {
+      const existing = await getStripe().customers.retrieve(org.stripeCustomerId);
+      if (!("deleted" in existing && existing.deleted)) return org.stripeCustomerId;
+    } catch (err) {
+      // Only "no such customer" justifies recreating; rethrow real errors
+      // (auth/network) so they aren't masked as a missing customer.
+      if (
+        !(err instanceof Stripe.errors.StripeInvalidRequestError && err.code === "resource_missing")
+      ) {
+        throw err;
+      }
+    }
+  }
 
   const customer = await getStripe().customers.create({
     name: org.name,


### PR DESCRIPTION
## What

Code prep for switching to a **new Stripe account** (fresh-account path — most customers aren't paying, no active auto-reload). Makes the switch safe for existing orgs **without any destructive prod data change**.

## Changes (`apps/web/lib/stripe.ts`)
- **Self-healing customer**: `getOrCreateStripeCustomer` now verifies the stored `stripeCustomerId` actually resolves in the *current* Stripe account. On `resource_missing` (or a deleted customer) it **recreates** the customer and updates the org, instead of passing a stale `cus_` (from the old account) to Checkout / Billing Portal / auto-reload — which would otherwise fail `No such customer` for every existing org after the switch. Real errors (auth/network) are rethrown, not masked. → an account migration is **self-healing per org**, so no `NULL`-ing of `stripeCustomerId` in prod is required.
- **Pinned `apiVersion`** (`2026-02-25.clover`, matching the `stripe@20.4.1` SDK's generated types) so a new account's default API version can't silently change event/object shapes.

## Why this is low-risk
- **Existing paying orgs keep working**: credit balances live in *our* DB (`creditBalance`/`freeCreditBalance`), not Stripe — unaffected by the account switch. Only the payment rail changes; the next top-up mints a fresh customer in the new account.
- **No product/price migration**: Checkout uses inline `price_data` (no stored Price/Product IDs).
- The added `customers.retrieve` runs only on customer-needing operations (Checkout/Portal/auto-reload), which are user-initiated / background — not a hot path.

## Still required for the cutover (operational, not in this PR)
- Register a new webhook endpoint on the new account (`/api/stripe/webhook`, events: `checkout.session.completed`, `charge.refunded`, `payment_intent.payment_failed`) and set the new `whsec_` + `sk_` in prod env. (I'll drive the Stripe-CLI setup + test events once the new-account login is shared; secrets get flipped by the team.)
- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` is declared but unused in code — rotating it is cosmetic.

## Follow-up (noted, not here)
- The webhook returns 200 even when a handler throws, so Stripe won't retry a transiently-failed credit grant — worth switching to 500-on-failure (separate reliability fix).

## Test plan
- `bun run typecheck` ✓ (3/3) · `eslint` ✓. End-to-end verification (real Checkout + webhook) will run against the new account via the Stripe CLI before cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1