### PR TITLE
fix(content): resolve website content-audit findings + prep octp 0.2.0 release

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octopus/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Octopus CLI. Native single-binary distribution via curl/irm. Includes a first-run TUI onboarding wizard.",

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -22,7 +22,7 @@ import { ensureProfilesMigrated, isValidProfileName, ensureProfile, setActivePro
 import { setActiveProfileOverride } from "./lib/paths.js";
 import { flagValue } from "./lib/args.js";
 
-const VERSION = "0.1.0";
+const VERSION = "0.2.0";
 
 /** Remove a `--flag <value>` pair from argv (the value is dropped only when the
  *  next token isn't itself a flag). Used to peel the global --account/--profile

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,5 +1,13 @@
+import type { Metadata } from "next";
 import { Suspense } from "react";
 import { LoginContent } from "./login-content";
+
+export const metadata: Metadata = {
+  title: "Sign in — Octopus",
+  alternates: {
+    canonical: "https://octopus-review.ai/login",
+  },
+};
 
 // The provider gate below reads runtime env, but without a dynamic marker
 // Next statically prerenders this page AT IMAGE BUILD TIME — where no OAuth

--- a/apps/web/app/(landing)/docs/about/page.tsx
+++ b/apps/web/app/(landing)/docs/about/page.tsx
@@ -80,8 +80,8 @@ export default function AboutPage() {
           />
           <ValueCard
             icon={<IconRocket className="size-4" />}
-            title="Free Forever"
-            description="The core product is free and always will be. No artificial limitations, no feature gates for essential functionality."
+            title="Free to self-host"
+            description="Self-host Octopus for free on your own infrastructure — the source is available under a Modified MIT License. The managed cloud is a paid, hosted option, with free credits to start and no card required."
           />
         </div>
       </Section>
@@ -113,7 +113,7 @@ export default function AboutPage() {
           horizon:
         </Paragraph>
         <ul className="mb-4 space-y-2">
-          <VisionItem text="Deeper integration with more Git providers beyond GitHub and Bitbucket" />
+          <VisionItem text="Deeper integration with more Git providers beyond GitHub, GitLab, and Bitbucket" />
           <VisionItem text="Smarter review engine that learns from your team's feedback over time" />
           <VisionItem text="Expanded CLI capabilities for CI/CD pipeline integration" />
           <VisionItem text="Plugin system for custom review rules and checks" />

--- a/apps/web/app/(landing)/docs/cli/claude-code-integration/page.tsx
+++ b/apps/web/app/(landing)/docs/cli/claude-code-integration/page.tsx
@@ -125,10 +125,10 @@ octp login --token oct_your_token_here`}</CodeBlock>
         <div className="mb-4 space-y-1.5">
           {[
             { severity: "Critical", color: "text-red-400", desc: "Security vulnerabilities, data loss risks" },
-            { severity: "High", color: "text-orange-400", desc: "Bugs, logic errors, performance issues" },
-            { severity: "Medium", color: "text-yellow-400", desc: "Code quality, maintainability concerns" },
-            { severity: "Low", color: "text-blue-400", desc: "Style, naming, minor improvements" },
-            { severity: "Info", color: "text-purple-400", desc: "Suggestions, best practices, tips" },
+            { severity: "Major", color: "text-orange-400", desc: "Bugs, logic errors, performance issues" },
+            { severity: "Minor", color: "text-yellow-400", desc: "Code quality, maintainability concerns" },
+            { severity: "Suggestion", color: "text-blue-400", desc: "Style, naming, improvement ideas" },
+            { severity: "Tip", color: "text-purple-400", desc: "Best practices, informational notes" },
           ].map((item) => (
             <div
               key={item.severity}

--- a/apps/web/app/(landing)/docs/cli/page.tsx
+++ b/apps/web/app/(landing)/docs/cli/page.tsx
@@ -5,7 +5,7 @@ import { CodeBlock } from "../self-hosting/code-block";
 export const metadata = {
   title: "CLI — Octopus Docs",
   description:
-    "Install the Octopus CLI and review pull requests, index repositories, or chat with your codebase from the terminal. Works with GitHub and Bitbucket today.",
+    "Install the Octopus CLI and review pull requests, index repositories, or chat with your codebase from the terminal. Works with GitHub, GitLab, and Bitbucket today.",
   alternates: {
     canonical: "https://octopus-review.ai/docs/cli",
   },

--- a/apps/web/app/(landing)/docs/docs-mobile-menu.tsx
+++ b/apps/web/app/(landing)/docs/docs-mobile-menu.tsx
@@ -29,14 +29,16 @@ const sections: MenuSection[] = [
     title: "Cloud Setup",
     items: [
       { href: "/docs/github-action", label: "GitHub Action" },
-      { href: "/docs/github-app", label: "GitHub App Setup" },
-      { href: "/docs/oauth-setup", label: "Google & GitHub Login" },
       { href: "/docs/integrations", label: "Integrations" },
     ],
   },
   {
     title: "Self-Host",
-    items: [{ href: "/docs/self-hosting", label: "Self-Hosting" }],
+    items: [
+      { href: "/docs/self-hosting", label: "Self-Hosting" },
+      { href: "/docs/github-app", label: "GitHub App (self-host)" },
+      { href: "/docs/oauth-setup", label: "Google & GitHub Login" },
+    ],
   },
   {
     title: "Features",

--- a/apps/web/app/(landing)/docs/docs-search.tsx
+++ b/apps/web/app/(landing)/docs/docs-search.tsx
@@ -66,7 +66,7 @@ const docsPages = [
     label: "CLI",
     description: "Installation, commands, authentication, and profiles.",
     icon: IconTerminal2,
-    keywords: ["terminal", "command", "npm", "bun", "login", "review", "index", "chat"],
+    keywords: ["terminal", "command", "install", "curl", "octp", "login", "review", "index", "chat"],
   },
   {
     href: "/docs/octopusignore",

--- a/apps/web/app/(landing)/docs/docs-sidebar.tsx
+++ b/apps/web/app/(landing)/docs/docs-sidebar.tsx
@@ -29,14 +29,16 @@ const sections: SidebarSection[] = [
     title: "Cloud Setup",
     items: [
       { href: "/docs/github-action", label: "GitHub Action" },
-      { href: "/docs/github-app", label: "GitHub App Setup" },
-      { href: "/docs/oauth-setup", label: "Google & GitHub Login" },
       { href: "/docs/integrations", label: "Integrations" },
     ],
   },
   {
     title: "Self-Host",
-    items: [{ href: "/docs/self-hosting", label: "Self-Hosting" }],
+    items: [
+      { href: "/docs/self-hosting", label: "Self-Hosting" },
+      { href: "/docs/github-app", label: "GitHub App (self-host)" },
+      { href: "/docs/oauth-setup", label: "Google & GitHub Login" },
+    ],
   },
   {
     title: "Features",

--- a/apps/web/app/(landing)/docs/dpa/page.tsx
+++ b/apps/web/app/(landing)/docs/dpa/page.tsx
@@ -94,7 +94,7 @@ export default function DpaPage() {
           When you self-host Octopus, no data leaves your infrastructure
           (unless you connect external integrations like a cloud LLM provider
           or Slack). In that arrangement Octopus is not your data processor —
-          you operate the software yourself, like any open-source server. A
+          you operate the software yourself, like any self-hosted server. A
           DPA is not required for self-hosted unless you have an external
           integration that brings a third party into scope.
         </P>

--- a/apps/web/app/(landing)/docs/faq/page.tsx
+++ b/apps/web/app/(landing)/docs/faq/page.tsx
@@ -56,7 +56,7 @@ const securityFaqs = [
 const integrationFaqs = [
   {
     q: "Which Git platforms are supported?",
-    a: "Octopus integrates with GitHub (including GitHub Enterprise), GitLab, and Bitbucket. It installs as a GitHub App or connects via Bitbucket OAuth, and listens for pull request webhooks.",
+    a: "Octopus integrates with GitHub (including GitHub Enterprise), GitLab, and Bitbucket. It installs as a GitHub App, or connects to GitLab and Bitbucket via OAuth, and listens for pull request and merge request webhooks.",
   },
   {
     q: "Can I connect Octopus to Slack?",

--- a/apps/web/app/(landing)/docs/faq/page.tsx
+++ b/apps/web/app/(landing)/docs/faq/page.tsx
@@ -14,7 +14,7 @@ export const metadata = {
 const generalFaqs = [
   {
     q: "What is Octopus?",
-    a: "Octopus is an AI-powered code review tool. It connects to your GitHub or Bitbucket repositories, indexes your codebase, and automatically reviews pull requests — posting findings as inline comments with severity levels.",
+    a: "Octopus is an AI-powered code review tool. It connects to your GitHub, GitLab, or Bitbucket repositories, indexes your codebase, and automatically reviews pull requests — posting findings as inline comments with severity levels.",
   },
   {
     q: "How does Octopus review my code?",
@@ -56,7 +56,7 @@ const securityFaqs = [
 const integrationFaqs = [
   {
     q: "Which Git platforms are supported?",
-    a: "Octopus integrates with GitHub (including GitHub Enterprise) and Bitbucket. It installs as a GitHub App or connects via Bitbucket OAuth, and listens for pull request webhooks.",
+    a: "Octopus integrates with GitHub (including GitHub Enterprise), GitLab, and Bitbucket. It installs as a GitHub App or connects via Bitbucket OAuth, and listens for pull request webhooks.",
   },
   {
     q: "Can I connect Octopus to Slack?",

--- a/apps/web/app/(landing)/docs/getting-started/page.tsx
+++ b/apps/web/app/(landing)/docs/getting-started/page.tsx
@@ -22,7 +22,7 @@ import {
 export const metadata = {
   title: "Getting Started | Octopus Docs",
   description:
-    "Connect your repo in two minutes and get AI code reviews on every pull request. Step-by-step setup guide for GitHub and Bitbucket, with examples.",
+    "Connect your repo in two minutes and get AI code reviews on every pull request. Step-by-step setup guide for GitHub, GitLab, and Bitbucket, with examples.",
   alternates: {
     canonical: "https://octopus-review.ai/docs/getting-started",
   },
@@ -67,7 +67,7 @@ export default function GettingStartedPage() {
           <FeatureCard
             icon={<IconPlugConnected className="size-4" />}
             title="Works With Your Tools"
-            description="GitHub, Bitbucket, Slack, Linear. Fits into your existing workflow."
+            description="GitHub, GitLab, Bitbucket, Slack, Linear. Fits into your existing workflow."
           />
         </div>
       </Section>
@@ -89,8 +89,8 @@ export default function GettingStartedPage() {
             title="Hosted for you"
             description="Sign in, install the GitHub App, and Octopus reviews every pull request automatically. No servers to run, no maintenance."
             links={[
-              { href: "/docs/github-app", label: "Install the GitHub App" },
-              { href: "/login", label: "Sign in" },
+              { href: "/login", label: "Install the GitHub App" },
+              { href: "/docs/pricing", label: "View pricing" },
             ]}
           />
           <PathCard
@@ -106,7 +106,7 @@ export default function GettingStartedPage() {
       {/* Step 1: Connect */}
       <Section title="1. Connect Your Repository">
         <Paragraph>
