### PR TITLE
feat(landing): cloud-first onboarding — terminal hero, cloud/self-host split, Docker-first self-host docs

### DIFF
--- a/apps/web/app/(auth)/login/login-content.tsx
+++ b/apps/web/app/(auth)/login/login-content.tsx
@@ -439,13 +439,13 @@ export function LoginContent({
           <p className="mt-10 text-xs leading-relaxed text-[#555]">
             Your code is never stored long-term or used to train models.
           </p>
-          <a
+          <Link
             href="/docs/self-hosting"
             className="mt-3 inline-flex items-center gap-1.5 text-xs text-[#10d8be]/70 transition-colors hover:text-[#10d8be]"
           >
             Prefer to run it yourself? Self-host Octopus
             <IconArrowRight className="size-3.5" />
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/apps/web/app/(auth)/login/login-content.tsx
+++ b/apps/web/app/(auth)/login/login-content.tsx
@@ -20,10 +20,11 @@ import {
   IconMail,
   IconBrandGithub,
   IconLock,
-  IconServer,
+  IconBolt,
   IconShieldLock,
   IconGitPullRequest,
   IconSparkles,
+  IconArrowRight,
 } from "@tabler/icons-react";
 
 /** Which OAuth providers the deployment has configured. Computed server-side
@@ -62,28 +63,28 @@ function MicrosoftIcon({ className }: { className?: string }) {
 
 const LOGIN_FEATURES = [
   {
-    icon: IconServer,
-    title: "Self-host anywhere",
+    icon: IconGitPullRequest,
+    title: "Reviews on every pull request",
     description:
-      "Run the entire platform on your own servers — reviews, code search and AI all stay inside your network.",
+      "Inline, source-backed comments on GitHub, GitLab and Bitbucket — minutes after every push.",
   },
   {
     icon: IconShieldLock,
-    title: "Your code stays yours",
+    title: "Catches issues before they merge",
     description:
-      "Use local AI models via Ollama or bring your own API keys. Your code is never used to train anyone's models.",
-  },
-  {
-    icon: IconGitPullRequest,
-    title: "Reviews that never sleep",
-    description:
-      "Inline pull-request reviews for GitHub, GitLab and Bitbucket, minutes after every push.",
+      "Bugs, security holes and anti-patterns flagged with severity, so they never reach production.",
   },
   {
     icon: IconSparkles,
-    title: "Whole-repo context",
+    title: "Learns your codebase",
     description:
-      "Repository-wide indexing grounds every finding in your actual codebase — not just the diff.",
+      "Repository-wide indexing grounds every finding in your actual code and team standards — not just the diff.",
+  },
+  {
+    icon: IconBolt,
+    title: "Free credits to start",
+    description:
+      "Sign in and get reviewing in two minutes. No credit card, nothing to install or run.",
   },
 ] as const;
 
@@ -413,10 +414,10 @@ export function LoginContent({
 
         <div className="relative z-10 w-full max-w-md px-12">
           <p className="text-xs font-medium uppercase tracking-[0.2em] text-[#10d8be]/70">
-            AI code review, on your terms
+            Your AI senior reviewer
           </p>
           <h2 className="mt-3 text-2xl font-semibold leading-snug text-white">
-            Ship better code without shipping your code away.
+            Every pull request, reviewed in minutes.
           </h2>
 
           <ul className="mt-10 space-y-7">
@@ -435,9 +436,16 @@ export function LoginContent({
             ))}
           </ul>
 
-          <p className="mt-10 text-xs text-[#555]">
-            AI-powered code reviews that never sleep.
+          <p className="mt-10 text-xs leading-relaxed text-[#555]">
+            Your code is never stored long-term or used to train models.
           </p>
+          <a
+            href="/docs/self-hosting"
+            className="mt-3 inline-flex items-center gap-1.5 text-xs text-[#10d8be]/70 transition-colors hover:text-[#10d8be]"
+          >
+            Prefer to run it yourself? Self-host Octopus
+            <IconArrowRight className="size-3.5" />
+          </a>
         </div>
       </div>
     </div>

--- a/apps/web/app/(landing)/docs/docs-mobile-menu.tsx
+++ b/apps/web/app/(landing)/docs/docs-mobile-menu.tsx
@@ -26,14 +26,17 @@ const sections: MenuSection[] = [
     ],
   },
   {
-    title: "Setup & Integrations",
+    title: "Cloud Setup",
     items: [
       { href: "/docs/github-action", label: "GitHub Action" },
       { href: "/docs/github-app", label: "GitHub App Setup" },
       { href: "/docs/oauth-setup", label: "Google & GitHub Login" },
       { href: "/docs/integrations", label: "Integrations" },
-      { href: "/docs/self-hosting", label: "Self-Hosting" },
     ],
+  },
+  {
+    title: "Self-Host",
+    items: [{ href: "/docs/self-hosting", label: "Self-Hosting" }],
   },
   {
     title: "Features",

--- a/apps/web/app/(landing)/docs/docs-sidebar.tsx
+++ b/apps/web/app/(landing)/docs/docs-sidebar.tsx
@@ -26,14 +26,17 @@ const sections: SidebarSection[] = [
     ],
   },
   {
-    title: "Setup & Integrations",
+    title: "Cloud Setup",
     items: [
       { href: "/docs/github-action", label: "GitHub Action" },
       { href: "/docs/github-app", label: "GitHub App Setup" },
       { href: "/docs/oauth-setup", label: "Google & GitHub Login" },
       { href: "/docs/integrations", label: "Integrations" },
-      { href: "/docs/self-hosting", label: "Self-Hosting" },
     ],
+  },
+  {
+    title: "Self-Host",
+    items: [{ href: "/docs/self-hosting", label: "Self-Hosting" }],
   },
   {
     title: "Features",

--- a/apps/web/app/(landing)/docs/getting-started/page.tsx
+++ b/apps/web/app/(landing)/docs/getting-started/page.tsx
@@ -16,6 +16,7 @@ import {
   IconServer,
   IconWand,
   IconBrain,
+  IconCloud,
 } from "@tabler/icons-react";
 
 export const metadata = {
@@ -67,6 +68,37 @@ export default function GettingStartedPage() {
             icon={<IconPlugConnected className="size-4" />}
             title="Works With Your Tools"
             description="GitHub, Bitbucket, Slack, Linear. Fits into your existing workflow."
+          />
+        </div>
+      </Section>
+
+      {/* Choose your path */}
+      <Section title="Choose Your Path">
+        <Paragraph>
+          Octopus comes two ways. Most teams use{" "}
+          <strong className="text-white">Cloud</strong> — fully hosted and set
+          up in minutes. If you&apos;d rather run everything on your own
+          infrastructure, the source-available{" "}
+          <strong className="text-white">Self-Host</strong> path is free.
+        </Paragraph>
+        <div className="mb-4 grid gap-3 sm:grid-cols-2">
+          <PathCard
+            recommended
+            icon={<IconCloud className="size-5" />}
+            eyebrow="Cloud · Free to start"
+            title="Hosted for you"
+            description="Sign in, install the GitHub App, and Octopus reviews every pull request automatically. No servers to run, no maintenance."
+            links={[
+              { href: "/docs/github-app", label: "Install the GitHub App" },
+              { href: "/login", label: "Sign in" },
+            ]}
+          />
+          <PathCard
+            icon={<IconServer className="size-5" />}
+            eyebrow="Self-Host · Free"
+            title="Run it yourself"
+            description="Deploy Octopus with Docker on your own infrastructure. Free and source-available — you keep full control of your data."
+            links={[{ href: "/docs/self-hosting", label: "Self-hosting guide" }]}
           />
         </div>
       </Section>
@@ -392,6 +424,76 @@ function ProviderCard({
         <p className="mt-0.5 text-xs leading-relaxed text-[#666]">
           {description}
         </p>
+      </div>
+    </div>
+  );
+}
+
+function PathCard({
+  icon,
+  eyebrow,
+  title,
+  description,
+  links,
+  recommended = false,
+}: {
+  icon: React.ReactNode;
+  eyebrow: string;
+  title: string;
+  description: string;
+  links: { href: string; label: string }[];
+  recommended?: boolean;
+}) {
+  return (
+    <div
+      className={`flex flex-col rounded-lg border p-5 ${
+        recommended
+          ? "border-[#10D8BE]/40 bg-[#10D8BE]/[0.04]"
+          : "border-white/[0.06] bg-white/[0.02]"
+      }`}
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <div
+          className={`flex size-9 items-center justify-center rounded-lg ${
+            recommended
+              ? "bg-[#10D8BE]/10 text-[#10D8BE]"
+              : "bg-white/[0.06] text-[#888]"
+          }`}
+        >
+          {icon}
+        </div>
+        {recommended && (
+          <span className="rounded-full bg-[#10D8BE]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#10D8BE]">
+            Recommended
+          </span>
+        )}
+      </div>
+      <div className="mb-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-[#555]">
+        {eyebrow}
+      </div>
+      <h3 className="text-base font-semibold text-white">{title}</h3>
+      <p className="mb-4 mt-1 text-xs leading-relaxed text-[#888]">
+        {description}
+      </p>
+      <div className="mt-auto flex flex-wrap items-center gap-x-4 gap-y-1">
+        {links.map((link, i) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={
+              i === 0
+                ? `inline-flex items-center gap-1 text-sm font-medium transition-colors ${
+                    recommended
+                      ? "text-[#10D8BE] hover:text-[#10D8BE]/80"
+                      : "text-white hover:text-white/80"
+                  }`
+                : "text-xs text-[#888] underline decoration-white/20 underline-offset-2 transition-colors hover:text-white"
+            }
+          >
+            {link.label}
+            {i === 0 && <IconArrowRight className="size-3.5" />}
+          </Link>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/app/(landing)/docs/self-hosting/page.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/page.tsx
@@ -1,6 +1,7 @@
 import { IconServer } from "@tabler/icons-react";
 import { CodeBlock } from "./code-block";
 import { EnvGenerator } from "./env-generator";
+import { Tabs } from "./tabs";
 
 export const metadata = {
   title: "Self-Hosting — Octopus Docs",
@@ -12,6 +13,183 @@ export const metadata = {
 };
 
 export default function SelfHostingPage() {
+  const composeFile = `# Self-host deployment compose — pulls the prebuilt public image instead of
+# building from source (see docker-compose.yml for the build-from-source dev
+# variant). The image bakes NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true, so
+# email/password sign-in is enabled out of the box.
+#
+#   docker compose -f docker-compose.selfhost.yml pull
+#   docker compose -f docker-compose.selfhost.yml up -d
+#
+# Pin a release by exporting OCTOPUS_VERSION (e.g. OCTOPUS_VERSION=1.0.27);
+# defaults to :latest. Migrations are NOT in the runtime image — run them from
+# a checkout of the matching tag (see docs/self-hosting).
+#
+# Change the published port by exporting OCTOPUS_PORT (defaults to 43300):
+#   OCTOPUS_PORT=8080 docker compose -f docker-compose.selfhost.yml up -d
+services:
+  web:
+    image: ghcr.io/octopusreview/octopus-selfhost:\${OCTOPUS_VERSION:-latest}
+    ports:
+      - "\${OCTOPUS_PORT:-43300}:3000"
+    # env_file delivers the operator's secrets into the container (the
+    # environment: block only overrides the compose-internal service URLs).
+    env_file:
+      - .env
+    environment:
+      - DATABASE_URL=postgresql://octopus:octopus@postgres:5432/octopus
+      - QDRANT_URL=http://qdrant:6333
+      - ENABLE_REVIEW_WORKERS=true
+    depends_on:
+      postgres:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:17-alpine
+    ports:
+      - "43332:5432"
+    environment:
+      POSTGRES_USER: octopus
+      POSTGRES_PASSWORD: octopus
+      POSTGRES_DB: octopus
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U octopus"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  qdrant:
+    image: qdrant/qdrant:v1.17.0
+    ports:
+      - "43333:6333"
+      - "43334:6334"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:6333/readyz"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  qdrant_data:`;
+
+  const installTabs = [
+    {
+      id: "docker",
+      label: "Docker (recommended)",
+      content: (
+        <>
+          <Step number={1} title="Clone the repository">
+            <CodeBlock>{`git clone https://github.com/octopusreview/octopus.git
+cd octopus`}</CodeBlock>
+          </Step>
+
+          <Step number={2} title="Create your .env file">
+            <Paragraph>
+              Use the{" "}
+              <a
+                href="#environment-variables"
+                className="text-white underline underline-offset-2 hover:text-[#ccc]"
+              >
+                environment generator below
+              </a>{" "}
+              to create a <Mono>.env</Mono> file with a pre-generated auth
+              secret, then save it to the project root. Fill in your API keys
+              before continuing.
+            </Paragraph>
+          </Step>
+
+          <Step number={3} title="Review docker-compose.selfhost.yml">
+            <Paragraph>
+              The repository&apos;s <Mono>docker-compose.selfhost.yml</Mono>{" "}
+              pulls the prebuilt public image{" "}
+              <Mono>ghcr.io/octopusreview/octopus-selfhost</Mono> (no local
+              build) and runs the <Mono>web</Mono> service, PostgreSQL, and
+              Qdrant together, with the database and Qdrant URLs wired for
+              Docker&apos;s internal network. Use it as-is:
+            </Paragraph>
+            <CodeBlock title="docker-compose.selfhost.yml">
+              {composeFile}
+            </CodeBlock>
+          </Step>
+
+          <Step number={4} title="Pull and run">
+            <CodeBlock>{`export OCTOPUS_VERSION=latest   # or a pinned release, e.g. 1.0.27
+docker compose -f docker-compose.selfhost.yml pull
+docker compose -f docker-compose.selfhost.yml up -d`}</CodeBlock>
+            <Paragraph>
+              The public image is built with{" "}
+              <Mono>NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true</Mono> already baked in,
+              so email/password sign-in and the first-boot admin work out of the
+              box — no build step and no build args needed. (To build from
+              source instead, use <Mono>docker-compose.yml</Mono> with{" "}
+              <Mono>docker compose build --build-arg NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true</Mono>
+              .)
+            </Paragraph>
+            <Paragraph>
+              Octopus is then available at{" "}
+              <Mono>http://localhost:43300</Mono>. To publish on a different
+              port, set <Mono>OCTOPUS_PORT</Mono> (defaults to{" "}
+              <Mono>43300</Mono>):
+            </Paragraph>
+            <CodeBlock>{`OCTOPUS_PORT=8080 docker compose -f docker-compose.selfhost.yml up -d`}</CodeBlock>
+          </Step>
+
+          <Step number={5} title="Run database migrations">
+            <Paragraph>
+              Migrations run from the repo checkout — the runtime image
+              doesn&apos;t ship the Prisma CLI or migration files.
+            </Paragraph>
+            <CodeBlock>{`cd packages/db
+DATABASE_URL=postgresql://octopus:octopus@localhost:43332/octopus bunx prisma migrate deploy`}</CodeBlock>
+          </Step>
+
+          <Step number={6} title="Open Octopus">
+            <Paragraph>
+              Visit <Mono>http://localhost:43300</Mono> to access your
+              self-hosted Octopus instance. Create your first account and
+              connect a GitHub repository to get started.
+            </Paragraph>
+          </Step>
+        </>
+      ),
+    },
+    {
+      id: "no-docker",
+      label: "Without Docker",
+      content: (
+        <>
+          <Paragraph>
+            If you prefer to run Octopus directly, you&apos;ll need PostgreSQL,
+            Qdrant, and Bun installed on your machine. Create your{" "}
+            <Mono>.env</Mono> file first using the generator below.
+          </Paragraph>
+          <CodeBlock>{`git clone https://github.com/octopusreview/octopus.git
+cd octopus
+bun install
+bun run db:generate
+bun run db:migrate
+bun run build
+bun run start`}</CodeBlock>
+          <Paragraph>
+            The standalone output is at{" "}
+            <Mono>apps/web/.next/standalone</Mono>. You can deploy this
+            directory directly.
+          </Paragraph>
+        </>
+      ),
+    },
+  ];
+
   return (
     <article className="max-w-3xl">
       <div className="mb-8">
@@ -43,66 +221,14 @@ export default function SelfHostingPage() {
       </Section>
 
       {/* Quick start */}
-      <Section title="Quick Start with Docker">
-        <Step number={1} title="Clone the repository">
-          <CodeBlock>{`git clone https://github.com/octopusreview/octopus.git
-cd octopus`}</CodeBlock>
-        </Step>
-
-        <Step number={2} title="Create your .env file">
-          <Paragraph>
-            Use the <a href="#environment-variables" className="text-white underline underline-offset-2 hover:text-[#ccc]">environment generator below</a> to
-            create a <Mono>.env</Mono> file with a pre-generated auth secret,
-            then save it to the project root. Fill in your API keys before
-            continuing.
-          </Paragraph>
-        </Step>
-
-        <Step number={3} title="Review docker-compose.selfhost.yml">
-          <Paragraph>
-            Use the repository&apos;s <Mono>docker-compose.selfhost.yml</Mono> — it
-            pulls the prebuilt public image{" "}
-            <Mono>ghcr.io/octopusreview/octopus-selfhost</Mono> (no local build)
-            and runs the <Mono>web</Mono> service, PostgreSQL, and Qdrant together
-            with the database and Qdrant URLs wired for Docker&apos;s internal
-            network. It publishes the app on <Mono>43300:3000</Mono>, uses{" "}
-            <Mono>postgres:17-alpine</Mono> (host port <Mono>43332</Mono>) and{" "}
-            <Mono>qdrant/qdrant:v1.17.0</Mono> (host port <Mono>43333</Mono>).
-            Pin a release with <Mono>OCTOPUS_VERSION</Mono> (defaults to{" "}
-            <Mono>latest</Mono>). Use it as-is.
-          </Paragraph>
-        </Step>
-
-        <Step number={4} title="Pull and run">
-          <CodeBlock>{`export OCTOPUS_VERSION=latest   # or a pinned release, e.g. 1.0.27
-docker compose -f docker-compose.selfhost.yml pull
-docker compose -f docker-compose.selfhost.yml up -d`}</CodeBlock>
-          <Paragraph>
-            The public image is built with{" "}
-            <Mono>NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true</Mono> already baked in, so
-            email/password sign-in and the first-boot admin work out of the box —
-            no build step and no build args needed. (To build from source instead,
-            use <Mono>docker-compose.yml</Mono> with{" "}
-            <Mono>docker compose build --build-arg NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true</Mono>.)
-          </Paragraph>
-        </Step>
-
-        <Step number={5} title="Run database migrations">
-          <Paragraph>
-            Migrations run from the repo checkout — the runtime image doesn&apos;t
-            ship the Prisma CLI or migration files.
-          </Paragraph>
-          <CodeBlock>{`cd packages/db
-DATABASE_URL=postgresql://octopus:octopus@localhost:43332/octopus bunx prisma migrate deploy`}</CodeBlock>
-        </Step>
-
-        <Step number={6} title="Open Octopus">
-          <Paragraph>
-            Visit <Mono>http://localhost:43300</Mono> to access your self-hosted
-            Octopus instance. Create your first account and connect a GitHub
-            repository to get started.
-          </Paragraph>
-        </Step>
+      <Section title="Quick Start">
+        <Paragraph>
+          The fastest way to run Octopus is the prebuilt Docker image — it needs
+          no build step and brings up the app, PostgreSQL, and Qdrant together.
+          Prefer to run against your own services instead? Switch to{" "}
+          <em>Without Docker</em>.
+        </Paragraph>
+        <Tabs tabs={installTabs} label="Installation method" />
       </Section>
 
       <Section title="All-local with Ollama (optional)">
@@ -225,34 +351,13 @@ DATABASE_URL=postgresql://octopus:octopus@localhost:43332/octopus bunx prisma mi
         </div>
       </Section>
 
-      {/* From source */}
-      <Section title="Running without Docker">
-        <Paragraph>
-          If you prefer to run Octopus directly, you&apos;ll need PostgreSQL,
-          Qdrant, and Bun installed on your machine. Create your{" "}
-          <Mono>.env</Mono> file first using the generator above.
-        </Paragraph>
-        <CodeBlock>{`git clone https://github.com/octopusreview/octopus.git
-cd octopus
-bun install
-bun run db:generate
-bun run db:migrate
-bun run build
-bun run start`}</CodeBlock>
-        <Paragraph>
-          The standalone output is at{" "}
-          <Mono>apps/web/.next/standalone</Mono>. You can deploy this directory
-          directly.
-        </Paragraph>
-      </Section>
-
       {/* Upgrading & rolling back */}
       <Section title="Upgrading & rolling back">
         <Paragraph>
           Check out a specific release tag in production rather than tracking{" "}
           <Mono>master</Mono> — that is what turns a rollback into re-checking-out
-          the previous tag. The published GHCR image is private, so self-hosters
-          build the image from source rather than pulling it.
+          the previous tag for the matching compose file and migrations. The
+          runtime image itself is pulled from GHCR.
         </Paragraph>
 
         <Step number={1} title="Upgrade">

--- a/apps/web/app/(landing)/docs/self-hosting/tabs.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/tabs.tsx
@@ -21,7 +21,9 @@ export function Tabs({
     else if (e.key === "End") next = tabs.length - 1;
     else return;
     e.preventDefault();
-    setActive(tabs[next].id);
+    const nextTab = tabs[next];
+    if (!nextTab) return;
+    setActive(nextTab.id);
     btnRefs.current[next]?.focus();
   }
 

--- a/apps/web/app/(landing)/docs/self-hosting/tabs.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/tabs.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useRef, useState, type KeyboardEvent, type ReactNode } from "react";
+
+export function Tabs({
+  tabs,
+  label = "Options",
+}: {
+  tabs: { id: string; label: string; content: ReactNode }[];
+  label?: string;
+}) {
+  const [active, setActive] = useState(tabs[0]?.id);
+  const activeTab = tabs.find((t) => t.id === active) ?? tabs[0];
+  const btnRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  function onKeyDown(e: KeyboardEvent<HTMLButtonElement>, i: number) {
+    let next = i;
+    if (e.key === "ArrowRight") next = (i + 1) % tabs.length;
+    else if (e.key === "ArrowLeft") next = (i - 1 + tabs.length) % tabs.length;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = tabs.length - 1;
+    else return;
+    e.preventDefault();
+    setActive(tabs[next].id);
+    btnRefs.current[next]?.focus();
+  }
+
+  return (
+    <div>
+      <div
+        role="tablist"
+        aria-label={label}
+        className="mb-4 flex gap-1 border-b border-white/[0.06]"
+      >
+        {tabs.map((tab, i) => {
+          const selected = tab.id === active;
+          return (
+            <button
+              key={tab.id}
+              ref={(el) => {
+                btnRefs.current[i] = el;
+              }}
+              type="button"
+              role="tab"
+              id={`tab-${tab.id}`}
+              aria-selected={selected}
+              aria-controls={`tabpanel-${tab.id}`}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => setActive(tab.id)}
+              onKeyDown={(e) => onKeyDown(e, i)}
+              className={`-mb-px border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+                selected
+                  ? "border-[#10D8BE] text-white"
+                  : "border-transparent text-[#888] hover:text-[#ccc]"
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+      {activeTab && (
+        <div
+          role="tabpanel"
+          id={`tabpanel-${activeTab.id}`}
+          aria-labelledby={`tab-${activeTab.id}`}
+          tabIndex={0}
+        >
+          {activeTab.content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -11,6 +11,7 @@ import { LandingMobileNav } from "@/components/landing-mobile-nav";
 import { LandingDesktopNav } from "@/components/landing-desktop-nav";
 import { WebGLToggleButton } from "@/components/webgl-toggle-button";
 import { RotatingHeroText } from "@/components/landing-rotating-hero";
+import { LandingTerminalHero } from "@/components/landing-terminal-hero";
 import { NewsletterForm } from "@/components/landing-newsletter";
 import { CliInstallSection } from "@/components/landing-cli-install";
 import { LandingStats } from "@/components/landing-stats";
@@ -21,8 +22,9 @@ import { FaqList } from "@/components/FaqList";
 import {
   IconBrandGithub,
   IconArrowRight,
-  IconCode,
-  IconShieldCheck,
+  IconCloud,
+  IconServer,
+  IconCheck,
   IconPlugConnected,
   IconRocket,
   IconBrain,
@@ -143,14 +145,15 @@ export default async function LandingPage() {
 
       {/* Hero — dark bg */}
       <section className="relative z-10 px-6 pb-20 pt-40 md:px-8 md:pb-28 md:pt-52">
-        <div className="mx-auto max-w-4xl text-center">
-          <h1 className="animate-fade-in text-4xl font-bold leading-[1.1] tracking-tight text-white [animation-delay:100ms] sm:text-5xl md:text-6xl lg:text-7xl">
+        <div className="mx-auto grid max-w-6xl items-center gap-12 lg:grid-cols-2 lg:gap-12">
+         <div className="text-center lg:text-left">
+          <h1 className="animate-fade-in text-4xl font-bold leading-[1.1] tracking-tight text-white [animation-delay:100ms] sm:text-5xl md:text-6xl">
             Review every PR
             <br />
             <span className="text-[#777]">with repo context.</span>
           </h1>
 
-          <p className="animate-fade-in mx-auto mt-6 min-h-16 max-w-2xl text-base leading-relaxed text-[#777] [animation-delay:200ms] sm:text-lg">
+          <p className="animate-fade-in mx-auto mt-6 min-h-16 max-w-2xl text-base leading-relaxed text-[#777] [animation-delay:200ms] sm:text-lg lg:mx-0">
             <RotatingHeroText
               texts={[
                 "Octopus indexes your codebase, applies team standards,\nand leaves source-backed comments with severity on every pull request.",
@@ -170,7 +173,7 @@ export default async function LandingPage() {
             />
           </p>
 
-          <div className="animate-fade-in mt-10 flex flex-col items-center gap-4 [animation-delay:300ms] sm:flex-row sm:justify-center">
+          <div className="animate-fade-in mt-10 flex flex-col items-center gap-4 [animation-delay:300ms] sm:flex-row sm:justify-center lg:justify-start">
             <TrackedLink
               href="/login"
               event="cta_click"
@@ -192,7 +195,11 @@ export default async function LandingPage() {
               View on GitHub
             </TrackedAnchor>
           </div>
+         </div>
 
+          <div className="animate-fade-in [animation-delay:400ms]">
+            <LandingTerminalHero className="mx-auto w-full max-w-xl lg:mx-0" />
+          </div>
         </div>
       </section>
 
@@ -260,65 +267,109 @@ export default async function LandingPage() {
         </div>
       </section>
 
-      {/* Source Available */}
-      <section id="open-source" className="relative z-10 scroll-mt-20 px-4 py-6 sm:px-8 md:px-12">
+      {/* Two ways to run — Cloud vs Self-Host */}
+      <section id="cloud-or-self-host" className="relative z-10 scroll-mt-20 px-4 py-6 sm:px-8 md:px-12">
         <div className="mx-auto max-w-6xl overflow-hidden rounded-3xl border border-white/[0.06] bg-[#161616] px-6 py-20 md:px-12 md:py-28">
           <div className="mx-auto max-w-5xl">
             <div className="mx-auto max-w-2xl text-center">
-              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-[#555]">Source Available</span>
+              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-[#555]">Cloud or self-host</span>
               <h2 className="mt-4 text-3xl font-bold tracking-tight text-white sm:text-4xl">
-                Source-available,
-                <br />
-                built in the open
+                Two ways to run Octopus
               </h2>
               <p className="mt-4 text-[#666] sm:text-lg">
-                Source-available under a Modified MIT License. Inspect the code,
-                self-host on your own infrastructure, or contribute.
+                Start reviewing in two minutes on our managed cloud, or run the
+                entire platform on your own infrastructure.
               </p>
             </div>
 
-            <div className="mt-12 grid gap-3 sm:grid-cols-3">
-              <div className="rounded-xl border border-white/[0.06] p-6 text-center transition-colors hover:border-white/[0.12]">
-                <div className="mx-auto flex size-10 items-center justify-center rounded-lg bg-white/[0.04] text-[#888]">
-                  <IconCode className="size-5" />
+            <div className="mt-12 grid gap-5 md:grid-cols-2">
+              {/* Cloud — primary */}
+              <div className="relative flex flex-col rounded-2xl border border-[#10D8BE]/30 bg-gradient-to-b from-[#10D8BE]/[0.06] to-transparent p-8">
+                <span className="absolute right-6 top-6 rounded-full border border-[#10D8BE]/30 bg-[#10D8BE]/10 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wider text-[#10D8BE]">
+                  Recommended
+                </span>
+                <div className="flex size-11 items-center justify-center rounded-xl bg-[#10D8BE]/10 text-[#10D8BE]">
+                  <IconCloud className="size-6" />
                 </div>
-                <h3 className="mt-4 font-semibold text-white">Source Available</h3>
-                <p className="mt-2 text-sm text-[#666]">
-                  Modified MIT License — read, modify, and self-host freely.
-                </p>
-              </div>
-              <div className="rounded-xl border border-white/[0.06] p-6 text-center transition-colors hover:border-white/[0.12]">
-                <div className="mx-auto flex size-10 items-center justify-center rounded-lg bg-white/[0.04] text-[#888]">
-                  <IconBrandGithub className="size-5" />
+                <h3 className="mt-5 text-xl font-semibold text-white">Cloud</h3>
+                <p className="mt-1.5 text-sm text-[#888]">Hosted for you. Nothing to run or maintain.</p>
+                <ul className="mt-6 space-y-3 text-sm text-[#bbb]">
+                  {[
+                    "Auto-reviews every PR via the GitHub App",
+                    "Free credits to start — usage-based after, no card",
+                    "Managed updates, backups and scaling",
+                    "Private: your code is never stored long-term or trained on",
+                  ].map((t) => (
+                    <li key={t} className="flex items-start gap-2.5">
+                      <IconCheck className="mt-0.5 size-4 shrink-0 text-[#10D8BE]" />
+                      <span>{t}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <TrackedLink
+                    href="/login"
+                    event="cta_click"
+                    eventParams={{ location: "cloud_or_self_host", label: "cloud_get_started" }}
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-[#10D8BE] px-5 py-2.5 text-sm font-medium text-[#0c0c0c] transition-colors hover:bg-[#0fbfa8]"
+                  >
+                    Get started free
+                    <IconArrowRight className="size-4" />
+                  </TrackedLink>
+                  <TrackedLink
+                    href="/docs/pricing"
+                    event="cta_click"
+                    eventParams={{ location: "cloud_or_self_host", label: "see_pricing" }}
+                    className="text-sm text-[#888] transition-colors hover:text-white"
+                  >
+                    See pricing
+                  </TrackedLink>
                 </div>
-                <h3 className="mt-4 font-semibold text-white">Community Driven</h3>
-                <p className="mt-2 text-sm text-[#666]">
-                  PRs welcome. Report bugs, request features, or build integrations.
-                </p>
               </div>
-              <div className="rounded-xl border border-white/[0.06] p-6 text-center transition-colors hover:border-white/[0.12]">
-                <div className="mx-auto flex size-10 items-center justify-center rounded-lg bg-white/[0.04] text-[#888]">
-                  <IconShieldCheck className="size-5" />
-                </div>
-                <h3 className="mt-4 font-semibold text-white">Self-Host Ready</h3>
-                <p className="mt-2 text-sm text-[#666]">
-                  Deploy on your own servers. Your code never leaves your infrastructure.
-                </p>
-              </div>
-            </div>
 
-            <div className="mt-8 flex justify-center">
-              <TrackedAnchor
-                href="https://github.com/octopusreview"
-                target="_blank"
-                rel="noopener noreferrer"
-                event="cta_click"
-                eventParams={{ location: "open_source_section", label: "star_on_github" }}
-                className="inline-flex items-center gap-2 rounded-full border border-white/[0.1] px-6 py-3 text-sm font-medium text-[#999] transition-colors hover:text-white"
-              >
-                <IconBrandGithub className="size-4" />
-                Star us on GitHub
-              </TrackedAnchor>
+              {/* Self-Host — secondary */}
+              <div className="flex flex-col rounded-2xl border border-white/[0.06] bg-white/[0.01] p-8">
+                <div className="flex size-11 items-center justify-center rounded-xl bg-white/[0.04] text-[#999]">
+                  <IconServer className="size-6" />
+                </div>
+                <h3 className="mt-5 text-xl font-semibold text-white">Self-host</h3>
+                <p className="mt-1.5 text-sm text-[#888]">Run it on your own servers. Free and source-available.</p>
+                <ul className="mt-6 space-y-3 text-sm text-[#bbb]">
+                  {[
+                    "Free & source-available (Modified MIT License)",
+                    "One Docker Compose file — up in minutes",
+                    "Your code never leaves your network",
+                    "Bring your own AI keys or run local models",
+                  ].map((t) => (
+                    <li key={t} className="flex items-start gap-2.5">
+                      <IconCheck className="mt-0.5 size-4 shrink-0 text-[#666]" />
+                      <span>{t}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <TrackedLink
+                    href="/docs/self-hosting"
+                    event="cta_click"
+                    eventParams={{ location: "cloud_or_self_host", label: "self_host_guide" }}
+                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/[0.12] px-5 py-2.5 text-sm font-medium text-[#ccc] transition-colors hover:border-white/[0.2] hover:text-white"
+                  >
+                    Read the self-host guide
+                    <IconArrowRight className="size-4" />
+                  </TrackedLink>
+                  <TrackedAnchor
+                    href="https://github.com/octopusreview"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    event="cta_click"
+                    eventParams={{ location: "cloud_or_self_host", label: "star_on_github" }}
+                    className="inline-flex items-center gap-1.5 text-sm text-[#888] transition-colors hover:text-white"
+                  >
+                    <IconBrandGithub className="size-4" />
+                    GitHub
+                  </TrackedAnchor>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/web/app/api/ask-octopus/route.ts
+++ b/apps/web/app/api/ask-octopus/route.ts
@@ -54,12 +54,12 @@ function isRateLimited(ip: string): boolean {
   return entry.count > RATE_LIMIT;
 }
 
-const SYSTEM_PROMPT = `You are Octopus Assistant, a helpful AI that answers questions about Octopus — an open-source, AI-powered code review tool.
+const SYSTEM_PROMPT = `You are Octopus Assistant, a helpful AI that answers questions about Octopus — a source-available, AI-powered code review tool.
 
 <octopus_overview>
-Octopus is an open-source, AI-powered code review tool available at https://octopus-review.ai. It connects to GitHub, GitLab, and Bitbucket, indexes your codebase using vector embeddings (OpenAI text-embedding-3-large, stored in Qdrant), and automatically reviews every pull request (and GitLab merge request). Findings are posted as inline PR comments with severity levels: 🔴 Critical, 🟠 Major, 🟡 Minor, 🔵 Suggestion, 💡 Tip.
+Octopus is a source-available, AI-powered code review tool available at https://octopus-review.ai. It connects to GitHub, GitLab, and Bitbucket, indexes your codebase using vector embeddings (OpenAI text-embedding-3-large, stored in Qdrant), and automatically reviews every pull request (and GitLab merge request). Findings are posted as inline PR comments with severity levels: 🔴 Critical, 🟠 Major, 🟡 Minor, 🔵 Suggestion, 💡 Tip.
 
-Key features: RAG Chat (ask questions about your codebase), CLI tool (npm install -g @octp/cli), Codebase Indexing, Knowledge Base (custom review rules), Team Sharing, Analytics, and integrations with Slack, Linear, and Jira (create Jira issues directly from review findings). Self-hostable with Docker (MIT license). Supports Bring Your Own Keys (BYOK) for Anthropic, OpenAI, Google, Cohere. Credit-based pricing with free tier.
+Key features: RAG Chat (ask questions about your codebase), CLI tool (npm install -g @octp/cli), Codebase Indexing, Knowledge Base (custom review rules), Team Sharing, Analytics, and integrations with Slack, Linear, and Jira (create Jira issues directly from review findings). Self-hostable with Docker (source-available, Modified MIT License). Supports Bring Your Own Keys (BYOK) for Anthropic, OpenAI, Google, Cohere. Credit-based pricing with free tier.
 
 Tech stack: Next.js (App Router, React 19), Prisma + PostgreSQL, Qdrant vector DB, Claude & OpenAI, Tailwind CSS, TypeScript, Turborepo monorepo.
 </octopus_overview>

--- a/apps/web/components/landing-footer.tsx
+++ b/apps/web/components/landing-footer.tsx
@@ -27,7 +27,7 @@ export function LandingFooter() {
               <span className="text-sm font-semibold text-white">Octopus</span>
             </div>
             <p className="mt-3 text-sm leading-relaxed text-[#555]">
-              AI-powered code review automation. Open source, self-hostable.
+              AI-powered code review automation. Source-available, self-hostable.
             </p>
             <div className="mt-4 flex items-center gap-3">
               <TrackedAnchor
@@ -419,7 +419,7 @@ export function LandingFooter() {
         <div className="mt-10 flex flex-col items-center gap-3 border-t border-white/[0.06] pt-6 sm:flex-row sm:justify-between">
           <div className="flex flex-col gap-1">
             <span className="text-xs text-[#333]">
-              &copy; {new Date().getFullYear()} Octopus. Open source code review
+              &copy; {new Date().getFullYear()} Octopus. Source-available code review
               automation.
             </span>
             <span className="text-xs text-[#333]">

--- a/apps/web/components/landing-terminal-hero.tsx
+++ b/apps/web/components/landing-terminal-hero.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// Auto-playing, non-interactive terminal for the marketing hero. Types a
+// scripted `octp login` -> `octp review --pr 42` -> findings sequence, then
+// loops. Zero dependencies: React state + one CSS keyframe for the caret.
+// Honors prefers-reduced-motion by rendering the full transcript statically.
+
+type Tone = "cmd" | "out" | "dim" | "ok" | "warn" | "crit" | "info";
+type Step = { kind: "cmd" | "out"; text: string; tone?: Tone };
+
+const SCRIPT: Step[] = [
+  { kind: "cmd", text: "octp login" },
+  { kind: "out", text: "→ Opening browser to authenticate…", tone: "dim" },
+  { kind: "out", text: "✓ Signed in as cem@acme.dev", tone: "ok" },
+  { kind: "cmd", text: "octp review --pr 42" },
+  { kind: "out", text: "→ Indexing repository · 128 files", tone: "dim" },
+  { kind: "out", text: "→ Reviewing diff with whole-repo context…", tone: "dim" },
+  { kind: "out", text: "⚠ 3 findings posted to PR #42", tone: "warn" },
+  { kind: "out", text: "  ● auth.ts:88 — token compared with == (timing-unsafe)", tone: "crit" },
+  { kind: "out", text: "  ● api/users.ts:23 — N+1 query inside request loop", tone: "warn" },
+  { kind: "out", text: "  ● date.ts:5 — prefer Intl.DateTimeFormat over manual format", tone: "info" },
+  { kind: "out", text: "✓ Review complete in 47s", tone: "ok" },
+];
+
+const TONE_CLASS: Record<Tone, string> = {
+  cmd: "text-white",
+  out: "text-[#c9c9c9]",
+  dim: "text-[#6a6a6a]",
+  ok: "text-[#10d8be]",
+  warn: "text-[#f0a868]",
+  crit: "text-[#ff6b6b]",
+  info: "text-[#6ea8fe]",
+};
+
+type Line = { text: string; tone: Tone };
+
+export function LandingTerminalHero({ className = "" }: { className?: string }) {
+  const [lines, setLines] = useState<Line[]>([]);
+  const [active, setActive] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [lines, active]);
+
+  useEffect(() => {
+    const reduce =
+      typeof window !== "undefined" &&
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    if (reduce) {
+      setLines(
+        SCRIPT.map((s) => ({ text: s.text, tone: s.kind === "cmd" ? "cmd" : s.tone ?? "out" })),
+      );
+      setActive(null);
+      return;
+    }
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const committed: Line[] = [];
+    const after = (ms: number, fn: () => void) => {
+      timer = setTimeout(() => {
+        if (!cancelled) fn();
+      }, ms);
+    };
+
+    const runStep = (i: number) => {
+      if (i >= SCRIPT.length) {
+        after(2800, () => {
+          committed.length = 0;
+          setLines([]);
+          setActive(null);
+          runStep(0);
+        });
+        return;
+      }
+      const step = SCRIPT[i];
+      if (step.kind === "cmd") {
+        setActive("");
+        let c = 0;
+        const typeChar = () => {
+          c += 1;
+          setActive(step.text.slice(0, c));
+          if (c < step.text.length) after(38, typeChar);
+          else
+            after(320, () => {
+              committed.push({ text: step.text, tone: "cmd" });
+              setLines([...committed]);
+              setActive(null);
+              after(280, () => runStep(i + 1));
+            });
+        };
+        after(300, typeChar);
+      } else {
+        after(step.text.startsWith("  ●") ? 200 : 420, () => {
+          committed.push({ text: step.text, tone: step.tone ?? "out" });
+          setLines([...committed]);
+          runStep(i + 1);
+        });
+      }
+    };
+    runStep(0);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, []);
+
+  return (
+    <div
+      aria-hidden="true"
+      className={`overflow-hidden rounded-2xl border border-white/[0.08] bg-[#0a0a0a] shadow-2xl shadow-black/40 ${className}`}
+    >
+      <style>{`@media (prefers-reduced-motion: no-preference){@keyframes octpBlink{0%,49%{opacity:1}50%,100%{opacity:0}}}`}</style>
+      {/* window chrome */}
+      <div className="flex items-center justify-between border-b border-white/[0.06] bg-white/[0.02] px-4 py-2.5">
+        <div className="flex gap-1.5">
+          <span className="size-3 rounded-full bg-[#ff5f57]/80" />
+          <span className="size-3 rounded-full bg-[#febc2e]/80" />
+          <span className="size-3 rounded-full bg-[#28c840]/80" />
+        </div>
+        <span className="font-mono text-[11px] text-[#666]">octp · ~/acme/api</span>
+        <span className="flex items-center gap-1.5 font-mono text-[11px] text-[#10d8be]">
+          <span className="size-1.5 rounded-full bg-[#10d8be]" />
+          ready
+        </span>
+      </div>
+      {/* body */}
+      <div
+        ref={scrollRef}
+        className="h-[300px] overflow-hidden px-4 py-3.5 font-mono text-[12.5px] leading-[1.7] sm:h-[340px] sm:text-[13px]"
+      >
+        {lines.map((line, i) => (
+          <div key={i} className={`whitespace-pre-wrap ${TONE_CLASS[line.tone]}`}>
+            {line.tone === "cmd" ? (
+              <>
+                <span className="text-[#10d8be]/80">$</span> {line.text}
+              </>
+            ) : (
+              line.text
+            )}
+          </div>
+        ))}
+        {/* active prompt + caret */}
+        <div className="whitespace-pre-wrap text-white">
+          <span className="text-[#10d8be]/80">$</span> {active ?? ""}
+          <span
+            className="ml-px inline-block h-[1.05em] w-[7px] translate-y-[2px] bg-[#10d8be]"
+            style={{ animation: "octpBlink 1s step-end infinite" }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -23,7 +23,7 @@ export const docsContent: DocsDocument[] = [
         heading: "Hero",
         text: `Octopus — Your AI code reviewer that never sleeps.
 Octopus reviews every pull request with deep context awareness. Catch bugs, enforce standards, and ship with confidence.
-Octopus is an open-source, AI-powered code review tool.`,
+Octopus is a source-available, AI-powered code review tool.`,
       },
       {
         heading: "How It Works",
@@ -48,8 +48,8 @@ Team Sharing — Share chat conversations with your team. Collaborate on code un
 Analytics — Track review activity, time to merge, token usage, and costs across your organization.`,
       },
       {
-        heading: "Open Source",
-        text: `Octopus is open source under the MIT License.
+        heading: "Source-Available",
+        text: `Octopus is source-available under a Modified MIT License.
 Community Driven — Contributions welcome. Open issues, submit PRs, and help shape the future of AI code review.
 Self-Host Ready — Run Octopus on your own infrastructure with Docker. Your code never leaves your servers.`,
       },
@@ -322,7 +322,7 @@ Running without Docker: Install Bun, set up PostgreSQL and Qdrant locally, run b
       {
         heading: "General",
         text: `Q: What is Octopus?
-A: Octopus is an open-source, AI-powered code review tool that indexes your codebase and automatically reviews pull requests with context-aware findings.
+A: Octopus is a source-available, AI-powered code review tool that indexes your codebase and automatically reviews pull requests with context-aware findings.
 
 Q: How does Octopus review code?
 A: When a PR is opened, Octopus fetches the diff, retrieves relevant code context via vector search, and uses an LLM (Claude or OpenAI) to analyze changes. Findings are posted as inline PR comments.
@@ -482,11 +482,11 @@ Rules: Never force-push. Show proposed fixes before applying. Make minimal chang
 Octopus is not a toy — it's a serious tool built by an independent developer who cares about code quality and developer experience.`,
       },
       {
-        heading: "Open Source Principles",
-        text: `Transparency: The entire codebase is open. You can read, audit, and understand exactly how your code is processed.
+        heading: "Source-Available Principles",
+        text: `Transparency: The full source is available. You can read, audit, and understand exactly how your code is processed.
 No vendor lock-in: Self-host on your own infrastructure. Bring your own API keys.
 Community driven: Contributions are welcome. Open issues, submit PRs, and help shape the future.
-Free forever: The open-source core will always be free.`,
+Free forever: The self-hosted, source-available core will always be free.`,
       },
       {
         heading: "Tech Stack",

--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -9,11 +9,14 @@
 # Pin a release by exporting OCTOPUS_VERSION (e.g. OCTOPUS_VERSION=1.0.27);
 # defaults to :latest. Migrations are NOT in the runtime image — run them from
 # a checkout of the matching tag (see docs/self-hosting).
+#
+# Change the published port by exporting OCTOPUS_PORT (defaults to 43300):
+#   OCTOPUS_PORT=8080 docker compose -f docker-compose.selfhost.yml up -d
 services:
   web:
     image: ghcr.io/octopusreview/octopus-selfhost:${OCTOPUS_VERSION:-latest}
     ports:
-      - "43300:3000"
+      - "${OCTOPUS_PORT:-43300}:3000"
     # env_file delivers the operator's secrets into the container (the
     # environment: block only overrides the compose-internal service URLs).
     env_file:


### PR DESCRIPTION
## What

Repositions the marketing site + onboarding around the **commercial cloud product**, with self-host as a clear **secondary** path.

**Homepage**
- **New terminal hero** (`landing-terminal-hero.tsx`) — two-column hero; the right column is an auto-playing terminal that types `octp login` → `octp review --pr 42` → findings, then loops. **Zero dependencies** (React state + one CSS keyframe), honors `prefers-reduced-motion`, and is `aria-hidden` so it doesn't spam screen readers.
- **"Two ways to run Octopus"** section (replaces the old "Source Available" block): **Cloud** (Recommended, teal) vs **Self-host** (secondary).

**Login** (`login-content.tsx`)
- Right panel flipped from self-host-centric to cloud-first: **"Your AI senior reviewer / Every pull request, reviewed in minutes."** + four cloud-value cards, with a demoted **"Prefer to run it yourself? Self-host →"** link.

**Docs**
- `getting-started` opens with a **Cloud / Self-Host "Choose Your Path"** split (Cloud primary).
- Sidebar + mobile menu split into **Cloud Setup** / **Self-Host** groups.
- `self-hosting` is now **Docker-first** via an accessible tab UI (`role="tablist"`, arrow-key nav), embedding the **real** `docker-compose.selfhost.yml`. Port is customizable via **`OCTOPUS_PORT`** (compose parametrized to `${OCTOPUS_PORT:-43300}`). Fixed a stale "image is private / build from source" note (it's public — pulled).

**Labeling cleanup (2nd commit)** — finishes #600: three surfaces still said "open source / MIT licensed" (the footer tagline + copyright, the **Ask-Octopus assistant** system prompt, and the **KB-seed** content). All → source-available / Modified MIT.

## Why

Octopus is a commercial product; the marketing surfaces led with self-hosting/privacy rather than the paid cloud value. This makes cloud the hero (people happily pay for code review), keeps a clean self-host path for the infra-minded, and removes the last inaccurate license claims.

## Test plan
- `bun run typecheck` clean · `bun run lint` 0 errors (1 pre-existing unrelated warning) · `bun run build` ✓ (145/145 pages)
- An adversarial 3-dimension review (copy/brand · frontend a11y+responsiveness · docs accuracy) ran pre-PR; all findings addressed (tab ARIA, reduced-motion caret, docs contradiction, the labeling misses above).

## Notes
- The Ask-Octopus **live KB** needs a re-seed (`/api/admin/seed-docs`) after deploy to propagate the corrected `docs-content.ts` copy.
- Retiring the COMMUNITY code tier remains a separate tracked follow-up (unchanged here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)