### PR TITLE
feat(cli): one CLI (octp), native install only; move CLI section under the hero

### DIFF
--- a/apps/web/app/(app)/settings/api-tokens/api-tokens-client.tsx
+++ b/apps/web/app/(app)/settings/api-tokens/api-tokens-client.tsx
@@ -242,18 +242,18 @@ function CliQuickStart() {
           <p className="text-muted-foreground mb-1.5 text-xs font-medium">
             1. Install the CLI
           </p>
-          <CodeBlock>npm install -g @octp/cli</CodeBlock>
+          <CodeBlock>curl -fsSL https://octopus-review.ai/install.sh | bash</CodeBlock>
         </div>
 
         <div>
           <p className="text-muted-foreground mb-1.5 text-xs font-medium">
             2. Log in (opens browser to authorize)
           </p>
-          <CodeBlock>octopus login</CodeBlock>
+          <CodeBlock>octp login</CodeBlock>
           <p className="text-muted-foreground mt-1.5 text-xs">
             Or use an existing token:{" "}
             <code className="rounded bg-stone-100 px-1 py-0.5 dark:bg-stone-700">
-              octopus login --token oct_...
+              octp login --token oct_...
             </code>
           </p>
         </div>
@@ -262,7 +262,7 @@ function CliQuickStart() {
           <p className="text-muted-foreground mb-1.5 text-xs font-medium">
             3. Verify your connection
           </p>
-          <CodeBlock>octopus whoami</CodeBlock>
+          <CodeBlock>octp whoami</CodeBlock>
         </div>
       </div>
 
@@ -272,22 +272,22 @@ function CliQuickStart() {
         </p>
         <div className="space-y-2">
           <CodeBlock>{`# List your repositories
-octopus repo list
+octp repo list
 
 # Index a repository for code search
-octopus repo index
+octp repo index
 
 # Review a pull request
-octopus pr review --pr <number>
+octp review --pr <number>
 
 # Chat with your codebase
-octopus repo chat
+octp chat
 
 # Add knowledge to your org
-octopus knowledge add <file>
+octp knowledge add <file>
 
 # Check your usage
-octopus usage`}</CodeBlock>
+octp usage`}</CodeBlock>
         </div>
       </div>
     </div>

--- a/apps/web/app/(auth)/cli/authorize/page.tsx
+++ b/apps/web/app/(auth)/cli/authorize/page.tsx
@@ -90,7 +90,7 @@ function AuthorizeContent() {
           <CardHeader>
             <CardTitle>Invalid Request</CardTitle>
             <CardDescription>
-              Missing device code. Please run <code>octopus login</code> from your terminal.
+              Missing device code. Please run <code>octp login</code> from your terminal.
             </CardDescription>
           </CardHeader>
         </Card>

--- a/apps/web/app/(landing)/docs/cli/claude-code-integration/page.tsx
+++ b/apps/web/app/(landing)/docs/cli/claude-code-integration/page.tsx
@@ -77,10 +77,7 @@ export default function ClaudeCodeIntegrationPage() {
 curl -fsSL https://octopus-review.ai/install.sh | bash
 
 # Windows (PowerShell)
-irm https://octopus-review.ai/install.ps1 | iex
-
-# Windows ARM
-npm install -g @octp/cli`}</CodeBlock>
+irm https://octopus-review.ai/install.ps1 | iex`}</CodeBlock>
 
         <h3 className="mb-2 mt-4 text-sm font-semibold text-white">
           2. Authenticate

--- a/apps/web/app/(landing)/docs/cli/page.tsx
+++ b/apps/web/app/(landing)/docs/cli/page.tsx
@@ -30,14 +30,9 @@ export default function CLIPage() {
 
       {/* Install */}
       <Section title="Installation">
-        <CodeBlock>npm install -g @octp/cli</CodeBlock>
-        <Paragraph>
-          Note: the npm package installs the legacy <Mono>octopus</Mono> binary,
-          which has a different command set. These docs cover the{" "}
-          <Mono>octp</Mono> CLI installed by the script below.
-        </Paragraph>
-        <Paragraph>Or with bun:</Paragraph>
-        <CodeBlock>bun add -g @octp/cli</CodeBlock>
+        <CodeBlock>curl -fsSL https://octopus-review.ai/install.sh | bash</CodeBlock>
+        <Paragraph>Or on Windows (PowerShell):</Paragraph>
+        <CodeBlock>{`powershell -c "irm https://octopus-review.ai/install.ps1 | iex"`}</CodeBlock>
       </Section>
 
       {/* Auth */}
@@ -244,26 +239,26 @@ octp agent serve --verbose`}</CodeBlock>
         </Paragraph>
 
         <CommandCard
-          command="octopus skills list"
+          command="octp skills list"
           description="List available Octopus skills."
         />
-        <CodeBlock>{`$ octopus skills list
+        <CodeBlock>{`$ octp skills list
 
   Skill        Description
   octopus-fix  Check open PRs for review comments, apply fixes, and push updates`}</CodeBlock>
 
         <CommandCard
-          command="octopus skills install"
+          command="octp skills install"
           description="Install Octopus skills for AI coding agents. By default installs for both Claude Code and Codex."
         />
         <CodeBlock>{`# Install for both Claude Code and Codex
-octopus skills install
+octp skills install
 
 # Install only for Claude Code
-octopus skills install --claude
+octp skills install --claude
 
 # Install only for Codex
-octopus skills install --codex`}</CodeBlock>
+octp skills install --codex`}</CodeBlock>
         <Paragraph>
           Once installed, you can use the skills as slash commands:
         </Paragraph>

--- a/apps/web/app/(landing)/docs/cli/page.tsx
+++ b/apps/web/app/(landing)/docs/cli/page.tsx
@@ -108,12 +108,12 @@ octp setup-token --no-open`}</CodeBlock>
       {/* PR commands */}
       <Section title="Pull Request Commands">
         <CommandCard
-          command="octp review <pr>"
+          command="octp review --pr <pr>"
           description="Trigger an AI review on a pull request. Accepts a PR number or full URL."
         />
         <Paragraph>Examples:</Paragraph>
-        <CodeBlock>{`octp review 42
-octp review https://github.com/owner/repo/pull/42`}</CodeBlock>
+        <CodeBlock>{`octp review --pr 42
+octp review --pr https://github.com/owner/repo/pull/42`}</CodeBlock>
       </Section>
 
       {/* Dependency Analysis */}

--- a/apps/web/app/(landing)/docs/faq/page.tsx
+++ b/apps/web/app/(landing)/docs/faq/page.tsx
@@ -72,7 +72,7 @@ const integrationFaqs = [
   },
   {
     q: "Is there a CLI?",
-    a: "Yes. The Octopus CLI lets you trigger reviews, index repositories, check usage, and chat with your codebase — all from the terminal. Install it with npm install -g @octp/cli.",
+    a: "Yes. The Octopus CLI lets you trigger reviews, index repositories, check usage, and chat with your codebase — all from the terminal. Install it with curl -fsSL https://octopus-review.ai/install.sh | bash.",
   },
 ];
 

--- a/apps/web/app/(landing)/docs/getting-started/page.tsx
+++ b/apps/web/app/(landing)/docs/getting-started/page.tsx
@@ -236,7 +236,7 @@ export default function GettingStartedPage() {
             description="Start an interactive chat session about your codebase. Ask questions, explore architecture."
           />
           <CommandRow
-            command="octp review 42"
+            command="octp review --pr 42"
             description="Trigger an AI review on any pull request by number or URL."
           />
           <CommandRow
@@ -266,7 +266,7 @@ export default function GettingStartedPage() {
         </div>
         <Paragraph>
           Install with{" "}
-          <Code>npm install -g @octp/cli</Code> and run{" "}
+          <Code>curl -fsSL https://octopus-review.ai/install.sh | bash</Code> and run{" "}
           <Code>octp login</Code> to get started. See the full{" "}
           <DocLink href="/docs/cli">CLI reference</DocLink> for all commands.
         </Paragraph>

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -145,7 +145,7 @@ export default async function LandingPage() {
 
       {/* Hero — dark bg */}
       <section className="relative z-10 px-6 pb-20 pt-40 md:px-8 md:pb-28 md:pt-52">
-        <div className="mx-auto grid max-w-6xl items-center gap-12 lg:grid-cols-2 lg:gap-12">
+        <div className="mx-auto grid max-w-6xl grid-cols-1 items-center gap-12 lg:grid-cols-2 lg:gap-12">
          <div className="text-center lg:text-left">
           <h1 className="animate-fade-in text-4xl font-bold leading-[1.1] tracking-tight text-white [animation-delay:100ms] sm:text-5xl md:text-6xl">
             Review every PR
@@ -197,7 +197,7 @@ export default async function LandingPage() {
           </div>
          </div>
 
-          <div className="animate-fade-in [animation-delay:400ms]">
+          <div className="min-w-0 animate-fade-in [animation-delay:400ms]">
             <LandingTerminalHero className="mx-auto w-full max-w-xl lg:mx-0" />
           </div>
         </div>

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -203,6 +203,9 @@ export default async function LandingPage() {
         </div>
       </section>
 
+      {/* Install the CLI — right below the terminal hero */}
+      <CliInstallSection />
+
       {/* How it works */}
       <section id="how-it-works" className="relative z-10 scroll-mt-20 px-4 pb-6 sm:px-8 md:px-12">
         <div className="relative mx-auto max-w-6xl">
@@ -249,11 +252,6 @@ export default async function LandingPage() {
                 title="Reviews on Autopilot"
                 description="Every new PR gets an instant, context-aware review automatically."
               />
-            </div>
-
-            {/* CLI Quick Install (embedded) */}
-            <div className="mt-16 border-t border-white/[0.06] pt-12">
-              <CliInstallSection embedded />
             </div>
 
           </div>

--- a/apps/web/app/api/ask-octopus/route.ts
+++ b/apps/web/app/api/ask-octopus/route.ts
@@ -59,7 +59,7 @@ const SYSTEM_PROMPT = `You are Octopus Assistant, a helpful AI that answers ques
 <octopus_overview>
 Octopus is a source-available, AI-powered code review tool available at https://octopus-review.ai. It connects to GitHub, GitLab, and Bitbucket, indexes your codebase using vector embeddings (OpenAI text-embedding-3-large, stored in Qdrant), and automatically reviews every pull request (and GitLab merge request). Findings are posted as inline PR comments with severity levels: 🔴 Critical, 🟠 Major, 🟡 Minor, 🔵 Suggestion, 💡 Tip.
 
-Key features: RAG Chat (ask questions about your codebase), CLI tool (npm install -g @octp/cli), Codebase Indexing, Knowledge Base (custom review rules), Team Sharing, Analytics, and integrations with Slack, Linear, and Jira (create Jira issues directly from review findings). Self-hostable with Docker (source-available, Modified MIT License). Supports Bring Your Own Keys (BYOK) for Anthropic, OpenAI, Google, Cohere. Credit-based pricing with free tier.
+Key features: RAG Chat (ask questions about your codebase), CLI tool (octp — installed via a native one-liner), Codebase Indexing, Knowledge Base (custom review rules), Team Sharing, Analytics, and integrations with Slack, Linear, and Jira (create Jira issues directly from review findings). Self-hostable with Docker (source-available, Modified MIT License). Supports Bring Your Own Keys (BYOK) for Anthropic, OpenAI, Google, Cohere. Credit-based pricing with free tier.
 
 Tech stack: Next.js (App Router, React 19), Prisma + PostgreSQL, Qdrant vector DB, Claude & OpenAI, Tailwind CSS, TypeScript, Turborepo monorepo.
 </octopus_overview>

--- a/apps/web/components/landing-cli-install.tsx
+++ b/apps/web/components/landing-cli-install.tsx
@@ -5,7 +5,6 @@ import { IconCopy, IconCheck, IconTerminal2 } from "@tabler/icons-react";
 import { TrackedLink } from "@/components/tracked-link";
 
 type Platform = "mac-linux" | "windows";
-type Method = "one-liner" | "npm";
 
 const DEFAULT_BASE_URL = "https://octopus-review.ai";
 
@@ -32,27 +31,15 @@ const STATIC_BASE_URL = safeBaseUrl(process.env.NEXT_PUBLIC_APP_URL) ?? DEFAULT_
 
 function buildInstallCommands(
   baseUrl: string,
-): Record<Platform, Record<Method, { comment: string; command: string }>> {
+): Record<Platform, { comment: string; command: string }> {
   return {
     "mac-linux": {
-      "one-liner": {
-        comment: "# Works on macOS & Linux. Installs everything.",
-        command: `curl -fsSL ${baseUrl}/install.sh | bash`,
-      },
-      npm: {
-        comment: "# Requires Node.js 18+",
-        command: "npm install -g @octp/cli",
-      },
+      comment: "# Works on macOS & Linux. Installs everything — no Node.js needed.",
+      command: `curl -fsSL ${baseUrl}/install.sh | bash`,
     },
     windows: {
-      "one-liner": {
-        comment: "# Works on Windows. If you use ARM Windows, use the npm installer.",
-        command: `powershell -c "irm ${baseUrl}/install.ps1 | iex"`,
-      },
-      npm: {
-        comment: "# Requires Node.js 18+",
-        command: "npm install -g @octp/cli",
-      },
+      comment: "# Works on Windows (PowerShell). Installs everything for you.",
+      command: `powershell -c "irm ${baseUrl}/install.ps1 | iex"`,
     },
   };
 }
@@ -60,11 +47,6 @@ function buildInstallCommands(
 const platformLabels: Record<Platform, string> = {
   "mac-linux": "macOS/Linux",
   windows: "Windows",
-};
-
-const methodLabels: Record<Method, string> = {
-  "one-liner": "One-liner",
-  npm: "npm",
 };
 
 function detectPlatform(): Platform | null {
@@ -75,15 +57,8 @@ function detectPlatform(): Platform | null {
   return null;
 }
 
-function detectWindowsArm(): boolean {
-  if (typeof navigator === "undefined") return false;
-  const ua = navigator.userAgent.toLowerCase();
-  return ua.includes("windows") && (ua.includes("arm") || ua.includes("aarch64"));
-}
-
 export function CliInstallSection({ embedded = false }: { embedded?: boolean } = {}) {
   const [platform, setPlatform] = useState<Platform>("mac-linux");
-  const [method, setMethod] = useState<Method>("one-liner");
   const [copied, setCopied] = useState(false);
   const [baseUrl, setBaseUrl] = useState<string>(STATIC_BASE_URL);
   const didDetect = useRef(false);
@@ -95,16 +70,12 @@ export function CliInstallSection({ embedded = false }: { embedded?: boolean } =
     const detected = detectPlatform();
     if (detected) setPlatform(detected);
 
-    if (detected === "windows" && detectWindowsArm()) {
-      setMethod("npm");
-    }
-
     const origin = safeBaseUrl(window.location?.origin);
     if (origin) setBaseUrl(origin);
   }, []);
 
   const installCommands = buildInstallCommands(baseUrl);
-  const current = installCommands[platform][method];
+  const current = installCommands[platform];
 
   async function handleCopy() {
     try {
@@ -118,7 +89,7 @@ export function CliInstallSection({ embedded = false }: { embedded?: boolean } =
 
   const content = (
     <>
-      <div className={embedded ? "mx-auto max-w-3xl" : "mx-auto max-w-3xl"}>
+      <div className="mx-auto max-w-3xl">
         {!embedded && (
           <div className="mx-auto max-w-2xl text-center">
             <span className="text-xs font-semibold uppercase tracking-[0.2em] text-[#555]">
@@ -144,74 +115,32 @@ export function CliInstallSection({ embedded = false }: { embedded?: boolean } =
 
         {/* Terminal card */}
         <div className={`${embedded ? "" : "mt-12 "}overflow-hidden rounded-2xl border border-white/[0.08] bg-[#0c0c0c]`}>
-          {/* Top bar: platform tabs + method tabs */}
-          <div className="flex flex-col gap-0 border-b border-white/[0.06] sm:flex-row sm:items-center sm:justify-between">
-            {/* Platform tabs */}
-            <div className="flex items-center gap-0 border-b border-white/[0.06] sm:border-b-0">
-              {/* Traffic lights */}
-              <div className="flex items-center gap-1.5 px-4">
-                <span className="size-2.5 rounded-full bg-[#ff5f57]" />
-                <span className="size-2.5 rounded-full bg-[#febc2e]" />
-                <span className="size-2.5 rounded-full bg-[#28c840]" />
-              </div>
-              {(["mac-linux", "windows"] as Platform[]).map((p) => (
-                <button
-                  key={p}
-                  onClick={() => setPlatform(p)}
-                  className={`px-4 py-3 text-xs font-medium transition-colors ${
-                    platform === p
-                      ? "bg-white/[0.06] text-white"
-                      : "text-[#555] hover:text-[#888]"
-                  }`}
-                >
-                  {platformLabels[p]}
-                </button>
-              ))}
+          {/* Top bar: platform tabs */}
+          <div className="flex items-center gap-0 border-b border-white/[0.06]">
+            {/* Traffic lights */}
+            <div className="flex items-center gap-1.5 px-4">
+              <span className="size-2.5 rounded-full bg-[#ff5f57]" />
+              <span className="size-2.5 rounded-full bg-[#febc2e]" />
+              <span className="size-2.5 rounded-full bg-[#28c840]" />
             </div>
-
-            {/* Method tabs */}
-            <div className="flex items-center gap-0">
-              {(["one-liner", "npm"] as Method[]).map((m) => (
-                <button
-                  key={m}
-                  onClick={() => setMethod(m)}
-                  className={`px-4 py-3 text-xs font-medium transition-colors ${
-                    method === m
-                      ? "text-white"
-                      : "text-[#555] hover:text-[#888]"
-                  }`}
-                >
-                  <span
-                    className={`rounded-full px-3 py-1 ${
-                      method === m
-                        ? "bg-[#10D8BE]/20 text-[#10D8BE]"
-                        : ""
-                    }`}
-                  >
-                    {methodLabels[m]}
-                  </span>
-                </button>
-              ))}
-            </div>
+            {(["mac-linux", "windows"] as Platform[]).map((p) => (
+              <button
+                key={p}
+                onClick={() => setPlatform(p)}
+                className={`px-4 py-3 text-xs font-medium transition-colors ${
+                  platform === p
+                    ? "bg-white/[0.06] text-white"
+                    : "text-[#555] hover:text-[#888]"
+                }`}
+              >
+                {platformLabels[p]}
+              </button>
+            ))}
           </div>
 
           {/* Code area */}
           <div className="relative px-6 py-6">
-            <p className="font-mono text-sm text-[#555]">
-              {platform === "windows" && method === "one-liner" ? (
-                <>
-                  # Works on Windows x86. ARM?{" "}
-                  <button
-                    onClick={() => setMethod("npm")}
-                    className="text-[#10D8BE] underline decoration-[#10D8BE]/30 underline-offset-2 transition-colors hover:decoration-[#10D8BE]"
-                  >
-                    Switch to npm
-                  </button>
-                </>
-              ) : (
-                current.comment
-              )}
-            </p>
+            <p className="font-mono text-sm text-[#555]">{current.comment}</p>
             <div className="mt-3 flex items-start gap-3">
               <span className="select-none font-mono text-sm text-[#10D8BE]">$</span>
               <code className="flex-1 break-all font-mono text-sm text-[#e0e0e0]">
@@ -234,10 +163,7 @@ export function CliInstallSection({ embedded = false }: { embedded?: boolean } =
 
         {/* Bottom note */}
         <p className="mt-4 text-center text-xs text-[#555]">
-          Works on macOS, Windows & Linux.{" "}
-          {method === "one-liner"
-            ? "The one-liner installs Node.js and everything else for you."
-            : "Requires Node.js 18+ installed."}
+          Works on macOS, Windows &amp; Linux. The installer sets up everything for you.
         </p>
 
         {/* Docs link */}

--- a/apps/web/components/landing-features.tsx
+++ b/apps/web/components/landing-features.tsx
@@ -313,7 +313,7 @@ function ChatPreview() {
 }
 
 function CliPreview() {
-  const command = "octopus pr review 42";
+  const command = "octp review --pr 42";
   const output = "Fetching diff for PR #42...\nRetrieving 847 context chunks...\nPosting inline findings to GitHub...";
   const typedCommand = useTypewriter(command, 45, 250);
   const typedOutput = useTypewriter(output, 28, 1300);

--- a/apps/web/components/landing-terminal-hero.tsx
+++ b/apps/web/components/landing-terminal-hero.tsx
@@ -112,7 +112,7 @@ export function LandingTerminalHero({ className = "" }: { className?: string }) 
   return (
     <div
       aria-hidden="true"
-      className={`overflow-hidden rounded-2xl border border-white/[0.08] bg-[#0a0a0a] shadow-2xl shadow-black/40 ${className}`}
+      className={`min-w-0 overflow-hidden rounded-2xl border border-white/[0.08] bg-[#0a0a0a] shadow-2xl shadow-black/40 ${className}`}
     >
       <style>{`@media (prefers-reduced-motion: no-preference){@keyframes octpBlink{0%,49%{opacity:1}50%,100%{opacity:0}}}`}</style>
       {/* window chrome */}
@@ -134,7 +134,7 @@ export function LandingTerminalHero({ className = "" }: { className?: string }) 
         className="h-[300px] overflow-hidden px-4 py-3.5 font-mono text-[12.5px] leading-[1.7] sm:h-[340px] sm:text-[13px]"
       >
         {lines.map((line, i) => (
-          <div key={i} className={`whitespace-pre-wrap ${TONE_CLASS[line.tone]}`}>
+          <div key={i} className={`whitespace-pre-wrap break-words ${TONE_CLASS[line.tone]}`}>
             {line.tone === "cmd" ? (
               <>
                 <span className="text-[#10d8be]/80">$</span> {line.text}
@@ -145,7 +145,7 @@ export function LandingTerminalHero({ className = "" }: { className?: string }) 
           </div>
         ))}
         {/* active prompt + caret */}
-        <div className="whitespace-pre-wrap text-white">
+        <div className="whitespace-pre-wrap break-words text-white">
           <span className="text-[#10d8be]/80">$</span> {active ?? ""}
           <span
             className="ml-px inline-block h-[1.05em] w-[7px] translate-y-[2px] bg-[#10d8be]"

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -113,8 +113,8 @@ The review pipeline: Webhook receives PR event → Octopus fetches the diff → 
       {
         heading: "4. Use the CLI",
         text: `Install the Octopus CLI for terminal-based workflows:
-npm install -g @octp/cli (or bun add -g @octp/cli)
-Key commands: octopus chat (chat with your codebase), octopus pr review <number> (review a specific PR), octopus index (re-index a repository), octopus knowledge add (add knowledge documents).`,
+curl -fsSL https://octopus-review.ai/install.sh | bash (macOS/Linux) or powershell -c "irm https://octopus-review.ai/install.ps1 | iex" (Windows)
+Key commands: octp chat (chat with your codebase), octp review --pr <number> (review a specific PR), octp repo index (re-index a repository), octp knowledge add (add knowledge documents).`,
       },
       {
         heading: "5. Customize Your Setup",
@@ -135,55 +135,55 @@ Notifications: Configure Slack and Linear integration for review events.`,
       {
         heading: "Installation",
         text: `Install the Octopus CLI globally:
-npm install -g @octp/cli
-or: bun add -g @octp/cli
-After installing, authenticate with: octopus login
-Verify your session with: octopus whoami`,
+curl -fsSL https://octopus-review.ai/install.sh | bash
+Windows: powershell -c "irm https://octopus-review.ai/install.ps1 | iex"
+After installing, authenticate with: octp login
+Verify your session with: octp whoami`,
       },
       {
         heading: "Repository Commands",
-        text: `octopus repos — List all connected repositories.
-octopus status — Show indexing status for a repository.
-octopus index — Re-index the current repository (or specify a repo).
-octopus analyze — Run AI analysis on a repository.
-octopus chat — Start an interactive chat session about your codebase.`,
+        text: `octp repo list — List all connected repositories.
+octp repo status — Show indexing status for a repository.
+octp repo index — Re-index the current repository (or specify a repo).
+octp repo analyze — Run AI analysis on a repository.
+octp chat — Start an interactive chat session about your codebase.`,
       },
       {
         heading: "Pull Request Commands",
-        text: `octopus pr review <number> — Review a specific pull request.
-You can also pass a full PR URL: octopus pr review https://github.com/org/repo/pull/142
+        text: `octp review --pr <number> — Review a specific pull request.
+You can also pass a full PR URL: octp review --pr https://github.com/org/repo/pull/142
 The CLI streams the review in real-time and posts findings to the PR.`,
       },
       {
         heading: "Dependency Analysis",
-        text: `octopus analyze-deps <repo-url> — Analyze dependencies for a repository.
+        text: `octp analyze-deps <repo-url> — Analyze dependencies for a repository.
 Checks for outdated packages, known vulnerabilities, and license compatibility.`,
       },
       {
         heading: "Knowledge Base",
-        text: `octopus knowledge list — List all knowledge documents.
-octopus knowledge add <file> — Add a document to the knowledge base.
-octopus knowledge remove <id> — Remove a knowledge document.
+        text: `octp knowledge list — List all knowledge documents.
+octp knowledge add <file> — Add a document to the knowledge base.
+octp knowledge remove <id> — Remove a knowledge document.
 Knowledge documents are referenced during code reviews for custom rules and guidelines.`,
       },
       {
         heading: "Local Agent",
-        text: `octopus watch — Start a local file watcher agent.
-octopus start — Start the local agent with semantic search (requires ripgrep or Claude CLI).
+        text: `octp agent serve — Run the local agent (Ollama LLM tasks + code search).
+octp agent watch [path] — Watch a repo directory so cloud chat can search it locally.
 The local agent monitors your project and provides real-time assistance.`,
       },
       {
         heading: "Skills",
-        text: `octopus skills list — List available automation skills.
-octopus skills install <name> — Install a skill for Claude Code or Codex.
+        text: `octp skills list — List available automation skills.
+octp skills install <name> — Install a skill for Claude Code or Codex.
 Skills are pre-built automation workflows like "Split and Ship" and "Octopus Fix".`,
       },
       {
         heading: "Configuration",
-        text: `octopus config list — Show current configuration.
-octopus config set <key> <value> — Set a configuration value.
-octopus usage — View token and credit usage.
-octopus logout — End your session.
+        text: `octp config list — Show current configuration.
+octp config set <key> <value> — Set a configuration value.
+octp usage — View token and credit usage.
+octp logout — End your session.
 Multiple profiles are supported for switching between accounts.`,
       },
     ],
@@ -368,7 +368,7 @@ Q: Does Octopus support monorepos?
 A: Yes. Octopus indexes the entire repository including all packages in a monorepo.
 
 Q: Is there a CLI?
-A: Yes. Install with npm install -g @octp/cli. Use it to review PRs, chat with your codebase, and manage knowledge.`,
+A: Yes. Install with curl -fsSL https://octopus-review.ai/install.sh | bash. Use it to review PRs, chat with your codebase, and manage knowledge.`,
       },
       {
         heading: "Pricing & Billing",


### PR DESCRIPTION
## What

Makes the whole site consistent about the CLI: **one binary, `octp`, installed natively** — and moves the install block higher on the homepage.

- **npm removed.** `landing-cli-install` is native-only now (`curl … install.sh | bash` / `irm … install.ps1 | iex`); dropped the npm method + the ARM-Windows npm fallback. Both installers verified serving 200.
- **CLI section moved up.** "Install the CLI" is now its own section **directly below the terminal hero**, out of "How it works."
- **Consistency sweep.** Every `octopus <verb>` → `octp` with correct syntax (e.g. `octopus pr review 42` → `octp review --pr 42`, `octopus repo chat` → `octp chat`, `octopus analyze-deps` → `octp analyze-deps`, `octopus watch/start` → `octp agent watch`/`octp agent serve`), and every `npm install -g @octp/cli` / `bun add -g @octp/cli` → the native installer. Across: the Features card, docs/cli (+ claude-code-integration), docs/faq, docs/getting-started, settings/api-tokens, auth/cli/authorize, the KB seed (`lib/docs-content.ts`), and the Ask-Octopus system prompt.

Mappings were verified against the **real `octp` command set** in `apps/cli/src/index.tsx`.

## Why

The site referenced an older `octopus`-named CLI + npm packaging in ~10 places, contradicting the actual `octp` binary. One name, one install path.

## Left untouched (intentional)
Product name "Octopus", the `/octopus` Slack slash command, the `@octopus` PR mention, the `octopus-fix` skill name, and Postgres `octopus:octopus` creds.

## Test plan
- `bun run typecheck` clean · `bun run lint` 0 errors (1 pre-existing unrelated warning) · `bun run build` ✓ (145/145 pages)
- Grep confirms **zero** remaining `octopus <verb>` CLI invocations or `npm install -g @octp/cli` in `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)