### PR TITLE
feat: per-org provider config — ollama base URL, ACP + OpenCode gateway credentials

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -250,6 +250,12 @@ export async function updateApiKeys(
   const cohereApiKey = (formData.get("cohereApiKey") as string)?.trim() || null;
   const grokApiKey = (formData.get("grokApiKey") as string)?.trim() || null;
   const openrouterApiKey = (formData.get("openrouterApiKey") as string)?.trim() || null;
+  // Per-org provider config: gateway/base-URL overrides + gateway API keys.
+  const ollamaBaseUrl = (formData.get("ollamaBaseUrl") as string)?.trim() || null;
+  const acpBaseUrl = (formData.get("acpBaseUrl") as string)?.trim() || null;
+  const acpApiKey = (formData.get("acpApiKey") as string)?.trim() || null;
+  const opencodeBaseUrl = (formData.get("opencodeBaseUrl") as string)?.trim() || null;
+  const opencodeApiKey = (formData.get("opencodeApiKey") as string)?.trim() || null;
 
   if (openaiApiKey && !openaiApiKey.startsWith("sk-")) {
     return { error: "Invalid OpenAI API key format." };
@@ -280,6 +286,13 @@ export async function updateApiKeys(
   if (cohereApiKey) data.cohereApiKey = encryptString(cohereApiKey);
   if (grokApiKey) data.grokApiKey = encryptString(grokApiKey);
   if (openrouterApiKey) data.openrouterApiKey = encryptString(openrouterApiKey);
+  // Base URLs are not secrets — stored as-is (SSRF-validated at use time by
+  // the provider). Gateway API keys are encrypted like the other BYOK keys.
+  if (ollamaBaseUrl) data.ollamaBaseUrl = ollamaBaseUrl;
+  if (acpBaseUrl) data.acpBaseUrl = acpBaseUrl;
+  if (acpApiKey) data.acpApiKey = encryptString(acpApiKey);
+  if (opencodeBaseUrl) data.opencodeBaseUrl = opencodeBaseUrl;
+  if (opencodeApiKey) data.opencodeApiKey = encryptString(opencodeApiKey);
 
   if (Object.keys(data).length === 0) {
     return { error: "Enter at least one API key to save." };

--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -16,6 +16,7 @@ import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
 import { canUserCreateOrg } from "@/lib/org-limits";
 import { MAX_OWNED_ORGS_PER_USER } from "@/lib/constants";
 import { encryptString } from "@/lib/crypto";
+import { validateProviderUrl } from "@/lib/providers/url-validation";
 import { writeAuditLog } from "@/lib/audit";
 import { canUseLiveTelemetry } from "@/lib/entitlements";
 import { getClientIp } from "@/lib/request-ip";
@@ -250,12 +251,6 @@ export async function updateApiKeys(
   const cohereApiKey = (formData.get("cohereApiKey") as string)?.trim() || null;
   const grokApiKey = (formData.get("grokApiKey") as string)?.trim() || null;
   const openrouterApiKey = (formData.get("openrouterApiKey") as string)?.trim() || null;
-  // Per-org provider config: gateway/base-URL overrides + gateway API keys.
-  const ollamaBaseUrl = (formData.get("ollamaBaseUrl") as string)?.trim() || null;
-  const acpBaseUrl = (formData.get("acpBaseUrl") as string)?.trim() || null;
-  const acpApiKey = (formData.get("acpApiKey") as string)?.trim() || null;
-  const opencodeBaseUrl = (formData.get("opencodeBaseUrl") as string)?.trim() || null;
-  const opencodeApiKey = (formData.get("opencodeApiKey") as string)?.trim() || null;
 
   if (openaiApiKey && !openaiApiKey.startsWith("sk-")) {
     return { error: "Invalid OpenAI API key format." };
@@ -286,13 +281,35 @@ export async function updateApiKeys(
   if (cohereApiKey) data.cohereApiKey = encryptString(cohereApiKey);
   if (grokApiKey) data.grokApiKey = encryptString(grokApiKey);
   if (openrouterApiKey) data.openrouterApiKey = encryptString(openrouterApiKey);
-  // Base URLs are not secrets — stored as-is (SSRF-validated at use time by
-  // the provider). Gateway API keys are encrypted like the other BYOK keys.
-  if (ollamaBaseUrl) data.ollamaBaseUrl = ollamaBaseUrl;
-  if (acpBaseUrl) data.acpBaseUrl = acpBaseUrl;
-  if (acpApiKey) data.acpApiKey = encryptString(acpApiKey);
-  if (opencodeBaseUrl) data.opencodeBaseUrl = opencodeBaseUrl;
-  if (opencodeApiKey) data.opencodeApiKey = encryptString(opencodeApiKey);
+
+  // Per-org provider config: gateway/base-URL overrides + gateway API keys.
+  // These clear when submitted empty — a present-but-empty field sets the
+  // column to null, an absent field (formData.get() === null) is left
+  // unchanged. (The BYOK keys above share the older can't-clear-inline pattern:
+  // they only clear via removeApiKey. Left as-is — out of scope for this fix.)
+  // Base URLs are not secrets, but they become server-side fetch targets, so
+  // they are SSRF-validated here before persisting; gateway API keys are
+  // encrypted like the other BYOK keys.
+  for (const field of ["ollamaBaseUrl", "acpBaseUrl", "opencodeBaseUrl"] as const) {
+    const raw = formData.get(field);
+    if (raw === null) continue;
+    const trimmed = (raw as string).trim();
+    if (!trimmed) {
+      data[field] = null;
+      continue;
+    }
+    try {
+      data[field] = validateProviderUrl(trimmed);
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : "Invalid provider URL." };
+    }
+  }
+  for (const field of ["acpApiKey", "opencodeApiKey"] as const) {
+    const raw = formData.get(field);
+    if (raw === null) continue;
+    const trimmed = (raw as string).trim();
+    data[field] = trimmed ? encryptString(trimmed) : null;
+  }
 
   if (Object.keys(data).length === 0) {
     return { error: "Enter at least one API key to save." };

--- a/apps/web/lib/providers/acp.ts
+++ b/apps/web/lib/providers/acp.ts
@@ -1,28 +1,58 @@
 import "server-only";
+import { prisma } from "@octopus/db";
+import { decryptStringMaybeLegacy } from "@/lib/crypto";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
 import { callOpenAiGateway } from "./openai-gateway";
 
 /**
  * ACPX — an OpenAI-compatible multi-vendor gateway (Agent Communication
- * Protocol). Configured per deployment via env:
+ * Protocol). Configurable per-org (Organization.acpBaseUrl + acpApiKey),
+ * which overrides the deployment-wide env default:
  *   ACP_BASE_URL — gateway origin (e.g. https://acpx.internal.example.com)
  *   ACP_API_KEY  — bearer token for the gateway
  * Model ids are namespaced "acp:<model>".
+ *
+ * The per-org key is stored encrypted at rest like the other BYOK keys, so it
+ * is decrypted here before use. The base URL is SSRF-validated inside
+ * callOpenAiGateway before it becomes a fetch target.
  */
+async function resolveConfig(orgId?: string | null): Promise<{ baseUrl: string; apiKey: string } | null> {
+  // Per-org config overrides the deployment env default.
+  if (orgId) {
+    const org = await prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { acpBaseUrl: true, acpApiKey: true },
+    });
+    if (org?.acpBaseUrl && org?.acpApiKey) {
+      return { baseUrl: org.acpBaseUrl, apiKey: decryptStringMaybeLegacy(org.acpApiKey) };
+    }
+  }
+  const envBase = process.env.ACP_BASE_URL;
+  const envKey = process.env.ACP_API_KEY;
+  if (envBase && envKey) return { baseUrl: envBase, apiKey: envKey };
+  return null;
+}
+
 export const acpProvider: Provider = {
   name: "acp",
   supportsJsonSchema: true,
-  async create(params: AiCreateParams): Promise<AiResponse> {
-    const baseUrl = process.env.ACP_BASE_URL;
-    const apiKey = process.env.ACP_API_KEY;
-    if (!baseUrl || !apiKey) {
-      throw new Error("ACPX is not configured — set ACP_BASE_URL and ACP_API_KEY.");
+  async create(
+    params: AiCreateParams,
+    _apiKey?: string | null,
+    orgId?: string | null,
+  ): Promise<AiResponse> {
+    const config = await resolveConfig(orgId);
+    if (!config) {
+      throw new Error(
+        "ACPX is not configured — set ACP_BASE_URL and ACP_API_KEY, or " +
+          "configure acpBaseUrl and acpApiKey on the organization.",
+      );
     }
     return callOpenAiGateway(params, {
       name: "acp",
       modelPrefix: "acp:",
-      baseUrl,
-      apiKey,
+      baseUrl: config.baseUrl,
+      apiKey: config.apiKey,
     });
   },
 };

--- a/apps/web/lib/providers/acp.ts
+++ b/apps/web/lib/providers/acp.ts
@@ -3,6 +3,7 @@ import { prisma } from "@octopus/db";
 import { decryptStringMaybeLegacy } from "@/lib/crypto";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
 import { callOpenAiGateway } from "./openai-gateway";
+import { validateProviderUrl } from "./url-validation";
 
 /**
  * ACPX — an OpenAI-compatible multi-vendor gateway (Agent Communication
@@ -13,8 +14,10 @@ import { callOpenAiGateway } from "./openai-gateway";
  * Model ids are namespaced "acp:<model>".
  *
  * The per-org key is stored encrypted at rest like the other BYOK keys, so it
- * is decrypted here before use. The base URL is SSRF-validated inside
- * callOpenAiGateway before it becomes a fetch target.
+ * is decrypted here before use. SSRF validation is applied only to the per-org
+ * (org-admin supplied) base URL; the env-configured ACP_BASE_URL is operator-
+ * controlled and may legitimately point at an internal host, so it is only
+ * normalized to an origin (private ranges allowed).
  */
 async function resolveConfig(orgId?: string | null): Promise<{ baseUrl: string; apiKey: string } | null> {
   // Per-org config overrides the deployment env default.
@@ -24,12 +27,12 @@ async function resolveConfig(orgId?: string | null): Promise<{ baseUrl: string; 
       select: { acpBaseUrl: true, acpApiKey: true },
     });
     if (org?.acpBaseUrl && org?.acpApiKey) {
-      return { baseUrl: org.acpBaseUrl, apiKey: decryptStringMaybeLegacy(org.acpApiKey) };
+      return { baseUrl: validateProviderUrl(org.acpBaseUrl), apiKey: decryptStringMaybeLegacy(org.acpApiKey) };
     }
   }
   const envBase = process.env.ACP_BASE_URL;
   const envKey = process.env.ACP_API_KEY;
-  if (envBase && envKey) return { baseUrl: envBase, apiKey: envKey };
+  if (envBase && envKey) return { baseUrl: validateProviderUrl(envBase, { hosted: false }), apiKey: envKey };
   return null;
 }
 

--- a/apps/web/lib/providers/ollama.ts
+++ b/apps/web/lib/providers/ollama.ts
@@ -1,6 +1,8 @@
 import "server-only";
 import OpenAI from "openai";
+import { prisma } from "@octopus/db";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
+import { validateProviderUrl } from "./url-validation";
 
 /**
  * Ollama exposes an OpenAI-compatible Chat Completions endpoint at
@@ -63,11 +65,39 @@ function getClient(): OpenAI {
   return platformClient;
 }
 
+/**
+ * Per-org override: an org admin can set `Organization.ollamaBaseUrl` to point
+ * at a non-default Ollama host, overriding the OLLAMA_SERVER_URL env default.
+ * The URL is org-admin-supplied, so it becomes the target of a server-side
+ * fetch — validate it (SSRF: blocks loopback/RFC1918/link-local in hosted mode)
+ * before building a client. Returns null when no per-org URL is set so the
+ * caller falls back to the env-configured platform client.
+ */
+async function resolveOrgClient(orgId: string | null): Promise<OpenAI | null> {
+  if (!orgId) return null;
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { ollamaBaseUrl: true },
+  });
+  if (!org?.ollamaBaseUrl) return null;
+  const base = validateProviderUrl(org.ollamaBaseUrl);
+  // Not cached: per-org base URLs vary, so the platformClient singleton can't
+  // serve them. The env-level basic-auth credentials are host-specific and
+  // intentionally not applied to a per-org host.
+  return new OpenAI({ apiKey: "ollama", baseURL: `${base}/v1` });
+}
+
 export const ollamaProvider: Provider = {
   name: "ollama",
   supportsJsonSchema: false, // Ollama can be asked for JSON but doesn't enforce a schema yet
-  async create(params: AiCreateParams): Promise<AiResponse> {
-    const client = getClient();
+  async create(
+    params: AiCreateParams,
+    _apiKey?: string | null,
+    orgId?: string | null,
+  ): Promise<AiResponse> {
+    // Per-org base URL overrides the env default; falls back to the cached
+    // env-configured platform client otherwise.
+    const client = (await resolveOrgClient(orgId ?? null)) ?? getClient();
 
     const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
     if (params.system) messages.push({ role: "system", content: params.system });

--- a/apps/web/lib/providers/openai-gateway.ts
+++ b/apps/web/lib/providers/openai-gateway.ts
@@ -1,16 +1,15 @@
 import "server-only";
 import OpenAI from "openai";
 import type { AiCreateParams, AiResponse, AiProvider } from "./index";
-import { validateProviderUrl } from "./url-validation";
 
 /**
  * Shared implementation for OpenAI-compatible gateway providers (acp, opencode,
  * and future custom-endpoint providers). The base URL + bearer token can come
  * from env (deployment-trusted) OR from per-org configuration (org-admin
- * supplied), so the URL is SSRF-validated here — it rejects loopback / RFC1918
- * / link-local hosts in hosted mode so a malicious org admin can't point this
- * at cloud metadata or an internal VPC service. Self-hosted deployments opt in
- * via SELF_HOSTED=true.
+ * supplied). SSRF validation is applied by the caller's resolve path — only to
+ * the per-org (user-supplied) URL, since env-configured gateways are operator-
+ * controlled and may legitimately live on internal hosts. The baseUrl passed in
+ * here is therefore already a validated, path-stripped origin.
  *
  * Caller supplies the provider name, the model-id namespace prefix to strip
  * (e.g. "acp:"), the gateway base URL, and the bearer token.
@@ -28,9 +27,9 @@ export async function callOpenAiGateway(
 ): Promise<AiResponse> {
   // Not cached across calls: with per-org config the base URL + token vary by
   // org, so a per-provider client singleton would leak one org's gateway/token
-  // to another. validateProviderUrl also strips any path/query so the SDK
-  // builds `<origin>/v1/chat/completions` cleanly.
-  const baseURL = `${validateProviderUrl(opts.baseUrl)}/v1`;
+  // to another. opts.baseUrl is already a validated origin (path/query stripped
+  // by the resolve path), so the SDK builds `<origin>/v1/chat/completions`.
+  const baseURL = `${opts.baseUrl}/v1`;
   const client = new OpenAI({ apiKey: opts.apiKey, baseURL });
 
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];

--- a/apps/web/lib/providers/openai-gateway.ts
+++ b/apps/web/lib/providers/openai-gateway.ts
@@ -1,13 +1,16 @@
 import "server-only";
 import OpenAI from "openai";
 import type { AiCreateParams, AiResponse, AiProvider } from "./index";
+import { validateProviderUrl } from "./url-validation";
 
 /**
  * Shared implementation for OpenAI-compatible gateway providers (acp, opencode,
- * and future custom-endpoint providers). These point at an operator-supplied
- * gateway (base URL + bearer token from env), so the endpoint is
- * deployment-trusted — no SSRF attacker surface. We still parse the URL and
- * require http(s) so a typo'd env value fails loudly at first use.
+ * and future custom-endpoint providers). The base URL + bearer token can come
+ * from env (deployment-trusted) OR from per-org configuration (org-admin
+ * supplied), so the URL is SSRF-validated here — it rejects loopback / RFC1918
+ * / link-local hosts in hosted mode so a malicious org admin can't point this
+ * at cloud metadata or an internal VPC service. Self-hosted deployments opt in
+ * via SELF_HOSTED=true.
  *
  * Caller supplies the provider name, the model-id namespace prefix to strip
  * (e.g. "acp:"), the gateway base URL, and the bearer token.
@@ -19,40 +22,16 @@ export type GatewayCallOptions = {
   apiKey: string;
 };
 
-function normalizeGatewayUrl(raw: string, providerName: string): string {
-  let parsed: URL;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    throw new Error(`${providerName} base URL is not a valid URL: ${raw.slice(0, 80)}`);
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new Error(`${providerName} base URL must use http(s); got ${parsed.protocol}`);
-  }
-  // Reduce to origin so the SDK builds `<origin>/v1/chat/completions` cleanly.
-  return parsed.origin;
-}
-
-// Cache one OpenAI client per provider. The gateway base URL + token come from
-// env (fixed for the process lifetime), so a single client per provider reuses
-// connections across calls instead of constructing a new one every request —
-// matching the singleton pattern in the other providers.
-const clientCache = new Map<AiProvider, OpenAI>();
-
-function getGatewayClient(opts: GatewayCallOptions): OpenAI {
-  const cached = clientCache.get(opts.name);
-  if (cached) return cached;
-  const baseURL = `${normalizeGatewayUrl(opts.baseUrl, opts.name)}/v1`;
-  const client = new OpenAI({ apiKey: opts.apiKey, baseURL });
-  clientCache.set(opts.name, client);
-  return client;
-}
-
 export async function callOpenAiGateway(
   params: AiCreateParams,
   opts: GatewayCallOptions,
 ): Promise<AiResponse> {
-  const client = getGatewayClient(opts);
+  // Not cached across calls: with per-org config the base URL + token vary by
+  // org, so a per-provider client singleton would leak one org's gateway/token
+  // to another. validateProviderUrl also strips any path/query so the SDK
+  // builds `<origin>/v1/chat/completions` cleanly.
+  const baseURL = `${validateProviderUrl(opts.baseUrl)}/v1`;
+  const client = new OpenAI({ apiKey: opts.apiKey, baseURL });
 
   const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
   if (params.system) messages.push({ role: "system", content: params.system });

--- a/apps/web/lib/providers/opencode.ts
+++ b/apps/web/lib/providers/opencode.ts
@@ -3,6 +3,7 @@ import { prisma } from "@octopus/db";
 import { decryptStringMaybeLegacy } from "@/lib/crypto";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
 import { callOpenAiGateway } from "./openai-gateway";
+import { validateProviderUrl } from "./url-validation";
 
 /**
  * OpenCode — an OpenAI-compatible gateway, same shape as ACPX with its own
@@ -13,8 +14,10 @@ import { callOpenAiGateway } from "./openai-gateway";
  * Model ids are namespaced "opencode:<model>".
  *
  * The per-org key is stored encrypted at rest like the other BYOK keys, so it
- * is decrypted here before use. The base URL is SSRF-validated inside
- * callOpenAiGateway before it becomes a fetch target.
+ * is decrypted here before use. SSRF validation is applied only to the per-org
+ * (org-admin supplied) base URL; the env-configured OPENCODE_BASE_URL is
+ * operator-controlled and may legitimately point at an internal host, so it is
+ * only normalized to an origin (private ranges allowed).
  */
 async function resolveConfig(orgId?: string | null): Promise<{ baseUrl: string; apiKey: string } | null> {
   // Per-org config overrides the deployment env default.
@@ -24,12 +27,12 @@ async function resolveConfig(orgId?: string | null): Promise<{ baseUrl: string; 
       select: { opencodeBaseUrl: true, opencodeApiKey: true },
     });
     if (org?.opencodeBaseUrl && org?.opencodeApiKey) {
-      return { baseUrl: org.opencodeBaseUrl, apiKey: decryptStringMaybeLegacy(org.opencodeApiKey) };
+      return { baseUrl: validateProviderUrl(org.opencodeBaseUrl), apiKey: decryptStringMaybeLegacy(org.opencodeApiKey) };
     }
   }
   const envBase = process.env.OPENCODE_BASE_URL;
   const envKey = process.env.OPENCODE_API_KEY;
-  if (envBase && envKey) return { baseUrl: envBase, apiKey: envKey };
+  if (envBase && envKey) return { baseUrl: validateProviderUrl(envBase, { hosted: false }), apiKey: envKey };
   return null;
 }
 

--- a/apps/web/lib/providers/opencode.ts
+++ b/apps/web/lib/providers/opencode.ts
@@ -1,28 +1,58 @@
 import "server-only";
+import { prisma } from "@octopus/db";
+import { decryptStringMaybeLegacy } from "@/lib/crypto";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
 import { callOpenAiGateway } from "./openai-gateway";
 
 /**
  * OpenCode — an OpenAI-compatible gateway, same shape as ACPX with its own
- * config. Configured per deployment via env:
+ * config. Configurable per-org (Organization.opencodeBaseUrl + opencodeApiKey),
+ * which overrides the deployment-wide env default:
  *   OPENCODE_BASE_URL — gateway origin
  *   OPENCODE_API_KEY  — bearer token for the gateway
  * Model ids are namespaced "opencode:<model>".
+ *
+ * The per-org key is stored encrypted at rest like the other BYOK keys, so it
+ * is decrypted here before use. The base URL is SSRF-validated inside
+ * callOpenAiGateway before it becomes a fetch target.
  */
+async function resolveConfig(orgId?: string | null): Promise<{ baseUrl: string; apiKey: string } | null> {
+  // Per-org config overrides the deployment env default.
+  if (orgId) {
+    const org = await prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { opencodeBaseUrl: true, opencodeApiKey: true },
+    });
+    if (org?.opencodeBaseUrl && org?.opencodeApiKey) {
+      return { baseUrl: org.opencodeBaseUrl, apiKey: decryptStringMaybeLegacy(org.opencodeApiKey) };
+    }
+  }
+  const envBase = process.env.OPENCODE_BASE_URL;
+  const envKey = process.env.OPENCODE_API_KEY;
+  if (envBase && envKey) return { baseUrl: envBase, apiKey: envKey };
+  return null;
+}
+
 export const opencodeProvider: Provider = {
   name: "opencode",
   supportsJsonSchema: true,
-  async create(params: AiCreateParams): Promise<AiResponse> {
-    const baseUrl = process.env.OPENCODE_BASE_URL;
-    const apiKey = process.env.OPENCODE_API_KEY;
-    if (!baseUrl || !apiKey) {
-      throw new Error("OpenCode is not configured — set OPENCODE_BASE_URL and OPENCODE_API_KEY.");
+  async create(
+    params: AiCreateParams,
+    _apiKey?: string | null,
+    orgId?: string | null,
+  ): Promise<AiResponse> {
+    const config = await resolveConfig(orgId);
+    if (!config) {
+      throw new Error(
+        "OpenCode is not configured — set OPENCODE_BASE_URL and OPENCODE_API_KEY, or " +
+          "configure opencodeBaseUrl and opencodeApiKey on the organization.",
+      );
     }
     return callOpenAiGateway(params, {
       name: "opencode",
       modelPrefix: "opencode:",
-      baseUrl,
-      apiKey,
+      baseUrl: config.baseUrl,
+      apiKey: config.apiKey,
     });
   },
 };

--- a/packages/db/prisma/migrations/20260704120000_add_per_org_provider_config/migration.sql
+++ b/packages/db/prisma/migrations/20260704120000_add_per_org_provider_config/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "organizations" ADD COLUMN     "acpApiKey" TEXT,
+ADD COLUMN     "acpBaseUrl" TEXT,
+ADD COLUMN     "ollamaBaseUrl" TEXT,
+ADD COLUMN     "opencodeApiKey" TEXT,
+ADD COLUMN     "opencodeBaseUrl" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -108,6 +108,18 @@ model Organization {
   googleApiKey         String?
   grokApiKey           String?
   openrouterApiKey     String?
+  // Custom Ollama base URL — overrides OLLAMA_SERVER_URL env when set. Used
+  // for self-hosted Octopus instances pointing at a non-default Ollama host
+  // (a different container, a different machine on the LAN, etc.).
+  ollamaBaseUrl        String?
+  // ACPX gateway — base URL + bearer token. SSRF-validated via
+  // url-validation.ts at use time. Both required to enable the provider;
+  // when null the provider raises a clear "not configured" error.
+  acpBaseUrl           String?
+  acpApiKey            String?
+  // OpenCode gateway — same shape as ACPX, separate config.
+  opencodeBaseUrl      String?
+  opencodeApiKey       String?
   // Claude Code provider config (self-host / per-org). authMode is
   // "subscription" (local `claude` CLI via the agent bridge) or "api-key"
   // (Anthropic SDK with claudeCodeApiKey, falling back to anthropicApiKey).


### PR DESCRIPTION
Adds nullable Organization columns (ollamaBaseUrl, acpBaseUrl/acpApiKey, opencodeBaseUrl/opencodeApiKey) with an expand-only migration; per-org values override env defaults in the ollama/acp/opencode providers; gateway keys are encrypted at rest exactly like existing BYOK keys (encryptString on write, decryptStringMaybeLegacy on read); base URLs are SSRF-validated via the existing validateProviderUrl; updateApiKeys accepts the new fields. Also removes the per-provider client cache in openai-gateway in favor of per-call clients (required for per-org URLs; construction cost is negligible vs the LLM call). (cemoso/octopus#19, #44, #45.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1