### PR TITLE
feat(review): content-signature finding merge — triage survives re-reviews

### DIFF
--- a/apps/web/lib/__tests__/finding-merge.test.ts
+++ b/apps/web/lib/__tests__/finding-merge.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "bun:test";
+import { findingSignature, mergeFindingsBySignature } from "@/lib/finding-merge";
+
+describe("findingSignature", () => {
+  it("returns the same signature for identical inputs", () => {
+    const a = findingSignature({
+      filePath: "src/x.ts",
+      category: "Security",
+      title: "SQL injection",
+    });
+    const b = findingSignature({
+      filePath: "src/x.ts",
+      category: "Security",
+      title: "SQL injection",
+    });
+    expect(a).toBe(b);
+  });
+
+  it("is case-insensitive for category and title", () => {
+    const a = findingSignature({
+      filePath: "src/x.ts",
+      category: "Security",
+      title: "SQL injection",
+    });
+    const b = findingSignature({
+      filePath: "src/x.ts",
+      category: "SECURITY",
+      title: "sql INJECTION",
+    });
+    expect(a).toBe(b);
+  });
+
+  it("collapses internal whitespace in title", () => {
+    const a = findingSignature({
+      filePath: "src/x.ts",
+      category: "Bug",
+      title: "Off by one",
+    });
+    const b = findingSignature({
+      filePath: "src/x.ts",
+      category: "Bug",
+      title: "Off  by\tone",
+    });
+    expect(a).toBe(b);
+  });
+
+  it("is case-sensitive for filePath (paths are exact)", () => {
+    const a = findingSignature({ filePath: "src/X.ts", category: "Bug", title: "T" });
+    const b = findingSignature({ filePath: "src/x.ts", category: "Bug", title: "T" });
+    expect(a).not.toBe(b);
+  });
+
+  it("changes when title content changes", () => {
+    const a = findingSignature({ filePath: "x", category: "c", title: "a" });
+    const b = findingSignature({ filePath: "x", category: "c", title: "b" });
+    expect(a).not.toBe(b);
+  });
+
+  it("returns a 16-char hex string", () => {
+    const sig = findingSignature({ filePath: "x", category: "c", title: "t" });
+    expect(sig).toHaveLength(16);
+    expect(sig).toMatch(/^[0-9a-f]+$/);
+  });
+});
+
+describe("mergeFindingsBySignature", () => {
+  type F = {
+    signature: string | null;
+    title: string;
+    status?: "open" | "acknowledged" | "wont-fix";
+    createdAt?: number;
+  };
+
+  // The inherit rule mirrors what reviewer.ts will do: copy triage + originals.
+  const inheritTriage = (next: F, prior: F): F => ({
+    ...next,
+    status: prior.status,
+    createdAt: prior.createdAt,
+  });
+
+  it("inherits prior state when signatures match", () => {
+    const prior: F[] = [
+      { signature: "a", title: "x", status: "acknowledged", createdAt: 100 },
+    ];
+    const current: F[] = [
+      { signature: "a", title: "x" },
+    ];
+    const result = mergeFindingsBySignature({ prior, current, inherit: inheritTriage });
+    expect(result.merged[0].status).toBe("acknowledged");
+    expect(result.merged[0].createdAt).toBe(100);
+    expect(result.inherited).toBe(1);
+    expect(result.added).toBe(0);
+    expect(result.obsoleted).toBe(0);
+  });
+
+  it("counts added findings (no prior match)", () => {
+    const prior: F[] = [{ signature: "a", title: "x", status: "open" }];
+    const current: F[] = [
+      { signature: "a", title: "x" },
+      { signature: "b", title: "new" },
+    ];
+    const result = mergeFindingsBySignature({ prior, current, inherit: inheritTriage });
+    expect(result.added).toBe(1);
+    expect(result.inherited).toBe(1);
+  });
+
+  it("counts obsoleted prior findings", () => {
+    const prior: F[] = [
+      { signature: "a", title: "x", status: "open" },
+      { signature: "b", title: "old", status: "open" },
+    ];
+    const current: F[] = [{ signature: "a", title: "x" }];
+    const result = mergeFindingsBySignature({ prior, current, inherit: inheritTriage });
+    expect(result.obsoleted).toBe(1);
+  });
+
+  it("does not merge findings without a signature", () => {
+    const prior: F[] = [{ signature: null, title: "legacy", status: "acknowledged" }];
+    const current: F[] = [{ signature: null, title: "legacy" }];
+    const result = mergeFindingsBySignature({ prior, current, inherit: inheritTriage });
+    expect(result.merged[0].status).toBeUndefined();
+    expect(result.inherited).toBe(0);
+    expect(result.added).toBe(1);
+  });
+
+  it("returns the same length as `current` (current is the source of truth)", () => {
+    const prior: F[] = [
+      { signature: "a", title: "x", status: "open" },
+      { signature: "b", title: "y", status: "open" },
+      { signature: "c", title: "z", status: "open" },
+    ];
+    const current: F[] = [
+      { signature: "a", title: "x" },
+      { signature: "d", title: "brand new" },
+    ];
+    const result = mergeFindingsBySignature({ prior, current, inherit: inheritTriage });
+    expect(result.merged).toHaveLength(2);
+    expect(result.inherited).toBe(1);
+    expect(result.added).toBe(1);
+    expect(result.obsoleted).toBe(2);
+  });
+
+  it("handles empty prior list", () => {
+    const current: F[] = [{ signature: "a", title: "x" }];
+    const result = mergeFindingsBySignature({ prior: [], current, inherit: inheritTriage });
+    expect(result.added).toBe(1);
+    expect(result.inherited).toBe(0);
+    expect(result.obsoleted).toBe(0);
+  });
+
+  it("handles empty current list", () => {
+    const prior: F[] = [{ signature: "a", title: "x", status: "open" }];
+    const result = mergeFindingsBySignature({ prior, current: [], inherit: inheritTriage });
+    expect(result.merged).toHaveLength(0);
+    expect(result.obsoleted).toBe(1);
+  });
+});

