### PR TITLE
feat: catalog rows for ollama/claude-code/openrouter, daily release-cache job, audit legal-hold

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -41,6 +41,14 @@ export async function register() {
       // the audit job to avoid simultaneous deleteMany load). Window tunable via
       // ACTIVITY_RETENTION_DAYS (default 30).
       await boss.schedule("enforce-activity-retention", "0 4 * * *");
+
+      // Daily release-cache refresh (05:00 UTC — offset from the retention jobs).
+      // Gated to self-hosted: the release-check/update panel only surfaces there
+      // (same server-side flag the admin bootstrap above uses). pg-boss dedups
+      // the cron across instances; the worker in queue-workers.ts does the fetch.
+      if (process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true") {
+        await boss.schedule("refresh-release-cache", "0 5 * * *");
+      }
     }
 
     // Graceful shutdown: wait for active jobs (e.g. in-progress reviews) to finish

--- a/apps/web/lib/__tests__/audit-retention.test.ts
+++ b/apps/web/lib/__tests__/audit-retention.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, afterEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 
 // Capture the `where` passed to deleteMany so we can assert the legal-hold
 // clause. Bun's module mocks are file-scoped and auto-cleaned — no restore.
@@ -16,9 +16,22 @@ mock.module("@octopus/db", () => ({
 
 import { enforceAuditLogRetention } from "@/lib/audit";
 
+const KEYS = ["AUDIT_LOG_LEGAL_HOLD_CATEGORIES", "AUDIT_LOG_RETENTION_DAYS"] as const;
+
 describe("enforceAuditLogRetention — legal-hold category skip", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {};
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
   afterEach(() => {
-    delete process.env.AUDIT_LOG_LEGAL_HOLD_CATEGORIES;
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
     lastWhere = null;
   });
 

--- a/apps/web/lib/__tests__/audit-retention.test.ts
+++ b/apps/web/lib/__tests__/audit-retention.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, mock, afterEach } from "bun:test";
+
+// Capture the `where` passed to deleteMany so we can assert the legal-hold
+// clause. Bun's module mocks are file-scoped and auto-cleaned — no restore.
+let lastWhere: Record<string, unknown> | null = null;
+mock.module("@octopus/db", () => ({
+  prisma: {
+    auditLog: {
+      deleteMany: async (args: { where: Record<string, unknown> }) => {
+        lastWhere = args.where;
+        return { count: 0 };
+      },
+    },
+  },
+}));
+
+import { enforceAuditLogRetention } from "@/lib/audit";
+
+describe("enforceAuditLogRetention — legal-hold category skip", () => {
+  afterEach(() => {
+    delete process.env.AUDIT_LOG_LEGAL_HOLD_CATEGORIES;
+    lastWhere = null;
+  });
+
+  it("deletes by cutoff only when no legal hold is configured", async () => {
+    await enforceAuditLogRetention(30);
+    expect(lastWhere?.createdAt).toBeDefined();
+    expect(lastWhere?.category).toBeUndefined();
+  });
+
+  it("excludes held categories from deletion when the env is set", async () => {
+    process.env.AUDIT_LOG_LEGAL_HOLD_CATEGORIES = "billing, admin";
+    await enforceAuditLogRetention(30);
+    expect(lastWhere?.category).toEqual({ notIn: ["billing", "admin"] });
+  });
+
+  it("ignores blank entries in the hold list", async () => {
+    process.env.AUDIT_LOG_LEGAL_HOLD_CATEGORIES = " , billing , ";
+    await enforceAuditLogRetention(30);
+    expect(lastWhere?.category).toEqual({ notIn: ["billing"] });
+  });
+});

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -62,6 +62,14 @@ export async function enforceAuditLogRetention(retentionDays?: number): Promise<
     .split(",")
     .map((c) => c.trim())
     .filter(Boolean);
+  const unknownHeld = heldCategories.filter((c) => !AUDIT_CATEGORY_SET.has(c));
+  if (unknownHeld.length > 0) {
+    console.warn(
+      `[audit] enforceAuditLogRetention: AUDIT_LOG_LEGAL_HOLD_CATEGORIES contains unknown categor${
+        unknownHeld.length === 1 ? "y" : "ies"
+      } ${JSON.stringify(unknownHeld)} — check for typos (known: ${AUDIT_CATEGORIES.join(", ")})`,
+    );
+  }
   const where: Prisma.AuditLogWhereInput = { createdAt: { lt: cutoff } };
   if (heldCategories.length > 0) {
     where.category = { notIn: heldCategories };

--- a/apps/web/lib/audit.ts
+++ b/apps/web/lib/audit.ts
@@ -44,6 +44,11 @@ export const AUDIT_LOG_DEFAULT_RETENTION_DAYS = 365;
  * The retention enforcement runs on a daily schedule (see queue-workers.ts
  * and the boss.schedule call in instrumentation.ts). Self-hosters can
  * disable it by leaving the schedule unset.
+ *
+ * Legal hold: rows whose `category` is listed in AUDIT_LOG_LEGAL_HOLD_CATEGORIES
+ * (comma-separated) are excluded from deletion regardless of age, so a hold can
+ * be placed on e.g. "billing,admin" for litigation/compliance without disabling
+ * retention for everything else.
  */
 export async function enforceAuditLogRetention(retentionDays?: number): Promise<number> {
   const envOverride = process.env.AUDIT_LOG_RETENTION_DAYS;
@@ -53,9 +58,15 @@ export async function enforceAuditLogRetention(retentionDays?: number): Promise<
     return 0;
   }
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-  const { count } = await prisma.auditLog.deleteMany({
-    where: { createdAt: { lt: cutoff } },
-  });
+  const heldCategories = (process.env.AUDIT_LOG_LEGAL_HOLD_CATEGORIES ?? "")
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean);
+  const where: Prisma.AuditLogWhereInput = { createdAt: { lt: cutoff } };
+  if (heldCategories.length > 0) {
+    where.category = { notIn: heldCategories };
+  }
+  const { count } = await prisma.auditLog.deleteMany({ where });
   if (count > 0) {
     console.log(`[audit] enforceAuditLogRetention: deleted ${count} rows older than ${days} days`);
   }

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -18,6 +18,10 @@ const FALLBACK_PRICING: Record<string, ModelPricing> = {
   "gemini-2.5-pro": { input: 1.25, output: 10 },
   "gemini-2.5-flash": { input: 0.15, output: 0.6 },
   "gpt-5.3-codex": { input: 1.75, output: 14 },
+  // Claude Code is subscription-billed (not per-token), so platform price is 0.
+  "claude-code:sonnet": { input: 0, output: 0 },
+  // OpenRouter Hermes 3 8B — estimate (~$0.10/$0.15 per 1M in/out).
+  "openrouter/nousresearch/hermes-3-llama-3.1-8b": { input: 0.1, output: 0.15 },
   "text-embedding-3-large": { input: 0.13, output: 0 },
   "rerank-v3.5": { input: 2000.0, output: 0 },
 };

--- a/apps/web/lib/queue-workers.ts
+++ b/apps/web/lib/queue-workers.ts
@@ -7,6 +7,7 @@ import {
 } from "./large-review-result";
 import { processCommunityReview, type CommunityReviewJobData } from "./community-review";
 import { enforceAuditLogRetention, enforceActivityEventRetention } from "./audit";
+import { refreshReleaseCache } from "./releases";
 import { runOllamaPull } from "./ollama-admin";
 import type { QueueConfig } from "./queue";
 
@@ -106,6 +107,24 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     }
   });
 
