### PR TITLE
fix(login): render the OAuth provider gate per-request, not at build time

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,6 +1,13 @@
 import { Suspense } from "react";
 import { LoginContent } from "./login-content";
 
+// The provider gate below reads runtime env, but without a dynamic marker
+// Next statically prerenders this page AT IMAGE BUILD TIME — where no OAuth
+// env exists — baking "(not configured)" into the HTML no matter what the
+// running container has. Force per-request rendering so the gate reflects
+// the deployment's actual configuration.
+export const dynamic = "force-dynamic";
+
 /**
  * Reads which OAuth providers the operator configured (presence only, never the
  * secrets) and passes it to the client form, so unconfigured buttons render


### PR DESCRIPTION
## What
Adds `export const dynamic = "force-dynamic"` to `app/(auth)/login/page.tsx`.

## Why
The page reads `GOOGLE/GITHUB/MICROSOFT_CLIENT_ID/SECRET` from `process.env` to disable unconfigured provider buttons — but with no dynamic marker, Next **statically prerenders it at `next build` time**, inside the Docker image build where none of those vars exist. So production bakes "(not configured)" into the HTML for every provider and all OAuth sign-in buttons are disabled, no matter what the running container's env contains. Verified live: the deployed containers have all six vars at runtime, yet the login page shows every provider disabled.

Magic-link login and existing sessions are unaffected; the OAuth backend (better-auth) is runtime-configured and fine — only the prerendered gate lies.

## Fix
Force per-request rendering so the gate reflects the deployment's actual configuration. A login page has no meaningful static-render benefit.

## Test plan
`bun run typecheck` + lint clean. Post-deploy verification: login page on a configured deployment shows enabled provider buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1