### PR TITLE
fix(billing): harden Stripe webhook — retry contract + idempotent refunds

### DIFF
--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -13,6 +13,14 @@ async function getReceiptUrl(paymentIntentId: string | null): Promise<string | n
   }
 }
 
+// A duplicate webhook delivery hits a UNIQUE constraint on the ledger row
+// (stripeSessionId for purchases, stripeRefundId for refunds), which Prisma
+// surfaces as error code P2002. That means "already processed" — safe to ACK.
+// Detect it structurally by code, not by matching the (unstable) message text.
+function isDuplicateLedgerError(err: unknown): boolean {
+  return (err as { code?: string } | null)?.code === "P2002";
+}
+
 export async function POST(req: NextRequest) {
   const body = await req.text();
   const signature = req.headers.get("stripe-signature");
@@ -29,70 +37,95 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
-  if (event.type === "checkout.session.completed") {
-    const session = event.data.object;
-    const orgId = session.metadata?.orgId;
-    const type = session.metadata?.type;
-    const amountUsd = Number(session.metadata?.amountUsd || 0);
+  // Single retry contract for value-bearing work: a duplicate delivery (P2002)
+  // is ACKed with 200 (idempotent skip); ANY other failure returns 500 so Stripe
+  // retries — otherwise a transient DB/Stripe error would silently drop a paid
+  // customer's credits, since we'd have ACKed 200 and Stripe never re-delivers.
+  try {
+    if (event.type === "checkout.session.completed") {
+      const session = event.data.object;
+      const orgId = session.metadata?.orgId;
+      const type = session.metadata?.type;
+      const amountUsd = Number(session.metadata?.amountUsd || 0);
 
-    if (orgId && type === "credit_purchase" && amountUsd > 0) {
-      try {
-        await addCredits(
-          orgId,
-          amountUsd,
-          "purchase",
-          `Credit purchase — $${amountUsd}`,
-          session.id,
-        );
-
-        // Fetch and store receipt URL
-        const receiptUrl = await getReceiptUrl(
-          typeof session.payment_intent === "string" ? session.payment_intent : null,
-        );
-        if (receiptUrl) {
-          await prisma.creditTransaction.update({
-            where: { stripeSessionId: session.id },
-            data: { receiptUrl },
-          });
-        }
-      } catch (err: unknown) {
-        if (
-          err instanceof Error &&
-          err.message.includes("Unique constraint")
-        ) {
-          console.log("[stripe-webhook] Duplicate session, skipping:", session.id);
-        } else {
-          console.error("[stripe-webhook] Failed to add credits:", err);
-        }
-      }
-    }
-  }
-
-  if (event.type === "charge.refunded") {
-    const charge = event.data.object;
-    const paymentIntentId = typeof charge.payment_intent === "string" ? charge.payment_intent : null;
-
-    if (paymentIntentId) {
-      // Find the original transaction by looking up the checkout session tied to this payment intent
-      const sessions = await getStripe().checkout.sessions.list({ payment_intent: paymentIntentId, limit: 1 });
-      const checkoutSession = sessions.data[0];
-      const orgId = checkoutSession?.metadata?.orgId;
-      const amountRefunded = charge.amount_refunded / 100;
-
-      if (orgId && amountRefunded > 0) {
+      if (orgId && type === "credit_purchase" && amountUsd > 0) {
         try {
-          await deductCredits(orgId, amountRefunded, `Refund — $${amountRefunded}`);
-          console.log(`[stripe-webhook] Refund processed: $${amountRefunded} for org ${orgId}`);
+          await addCredits(
+            orgId,
+            amountUsd,
+            "purchase",
+            `Credit purchase — $${amountUsd}`,
+            session.id,
+          );
         } catch (err) {
-          console.error("[stripe-webhook] Failed to process refund:", err);
+          if (isDuplicateLedgerError(err)) {
+            console.log("[stripe-webhook] Duplicate session, skipping:", session.id);
+            return NextResponse.json({ received: true });
+          }
+          throw err;
+        }
+
+        // Best-effort receipt backfill — the credits are already committed, so a
+        // failure here must NOT turn into a 500 that re-drives the grant.
+        try {
+          const receiptUrl = await getReceiptUrl(
+            typeof session.payment_intent === "string" ? session.payment_intent : null,
+          );
+          if (receiptUrl) {
+            await prisma.creditTransaction.update({
+              where: { stripeSessionId: session.id },
+              data: { receiptUrl },
+            });
+          }
+        } catch (err) {
+          console.error("[stripe-webhook] Receipt URL backfill failed (non-fatal):", err);
         }
       }
     }
-  }
 
-  if (event.type === "payment_intent.payment_failed") {
-    const intent = event.data.object;
-    console.error("[stripe-webhook] Payment failed:", intent.id, intent.last_payment_error?.message);
+    if (event.type === "charge.refunded") {
+      const charge = event.data.object;
+      const paymentIntentId = typeof charge.payment_intent === "string" ? charge.payment_intent : null;
+
+      if (paymentIntentId) {
+        // Find the org via the checkout session tied to this payment intent.
+        const sessions = await getStripe().checkout.sessions.list({ payment_intent: paymentIntentId, limit: 1 });
+        const orgId = sessions.data[0]?.metadata?.orgId;
+
+        if (orgId) {
+          // Deduct each refund INDIVIDUALLY, keyed on its own id, using the
+          // per-refund amount — NOT charge.amount_refunded, which is the running
+          // cumulative total (deducting that on every delivery, or on a second
+          // partial refund, would over-debit). The unique stripeRefundId makes a
+          // redelivered event a no-op (P2002 → rolled back). Auto-paginate so a
+          // charge with >100 refunds is fully covered, and only act on refunds
+          // that actually moved money — pending/failed/canceled refunds still
+          // carry a nonzero `amount` but must not debit the balance.
+          for await (const refund of getStripe().refunds.list({ charge: charge.id })) {
+            const amount = refund.amount / 100;
+            if (refund.status !== "succeeded" || amount <= 0) continue;
+            try {
+              await deductCredits(orgId, amount, `Refund — $${amount}`, refund.id);
+              console.log(`[stripe-webhook] Refund processed: $${amount} for org ${orgId} (${refund.id})`);
+            } catch (err) {
+              if (isDuplicateLedgerError(err)) {
+                console.log("[stripe-webhook] Duplicate refund, skipping:", refund.id);
+                continue;
+              }
+              throw err;
+            }
+          }
+        }
+      }
+    }
+
+    if (event.type === "payment_intent.payment_failed") {
+      const intent = event.data.object;
+      console.error("[stripe-webhook] Payment failed:", intent.id, intent.last_payment_error?.message);
+    }
+  } catch (err) {
+    console.error("[stripe-webhook] Processing failed — returning 500 so Stripe retries:", err);
+    return NextResponse.json({ error: "processing failed" }, { status: 500 });
   }
 
   return NextResponse.json({ received: true });

--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -72,6 +72,18 @@ let mockPaymentIntentsCreate = mock(() =>
 );
 let mockChargesRetrieve = mock(() => Promise.resolve({ receipt_url: null }));
 
+type StubRefund = { id: string; amount: number; status: string };
+// The route auto-paginates refunds via `for await (... of stripe.refunds.list())`,
+// so the stub must be async-iterable (mirrors the SDK's ApiListPromise).
+function asyncRefundList(items: StubRefund[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const item of items) yield item;
+    },
+  };
+}
+let mockRefundsList = mock(() => asyncRefundList([]));
+
 mock.module("@octopus/db", () => ({
   prisma: {
     organization: {
@@ -86,16 +98,25 @@ mock.module("@octopus/db", () => ({
     autoReloadConfig: {
       findUnique: (...args: unknown[]) => mockAutoReloadConfigFindUnique(...args),
     },
-    $transaction: (callback: (tx: unknown) => Promise<unknown>) =>
-      callback({
-        $queryRaw: (...args: unknown[]) => mockTxQueryRaw(...args),
-        organization: {
-          update: (...args: unknown[]) => mockTxOrganizationUpdate(...args),
-        },
-        creditTransaction: {
-          create: (...args: unknown[]) => mockTxCreditTransactionCreate(...args),
-        },
-      }),
+    $transaction: async (callback: (tx: unknown) => Promise<unknown>) => {
+      const snapshot = { ...orgState };
+      try {
+        return await callback({
+          $queryRaw: (...args: unknown[]) => mockTxQueryRaw(...args),
+          organization: {
+            update: (...args: unknown[]) => mockTxOrganizationUpdate(...args),
+          },
+          creditTransaction: {
+            create: (...args: unknown[]) => mockTxCreditTransactionCreate(...args),
+          },
+        });
+      } catch (err) {
+        // Simulate transactional rollback so idempotency tests can assert the
+        // balance is unchanged when the ledger insert hits a UNIQUE violation.
+        orgState = snapshot;
+        throw err;
+      }
+    },
   },
 }));
 
@@ -110,6 +131,9 @@ mock.module("@/lib/stripe", () => ({
       sessions: {
         list: (...args: unknown[]) => mockCheckoutSessionsList(...args),
       },
+    },
+    refunds: {
+      list: (...args: unknown[]) => mockRefundsList(...args),
     },
     paymentIntents: {
       create: (...args: unknown[]) => mockPaymentIntentsCreate(...args),
@@ -197,6 +221,7 @@ function resetBillingMocks() {
     Promise.resolve({ status: "succeeded", latest_charge: null }),
   );
   mockChargesRetrieve = mock(() => Promise.resolve({ receipt_url: null }));
+  mockRefundsList = mock(() => asyncRefundList([]));
 }
 
 function stripeRequest(body = "{}") {
@@ -369,11 +394,15 @@ describe("Stripe webhook route", () => {
       type: "charge.refunded",
       data: {
         object: {
+          id: "ch_refund",
           payment_intent: "pi_refund",
           amount_refunded: 1250,
         },
       },
     };
+    mockRefundsList = mock(() =>
+      asyncRefundList([{ id: "re_1", amount: 1250, status: "succeeded" }]),
+    );
 
     const response = await POST(stripeRequest() as never);
 
@@ -382,16 +411,110 @@ describe("Stripe webhook route", () => {
       payment_intent: "pi_refund",
       limit: 1,
     });
+    // Per-refund amount keyed on the refund id (idempotency), not the cumulative
+    // charge.amount_refunded.
+    expect(mockRefundsList).toHaveBeenCalledWith({ charge: "ch_refund" });
     expect(orgState).toEqual({ creditBalance: 15.5, freeCreditBalance: 0 });
     expect(createdTransactions).toEqual([
       {
         amount: -12.5,
         type: "usage",
         description: "Refund — $12.5",
+        stripeRefundId: "re_1",
         balanceAfter: 15.5,
         organizationId: "org_1",
       },
     ]);
+  });
+
+  it("deducts each partial refund by its own amount, not the cumulative charge total", async () => {
+    currentEvent = {
+      type: "charge.refunded",
+      data: {
+        object: { id: "ch_multi", payment_intent: "pi_multi", amount_refunded: 1000 },
+      },
+    };
+    // Two $5 partial refunds: charge.amount_refunded is the cumulative 1000, but
+    // the handler must deduct 5 + 5 keyed per refund id (not 10 + 10).
+    mockRefundsList = mock(() =>
+      asyncRefundList([
+        { id: "re_a", amount: 500, status: "succeeded" },
+        { id: "re_b", amount: 500, status: "succeeded" },
+      ]),
+    );
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(createdTransactions.map((t) => (t as { amount: number }).amount)).toEqual([-5, -5]);
+    expect(
+      createdTransactions.map((t) => (t as { stripeRefundId: string }).stripeRefundId),
+    ).toEqual(["re_a", "re_b"]);
+  });
+
+  it("acknowledges a duplicate refund delivery (P2002) with 200 instead of erroring", async () => {
+    currentEvent = {
+      type: "charge.refunded",
+      data: {
+        object: { id: "ch_dup", payment_intent: "pi_dup", amount_refunded: 500 },
+      },
+    };
+    mockRefundsList = mock(() =>
+      asyncRefundList([{ id: "re_dup", amount: 500, status: "succeeded" }]),
+    );
+    // Redelivered refund hits the UNIQUE(stripeRefundId) constraint → P2002 →
+    // the transaction rolls back, so the balance must be left untouched.
+    mockTxCreditTransactionCreate = mock(() =>
+      Promise.reject(Object.assign(new Error("Unique constraint failed"), { code: "P2002" })),
+    );
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ received: true });
+    expect(orgState).toEqual({ creditBalance: 20, freeCreditBalance: 8 });
+  });
+
+  it("skips refunds that did not actually move money (non-succeeded status)", async () => {
+    currentEvent = {
+      type: "charge.refunded",
+      data: {
+        object: { id: "ch_pending", payment_intent: "pi_pending", amount_refunded: 500 },
+      },
+    };
+    // A pending/failed refund still carries a nonzero amount but moved no money.
+    mockRefundsList = mock(() =>
+      asyncRefundList([{ id: "re_pending", amount: 500, status: "pending" }]),
+    );
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(createdTransactions).toEqual([]);
+    expect(orgState).toEqual({ creditBalance: 20, freeCreditBalance: 8 });
+  });
+
+  it("returns 500 so Stripe retries when a credit grant fails transiently", async () => {
+    currentEvent = {
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_fail",
+          metadata: { orgId: "org_1", type: "credit_purchase", amountUsd: "25" },
+          payment_intent: "pi_fail",
+        },
+      },
+    };
+    // Non-duplicate (transient) DB error mid-grant must NOT be ACKed with 200,
+    // otherwise Stripe never retries and the paid customer loses the credits.
+    mockTxCreditTransactionCreate = mock(() =>
+      Promise.reject(new Error("connection terminated")),
+    );
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "processing failed" });
   });
 
   it("acknowledges unknown event types without touching credits", async () => {

--- a/apps/web/lib/credits.ts
+++ b/apps/web/lib/credits.ts
@@ -73,6 +73,11 @@ export async function deductCredits(
   orgId: string,
   amount: number,
   description: string,
+  // When set (refund path), the ledger row carries this id under a UNIQUE
+  // column so a replayed/duplicate refund event hits a constraint violation and
+  // the whole transaction rolls back instead of debiting twice. Left undefined
+  // for ordinary usage deductions (which are intentionally non-unique).
+  stripeRefundId?: string,
 ): Promise<void> {
   if (amount <= 0) return;
 
@@ -116,6 +121,7 @@ export async function deductCredits(
         amount: -amount,
         type: "usage",
         description,
+        stripeRefundId,
         balanceAfter: totalAfter,
         organizationId: orgId,
       },

--- a/packages/db/prisma/migrations/20260701130000_add_credit_transaction_refund_id/migration.sql
+++ b/packages/db/prisma/migrations/20260701130000_add_credit_transaction_refund_id/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "credit_transactions" ADD COLUMN     "stripeRefundId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "credit_transactions_stripeRefundId_key" ON "credit_transactions"("stripeRefundId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -691,6 +691,7 @@ model CreditTransaction {
   type                  String   // "purchase" | "usage" | "free_credit" | "refund" | "auto_reload" | "coupon"
   description           String?
   stripeSessionId       String?  @unique
+  stripeRefundId        String?  @unique
   receiptUrl            String?
   balanceAfter          Decimal  @db.Decimal(12, 4)
   createdAt             DateTime @default(now())


### PR DESCRIPTION
## What

Hardens the Stripe **webhook handler** so the credit money-flow is reliable and idempotent, ahead of an upcoming Stripe account switch (which amplifies the failure windows below). Two pre-existing critical bugs are fixed, plus a robustness follow-up.

1. **Retry contract — stop silently dropping paid credits.** The handler previously returned `200` for *every* outcome and the credit-grant `catch` only logged. A transient failure during `addCredits` (DB blip, Stripe hiccup) therefore returned `200`, so Stripe never retried and the paying customer never got credits. Now value-bearing work follows a single contract: a **duplicate delivery (Prisma `P2002`) is ACKed with `200`** (idempotent skip), and **any other failure returns `500`** so Stripe retries.

2. **Refund idempotency + per-refund delta — stop double-debiting.** The refund path read `charge.amount_refunded` (the *cumulative* total) and called `deductCredits` with **no idempotency key**, so a redelivered event or a second partial refund deducted again. Now it iterates `refunds.list({ charge })`, deducts **each refund's own amount keyed on its `re_…` id**, and a redelivery hits a new `UNIQUE(stripeRefundId)` constraint → the `$transaction` rolls back → no double-debit.

3. **Robustness:** duplicate detection now checks `err.code === "P2002"` (the documented, stable signal) instead of substring-matching the Prisma error message; the receipt-URL backfill moved out of the grant's retry path (a backfill failure must not re-drive a committed grant).

## Why

A pre-merge audit of the webhook against Stripe's at-least-once delivery model found both #1 and #2 as 🔴 money-flow bugs. They exist today, but the account migration makes them more exercisable (cold caches + first-touch customer self-heal widen the transient-error window exactly when the first live events arrive, and creating a new endpoint can trigger initial deliveries/retries). Fixing them is the prerequisite for a safe cutover.

## Changes

- `apps/web/app/api/stripe/webhook/route.ts` — outer try/catch retry contract; per-refund idempotent deduction; structural `P2002` check; receipt backfill isolated.
- `apps/web/lib/credits.ts` — `deductCredits` gains an **optional trailing** `stripeRefundId?: string`, written to the ledger row. Backward-compatible: the usage-deduction caller is unchanged and stores `null` (Postgres allows many `NULL`s under a UNIQUE index).
- `packages/db/prisma/schema.prisma` — `CreditTransaction.stripeRefundId String? @unique`.
- `packages/db/prisma/migrations/20260701130000_add_credit_transaction_refund_id/` — **expand-only** (ADD COLUMN nullable + CREATE UNIQUE INDEX); passes the migrate-check gate, so code can roll back without a DB rollback.

## Test plan

- `apps/web/lib/__tests__/billing.test.ts`: updated the refund test for the per-refund/keyed design and added 3 regression tests — (a) two partial refunds deduct `5 + 5`, not the cumulative `1000`; (b) a duplicate refund (`P2002`) is ACKed `200`; (c) a transient grant failure returns `500` so Stripe retries.
- `cd apps/web && bun test` → **460 pass / 0 fail**. `bun run typecheck` clean; `bun run lint` clean for changed files.

## Risk

Low. Behavior change is intentional and confined to the webhook + an additive optional param. The migration is expand-only. No caller signature breaks. The only outward behavior difference is the corrected `500`-on-transient-failure (so Stripe retries) and correct refund accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1
