### PR TITLE
fix(docker): keep CHANGELOG.md in the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,6 @@ node_modules
 !.env.example
 docs
 *.md
+# CHANGELOG.md is COPYed by apps/web/Dockerfile (the in-app Updates page reads it),
+# so it must stay in the build context despite the *.md exclusion above.
+!CHANGELOG.md


### PR DESCRIPTION
## What
`apps/web/Dockerfile` COPYs `CHANGELOG.md` (lines 25, 55 — the in-app Updates page reads it), but `.dockerignore` has `*.md`, which excluded it from the build context. The release image build (`v1.0.20`) failed with `"/CHANGELOG.md": not found`.

## Why now
Earlier 1.0.x tags predate the `CHANGELOG.md` COPY (added with the self-host Updates page + blue-green Dockerfile work), so v1.0.20 is the first release to hit it.

## Fix
Add `!CHANGELOG.md` after `*.md` — the same negation pattern already used for `!.env.example` in this file. Other root markdown stays excluded.

## Test
Verified with a busybox build against the real `.dockerignore`:
```
FROM busybox
COPY CHANGELOG.md /changelog.md
RUN test -s /changelog.md   # PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1