### PR TITLE
feat(self-host): public prebuilt image (octopus-selfhost) + pull-based install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,19 +62,22 @@ jobs:
           # add linux/arm64 to platforms when there's demand.
           platforms: linux/amd64
           push: true
+          # The self-host distribution lives on a SEPARATE package
+          # (octopusreview/octopus-selfhost) which is PUBLIC, so self-hosters can
+          # `docker compose pull` it. The private `octopus` package holds only
+          # the hosted-deploy variant below — keeping prod images off the public
+          # package. Visibility is per-package, which is why they're split.
           tags: |
-            ${{ steps.tags.outputs.image_name }}:${{ steps.tags.outputs.semver }}
-            ${{ steps.tags.outputs.image_name }}:latest
+            ${{ steps.tags.outputs.image_name }}-selfhost:${{ steps.tags.outputs.semver }}
+            ${{ steps.tags.outputs.image_name }}-selfhost:latest
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.tags.outputs.semver }}
           build-args: |
             NEXT_PUBLIC_BUILD_ID=${{ github.sha }}
             NEXT_PUBLIC_APP_VERSION=${{ steps.tags.outputs.semver }}
-            # Self-host build variant: ships the Updates page + nav entry (gated
-            # on this build-time flag). Note the GHCR package is currently
-            # PRIVATE, so self-hosters build from source; these tags serve
-            # org-internal use until/unless the package is made public.
+            # Ships the Updates page + nav entry (gated on this build-time flag).
+            # No app-slug/pubby baked here — safe to publish publicly.
             NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true
           # Distinct cache scope per variant — with the shared default scope the
           # two builds would overwrite each other's cache every release.
@@ -119,16 +122,18 @@ jobs:
           generate_release_notes: true
           name: ${{ steps.tags.outputs.semver }}
           body: |
-            To upgrade a self-hosted instance, rebuild from the tagged source
-            (the GHCR image is private and the runtime image ships no migrations):
+            To upgrade a self-hosted instance, pull the new public image and
+            apply migrations (the runtime image ships no migrations, so run them
+            from a checkout of this tag):
 
             ```bash
-            git pull                       # or: git fetch --tags && git checkout vX.Y.Z
-            docker compose build --build-arg NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true
+            git fetch --tags && git checkout vX.Y.Z    # for the compose file + migrations
+            export OCTOPUS_VERSION=${{ steps.tags.outputs.semver }}
+            docker compose -f docker-compose.selfhost.yml pull
             # migrate FIRST (expand-only, safe under the still-running old version) ...
             cd packages/db && DATABASE_URL=postgresql://octopus:octopus@localhost:43332/octopus bunx prisma migrate deploy && cd ../..
-            # ... then start the new version
-            docker compose up -d
+            # ... then roll to the new version
+            docker compose -f docker-compose.selfhost.yml up -d
             ```
 
             Then verify:

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ deploy.ini
 deploy.sh
 docker-compose.*.yml
 !docker-compose.yml
+# committed, public compose files (no secrets — safe to track):
+!docker-compose.selfhost.yml
+!docker-compose.ollama.yml
 
 # database
 *.sql

--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ cd octopus
 cp .env.example .env
 # Edit .env with your API keys and configuration
 
-# Build (the build arg compiles in email/password login for self-hosted
-# instances) and start all services (PostgreSQL, Qdrant, Web)
-docker compose build --build-arg NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true
-docker compose up -d
+# Pull the prebuilt public image + start all services (PostgreSQL, Qdrant, Web).
+# The image bakes in email/password login for self-hosted instances — no build.
+export OCTOPUS_VERSION=latest   # or a pinned release, e.g. 1.0.27
+docker compose -f docker-compose.selfhost.yml pull
+docker compose -f docker-compose.selfhost.yml up -d
 
 # Run database migrations — from the checkout, not inside the container
 # (the runtime image ships only the compiled app, no prisma/schema)
@@ -136,7 +137,10 @@ cd ../..
 
 Octopus will be available at `http://localhost:43300`.
 
-See [docker-compose.yml](docker-compose.yml) for service configuration.
+Prefer to build from source? Use `docker-compose.yml` with
+`docker compose build --build-arg NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true`.
+See [docker-compose.selfhost.yml](docker-compose.selfhost.yml) (pull) and
+[docker-compose.yml](docker-compose.yml) (build) for service configuration.
 
 ## How It Works
 