--- a/apps/web/lib/community-pr-persist.ts
+++ b/apps/web/lib/community-pr-persist.ts
@@ -1,6 +1,6 @@
-import { prisma } from "@octopus/db";
+import { prisma, type Prisma } from "@octopus/db";
 import type { InlineFinding } from "@/lib/review-dedup";
-import { findingSignature } from "@/lib/finding-merge";
+import { findingSignature, mergeFindingsBySignature, inheritReviewIssueTriage } from "@/lib/finding-merge";
 
 const SEVERITY_MAP: Record<string, string> = {
   "🔴": "critical",
@@ -64,23 +64,29 @@ export async function persistCommunityReviewToPR(input: CommunityPRPersistInput)
     },
   });
 
-  await prisma.reviewIssue.deleteMany({ where: { pullRequestId: pr.id } });
-
-  if (findings.length > 0) {
-    await prisma.reviewIssue.createMany({
-      data: findings.map((f) => {
-        const title = f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim();
-        return {
-          pullRequestId: pr.id,
-          title,
-          description: f.description || f.category,
-          severity: SEVERITY_MAP[f.severity] ?? "medium",
-          filePath: f.filePath || null,
-          lineNumber: f.startLine || null,
-          confidence: f.confidence ? String(f.confidence) : null,
-          signature: findingSignature({ filePath: f.filePath || "", category: f.category, title }),
-        };
-      }),
-    });
-  }
+  // Signature-matched findings inherit prior triage state; delete+create run
+  // atomically so a mid-way failure can never wipe triage without replacement.
+  const priorIssues = await prisma.reviewIssue.findMany({ where: { pullRequestId: pr.id } });
+  const current: Prisma.ReviewIssueCreateManyInput[] = findings.map((f) => {
+    const title = f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim();
+    return {
+      pullRequestId: pr.id,
+      title,
+      description: f.description || f.category,
+      severity: SEVERITY_MAP[f.severity] ?? "medium",
+      filePath: f.filePath || null,
+      lineNumber: f.startLine || null,
+      confidence: f.confidence ? String(f.confidence) : null,
+      signature: findingSignature({ filePath: f.filePath || "", category: f.category, title }),
+    };
+  });
+  const { merged } = mergeFindingsBySignature<Prisma.ReviewIssueCreateManyInput>({
+    prior: priorIssues,
+    current,
+    inherit: inheritReviewIssueTriage,
+  });
+  await prisma.$transaction([
+    prisma.reviewIssue.deleteMany({ where: { pullRequestId: pr.id } }),
+    ...(merged.length > 0 ? [prisma.reviewIssue.createMany({ data: merged })] : []),
+  ]);
 }