+  // Daily release-cache refresh (self-hosted) — scheduled in instrumentation.ts
+  // via boss.schedule(). Keeps SystemConfig.latestRelease warm so the update
+  // panel/route serves a fresh answer without a lazy cache miss. Idempotent:
+  // a single upsert row, safe to run repeatedly.
+  await boss.work("refresh-release-cache", async (jobs) => {
+    for (const job of jobs) {
+      try {
+        const release = await refreshReleaseCache();
+        console.log(
+          `[queue] refresh-release-cache ${job.id}: ${release ? release.tagName : "fetch failed, cache unchanged"}`,
+        );
+      } catch (err) {
+        console.error(`[queue] refresh-release-cache failed (job ${job.id}):`, err);
+        throw err;
+      }
+    }
+  });
+
   // Admin-triggered Ollama model download (self-hosted). runOllamaPull is
   // self-contained: it records progress/failure in the OllamaModelPull row and
   // never throws, so a failed download doesn't trip pg-boss retries.
@@ -116,5 +135,5 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     }
   });
 
-  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review, enforce-audit-retention, enforce-activity-retention, pull-ollama-model");
+  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review, enforce-audit-retention, enforce-activity-retention, refresh-release-cache, pull-ollama-model");
 }

--- a/apps/web/lib/queue.ts
+++ b/apps/web/lib/queue.ts
@@ -115,6 +115,14 @@ export async function startQueue(): Promise<PgBoss> {
     expireInSeconds: 600, // 10 min — a deleteMany shouldn't take long
   }).catch(() => {});
 
