### PR TITLE
fix(deps): bump nodemailer to ^9.0.1 (Dependabot high, alert #22)

### DIFF
--- a/apps/web/lib/__tests__/email-send.test.ts
+++ b/apps/web/lib/__tests__/email-send.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Transporter smoke test for the nodemailer v9 bump: intercept createTransport
+// and assert lib/email.ts wires the transport from env and passes the message
+// shape sendMail expects. Guards the createTransport/sendMail API surface we
+// actually use (no v9 types are published yet — @types/nodemailer is 8.x).
+const sendMailMock = mock(() => Promise.resolve({ messageId: "test" }));
+const createTransportMock = mock(() => ({ sendMail: sendMailMock }));
+
+mock.module("nodemailer", () => ({
+  default: { createTransport: (...args: unknown[]) => createTransportMock(...args) },
+}));
+mock.module("@/lib/audit", () => ({
+  writeAuditLog: () => Promise.resolve(),
+}));
+
+process.env.EMAIL_HOST = "smtp.test";
+process.env.EMAIL_PORT = "587";
+process.env.EMAIL_SECURE = "false";
+process.env.EMAIL_USER = "u";
+process.env.EMAIL_PASSWORD = "p";
+process.env.EMAIL_FROM = "noreply@test";
+process.env.EMAIL_FROM_NAME = "Octopus";
+
+const { sendEmail } = await import("@/lib/email");
+
+describe("email transporter (nodemailer v9 surface)", () => {
+  beforeEach(() => sendMailMock.mockClear());
+
+  it("builds the transport from env with the v9 createTransport options shape", () => {
+    expect(createTransportMock).toHaveBeenCalledTimes(1);
+    const opts = createTransportMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.host).toBe("smtp.test");
+    expect(opts.port).toBe(587);
+    expect(opts.secure).toBe(false);
+    expect(opts.auth).toEqual({ user: "u", pass: "p" });
+  });
+
+  it("sends with the from/to/subject/html message shape", async () => {
+    await sendEmail({ to: "dev@example.com", subject: "hi", html: "<b>hi</b>" });
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    const msg = sendMailMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(msg.from).toBe('"Octopus" <noreply@test>');
+    expect(msg.to).toBe("dev@example.com");
+    expect(msg.subject).toBe("hi");
+    expect(msg.html).toBe("<b>hi</b>");
+    expect(msg).not.toHaveProperty("raw");
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,7 +38,7 @@
     "mermaid": "^11.14.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
-    "nodemailer": "^8.0.7",
+    "nodemailer": "^9.0.1",
     "openai": "^6.39.0",
     "pg-boss": "^12.15.0",
     "radix-ui": "^1.4.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -64,7 +64,7 @@
     "@octopus/tsconfig": "workspace:*",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^25",
-    "@types/nodemailer": "^8.0.0",
+    "@types/nodemailer": "^8.0.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/three": "^0.183.1",

--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
         "@octopus/tsconfig": "workspace:*",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^25",
-        "@types/nodemailer": "^8.0.0",
+        "@types/nodemailer": "^8.0.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/three": "^0.183.1",
@@ -1043,7 +1043,7 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
-    "@types/nodemailer": ["@types/nodemailer@8.0.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA=="],
+    "@types/nodemailer": ["@types/nodemailer@8.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw=="],
 
     "@types/offscreencanvas": ["@types/offscreencanvas@2019.7.3", "", {}, "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
     "apps/web": {
       "name": "@octopus/web",
-      "version": "0.1.0",
+      "version": "1.0.26",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@aws-sdk/client-s3": "^3.1030.0",
@@ -55,7 +55,7 @@
         "mermaid": "^11.14.0",
         "next": "16.2.6",
         "next-themes": "^0.4.6",
-        "nodemailer": "^8.0.7",
+        "nodemailer": "^9.0.1",
         "openai": "^6.39.0",
         "pg-boss": "^12.15.0",
         "radix-ui": "^1.4.3",
@@ -2239,7 +2239,7 @@
 
     "node-releases": ["node-releases@2.0.36", "", {}, "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA=="],
 
-    "nodemailer": ["nodemailer@8.0.7", "", {}, "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow=="],
+    "nodemailer": ["nodemailer@9.0.3", "", {}, "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw=="],
 
     "non-error": ["non-error@0.1.0", "", {}, "sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ=="],
 


### PR DESCRIPTION
Bumps nodemailer past the high-severity advisory (message-level `raw` option bypassing `disableFileAccess`/`disableUrlAccess` → arbitrary file read / SSRF). Resolved: 9.0.3. Our email code never passes `raw`, so this is preventive. typecheck clean; web suite 473 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1