### PR TITLE
fix(docker): copy apps/cli manifest so frozen-lockfile passes

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -6,6 +6,11 @@ FROM base AS deps
 WORKDIR /app
 COPY package.json bun.lock ./
 COPY apps/web/package.json ./apps/web/
+# apps/cli is a workspace recorded in bun.lock; without its manifest the
+# in-container workspace set differs from the lockfile and `bun install
+# --frozen-lockfile` fails ("lockfile had changes"). The web image doesn't run
+# the CLI, but the manifest must be present for the frozen install to validate.
+COPY apps/cli/package.json ./apps/cli/
 COPY packages/db/package.json ./packages/db/
 COPY packages/package-analyzer/package.json ./packages/package-analyzer/
 COPY tools/tsconfig/package.json ./tools/tsconfig/


### PR DESCRIPTION
## What
The web image's `deps` stage runs `bun install --frozen-lockfile` but never COPYs `apps/cli/package.json`.

## Why it broke the release build
`apps/cli` (the octp CLI, added after the last release) is a workspace recorded in `bun.lock`. Without its manifest in the build context, the in-container workspace set differs from the lockfile, so `--frozen-lockfile` fails with `error: lockfile had changes, but lockfile is frozen`. A local install passes only because the working tree has `apps/cli/`. This is why `v1.0.20`/`v1.0.21` image builds failed.

## Fix
Add `COPY apps/cli/package.json ./apps/cli/` to the deps stage. The web image doesn't run the CLI, but the manifest must be present for bun to validate the workspace graph under a frozen install.

## Test
`docker build --target deps -f apps/web/Dockerfile .` now succeeds under `oven/bun:1-alpine` (bun 1.3.14) — confirmed the workspace set matches the lockfile, so **no bun version pin is needed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1