--- a/apps/web/app/(landing)/docs/self-hosting/page.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/page.tsx
@@ -58,31 +58,32 @@ cd octopus`}</CodeBlock>
           </Paragraph>
         </Step>
 
-        <Step number={3} title="Review the bundled docker-compose.yml">
+        <Step number={3} title="Review docker-compose.selfhost.yml">
           <Paragraph>
-            The repository&apos;s <Mono>docker-compose.yml</Mono> is the source of
-            truth — it runs the <Mono>web</Mono> service, PostgreSQL, and Qdrant
-            together and wires the database and Qdrant URLs for Docker&apos;s
-            internal network. It publishes the app on{" "}
-            <Mono>43300:3000</Mono>, uses <Mono>postgres:17-alpine</Mono> (host
-            port <Mono>43332</Mono>) and <Mono>qdrant/qdrant:v1.17.0</Mono> (host
-            port <Mono>43333</Mono>), and sets{" "}
-            <Mono>ENABLE_REVIEW_WORKERS=true</Mono>. There is nothing to copy or
-            edit here — use the file as-is.
+            Use the repository&apos;s <Mono>docker-compose.selfhost.yml</Mono> — it
+            pulls the prebuilt public image{" "}
+            <Mono>ghcr.io/octopusreview/octopus-selfhost</Mono> (no local build)
+            and runs the <Mono>web</Mono> service, PostgreSQL, and Qdrant together
+            with the database and Qdrant URLs wired for Docker&apos;s internal
+            network. It publishes the app on <Mono>43300:3000</Mono>, uses{" "}
+            <Mono>postgres:17-alpine</Mono> (host port <Mono>43332</Mono>) and{" "}
+            <Mono>qdrant/qdrant:v1.17.0</Mono> (host port <Mono>43333</Mono>).
+            Pin a release with <Mono>OCTOPUS_VERSION</Mono> (defaults to{" "}
+            <Mono>latest</Mono>). Use it as-is.
           </Paragraph>
         </Step>
 
-        <Step number={4} title="Build and run">
-          <CodeBlock>{`docker compose build --build-arg NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true
-docker compose up -d`}</CodeBlock>
+        <Step number={4} title="Pull and run">
+          <CodeBlock>{`export OCTOPUS_VERSION=latest   # or a pinned release, e.g. 1.0.27
+docker compose -f docker-compose.selfhost.yml pull
+docker compose -f docker-compose.selfhost.yml up -d`}</CodeBlock>
           <Paragraph>
-            First run will build the Octopus image from source — this may take a
-            few minutes. Subsequent starts use the cached image.
-          </Paragraph>
-          <Paragraph>
-            Without <Mono>NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true</Mono> baked in at
-            build time, email/password sign-in is compiled out and the first-boot
-            admin cannot log in.
+            The public image is built with{" "}
+            <Mono>NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true</Mono> already baked in, so
+            email/password sign-in and the first-boot admin work out of the box —
+            no build step and no build args needed. (To build from source instead,
+            use <Mono>docker-compose.yml</Mono> with{" "}
+            <Mono>docker compose build --build-arg NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true</Mono>.)
           </Paragraph>
         </Step>
 
@@ -256,18 +257,19 @@ bun run start`}</CodeBlock>
 
         <Step number={1} title="Upgrade">
           <Paragraph>
-            Pull the new code, rebuild the image, restart, then apply migrations.
-            Octopus migrations are <strong>additive (expand-only)</strong> and
-            therefore backward-compatible — the previous image keeps working
-            against the new schema, which is exactly what makes the rollback
-            below safe.
+            Check out the new tag (for the compose file + migration files), pull
+            the new image, apply migrations, then roll. Octopus migrations are{" "}
+            <strong>additive (expand-only)</strong> and therefore
+            backward-compatible — the previous image keeps working against the new
+            schema, which is exactly what makes the rollback below safe.
           </Paragraph>
-          <CodeBlock>{`git pull                       # or: git fetch --tags && git checkout vX.Y.Z
-docker compose build --build-arg NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true
+          <CodeBlock>{`git fetch --tags && git checkout vX.Y.Z
+export OCTOPUS_VERSION=X.Y.Z
+docker compose -f docker-compose.selfhost.yml pull
 # migrate FIRST (expand-only, safe under the still-running old version) ...
 cd packages/db && DATABASE_URL=postgresql://octopus:octopus@localhost:43332/octopus bunx prisma migrate deploy && cd ../..
-# ... then start the new version
-docker compose up -d`}</CodeBlock>
+# ... then roll to the new version
+docker compose -f docker-compose.selfhost.yml up -d`}</CodeBlock>
         </Step>
 
         <Step number={2} title="Verify before sending traffic">