-          Start by connecting your GitHub or Bitbucket account from the
+          Start by connecting your GitHub, GitLab, or Bitbucket account from the
           dashboard. Octopus will install as a GitHub App or set up Bitbucket
           OAuth to receive webhook events from your repositories.
         </Paragraph>
@@ -197,26 +197,26 @@ export default function GettingStartedPage() {
           <SeverityRow
             icon={<IconAlertTriangle className="size-4" />}
             color="text-orange-400"
-            label="Warning"
+            label="Major"
             description="Logic errors, performance issues, potential edge cases."
           />
           <SeverityRow
             icon={<IconAlertCircle className="size-4" />}
             color="text-yellow-400"
-            label="Caution"
+            label="Minor"
             description="Code quality, maintainability, and best practice concerns."
           />
           <SeverityRow
             icon={<IconInfoCircle className="size-4" />}
             color="text-blue-400"
-            label="Info"
-            description="Informational notes about the code, documentation, or conventions."
+            label="Suggestion"
+            description="Optional improvements, alternative approaches, and ideas."
           />
           <SeverityRow
             icon={<IconBulb className="size-4" />}
-            color="text-purple-400"
-            label="Suggestion"
-            description="Optional improvements, alternative approaches, and ideas."
+            color="text-amber-400"
+            label="Tip"
+            description="Informational notes about the code, documentation, or conventions."
           />
         </div>
       </Section>
@@ -309,7 +309,7 @@ export default function GettingStartedPage() {
             href="/docs/integrations"
             icon={<IconPlugConnected className="size-4" />}
             title="Integrations"
-            description="Connect GitHub, Bitbucket, Slack, and Linear"
+            description="Connect GitHub, GitLab, Bitbucket, Slack, and Linear"
           />
           <NextStepCard
             href="/docs/cli"

--- a/apps/web/app/(landing)/docs/getting-started/page.tsx
+++ b/apps/web/app/(landing)/docs/getting-started/page.tsx
@@ -3,6 +3,7 @@ import {
   IconRocket,
   IconBrandGithub,
   IconBrandBitbucket,
+  IconBrandGitlab,
   IconGitPullRequest,
   IconAlertTriangle,
   IconAlertCircle,
@@ -107,14 +108,19 @@ export default function GettingStartedPage() {
       <Section title="1. Connect Your Repository">
         <Paragraph>
           Start by connecting your GitHub, GitLab, or Bitbucket account from the
-          dashboard. Octopus will install as a GitHub App or set up Bitbucket
-          OAuth to receive webhook events from your repositories.
+          dashboard. Octopus installs as a GitHub App, or connects to GitLab and
+          Bitbucket via OAuth, to receive webhook events from your repositories.
         </Paragraph>
-        <div className="mb-4 grid gap-3 sm:grid-cols-2">
+        <div className="mb-4 grid gap-3 sm:grid-cols-3">
           <ProviderCard
             icon={<IconBrandGithub className="size-5" />}
             name="GitHub"
             description="Install the GitHub App, select repositories, and you're ready to go."
+          />
+          <ProviderCard
+            icon={<IconBrandGitlab className="size-5" />}
+            name="GitLab"
+            description="Connect via OAuth (gitlab.com or self-managed); Octopus reviews every merge request."
           />
           <ProviderCard
             icon={<IconBrandBitbucket className="size-5" />}
@@ -214,7 +220,7 @@ export default function GettingStartedPage() {
           />
           <SeverityRow
             icon={<IconBulb className="size-4" />}
-            color="text-amber-400"
+            color="text-purple-400"
             label="Tip"
             description="Informational notes about the code, documentation, or conventions."
           />

--- a/apps/web/app/(landing)/docs/github-action/page.tsx
+++ b/apps/web/app/(landing)/docs/github-action/page.tsx
@@ -401,7 +401,7 @@ export default function GitHubActionPage() {
           For larger repositories that prefer not to grant a writable token in
           CI at all, install the{" "}
           <a
-            href="/docs/github-app"
+            href="/login"
             className="text-[#10D8BE] hover:underline"
           >
             Octopus GitHub App
@@ -504,14 +504,14 @@ export default function GitHubActionPage() {
       <Section title="Related">
         <div className="grid gap-2 sm:grid-cols-2">
           <RelatedLink
-            href="/docs/github-app"
+            href="/login"
             title="GitHub App"
             description="Install the App for zero-config PR reviews."
           />
           <RelatedLink
             href="/docs/integrations"
             title="Integrations"
-            description="GitHub, Bitbucket, Slack, Linear."
+            description="GitHub, GitLab, Bitbucket, Slack, Linear."
           />
           <RelatedLink
             href="/docs/cli"

--- a/apps/web/app/(landing)/docs/github-app/page.tsx
+++ b/apps/web/app/(landing)/docs/github-app/page.tsx
@@ -51,7 +51,7 @@ export default function GithubAppPage() {
           </li>
         </UL>
         <P>
-          For one-off <Mono>octp review &lt;PR&gt;</Mono> from the CLI, a
+          For one-off <Mono>octp review --pr &lt;PR&gt;</Mono> from the CLI, a
           personal token works fine. The web app + auto-review-every-PR flow
           needs the App.
         </P>

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -33,7 +33,7 @@ import {
 const landingFaqs = [
   {
     q: "What is Octopus?",
-    a: "Octopus is an AI-powered code review tool that connects to GitHub and Bitbucket, indexes your codebase for deep context, and automatically reviews every pull request — posting findings as inline comments with severity levels.",
+    a: "Octopus is an AI-powered code review tool that connects to GitHub, GitLab, and Bitbucket, indexes your codebase for deep context, and automatically reviews every pull request — posting findings as inline comments with severity levels.",
   },
   {
     q: "How does the automated review work?",
@@ -64,19 +64,20 @@ const productJsonLd = {
   url: "https://octopus-review.ai",
   logo: "https://octopus-review.ai/logo.svg",
   description:
-    "AI-powered code review tool that connects to GitHub and Bitbucket, indexes your codebase, and automatically reviews pull requests with severity-rated findings.",
+    "AI-powered code review tool that connects to GitHub, GitLab, and Bitbucket, indexes your codebase, and automatically reviews pull requests with severity-rated findings.",
   applicationCategory: "DeveloperApplication",
   operatingSystem: "Web",
   offers: {
     "@type": "Offer",
     price: "0",
     priceCurrency: "USD",
+    url: "https://octopus-review.ai/docs/pricing",
   },
   featureList: [
     "Automated pull request review",
     "Codebase indexing with vector search",
     "Severity-rated findings (Critical, Major, Minor, Suggestion, Tip)",
-    "GitHub and Bitbucket integration",
+    "GitHub, GitLab, and Bitbucket integration",
     "Slack and Linear integration",
     "Self-hostable with Docker",
     "Bring Your Own API keys",
@@ -163,7 +164,7 @@ export default async function LandingPage() {
                 "Deep context awareness across your entire codebase",
                 "Indexes every file, function, and relationship in your repo",
                 "Posts inline comments with severity levels directly on your PRs",
-                "Works with GitHub and Bitbucket out of the box",
+                "Works with GitHub, GitLab, and Bitbucket out of the box",
                 "Source-available and self-hostable, your code never leaves your servers",
                 "Improves over time with team feedback on every finding",
                 "Powered by Claude, understands any language, any framework",
@@ -482,7 +483,7 @@ export default async function LandingPage() {
             <br />
             code review workflow?
           </h2>
-          <p className="mt-4 text-[#666] sm:text-lg">Source-available and self-hostable. Set up in under 2 minutes.</p>
+          <p className="mt-4 text-[#666] sm:text-lg">Start reviewing in two minutes on our managed cloud — free credits, no card.</p>
           <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
             <TrackedLink
               href="/login"
@@ -494,7 +495,7 @@ export default async function LandingPage() {
               <IconArrowRight className="size-4" />
             </TrackedLink>
           </div>
-          <p className="mt-6 text-xs text-[#444]">No credit card required. Self-host or use our cloud.</p>
+          <p className="mt-6 text-xs text-[#444]">No credit card required. Or self-host for free.</p>
         </div>
       </section>
 

--- a/apps/web/app/(landing)/vs-coderabbit/page.tsx
+++ b/apps/web/app/(landing)/vs-coderabbit/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     "Octopus vs CodeRabbit",
     "CodeRabbit alternative",
     "AI code review comparison",
-    "open source code review",
+    "source-available code review",
     "self-hosted code review",
   ],
   openGraph: {

--- a/apps/web/app/(landing)/vs-greptile/page.tsx
+++ b/apps/web/app/(landing)/vs-greptile/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     "Octopus vs Greptile",
     "Greptile alternative",
     "AI code review comparison",
-    "open source code review",
+    "source-available code review",
     "RAG code review",
   ],
   openGraph: {
@@ -41,7 +41,7 @@ const faqs = [
     a: "The foundation is similar: both use RAG (Retrieval Augmented Generation) with pre-indexed vector embeddings to give the LLM relevant codebase context during review and chat. Where they differ is positioning, deployment, and licensing rather than core architecture.",
   },
   {
-    q: "Is Octopus open source?",
+    q: "Is Octopus open source or source-available?",
     a: "Octopus is source-available under a Modified MIT License and free to self-host on your own infrastructure. Greptile is a proprietary SaaS. If audit, customization, or running fully on-prem matters for your team, Octopus is the only option of the two.",
   },
   {

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -7,6 +7,17 @@ const disallow = [
   "/settings",
   "/admin",
   "/onboarding",
+  "/monitor",
+  "/chat",
+  "/package-analyzer",
+  "/usage",
+  "/repositories",
+  "/knowledge",
+  "/complete-profile",
+  "/review-logs",
+  "/timeline",
+  "/issues",
+  "/coupon",
 ];
 
 export default function robots(): MetadataRoute.Robots {

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -58,12 +58,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.6,
     },
     {
-      url: `${SITE_URL}/docs`,
-      lastModified: now,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
       url: `${SITE_URL}/docs/about`,
       lastModified: now,
       changeFrequency: "monthly",
@@ -152,6 +146,60 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: now,
       changeFrequency: "yearly",
       priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/docs/github-app`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/docs/oauth-setup`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/docs/security`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/docs/security-overview`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/docs/data-retention`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/docs/dpa`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/docs/sub-processors`,
+      lastModified: now,
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/docs/changelog`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}/status`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.5,
     },
   ];
 

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -284,11 +284,12 @@ Anthropic API key for Claude (reviews and chat).`,
       {
         heading: "Quick Start with Docker",
         text: `1. Clone the repository: git clone https://github.com/octopusreview/octopus.git
-2. Create a .env file with your configuration (an auto-generator is provided on the docs page).
-3. Run with Docker Compose: docker compose up -d --build
-4. Run database migrations: docker compose exec octopus bun run db:migrate
-5. Access Octopus at http://localhost:3000
-Docker Compose includes PostgreSQL and Qdrant containers.`,
+2. Create a .env file with your configuration (an auto-generator is provided on the docs page). Pin OCTOPUS_VERSION to the release tag you want to run.
+3. Pull the prebuilt self-host image: docker compose -f docker-compose.selfhost.yml pull
+4. Start the stack: docker compose -f docker-compose.selfhost.yml up -d
+5. Run database migrations from a checkout matching OCTOPUS_VERSION: docker compose -f docker-compose.selfhost.yml exec octopus bun run db:migrate
+6. Access Octopus at http://localhost:43300 (set OCTOPUS_PORT to override the default 43300).
+The self-host compose file includes PostgreSQL and Qdrant containers.`,
       },
       {
         heading: "Environment Variables",
@@ -486,7 +487,7 @@ Octopus is not a toy — it's a serious tool built by an independent developer w
         text: `Transparency: The full source is available. You can read, audit, and understand exactly how your code is processed.
 No vendor lock-in: Self-host on your own infrastructure. Bring your own API keys.
 Community driven: Contributions are welcome. Open issues, submit PRs, and help shape the future.
-Free forever: The self-hosted, source-available core will always be free.`,
+Free to self-host: run the source-available core on your own infrastructure at no cost. The managed cloud is a paid, credit-based service with free credits to start.`,
       },
       {
         heading: "Tech Stack",

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -2,20 +2,21 @@
 
 > AI-powered code review tool
 
-Octopus is a source-available, AI-powered code review platform. It connects to GitHub and Bitbucket repositories, indexes codebases using vector embeddings, and automatically reviews pull requests — posting findings as inline comments with severity levels.
+Octopus is a source-available, AI-powered code review platform. It connects to GitHub, GitLab, and Bitbucket repositories, indexes codebases using vector embeddings, and automatically reviews pull requests — posting findings as inline comments with severity levels.
 
 ## Core Features
 
 - **Automated PR Review**: AI analyzes pull request diffs with full codebase context
 - **Severity Ratings**: Findings rated as 🔴 Critical, 🟠 Major, 🟡 Minor, 🔵 Suggestion, 💡 Tip
 - **Codebase Indexing**: Vector search over your entire codebase for context-aware reviews
-- **Multi-Provider AI**: Supports Claude (Anthropic) and OpenAI models
+- **Multi-Provider AI**: Supports Anthropic Claude, OpenAI, and Google Gemini models
 - **Organization Knowledge**: Custom rules and guidelines per organization
 - **Re-review**: Address feedback and re-trigger reviews on updated code
 
 ## Integrations
 
 - GitHub (App installation)
+- GitLab (OAuth)
 - Bitbucket (OAuth webhooks)
 - Linear (issue creation from findings)
 - Slack (ask questions about your codebase)


### PR DESCRIPTION
## What

A deep fan-out audit of the marketing/docs site (6 dimensions) surfaced 36 inconsistencies from the recent cloud-first / source-available / `octp` changes. This fixes all of them in one pass, plus preps the first native `octp` release.

### Routing / audience (the bug that kicked this off)
- The Cloud "**Install the GitHub App →**" CTA on getting-started pointed at `/docs/github-app` — which is the **self-host "create your own app"** guide (`github.com/settings/apps/new`). Now → `/login` (hosted install). Fixed the duplicate second link (→ `/docs/pricing`), and the github-action page's hosted-App links.
- Moved `/docs/github-app` (retitled "GitHub App (self-host)") and `/docs/oauth-setup` from the **Cloud Setup** sidebar group into **Self-Host** (both are self-host guides). Sidebar + mobile menu kept in sync.

### Provider consistency
- **GitLab** (a Live provider) was missing across many pages that said only "GitHub and Bitbucket" — fixed on the homepage (copy + JSON-LD + FAQ), getting-started, faq, cli, github-action, about roadmap, and `llms.txt`.

### Severity labels
- Two divergent schemes (`Critical/Warning/Caution/Info/Suggestion` and `Critical/High/Medium/Low/Info`) unified to the canonical **Critical / Major / Minor / Suggestion / Tip**.

### Positioning / labeling
- Bottom CTA leads with managed cloud; "Free Forever" card + KB "free forever" seed reframed to scope free→self-host (cloud is paid, free credits to start); `dpa` "open-source server" → "self-hosted"; `vs-*` keyword + a FAQ question de-"open-source"d.

### KB seed
- The Ask-Octopus self-hosting answer updated to the real Docker-first flow (`docker-compose.selfhost.yml`, `OCTOPUS_PORT` 43300); model list → Claude / OpenAI / Gemini.

### SEO
- Sitemap adds 9 missing indexable routes + drops the `/docs` redirect entry; robots disallows the remaining authenticated app routes; `/login` gets its own title + canonical; homepage JSON-LD offers → `/docs/pricing`.

### CLI release prep (2nd commit)
- Bumped `octp` `VERSION` + `package.json` to **0.2.0**. `octp-v0.1.0` was rolled back so no `octp-v*` release exists — the native `install.sh` the site now mandates had nothing to fetch. After merge I'll cut `octp-v0.2.0` (→ `octp-release.yml` builds the native binaries) so the install actually works. **This also unblocks retiring `octopusreview/octopus-cli`.**

## Test plan
- `typecheck` clean · `lint` 0 errors (1 pre-existing warning) · `build` ✓ (145/145)
- grep confirms zero remaining false "open source/MIT" claims, `/docs/github-app` no longer used as a cloud CTA target, and sidebar reorg applied to both nav files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)