### PR TITLE
ci(release): push to GHCR with a scoped PAT, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,10 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # The org enforces read-only GITHUB_TOKEN for workflows, so it can't
+          # push to GHCR. Use a dedicated PAT (repo secret GHCR_PAT) scoped to
+          # write:packages instead of broadening the org-wide token policy.
+          password: ${{ secrets.GHCR_PAT }}
 
       - name: Derive image tags
         id: tags


### PR DESCRIPTION
## What
Point `release.yml`'s GHCR login at a dedicated repo secret `GHCR_PAT` (scoped `write:packages`) instead of the automatic `GITHUB_TOKEN`.

## Why
The org enforces read-only workflow tokens org-wide (`409: Write permissions for workflows are disabled by the organization`), so `GITHUB_TOKEN` can't push to GHCR — the release image build fails at push with `403 Forbidden`. Using a scoped PAT publishes the image **without** removing the org's read-only default (better security posture than flipping the whole org to read-write).

## Required before next release
Set the repo secret: `gh secret set GHCR_PAT --repo octopusreview/octopus` with a token that has `write:packages`.

## Risk
Low — one-line credential source change in a tag-triggered workflow; no app/runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1