@@ -280,14 +282,15 @@ curl -fsS http://localhost:43300/api/version   # confirm the new version`}</Code
 
         <Step number={3} title="Roll back (if needed)">
           <Paragraph>
-            Check out the <strong>previous</strong> release tag, rebuild, and
-            restart. <strong>Do not roll back the database.</strong> Because every
-            migration is additive, the older image runs fine against the newer
-            schema, so you keep all data and avoid a risky down-migration.
+            Point <Mono>OCTOPUS_VERSION</Mono> at the <strong>previous</strong>{" "}
+            release and roll. <strong>Do not roll back the database.</strong>{" "}
+            Because every migration is additive, the older image runs fine against
+            the newer schema, so you keep all data and avoid a risky
+            down-migration.
           </Paragraph>
-          <CodeBlock>{`git checkout vX.Y.Z            # the previous release tag
-docker compose build --build-arg NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true
-docker compose up -d`}</CodeBlock>
+          <CodeBlock>{`export OCTOPUS_VERSION=X.Y.Z    # the previous release
+docker compose -f docker-compose.selfhost.yml pull
+docker compose -f docker-compose.selfhost.yml up -d`}</CodeBlock>
         </Step>
 
         <Paragraph>

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -1,0 +1,65 @@
+# Self-host deployment compose — pulls the prebuilt public image instead of
+# building from source (see docker-compose.yml for the build-from-source dev
+# variant). The image bakes NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true, so
+# email/password sign-in is enabled out of the box.
+#
+#   docker compose -f docker-compose.selfhost.yml pull
+#   docker compose -f docker-compose.selfhost.yml up -d
+#
+# Pin a release by exporting OCTOPUS_VERSION (e.g. OCTOPUS_VERSION=1.0.27);
+# defaults to :latest. Migrations are NOT in the runtime image — run them from
+# a checkout of the matching tag (see docs/self-hosting).
+services:
+  web:
+    image: ghcr.io/octopusreview/octopus-selfhost:${OCTOPUS_VERSION:-latest}
+    ports:
+      - "43300:3000"
+    # env_file delivers the operator's secrets into the container (the
+    # environment: block only overrides the compose-internal service URLs).
+    env_file:
+      - .env
+    environment:
+      - DATABASE_URL=postgresql://octopus:octopus@postgres:5432/octopus
+      - QDRANT_URL=http://qdrant:6333
+      - ENABLE_REVIEW_WORKERS=true
+    depends_on:
+      postgres:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:17-alpine
+    ports:
+      - "43332:5432"
+    environment:
+      POSTGRES_USER: octopus
+      POSTGRES_PASSWORD: octopus
+      POSTGRES_DB: octopus
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U octopus"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  qdrant:
+    image: qdrant/qdrant:v1.17.0
+    ports:
+      - "43333:6333"
+      - "43334:6334"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:6333/readyz"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  qdrant_data:


### PR DESCRIPTION
## What
Publishes a **public**, prebuilt self-host image so self-hosters can `docker compose pull` instead of building from source (~10 min build + 4 GB RAM gone).

## The package split (why it's safe)
GHCR visibility is **per-package**, and today both variants share `ghcr.io/octopusreview/octopus`. So this moves the **self-host** image to a **new** package `ghcr.io/octopusreview/octopus-selfhost` (to be made public) and leaves the **hosted-deploy/prod** images (`:X.Y.Z-prod`, `:latest-web`, `:latest-engine`) on the existing **private** `octopus` package — untouched. Prod deploy (deploy-wdc + the server compose) needs **zero changes**.

The self-host image bakes only `NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true` + build id + version — **no app-slug/Pubby/secrets** — so it is safe to publish.

## Changes
- `release.yml`: self-host step → `octopus-selfhost:{X.Y.Z,latest}`; prod step unchanged; release notes switched to the pull-based upgrade flow.
- `docker-compose.selfhost.yml` (new): pull-based, `image: …/octopus-selfhost:${OCTOPUS_VERSION:-latest}`; `docker-compose.yml` stays the build-from-source dev variant.
- docs/self-hosting + README: quickstart/upgrade/rollback pull the public image; the login flag is pre-baked (no build arg to remember). Migrations still run from a checkout of the tag (runtime image ships no prisma).

## Post-merge (one manual step)
After the next release publishes the `octopus-selfhost` package, its visibility must be flipped to **public** in the org package settings (per-package UI toggle — no API). Then a public `docker compose -f docker-compose.selfhost.yml pull` works with no auth.

Delivers WS1.2 (previously deferred while the image was private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0132yj9XRWWQ4FucyZT4DkG1