--- a/apps/web/lib/community-pr-persist.ts
+++ b/apps/web/lib/community-pr-persist.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@octopus/db";
 import type { InlineFinding } from "@/lib/review-dedup";
+import { findingSignature } from "@/lib/finding-merge";
 
 const SEVERITY_MAP: Record<string, string> = {
   "🔴": "critical",
@@ -67,15 +68,19 @@ export async function persistCommunityReviewToPR(input: CommunityPRPersistInput)
 
   if (findings.length > 0) {
     await prisma.reviewIssue.createMany({
-      data: findings.map((f) => ({
-        pullRequestId: pr.id,
-        title: f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim(),
-        description: f.description || f.category,
-        severity: SEVERITY_MAP[f.severity] ?? "medium",
-        filePath: f.filePath || null,
-        lineNumber: f.startLine || null,
-        confidence: f.confidence ? String(f.confidence) : null,
-      })),
+      data: findings.map((f) => {
+        const title = f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim();
+        return {
+          pullRequestId: pr.id,
+          title,
+          description: f.description || f.category,
+          severity: SEVERITY_MAP[f.severity] ?? "medium",
+          filePath: f.filePath || null,
+          lineNumber: f.startLine || null,
+          confidence: f.confidence ? String(f.confidence) : null,
+          signature: findingSignature({ filePath: f.filePath || "", category: f.category, title }),
+        };
+      }),
     });
   }
 }

--- a/apps/web/lib/finding-merge.ts
+++ b/apps/web/lib/finding-merge.ts
@@ -90,3 +90,38 @@ export function mergeFindingsBySignature<T extends { signature?: string | null }
     obsoleted,
   };
 }
+
+/**
+ * The canonical triage-state inheritance used by every persistence path:
+ * a signature-matched finding keeps the user's acknowledgement, feedback,
+ * tracker links, posted-comment id, and original createdAt. Prior rows are
+ * full DB records at runtime; keys are copied only when present, so this
+ * satisfies the mergeFindingsBySignature contract ((next: T, prior: T) => T)
+ * for any row shape.
+ */
+const TRIAGE_KEYS = [
+  "acknowledgedAt",
+  "feedback",
+  "feedbackAt",
+  "feedbackBy",
+  "linearIssueId",
+  "linearIssueUrl",
+  "jiraIssueKey",
+  "jiraIssueUrl",
+  "githubIssueNumber",
+  "githubIssueUrl",
+  "githubCommentId",
+  "createdAt",
+] as const;
+
+export function inheritReviewIssueTriage<T extends { signature?: string | null }>(
+  next: T,
+  prior: T,
+): T {
+  const out: Record<string, unknown> = { ...(next as Record<string, unknown>) };
+  const p = prior as Record<string, unknown>;
+  for (const key of TRIAGE_KEYS) {
+    if (key in p) out[key] = p[key];
+  }
+  return out as T;
+}

