### PR TITLE
feat: /settings/integrations/local-agent page

### DIFF
--- a/apps/web/app/(app)/settings/integrations/local-agent/local-agent-table.tsx
+++ b/apps/web/app/(app)/settings/integrations/local-agent/local-agent-table.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export type Agent = {
+  id: string;
+  name: string;
+  status: string;
+  lastSeenAt: string | null;
+  capabilities: string[];
+  machineInfo: Record<string, string> | null;
+  createdAt: string;
+};
+
+export function LocalAgentTable({
+  agents,
+  canRevoke,
+}: {
+  agents: Agent[];
+  canRevoke: boolean;
+}) {
+  const router = useRouter();
+  const [revoking, setRevoking] = useState<string | null>(null);
+  // The id of the agent whose Revoke button is in "confirm" state. Resets after
+  // 5s of inactivity so an accidental first-click doesn't sit primed forever.
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [error, setError] = useState<string>("");
+
+  if (agents.length === 0) {
+    return (
+      <div className="rounded border border-[#222] p-6 text-center text-sm text-[#888]">
+        No agents registered yet. Start one with <code className="text-white">octp agent serve</code>.
+      </div>
+    );
+  }
+
+  const armConfirm = (id: string) => {
+    setConfirmingId(id);
+    setError("");
+    // Auto-disarm after 5s so a stray first-click doesn't leave the button
+    // primed indefinitely.
+    setTimeout(() => {
+      setConfirmingId((current) => (current === id ? null : current));
+    }, 5000);
+  };
+
+  const onRevoke = async (id: string) => {
+    setRevoking(id);
+    setConfirmingId(null);
+    setError("");
+    try {
+      const res = await fetch(`/api/agent/${encodeURIComponent(id)}`, { method: "DELETE" });
+      if (!res.ok) {
+        setError(`Revoke failed: HTTP ${res.status}`);
+        return;
+      }
+      router.refresh();
+    } catch (e) {
+      setError(`Revoke failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setRevoking(null);
+    }
+  };
+
+  return (
+    <div>
+      {error ? <div className="mb-3 rounded bg-red-950 px-3 py-2 text-sm text-red-200">{error}</div> : null}
+      <div className="overflow-x-auto rounded border border-[#222]">
+        <table className="w-full text-left text-xs">
+          <thead className="bg-[#0a0a0a] text-[#888]">
+            <tr>
+              <th className="px-3 py-2 font-semibold">Name</th>
+              <th className="px-3 py-2 font-semibold">Status</th>
+              <th className="px-3 py-2 font-semibold">Last seen</th>
+              <th className="px-3 py-2 font-semibold">Capabilities</th>
+              <th className="px-3 py-2 font-semibold">Machine</th>
+              {canRevoke ? <th className="px-3 py-2 font-semibold">Actions</th> : null}
+            </tr>
+          </thead>
+          <tbody>
+            {agents.map((a) => (
+              <tr key={a.id} className="border-t border-[#191919] align-top text-[#ccc]">
+                <td className="px-3 py-2 font-mono">{a.name}</td>
+                <td className="px-3 py-2">
+                  <StatusPill status={a.status} />
+                </td>
+                <td className="px-3 py-2 text-[#888]">
+                  {a.lastSeenAt ? new Date(a.lastSeenAt).toLocaleString() : "never"}
+                </td>
+                <td className="px-3 py-2 text-[#888]">
+                  {a.capabilities.length > 0 ? a.capabilities.join(", ") : "—"}
+                </td>
+                <td className="px-3 py-2 text-[#888]">
+                  {a.machineInfo
+                    ? `${a.machineInfo.os ?? "?"} · ${a.machineInfo.hostname ?? "?"} · node ${a.machineInfo.nodeVersion ?? "?"}`
+                    : "—"}
+                </td>
+                {canRevoke ? (
+                  <td className="px-3 py-2">
+                    {confirmingId === a.id ? (
+                      <div className="flex items-center gap-1">
+                        <button
+                          type="button"
+                          className="rounded border border-red-700 bg-red-950 px-2 py-1 text-[11px] font-semibold text-red-100 hover:bg-red-900 disabled:opacity-50"
+                          disabled={revoking === a.id}
+                          onClick={() => onRevoke(a.id)}
+                        >
+                          Confirm revoke
+                        </button>
+                        <button
+                          type="button"
+                          className="rounded border border-[#333] px-2 py-1 text-[11px] text-[#888] hover:bg-[#1a1a1a]"
+                          onClick={() => setConfirmingId(null)}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        className="rounded border border-red-900 bg-red-950/40 px-2 py-1 text-[11px] text-red-200 hover:bg-red-950 disabled:opacity-50"
+                        disabled={revoking === a.id}
+                        onClick={() => armConfirm(a.id)}
+                      >
+                        {revoking === a.id ? "Revoking…" : "Revoke"}
+                      </button>
+                    )}
+                  </td>
+                ) : null}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function StatusPill({ status }: { status: string }) {
+  const color =
+    status === "online" ? "bg-green-950 text-green-300" : "bg-[#1a1a1a] text-[#888]";
+  return <span className={`rounded px-2 py-0.5 text-[11px] ${color}`}>{status}</span>;
+}

--- a/apps/web/app/(app)/settings/integrations/local-agent/page.tsx
+++ b/apps/web/app/(app)/settings/integrations/local-agent/page.tsx
@@ -1,0 +1,136 @@
+import { headers, cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { prisma, type Prisma } from "@octopus/db";
+import { LocalAgentTable } from "./local-agent-table";
+
+// Heartbeat cadence is 30s; allow up to 3 missed beats before we surface as offline.
+const STALE_THRESHOLD_MS = 90 * 1000;
+
+/**
+ * Local Agent settings.
+ *
+ * Lists every registered LocalAgent for the org with status, capabilities,
+ * machine info, and a revoke action. Also shows the install one-liner so
+ * a new agent can be spun up without leaving the page.
+ *
+ * The agent itself ships in `apps/cli/` (`octp agent serve`) — see PR #91.
+ * Background on what a local agent does: PR #90 + the bridge dispatch in
+ * the `local` provider.
+ */
+export default async function LocalAgentSettingsPage() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) redirect("/login");
+
+  const cookieStore = await cookies();
+  const currentOrgId = cookieStore.get("current_org_id")?.value;
+
+  const member = await prisma.organizationMember.findFirst({
+    where: {
+      userId: session.user.id,
+      ...(currentOrgId ? { organizationId: currentOrgId } : {}),
+      deletedAt: null,
+    },
+    select: { organizationId: true, role: true },
+  });
+  if (!member) redirect("/dashboard");
+
+  const orgId = member.organizationId;
+
+  // Stale agents: rather than mutating the DB on every page render (writes on
+  // GETs are a smell + cause contention under traffic), we just derive the
+  // displayed status at render time. The agent process keeps its own status
+  // pinned via heartbeats; this view is only filtering out the "online but
+  // hasn't actually pinged in 90s" race.
+  const staleCutoff = Date.now() - STALE_THRESHOLD_MS;
+
+  const agents = await prisma.localAgent.findMany({
+    where: { organizationId: orgId },
+    orderBy: [{ status: "asc" }, { lastSeenAt: "desc" }],
+    select: {
+      id: true,
+      name: true,
+      status: true,
+      lastSeenAt: true,
+      capabilities: true,
+      machineInfo: true,
+      createdAt: true,
+    },
+  });
+
+  // Active API tokens — needed for the install one-liner. We only show count;
+  // the user copies an existing token from /settings/api-tokens.
+  // Filter to actually-usable tokens: a revoked token (deletedAt set) and an
+  // expired token are both rejected by authenticateApiToken at request time,
+  // so counting them here gives the user a misleading "{N} active" number
+  // that doesn't match what they see on /settings/api-tokens.
+  const tokenCount = await prisma.orgApiToken.count({
+    where: {
+      organizationId: orgId,
+      deletedAt: null,
+      OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+    },
+  });
+
+  return (
+    <div className="max-w-4xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold text-white">Local Agent</h1>
+        <p className="mt-1 text-sm text-[#888]">
+          Run reviews through a model installed on your laptop (Ollama, Claude
+          Code subscription, etc.) instead of a hosted provider. Useful for
+          local-first development, no-cost runs, or when you can&apos;t share
+          code with a cloud API.
+        </p>
+      </div>
+
+      <section className="mb-8 rounded border border-[#222] p-4">
+        <h2 className="mb-2 text-sm font-semibold text-white">How it works</h2>
+        <ol className="list-decimal space-y-1 pl-5 text-sm text-[#888]">
+          <li>Install <code>octp</code> via the curl/irm one-liner (<a href="/docs/cli" className="text-cyan-400 underline">docs</a>).</li>
+          <li>Create an API token at <a href="/settings/api-tokens" className="text-cyan-400 underline">Settings → Auth Tokens</a> ({tokenCount} active).</li>
+          <li>Start the agent: <code className="rounded bg-[#0a0a0a] px-1.5 py-0.5">octp agent serve</code></li>
+          <li>Set a repo&apos;s review model to <code>local:&lt;model-id&gt;</code> at <a href="/settings/models" className="text-cyan-400 underline">Models</a>.</li>
+          <li>Open a PR — Octopus routes the review through your machine.</li>
+        </ol>
+      </section>
+
+      <h2 className="mb-3 text-sm font-semibold text-white">Registered agents</h2>
+      <LocalAgentTable
+        agents={agents.map((a) => ({
+          id: a.id,
+          name: a.name,
+          // Derive offline at render time — see STALE_THRESHOLD_MS note above.
+          status:
+            a.status === "online" &&
+            (!a.lastSeenAt || a.lastSeenAt.getTime() < staleCutoff)
+              ? "offline"
+              : a.status,
+          lastSeenAt: a.lastSeenAt?.toISOString() ?? null,
+          capabilities: parseCapabilities(a.capabilities),
+          machineInfo: parseMachineInfo(a.machineInfo),
+          createdAt: a.createdAt.toISOString(),
+        }))}
+        canRevoke={member.role === "owner" || member.role === "admin"}
+      />
+    </div>
+  );
+}
+
+/**
+ * `capabilities` is a `Json` column — runtime shape isn't guaranteed by
+ * Prisma's types. Validate before passing to the client component.
+ */
+function parseCapabilities(value: Prisma.JsonValue | null): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string");
+}
+
+function parseMachineInfo(value: Prisma.JsonValue | null): Record<string, string> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === "string") out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}

--- a/apps/web/app/(app)/settings/integrations/local-agent/page.tsx
+++ b/apps/web/app/(app)/settings/integrations/local-agent/page.tsx
@@ -2,10 +2,8 @@ import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma, type Prisma } from "@octopus/db";
+import { AGENT_STALE_THRESHOLD_MS } from "@/lib/agent-constants";
 import { LocalAgentTable } from "./local-agent-table";
-
-// Heartbeat cadence is 30s; allow up to 3 missed beats before we surface as offline.
-const STALE_THRESHOLD_MS = 90 * 1000;
 
 /**
  * Local Agent settings.
@@ -24,25 +22,30 @@ export default async function LocalAgentSettingsPage() {
 
   const cookieStore = await cookies();
   const currentOrgId = cookieStore.get("current_org_id")?.value;
+  // Resolve the org strictly from the active-org cookie — the same way
+  // DELETE /api/agent/[id] does. If we fell back to the user's first
+  // membership when the cookie is absent, we could list one org's agents
+  // while the revoke endpoint (which requires the cookie) refused them.
+  if (!currentOrgId) redirect("/dashboard");
 
   const member = await prisma.organizationMember.findFirst({
     where: {
       userId: session.user.id,
-      ...(currentOrgId ? { organizationId: currentOrgId } : {}),
+      organizationId: currentOrgId,
       deletedAt: null,
     },
-    select: { organizationId: true, role: true },
+    select: { role: true },
   });
   if (!member) redirect("/dashboard");
 
-  const orgId = member.organizationId;
+  const orgId = currentOrgId;
 
   // Stale agents: rather than mutating the DB on every page render (writes on
   // GETs are a smell + cause contention under traffic), we just derive the
   // displayed status at render time. The agent process keeps its own status
   // pinned via heartbeats; this view is only filtering out the "online but
   // hasn't actually pinged in 90s" race.
-  const staleCutoff = Date.now() - STALE_THRESHOLD_MS;
+  const staleCutoff = Date.now() - AGENT_STALE_THRESHOLD_MS;
 
   const agents = await prisma.localAgent.findMany({
     where: { organizationId: orgId },
@@ -100,7 +103,7 @@ export default async function LocalAgentSettingsPage() {
         agents={agents.map((a) => ({
           id: a.id,
           name: a.name,
-          // Derive offline at render time — see STALE_THRESHOLD_MS note above.
+          // Derive offline at render time — see AGENT_STALE_THRESHOLD_MS note above.
           status:
             a.status === "online" &&
             (!a.lastSeenAt || a.lastSeenAt.getTime() < staleCutoff)


### PR DESCRIPTION
Dedicated settings page listing the org's local agents (status, lastSeenAt, capabilities, machine info) with admin revoke via the existing DELETE /api/agent/[id], plus links to token issuance and the CLI docs. (cemoso/octopus#21.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1