### PR TITLE
feat(cli): /onboard chat command + RepoStep opens the install URL

### DIFF
--- a/apps/cli/src/OnboardWizard.tsx
+++ b/apps/cli/src/OnboardWizard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Box } from "ink";
+import { Box, render } from "ink";
 import { Header } from "./components/Header.js";
 import { WelcomeStep } from "./steps/WelcomeStep.js";
 import { AuthStep } from "./steps/AuthStep.js";
@@ -166,4 +166,15 @@ export function OnboardWizard({ reset = false }: OnboardWizardProps = {}) {
       {activeKey === "done" && <DoneStep answers={answers} />}
     </Box>
   );
+}
+
+/**
+ * Render the wizard and resolve once the user exits it. Shared by the
+ * `octp onboard` entry point and the chat `/onboard` slash command so both
+ * launch the exact same component. Pass `reset` to pre-seed answers from the
+ * saved config.
+ */
+export async function renderWizard(reset = false): Promise<void> {
+  const { waitUntilExit } = render(<OnboardWizard reset={reset} />);
+  await waitUntilExit();
 }

--- a/apps/cli/src/commands/chat.ts
+++ b/apps/cli/src/commands/chat.ts
@@ -132,7 +132,7 @@ export async function chatCommand(argv: string[]): Promise<number> {
         // Slash-command dispatch. Currently just '/onboard': cleanly leave
         // chat and hand off to the onboarding wizard (same component as
         // `octp onboard`), pre-seeding existing config via the reset path.
-        if (message === "/onboard") {
+        if (message.toLowerCase() === "/onboard") {
           launchOnboard = true;
           finish(0);
           return;

--- a/apps/cli/src/commands/chat.ts
+++ b/apps/cli/src/commands/chat.ts
@@ -4,6 +4,7 @@ import { streamData } from "../lib/api.js";
 import { hasFlag, flagValue, positionals } from "../lib/args.js";
 import { resolveRepo } from "../lib/repo-resolver.js";
 import { error, info, c, sanitizeTerminal } from "../lib/output.js";
+import { renderWizard } from "../OnboardWizard.js";
 
 const USAGE = `octp chat — chat with Octopus about a repository
 
@@ -96,13 +97,16 @@ export async function chatCommand(argv: string[]): Promise<number> {
   }
 
   // Interactive REPL.
-  info(`Chatting about ${c.bold(label)}. Type 'exit' or Ctrl+C to quit.\n`);
+  info(`Chatting about ${c.bold(label)}. Type 'exit' or Ctrl+C to quit, '/onboard' to re-run setup.\n`);
 
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   let conversationId: string | null = null;
   let exitCode = 0;
+  // Set when the user types '/onboard': close the REPL, then launch the
+  // onboarding wizard after readline has released stdin (Ink needs to own it).
+  let launchOnboard = false;
 
-  return await new Promise<number>((resolve) => {
+  const code = await new Promise<number>((resolve) => {
     let closed = false;
     const finish = (code: number) => {
       if (closed) return;
@@ -122,6 +126,14 @@ export async function chatCommand(argv: string[]): Promise<number> {
           return;
         }
         if (message.toLowerCase() === "exit") {
+          finish(0);
+          return;
+        }
+        // Slash-command dispatch. Currently just '/onboard': cleanly leave
+        // chat and hand off to the onboarding wizard (same component as
+        // `octp onboard`), pre-seeding existing config via the reset path.
+        if (message === "/onboard") {
+          launchOnboard = true;
           finish(0);
           return;
         }
@@ -160,4 +172,12 @@ export async function chatCommand(argv: string[]): Promise<number> {
 
     ask();
   });
+
+  // Deferred to here so readline has fully closed and released stdin before
+  // Ink's wizard takes it over. `reset` pre-seeds the saved config.
+  if (launchOnboard) {
+    await renderWizard(true);
+  }
+
+  return code;
 }

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
-import React from "react";
-import { render } from "ink";
-import { OnboardWizard } from "./OnboardWizard.js";
+import { renderWizard } from "./OnboardWizard.js";
 import { isOnboarded, loadConfig } from "./lib/config.js";
 import { agentServeCommand } from "./commands/agent-serve.js";
 import { agentWatchCommand } from "./commands/agent-watch.js";
@@ -154,27 +152,27 @@ async function main(rawArgv: string[]): Promise<number> {
       return 0;
     }
     {
-      const code = await renderWizard(argv.includes("--reset"));
+      await renderWizard(argv.includes("--reset"));
       // If signing in under a named account (--account), register + activate it
       // so the wizard's credentials land in a tracked profile (parity with login).
       if (acctFlag) {
         await ensureProfile(acctFlag);
         await setActiveProfile(acctFlag);
       }
-      return code;
+      return 0;
     }
   }
 
   if (first === "onboard") {
     {
-      const code = await renderWizard(argv.includes("--reset"));
+      await renderWizard(argv.includes("--reset"));
       // If signing in under a named account (--account), register + activate it
       // so the wizard's credentials land in a tracked profile (parity with login).
       if (acctFlag) {
         await ensureProfile(acctFlag);
         await setActiveProfile(acctFlag);
       }
-      return code;
+      return 0;
     }
   }
 
@@ -224,14 +222,6 @@ async function main(rawArgv: string[]): Promise<number> {
   console.error(`Unknown command: ${first}`);
   console.error("Run `octp --help` for a list of commands.");
   return 2;
-}
-
-async function renderWizard(reset = false): Promise<number> {
-  await new Promise<void>((resolve) => {
-    const { waitUntilExit } = render(<OnboardWizard reset={reset} />);
-    waitUntilExit().then(() => resolve());
-  });
-  return 0;
 }
 
 // Reusable entry point for other packages that want to embed onboarding.

--- a/apps/cli/src/lib/auth.ts
+++ b/apps/cli/src/lib/auth.ts
@@ -41,12 +41,16 @@ export interface DeviceFlowOptions {
  * `exec("open \"" + url + "\"")` — string interpolation into a shell, a
  * command-injection vector. Best-effort: the URL is also printed for manual
  * open, so a spawn failure is non-fatal.
+ *
+ * Resolves `true` once the browser process spawns successfully and `false`
+ * if it never launches (bad URL, missing opener, spawn throw) so callers can
+ * distinguish "opened" from "here's the URL, open it yourself".
  */
-export function openBrowser(url: string): void {
+export function openBrowser(url: string): Promise<boolean> {
   try {
     new URL(url);
   } catch {
-    return;
+    return Promise.resolve(false);
   }
   let cmd: string;
   let args: string[];
@@ -62,13 +66,18 @@ export function openBrowser(url: string): void {
     cmd = "xdg-open";
     args = [url];
   }
-  try {
-    const child = spawn(cmd, args, { stdio: "ignore", detached: true });
-    child.on("error", () => {}); // ENOENT (no xdg-open) etc. — ignore, URL is printed
-    child.unref();
-  } catch {
-    // ignore — URL was surfaced for manual open
-  }
+  return new Promise<boolean>((resolve) => {
+    try {
+      const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+      child.on("error", () => resolve(false)); // ENOENT (no xdg-open) etc. — URL is printed
+      child.on("spawn", () => {
+        child.unref();
+        resolve(true);
+      });
+    } catch {
+      resolve(false); // URL was surfaced for manual open
+    }
+  });
 }
 
 export async function runDeviceFlow(
@@ -105,7 +114,7 @@ export async function runDeviceFlow(
 
   const authorizeUrl = `${baseUrl}/cli/authorize?code=${encodeURIComponent(deviceCode)}`;
   onAuthorizeUrl?.(authorizeUrl);
-  if (!noOpen) openBrowser(authorizeUrl);
+  if (!noOpen) void openBrowser(authorizeUrl);
 
   const expiry = new Date(expiresAt).getTime();
   let attempts = 0;

--- a/apps/cli/src/lib/auth.ts
+++ b/apps/cli/src/lib/auth.ts
@@ -42,7 +42,7 @@ export interface DeviceFlowOptions {
  * command-injection vector. Best-effort: the URL is also printed for manual
  * open, so a spawn failure is non-fatal.
  */
-function openBrowser(url: string): void {
+export function openBrowser(url: string): void {
   try {
     new URL(url);
   } catch {

--- a/apps/cli/src/steps/RepoStep.tsx
+++ b/apps/cli/src/steps/RepoStep.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import { loadCredentials } from "../lib/credentials.js";
 import { getJson } from "../lib/api.js";
+import { openBrowser } from "../lib/auth.js";
 
 const GITHUB_APP_SLUG = process.env.OCTOPUS_GITHUB_APP_SLUG ?? "octopus-review";
 
@@ -38,10 +39,23 @@ export function RepoStep({ onNext }: RepoStepProps) {
   const [repos, setRepos] = useState<Repo[]>([]);
   const [error, setError] = useState<string>("");
   const [installUrl, setInstallUrl] = useState<string>("");
+  const [opened, setOpened] = useState(false);
 
   useInput((_input, key) => {
     if (key.escape && phase !== "loading") onNext();
   });
+
+  // Open the GitHub App install page in the system browser (reusing the same
+  // shell-free helper the PKCE auth step uses). The URL stays on screen as a
+  // fallback, so a spawn failure is non-fatal.
+  const handleSelect = (value: string) => {
+    if (value === "install") {
+      openBrowser(installUrl);
+      setOpened(true);
+      return;
+    }
+    onNext();
+  };
 
   useEffect(() => {
     (async () => {
@@ -107,12 +121,14 @@ export function RepoStep({ onNext }: RepoStepProps) {
         <Text> </Text>
         <Text dimColor>Open the URL in your browser, pick a repo, click Install.</Text>
         <Text dimColor>You can always do this later from the Octopus web UI.</Text>
+        {opened ? <Text color="green">Opened the install page in your browser.</Text> : null}
         <Text> </Text>
         <SelectInput
           items={[
+            { label: "Install the Octopus GitHub App (opens browser)", value: "install" },
             { label: "Continue (I'll install later)", value: "continue" },
           ]}
-          onSelect={() => onNext()}
+          onSelect={(item) => handleSelect(item.value)}
         />
       </Box>
     );
@@ -134,10 +150,14 @@ export function RepoStep({ onNext }: RepoStepProps) {
       <Text dimColor>
         Add more repos at <Text color="cyan">{installUrl}</Text>
       </Text>
+      {opened ? <Text color="green">Opened the install page in your browser.</Text> : null}
       <Text> </Text>
       <SelectInput
-        items={[{ label: "Continue", value: "continue" }]}
-        onSelect={() => onNext()}
+        items={[
+          { label: "Install on another repo (opens browser)", value: "install" },
+          { label: "Continue", value: "continue" },
+        ]}
+        onSelect={(item) => handleSelect(item.value)}
       />
     </Box>
   );

--- a/apps/cli/src/steps/RepoStep.tsx
+++ b/apps/cli/src/steps/RepoStep.tsx
@@ -39,7 +39,7 @@ export function RepoStep({ onNext }: RepoStepProps) {
   const [repos, setRepos] = useState<Repo[]>([]);
   const [error, setError] = useState<string>("");
   const [installUrl, setInstallUrl] = useState<string>("");
-  const [opened, setOpened] = useState(false);
+  const [openState, setOpenState] = useState<"idle" | "opened" | "failed">("idle");
 
   useInput((_input, key) => {
     if (key.escape && phase !== "loading") onNext();
@@ -47,11 +47,12 @@ export function RepoStep({ onNext }: RepoStepProps) {
 
   // Open the GitHub App install page in the system browser (reusing the same
   // shell-free helper the PKCE auth step uses). The URL stays on screen as a
-  // fallback, so a spawn failure is non-fatal.
-  const handleSelect = (value: string) => {
+  // fallback, so a spawn failure is non-fatal — we just tell the user to open
+  // it themselves rather than claiming success.
+  const handleSelect = async (value: string) => {
     if (value === "install") {
-      openBrowser(installUrl);
-      setOpened(true);
+      const opened = await openBrowser(installUrl);
+      setOpenState(opened ? "opened" : "failed");
       return;
     }
     onNext();
@@ -121,14 +122,19 @@ export function RepoStep({ onNext }: RepoStepProps) {
         <Text> </Text>
         <Text dimColor>Open the URL in your browser, pick a repo, click Install.</Text>
         <Text dimColor>You can always do this later from the Octopus web UI.</Text>
-        {opened ? <Text color="green">Opened the install page in your browser.</Text> : null}
+        {openState === "opened" ? (
+          <Text color="green">Opened the install page in your browser.</Text>
+        ) : null}
+        {openState === "failed" ? (
+          <Text color="yellow">Could not open a browser — use the URL above.</Text>
+        ) : null}
         <Text> </Text>
         <SelectInput
           items={[
             { label: "Install the Octopus GitHub App (opens browser)", value: "install" },
             { label: "Continue (I'll install later)", value: "continue" },
           ]}
-          onSelect={(item) => handleSelect(item.value)}
+          onSelect={(item) => void handleSelect(item.value)}
         />
       </Box>
     );
@@ -150,7 +156,12 @@ export function RepoStep({ onNext }: RepoStepProps) {
       <Text dimColor>
         Add more repos at <Text color="cyan">{installUrl}</Text>
       </Text>
-      {opened ? <Text color="green">Opened the install page in your browser.</Text> : null}
+      {openState === "opened" ? (
+        <Text color="green">Opened the install page in your browser.</Text>
+      ) : null}
+      {openState === "failed" ? (
+        <Text color="yellow">Could not open a browser — use the URL above.</Text>
+      ) : null}
       <Text> </Text>
       <SelectInput
         items={[


### PR DESCRIPTION
Chat REPL gains a /onboard slash command that relaunches the onboarding wizard (shared renderWizard helper); RepoStep's GitHub-App option now opens the install URL in the browser via the same helper the PKCE auth uses (URL still printed as fallback). CLI tests: 106 pass. (cemoso/octopus#70, #69.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1