--- a/apps/web/lib/finding-merge.ts
+++ b/apps/web/lib/finding-merge.ts
@@ -1,0 +1,92 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Compute a stable, content-derived signature for a finding.
+ *
+ * The signature is the prefix of a SHA-256 hash over a canonical
+ * representation of the finding's identity:
+ *   - filePath (exact, no normalisation)
+ *   - category (case-insensitive, trimmed)
+ *   - title (case-insensitive, trimmed, internal whitespace collapsed)
+ *
+ * Deliberately excluded:
+ *   - severity, confidence, description, suggestion, line numbers — these
+ *     can drift between runs for the same underlying issue without the
+ *     finding being a different bug. Including them would defeat merging.
+ *
+ * 16 hex chars = 64 bits of entropy. At 1000 findings per PR the collision
+ * probability is ~2.7e-14 — fine for this use case, and short enough to
+ * eyeball in logs.
+ */
+export function findingSignature(input: {
+  filePath: string;
+  category: string;
+  title: string;
+}): string {
+  const canonical = JSON.stringify({
+    f: input.filePath,
+    c: input.category.trim().toLowerCase(),
+    t: input.title.trim().toLowerCase().replace(/\s+/g, " "),
+  });
+  return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
+}
+
+export type MergeResult<T> = {
+  /** Findings to persist after merge — same length as `current`. */
+  merged: T[];
+  /** How many current findings inherited state from a prior finding. */
+  inherited: number;
+  /** How many current findings are new (no prior match). */
+  added: number;
+  /** Prior findings that no current finding matched (likely resolved). */
+  obsoleted: number;
+};
+
+/**
+ * Match current findings against prior findings by signature. For each match,
+ * apply `inherit` to copy user-triage state (acknowledgement, feedback,
+ * tracker IDs, original createdAt) from the prior finding onto the current one.
+ *
+ * Findings without signatures cannot participate in merging — they pass
+ * through unchanged. Callers should compute signatures via {@link findingSignature}
+ * before calling this.
+ */
+export function mergeFindingsBySignature<T extends { signature?: string | null }>(args: {
+  prior: T[];
+  current: T[];
+  inherit: (next: T, prior: T) => T;
+}): MergeResult<T> {
+  const { prior, current, inherit } = args;
+
+  const priorBySig = new Map<string, T>();
+  for (const p of prior) {
+    if (p.signature) priorBySig.set(p.signature, p);
+  }
+
+  const merged: T[] = [];
+  const seenSigs = new Set<string>();
+  let inherited = 0;
+
+  for (const c of current) {
+    if (c.signature && priorBySig.has(c.signature)) {
+      merged.push(inherit(c, priorBySig.get(c.signature)!));
+      seenSigs.add(c.signature);
+      inherited += 1;
+    } else {
+      merged.push(c);
+      if (c.signature) seenSigs.add(c.signature);
+    }
+  }
+
+  let obsoleted = 0;
+  for (const p of prior) {
+    if (p.signature && !seenSigs.has(p.signature)) obsoleted += 1;
+  }
+
+  return {
+    merged,
+    inherited,
+    added: merged.length - inherited,
+    obsoleted,
+  };
+}

