### PR TITLE
ci(release): also build the hosted-deploy image variant

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,10 @@ jobs:
             # This GHCR image is the self-hosted distribution, so the Updates
             # page + nav entry (gated on this build-time flag) ship enabled.
             NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Distinct cache scope per variant — with the shared default scope the
+          # two builds would overwrite each other's cache every release.
+          cache-from: type=gha,scope=selfhost
+          cache-to: type=gha,mode=max,scope=selfhost
 
       # Hosted-deployment variant of the same commit. NEXT_PUBLIC_* values are
       # inlined into the client bundle at build time, so the hosted instance
@@ -87,7 +89,7 @@ jobs:
       # running services — they only change on an explicit service update.
       # Skipped when the variables are unset (e.g. on forks).
       - name: Build + push image (hosted deploy variant)
-        if: ${{ vars.NEXT_PUBLIC_PUBBY_KEY != '' }}
+        if: ${{ vars.NEXT_PUBLIC_PUBBY_KEY != '' && vars.NEXT_PUBLIC_GITHUB_APP_SLUG != '' }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -106,8 +108,8 @@ jobs:
             NEXT_PUBLIC_APP_VERSION=${{ steps.tags.outputs.semver }}
             NEXT_PUBLIC_GITHUB_APP_SLUG=${{ vars.NEXT_PUBLIC_GITHUB_APP_SLUG }}
             NEXT_PUBLIC_PUBBY_KEY=${{ vars.NEXT_PUBLIC_PUBBY_KEY }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=prod
+          cache-to: type=gha,mode=max,scope=prod
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           echo "semver=$SEMVER" >> $GITHUB_OUTPUT
           echo "image_name=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
-      - name: Build + push image
+      - name: Build + push image (self-host distribution)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -65,12 +65,47 @@ jobs:
           tags: |
             ${{ steps.tags.outputs.image_name }}:${{ steps.tags.outputs.semver }}
             ${{ steps.tags.outputs.image_name }}:latest
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tags.outputs.semver }}
           build-args: |
             NEXT_PUBLIC_BUILD_ID=${{ github.sha }}
             NEXT_PUBLIC_APP_VERSION=${{ steps.tags.outputs.semver }}
             # This GHCR image is the self-hosted distribution, so the Updates
             # page + nav entry (gated on this build-time flag) ship enabled.
             NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Hosted-deployment variant of the same commit. NEXT_PUBLIC_* values are
+      # inlined into the client bundle at build time, so the hosted instance
+      # needs its own build: selfHosted OFF, plus the instance's GitHub App
+      # slug + Pubby key (both are client-exposed identifiers, not secrets —
+      # they ship in every page's JS — hence repo *variables*, not secrets).
+      # Pushes an immutable `X.Y.Z-prod` plus the `latest-web`/`latest-engine`
+      # aliases the deployment stack pulls. Moving the aliases does NOT touch
+      # running services — they only change on an explicit service update.
+      # Skipped when the variables are unset (e.g. on forks).
+      - name: Build + push image (hosted deploy variant)
+        if: ${{ vars.NEXT_PUBLIC_PUBBY_KEY != '' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.tags.outputs.image_name }}:${{ steps.tags.outputs.semver }}-prod
+            ${{ steps.tags.outputs.image_name }}:latest-web
+            ${{ steps.tags.outputs.image_name }}:latest-engine
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.tags.outputs.semver }}
+          build-args: |
+            NEXT_PUBLIC_BUILD_ID=${{ github.sha }}
+            NEXT_PUBLIC_APP_VERSION=${{ steps.tags.outputs.semver }}
+            NEXT_PUBLIC_GITHUB_APP_SLUG=${{ vars.NEXT_PUBLIC_GITHUB_APP_SLUG }}
+            NEXT_PUBLIC_PUBBY_KEY=${{ vars.NEXT_PUBLIC_PUBBY_KEY }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
## What
Adds a second `docker/build-push-action` step to `release.yml` building the **hosted-deploy variant** of the same commit: `selfHosted` off + `NEXT_PUBLIC_GITHUB_APP_SLUG`/`NEXT_PUBLIC_PUBBY_KEY` build args (client-exposed identifiers, supplied as repo **variables** — already set). Pushes immutable `X.Y.Z-prod` + the `latest-web`/`latest-engine` aliases the hosted deployment pulls. Adds OCI `revision`/`version` labels to both variants.

## Why
The existing image bakes `NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true` (correct for the self-host distribution), so the hosted deployment could never use it — it has been building on the production host at deploy time: slow (~8 min on-box Next build competing with live traffic), and it ships a working tree rather than a reviewed commit. With this, deploys pull a CI-built, SHA-labeled image instead.

## Notes for review
- The prod step is `if: vars.NEXT_PUBLIC_PUBBY_KEY != ''` so forks/self-host clones without the variables skip it cleanly.
- Pushing the `latest-web`/`latest-engine` aliases does **not** restart anything — running services only re-resolve tags on an explicit service update.
- Both steps share the GHA layer cache; only the Next build stage re-runs for the second variant (build args differ).
- `NEXT_PUBLIC_*` values are inlined into client bundles by definition — they are identifiers, not secrets, hence repo variables.

## Test plan
Covered by cutting the next release tag: expect both variants published (`X.Y.Z`, `latest`, `X.Y.Z-prod`, `latest-web`, `latest-engine`) with OCI labels; a `--skip-build` deployment then pulls `latest-web` instead of building on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1