+  // Daily self-hosted release-cache refresh (scheduled in instrumentation.ts,
+  // worked in queue-workers.ts). Same pg-boss v12 requirement — the queue must
+  // exist before schedule()/work() or the cron silently no-ops.
+  await boss.createQueue("refresh-release-cache", {
+    retryLimit: 1,
+    expireInSeconds: 300, // 5 min — a single GitHub fetch + upsert
+  }).catch(() => {});
+
   // Admin-triggered Ollama model downloads (self-hosted). Long expiry — a
   // large model is many GB. No auto-retry: runOllamaPull records failures in
   // the OllamaModelPull row itself and re-pulls are admin-driven from the UI.

--- a/apps/web/lib/releases.ts
+++ b/apps/web/lib/releases.ts
@@ -97,6 +97,19 @@ export async function fetchLatestRelease(): Promise<CachedRelease | null> {
 }
 
 /**
+ * Force-refresh the release cache: fetch fresh from GitHub and persist,
+ * regardless of the current cache's staleness. Used by the daily
+ * 'refresh-release-cache' worker (see queue-workers.ts) to keep
+ * SystemConfig.latestRelease warm so read paths never pay a lazy miss.
+ * Returns the fetched release, or null if the fetch failed (cache untouched).
+ */
+export async function refreshReleaseCache(): Promise<CachedRelease | null> {
+  const fresh = await fetchLatestRelease();
+  if (fresh) await writeReleaseCache(fresh);
+  return fresh;
+}
+
+/**
  * Get-or-refresh wrapper. Reads cache; on miss or stale, fetches fresh and
  * persists. Used by the route handler so the user gets a useful answer even
  * if the daily worker hasn't run yet.

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -721,6 +721,18 @@ async function main() {
     { modelId: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash", provider: "google", category: "llm", inputPrice: 0.15, outputPrice: 0.6, sortOrder: 6 },
     // OpenAI — Codex is the only OpenAI LLM we offer; served via the Responses API.
     { modelId: "gpt-5.3-codex", displayName: "GPT-5.3 Codex", provider: "openai", category: "llm", inputPrice: 1.75, outputPrice: 14, sortOrder: 7 },
+    // Claude Code — routed via the "claude-code:" prefix (see ai-router.ts).
+    // Billed against the operator's Claude subscription/OAuth, not per token,
+    // so the platform price is 0 (metered spend is tracked out-of-band).
+    { modelId: "claude-code:sonnet", displayName: "Claude Code (Sonnet)", provider: "claude-code", category: "llm", inputPrice: 0, outputPrice: 0, sortOrder: 8 },
+    // OpenRouter — the "openrouter/…"-namespaced id forces OpenRouter routing.
+    // Price is an estimate (~$0.10/$0.15 per 1M in/out for Hermes 3 8B).
+    { modelId: "openrouter/nousresearch/hermes-3-llama-3.1-8b", displayName: "Nous Hermes 3 8B (OpenRouter)", provider: "openrouter", category: "llm", inputPrice: 0.1, outputPrice: 0.15, sortOrder: 9 },
+    // Ollama (local — runs on the operator's own machine, zero cost)
+    { modelId: "ollama:qwen2.5-coder:32b", displayName: "Qwen 2.5 Coder 32B (Ollama)", provider: "ollama", category: "llm", inputPrice: 0, outputPrice: 0, sortOrder: 20 },
+    { modelId: "ollama:llama3.3", displayName: "Llama 3.3 (Ollama)", provider: "ollama", category: "llm", inputPrice: 0, outputPrice: 0, sortOrder: 21 },
+    { modelId: "ollama:deepseek-coder-v2", displayName: "DeepSeek Coder v2 (Ollama)", provider: "ollama", category: "llm", inputPrice: 0, outputPrice: 0, sortOrder: 22 },
+    { modelId: "ollama:nousresearch/hermes-3-llama-3.1-8b", displayName: "Nous Hermes 3 8B (Ollama)", provider: "ollama", category: "llm", inputPrice: 0, outputPrice: 0, sortOrder: 23 },
     // Embeddings
     { modelId: "text-embedding-3-large", displayName: "Embedding 3 Large", provider: "openai", category: "embedding", inputPrice: 0.13, outputPrice: 0, sortOrder: 0 },
     { modelId: "text-embedding-3-small", displayName: "Embedding 3 Small", provider: "openai", category: "embedding", inputPrice: 0.02, outputPrice: 0, sortOrder: 1 },


### PR DESCRIPTION
Seeds AvailableModel rows for local Ollama models (qwen2.5-coder:32b, llama3.3, deepseek-coder-v2, hermes-3), claude-code:sonnet (subscription, $0) and openrouter hermes-3 (+cost.ts pricing); adds a daily pg-boss 'refresh-release-cache' job (self-hosted gated, registered like the other crons); audit retention now honors AUDIT_LOG_LEGAL_HOLD_CATEGORIES (rows in held categories are never deleted) with tests. (cemoso/octopus#22, #72, #73, #12, #41.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1