--- a/apps/web/lib/large-review-result.ts
+++ b/apps/web/lib/large-review-result.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@octopus/db";
+import { prisma, type Prisma } from "@octopus/db";
 import { pubby } from "@/lib/pubby";
 import {
   createPullRequestComment as ghCreatePullRequestComment,
@@ -7,7 +7,7 @@ import {
   updateCheckRun as ghUpdateCheckRun,
 } from "@/lib/github";
 import { parseFindings } from "@/lib/review-dedup";
-import { findingSignature } from "@/lib/finding-merge";
+import { findingSignature, mergeFindingsBySignature, inheritReviewIssueTriage } from "@/lib/finding-merge";
 import {
   buildLowSeveritySummary,
   stripDetailedFindings,
@@ -218,24 +218,36 @@ export async function handleLargeReviewResult(
   }
 
   // 4. Persist findings to review_issues
-  await prisma.reviewIssue.deleteMany({ where: { pullRequestId: pr.id } });
-  if (findings.length > 0) {
-    await prisma.reviewIssue.createMany({
-      data: findings.map((f) => {
-        const title = f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim();
-        return {
-          title,
-          description: f.description || f.category,
-          severity: SEVERITY_TO_DB[f.severity] ?? "medium",
-          filePath: f.filePath || null,
-          lineNumber: f.startLine || null,
-          confidence: f.confidence ? String(f.confidence) : null,
-          pullRequestId: pr.id,
-          signature: findingSignature({ filePath: f.filePath || "", category: f.category, title }),
-        };
-      }),
-    });
-    console.log(`[large-review-result] Saved ${findings.length} review issues to DB`);
+  // Signature-matched findings inherit prior triage state; delete+create run
+  // atomically so a mid-way failure can never wipe triage without replacement.
+  const priorIssues = await prisma.reviewIssue.findMany({ where: { pullRequestId: pr.id } });
+  const current: Prisma.ReviewIssueCreateManyInput[] = findings.map((f) => {
+    const title = f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim();
+    return {
+      title,
+      description: f.description || f.category,
+      severity: SEVERITY_TO_DB[f.severity] ?? "medium",
+      filePath: f.filePath || null,
+      lineNumber: f.startLine || null,
+      confidence: f.confidence ? String(f.confidence) : null,
+      pullRequestId: pr.id,
+      signature: findingSignature({ filePath: f.filePath || "", category: f.category, title }),
+    };
+  });
+  const { merged, inherited } = mergeFindingsBySignature<Prisma.ReviewIssueCreateManyInput>({
+    prior: priorIssues,
+    current,
+    inherit: inheritReviewIssueTriage,
+  });
+  await prisma.$transaction([
+    prisma.reviewIssue.deleteMany({ where: { pullRequestId: pr.id } }),
+    ...(merged.length > 0 ? [prisma.reviewIssue.createMany({ data: merged })] : []),
+  ]);
+  if (merged.length > 0) {
+    console.log(
+      `[large-review-result] Saved ${merged.length} review issues to DB` +
+        (inherited > 0 ? ` (${inherited} inherited prior triage state)` : ""),
+    );
   }
 
   // 5. Mark PR completed

--- a/apps/web/lib/large-review-result.ts
+++ b/apps/web/lib/large-review-result.ts
@@ -7,6 +7,7 @@ import {
   updateCheckRun as ghUpdateCheckRun,
 } from "@/lib/github";
 import { parseFindings } from "@/lib/review-dedup";
+import { findingSignature } from "@/lib/finding-merge";
 import {
   buildLowSeveritySummary,
   stripDetailedFindings,
@@ -220,15 +221,19 @@ export async function handleLargeReviewResult(
   await prisma.reviewIssue.deleteMany({ where: { pullRequestId: pr.id } });
   if (findings.length > 0) {
     await prisma.reviewIssue.createMany({
-      data: findings.map((f) => ({
-        title: f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim(),
-        description: f.description || f.category,
-        severity: SEVERITY_TO_DB[f.severity] ?? "medium",
-        filePath: f.filePath || null,
-        lineNumber: f.startLine || null,
-        confidence: f.confidence ? String(f.confidence) : null,
-        pullRequestId: pr.id,
-      })),
+      data: findings.map((f) => {
+        const title = f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim();
+        return {
+          title,
+          description: f.description || f.category,
+          severity: SEVERITY_TO_DB[f.severity] ?? "medium",
+          filePath: f.filePath || null,
+          lineNumber: f.startLine || null,
+          confidence: f.confidence ? String(f.confidence) : null,
+          pullRequestId: pr.id,
+          signature: findingSignature({ filePath: f.filePath || "", category: f.category, title }),
+        };
+      }),
     });
     console.log(`[large-review-result] Saved ${findings.length} review issues to DB`);
   }

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { prisma } from "@octopus/db";
+import { prisma, type Prisma } from "@octopus/db";
 import { pubby } from "@/lib/pubby";
 import {
   searchSimilarChunks,
@@ -21,6 +21,7 @@ import { generateSparseVector } from "@/lib/sparse-vector";
 import { substitutePromptVars } from "@/lib/prompt-substitute";
 import { rerankDocuments } from "@/lib/reranker";
 import { resolveReviewLanguage } from "@/lib/review-language";
+import { findingSignature, mergeFindingsBySignature } from "@/lib/finding-merge";
 import { getAlwaysIncludeKnowledge, mergeKnowledgeChunks } from "@/lib/knowledge-context";
 import {
   fetchRepoConfigFile,
@@ -2228,6 +2229,15 @@ Rules:
     }
 
     // Step 6: Persist parsed findings as ReviewIssue records (ALL findings, not just capped/inline)
+    // Fetch prior findings BEFORE clearing so that on a re-review, a finding whose
+    // content signature is unchanged inherits its user-triage state (acknowledgement,
+    // feedback, tracker links, original createdAt) instead of resurfacing as brand-new.
+    // This exact-signature inheritance complements the earlier fuzzy (keyword +
+    // line-proximity) dedup rather than replacing it — see lib/finding-merge.ts.
+    const priorIssues = await prisma.reviewIssue.findMany({
+      where: { pullRequestId: pr.id },
+    });
+
     // Clear previous findings first (re-review idempotency)
     await prisma.reviewIssue.deleteMany({
       where: { pullRequestId: pr.id },
@@ -2244,18 +2254,45 @@ Rules:
         "💡": "low",
       };
 
-      await prisma.reviewIssue.createMany({
-        data: allPersistFindings.map((f) => ({
-          title: f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim(),
+      const current: Prisma.ReviewIssueCreateManyInput[] = allPersistFindings.map((f) => {
+        const title = f.title.replace(/^(CRITICAL|HIGH|MEDIUM|LOW|INFO)\s*—\s*/i, "").trim();
+        return {
+          title,
           description: f.description || f.category,
           severity: severityMap[f.severity] ?? "medium",
           filePath: f.filePath || null,
           lineNumber: f.startLine || null,
           confidence: f.confidence ? String(f.confidence) : null,
           pullRequestId: pr.id,
-        })),
+          signature: findingSignature({ filePath: f.filePath || "", category: f.category, title }),
+        };
       });
-      console.log(`[reviewer] Saved ${allPersistFindings.length} review issues to DB`);
+
+      const { merged, inherited } = mergeFindingsBySignature<Prisma.ReviewIssueCreateManyInput>({
+        prior: priorIssues,
+        current,
+        inherit: (next, prior) => ({
+          ...next,
+          acknowledgedAt: prior.acknowledgedAt,
+          feedback: prior.feedback,
+          feedbackAt: prior.feedbackAt,
+          feedbackBy: prior.feedbackBy,
+          linearIssueId: prior.linearIssueId,
+          linearIssueUrl: prior.linearIssueUrl,
+          jiraIssueKey: prior.jiraIssueKey,
+          jiraIssueUrl: prior.jiraIssueUrl,
+          githubIssueNumber: prior.githubIssueNumber,
+          githubIssueUrl: prior.githubIssueUrl,
+          githubCommentId: prior.githubCommentId,
+          createdAt: prior.createdAt,
+        }),
+      });
+
+      await prisma.reviewIssue.createMany({ data: merged });
+      console.log(
+        `[reviewer] Saved ${merged.length} review issues to DB` +
+          (inherited > 0 ? ` (${inherited} inherited prior triage state)` : ""),
+      );
     }
 
     // Step 7: Mark as completed + update check run

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -21,7 +21,7 @@ import { generateSparseVector } from "@/lib/sparse-vector";
 import { substitutePromptVars } from "@/lib/prompt-substitute";
 import { rerankDocuments } from "@/lib/reranker";
 import { resolveReviewLanguage } from "@/lib/review-language";
-import { findingSignature, mergeFindingsBySignature } from "@/lib/finding-merge";
+import { findingSignature, mergeFindingsBySignature, inheritReviewIssueTriage } from "@/lib/finding-merge";
 import { getAlwaysIncludeKnowledge, mergeKnowledgeChunks } from "@/lib/knowledge-context";
 import {
   fetchRepoConfigFile,
@@ -2238,12 +2238,12 @@ Rules:
       where: { pullRequestId: pr.id },
     });
 
-    // Clear previous findings first (re-review idempotency)
-    await prisma.reviewIssue.deleteMany({
-      where: { pullRequestId: pr.id },
-    });
-
-    // Persist all parsed findings (pre-filter) for dashboard/scoring
+    // Persist all parsed findings (pre-filter) for dashboard/scoring. The
+    // delete+create replacement happens in ONE transaction below so a failure
+    // mid-way can never wipe prior findings (and their triage state) without
+    // writing the replacements.
+    let mergedIssues: Prisma.ReviewIssueCreateManyInput[] = [];
+    let inheritedCount = 0;
     const allPersistFindings = allParsedFindings;
     if (allPersistFindings.length > 0) {
       const severityMap: Record<string, string> = {
@@ -2271,27 +2271,24 @@ Rules:
       const { merged, inherited } = mergeFindingsBySignature<Prisma.ReviewIssueCreateManyInput>({
         prior: priorIssues,
         current,
-        inherit: (next, prior) => ({
-          ...next,
-          acknowledgedAt: prior.acknowledgedAt,
-          feedback: prior.feedback,
-          feedbackAt: prior.feedbackAt,
-          feedbackBy: prior.feedbackBy,
-          linearIssueId: prior.linearIssueId,
-          linearIssueUrl: prior.linearIssueUrl,
-          jiraIssueKey: prior.jiraIssueKey,
-          jiraIssueUrl: prior.jiraIssueUrl,
-          githubIssueNumber: prior.githubIssueNumber,
-          githubIssueUrl: prior.githubIssueUrl,
-          githubCommentId: prior.githubCommentId,
-          createdAt: prior.createdAt,
-        }),
+        inherit: inheritReviewIssueTriage,
       });
+      mergedIssues = merged;
+      inheritedCount = inherited;
+    }
 
-      await prisma.reviewIssue.createMany({ data: merged });
+    // Atomic replace: clear + insert together (re-review idempotency without
+    // a window where triage-bearing rows are deleted but replacements unwritten).
+    await prisma.$transaction([
+      prisma.reviewIssue.deleteMany({ where: { pullRequestId: pr.id } }),
+      ...(mergedIssues.length > 0
+        ? [prisma.reviewIssue.createMany({ data: mergedIssues })]
+        : []),
+    ]);
+    if (mergedIssues.length > 0) {
       console.log(
-        `[reviewer] Saved ${merged.length} review issues to DB` +
-          (inherited > 0 ? ` (${inherited} inherited prior triage state)` : ""),
+        `[reviewer] Saved ${mergedIssues.length} review issues to DB` +
+          (inheritedCount > 0 ? ` (${inheritedCount} inherited prior triage state)` : ""),
       );
     }
 

--- a/packages/db/prisma/migrations/20260704140000_add_review_issue_signature/migration.sql
+++ b/packages/db/prisma/migrations/20260704140000_add_review_issue_signature/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "review_issues" ADD COLUMN     "signature" TEXT;
+
+-- CreateIndex
+CREATE INDEX "review_issues_pullRequestId_signature_idx" ON "review_issues"("pullRequestId", "signature");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -335,6 +335,13 @@ model ReviewIssue {
   feedbackBy     String?
   createdAt      DateTime  @default(now())
 
+  // Content-derived signature for cross-review merging. When a PR is re-reviewed,
+  // findings whose signatures match a prior finding inherit its user-triage state
+  // (acknowledgedAt, feedback*, *IssueId, *CommentId, createdAt) so the dev does
+  // not have to re-triage the same issue on every push. Nullable for legacy rows
+  // that predate the introduction of signatures.
+  signature String?
+
   linearIssueId  String?
   linearIssueUrl String?
   jiraIssueKey   String?
@@ -347,6 +354,7 @@ model ReviewIssue {
   pullRequest   PullRequest @relation(fields: [pullRequestId], references: [id], onDelete: Cascade)
 
   @@index([pullRequestId])
+  @@index([pullRequestId, signature])
   @@map("review_issues")
 }
 


### PR DESCRIPTION
## What
Adds `ReviewIssue.signature` (nullable TEXT + `(pullRequestId, signature)` index, expand-only migration) computed from normalized `filePath`/`category`/`title`, plus `lib/finding-merge.ts` (`findingSignature`, `mergeFindingsBySignature`). On a re-review, findings whose signature matches a prior finding **inherit the user's triage state** — `acknowledgedAt`, `feedback*`, Linear/Jira issue links, comment ids, original `createdAt` — instead of reappearing as brand-new on every push. Wired into all three persistence paths (reviewer, community-pr-persist, large-review-result).

## Notes
- **Complements** the existing fuzzy (keyword + line-proximity) intra-review dedup; this layer is exact-signature **cross-review** inheritance.
- Legacy rows have NULL signatures and simply never match — no backfill needed.
- 13 new tests; full web suite 474 pass; typecheck/lint clean.

Completes Workstream 6 (the last open roadmap epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1