### PR TITLE
feat(blog): Phase 2 — tags & categories (sidebar + tag cloud)

### DIFF
--- a/apps/web/app/(landing)/blog/[slug]/page.tsx
+++ b/apps/web/app/(landing)/blog/[slug]/page.tsx
@@ -39,6 +39,7 @@ export async function generateMetadata({
   return {
     title: `${post.title} — Octopus Blog`,
     description: post.excerpt ?? undefined,
+    keywords: post.tags.length > 0 ? post.tags : undefined,
     alternates: {
       canonical: canonicalUrl,
     },
@@ -72,7 +73,7 @@ export default async function BlogPostPage({
 
   const canonicalUrl = canonicalUrlFor(slug);
   const headings = extractHeadings(post.content);
-  const minutes = readingTimeMinutes(post.content);
+  const minutes = post.readingTime ?? readingTimeMinutes(post.content);
   const wordCount = proseWordCount(post.content);
 
   const blogPostingJsonLd = {
@@ -84,6 +85,8 @@ export default async function BlogPostPage({
     datePublished: post.publishedAt?.toISOString(),
     dateModified: (post.updatedAt ?? post.publishedAt)?.toISOString(),
     wordCount,
+    ...(post.tags.length > 0 ? { keywords: post.tags.join(", ") } : {}),
+    ...(post.category ? { articleSection: post.category } : {}),
     author: {
       "@type": "Person",
       name: post.authorName,
@@ -158,6 +161,15 @@ export default async function BlogPostPage({
               />
             )}
 
+            {post.category && (
+              <Link
+                href={`/blog?category=${encodeURIComponent(post.category)}`}
+                className="mb-3 inline-block text-xs font-semibold uppercase tracking-[0.2em] text-[#10D8BE] transition-colors hover:text-[#10D8BE]/80"
+              >
+                {post.category}
+              </Link>
+            )}
+
             <h1 className="mb-4 text-4xl font-bold tracking-tight">{post.title}</h1>
 
             <div className="mb-10 flex flex-wrap items-center gap-3 text-sm text-[#555]">
@@ -190,6 +202,20 @@ export default async function BlogPostPage({
             <div className="text-[#a0a0a0] [&_h1]:text-white [&_h2]:text-white [&_h3]:text-white [&_strong]:text-white [&_a]:text-[#10D8BE] [&_code]:bg-white/[0.06] [&_pre]:bg-white/[0.04] [&_pre]:border [&_pre]:border-white/[0.06] [&_blockquote]:border-[#333] [&_th]:border-[#333] [&_td]:border-[#333] [&_hr]:border-[#333] [&_table]:border-[#333]">
               <BlogContent content={post.content} />
             </div>
+
+            {post.tags.length > 0 && (
+              <div className="mt-10 flex flex-wrap gap-2 border-t border-white/[0.06] pt-6">
+                {post.tags.map((t) => (
+                  <Link
+                    key={t}
+                    href={`/blog?tag=${encodeURIComponent(t)}`}
+                    className="rounded-full border border-white/[0.08] px-3 py-1 text-xs text-[#888] transition-colors hover:border-[#10D8BE]/40 hover:text-[#10D8BE]"
+                  >
+                    #{t}
+                  </Link>
+                ))}
+              </div>
+            )}
           </article>
 
           <aside className="hidden lg:block">

--- a/apps/web/app/(landing)/blog/page.tsx
+++ b/apps/web/app/(landing)/blog/page.tsx
@@ -6,7 +6,7 @@ import { prisma } from "@octopus/db";
 import { LandingFooter } from "@/components/landing-footer";
 import { LandingMobileNav } from "@/components/landing-mobile-nav";
 import { LandingDesktopNav } from "@/components/landing-desktop-nav";
-import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import { IconChevronLeft, IconChevronRight, IconX } from "@tabler/icons-react";
 import { BlogSearch } from "@/components/blog-search";
 import { ScrollToTop } from "@/components/scroll-to-top";
 
@@ -32,20 +32,39 @@ export const metadata: Metadata = {
 export default async function BlogPage({
   searchParams,
 }: {
-  searchParams: Promise<{ page?: string; q?: string }>;
+  searchParams: Promise<{
+    page?: string;
+    q?: string;
+    category?: string;
+    tag?: string;
+  }>;
 }) {
-  const { page: pageParam, q: searchQuery } = await searchParams;
+  const {
+    page: pageParam,
+    q: searchQuery,
+    category: categoryParam,
+    tag: tagParam,
+  } = await searchParams;
   const page = Math.max(1, parseInt(pageParam ?? "1", 10) || 1);
   const query = searchQuery?.trim() || "";
+  const category = categoryParam?.trim() || "";
+  const tag = tagParam?.trim() || "";
 
   const session = await auth.api
     .getSession({ headers: await headers() })
     .catch(() => null);
   const isLoggedIn = !!session;
 
-  const where = {
+  // Base scope: every published, non-deleted post. The sidebar aggregations
+  // use this so they always reflect the full corpus, not the active filter.
+  const baseWhere = {
     status: "published" as const,
     deletedAt: null,
+  };
+
+  // Post-list scope: base scope narrowed by the active search / category / tag.
+  const where = {
+    ...baseWhere,
     ...(query
       ? {
           OR: [
@@ -55,9 +74,11 @@ export default async function BlogPage({
           ],
         }
       : {}),
+    ...(category ? { category } : {}),
+    ...(tag ? { tags: { has: tag } } : {}),
   };
 
-  const [posts, totalCount] = await Promise.all([
+  const [posts, totalCount, categoryGroups, tagRows] = await Promise.all([
     prisma.blogPost.findMany({
       where,
       orderBy: { publishedAt: "desc" },
@@ -70,19 +91,71 @@ export default async function BlogPage({
         coverImageUrl: true,
         publishedAt: true,
         authorName: true,
+        readingTime: true,
       },
     }),
     prisma.blogPost.count({ where }),
+    prisma.blogPost.groupBy({
+      by: ["category"],
+      where: baseWhere,
+      _count: { _all: true },
+    }),
+    prisma.blogPost.findMany({ where: baseWhere, select: { tags: true } }),
   ]);
 
   const totalPages = Math.ceil(totalCount / POSTS_PER_PAGE);
+
+  // Distinct categories + counts across all published posts (null ignored).
+  const categories = categoryGroups
+    .map((g) => ({ name: g.category, count: g._count._all }))
+    .filter((c): c is { name: string; count: number } => c.name != null)
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+
+  // Tag frequency across all published posts, for the weighted tag cloud.
+  const tagFreq = new Map<string, number>();
+  for (const row of tagRows) {
+    for (const t of row.tags) tagFreq.set(t, (tagFreq.get(t) ?? 0) + 1);
+  }
+  const tagCloud = [...tagFreq.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+  const maxTagCount = tagCloud.length ? tagCloud[0].count : 0;
+  const minTagCount = tagCloud.length ? tagCloud[tagCloud.length - 1].count : 0;
+
+  const hasSidebar = categories.length > 0 || tagCloud.length > 0;
+
+  // Build a /blog URL from an explicit final param set (page 1 omitted so the
+  // canonical first page stays clean). Used by filter links + pagination so
+  // the active params (q, category, tag) always carry over.
+  const makeHref = (p: {
+    q?: string;
+    category?: string;
+    tag?: string;
+    page?: number;
+  }) => {
+    const sp = new URLSearchParams();
+    if (p.q) sp.set("q", p.q);
+    if (p.category) sp.set("category", p.category);
+    if (p.tag) sp.set("tag", p.tag);
+    if (p.page && p.page > 1) sp.set("page", String(p.page));
+    const s = sp.toString();
+    return s ? `/blog?${s}` : "/blog";
+  };
+
+  // Tag-cloud visual weighting: 0 (least frequent) → 3 (most frequent).
+  const tagWeight = (count: number) =>
+    maxTagCount === minTagCount
+      ? 2
+      : Math.round(((count - minTagCount) / (maxTagCount - minTagCount)) * 3);
+  const TAG_SIZE = ["text-xs", "text-xs", "text-sm", "text-sm"];
+  const TAG_TONE = ["text-[#666]", "text-[#888]", "text-[#aaa]", "text-white"];
 
   return (
     <div className="min-h-screen bg-[#0c0c0c] text-white">
       <LandingDesktopNav isLoggedIn={isLoggedIn} />
       <LandingMobileNav isLoggedIn={isLoggedIn} />
 
-      <main className="mx-auto max-w-5xl px-6 pt-32 pb-20">
+      <main className="mx-auto max-w-6xl px-6 pt-32 pb-20">
         <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="text-4xl font-bold tracking-tight">Blog</h1>
@@ -93,136 +166,236 @@ export default async function BlogPage({
           <BlogSearch />
         </div>
 
-        {query && (
-          <p className="mb-6 text-sm text-[#555]">
-            {totalCount} result{totalCount !== 1 ? "s" : ""} for &ldquo;{query}
-            &rdquo;
-          </p>
-        )}
-
-        {posts.length === 0 ? (
-          <p className="text-[#555]">
-            {query ? "No posts found." : "No posts yet. Check back soon."}
-          </p>
-        ) : (
-          <div>
-            {/* Featured post (first one) */}
-            {(() => {
-              const featured = posts[0];
-              const rest = posts.slice(1);
-              return (
-                <>
-                  <Link
-                    href={`/blog/${featured.slug}`}
-                    className="group block rounded-xl border border-white/[0.06] p-6 transition-colors hover:border-white/[0.12] hover:bg-white/[0.02]"
-                  >
-                    {featured.coverImageUrl && (
-                      <img
-                        src={featured.coverImageUrl}
-                        alt={`Cover image for "${featured.title}"`}
-                        width={1200}
-                        height={630}
-                        loading="eager"
-                        fetchPriority="high"
-                        decoding="async"
-                        className="mb-4 aspect-[1200/630] w-full rounded-lg object-cover"
-                      />
-                    )}
-                    <h2 className="mb-2 text-2xl font-semibold text-white group-hover:text-[#10D8BE] transition-colors">
-                      {featured.title}
-                    </h2>
-                    {featured.excerpt && (
-                      <p className="mb-3 text-[#888] line-clamp-2">
-                        {featured.excerpt}
-                      </p>
-                    )}
-                    <div className="flex items-center gap-3 text-sm text-[#555]">
-                      <span>{featured.authorName}</span>
-                      <span>·</span>
-                      <time>
-                        {featured.publishedAt
-                          ? new Date(featured.publishedAt).toLocaleDateString(
-                              "en-US",
-                              {
-                                year: "numeric",
-                                month: "long",
-                                day: "numeric",
-                              },
-                            )
-                          : ""}
-                      </time>
-                    </div>
-                  </Link>
-
-                  {/* Compact list for the rest */}
-                  {rest.length > 0 && (
-                    <div className="mt-8 divide-y divide-white/[0.06] rounded-xl border border-white/[0.06]">
-                      {rest.map((post) => (
+        <div
+          className={
+            hasSidebar
+              ? "lg:grid lg:grid-cols-[15rem_minmax(0,1fr)] lg:gap-12"
+              : ""
+          }
+        >
+          {hasSidebar && (
+            <aside className="mb-10 lg:mb-0 lg:sticky lg:top-28 lg:self-start">
+              {categories.length > 0 && (
+                <div>
+                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-[#888]">
+                    Categories
+                  </h2>
+                  <nav className="flex flex-col gap-1.5 text-sm">
+                    <Link
+                      href={makeHref({ q: query, tag })}
+                      className={`transition-colors ${
+                        category
+                          ? "text-[#888] hover:text-white"
+                          : "text-[#10D8BE]"
+                      }`}
+                    >
+                      All posts
+                    </Link>
+                    {categories.map((c) => {
+                      const active = c.name === category;
+                      return (
                         <Link
-                          key={post.slug}
-                          href={`/blog/${post.slug}`}
-                          className="group flex items-center gap-5 px-6 py-5 transition-colors hover:bg-white/[0.02]"
+                          key={c.name}
+                          href={makeHref({ q: query, category: c.name, tag })}
+                          className={`flex items-center justify-between gap-3 transition-colors ${
+                            active
+                              ? "text-[#10D8BE]"
+                              : "text-[#888] hover:text-white"
+                          }`}
                         >
-                          {post.coverImageUrl && (
-                            <img
-                              src={post.coverImageUrl}
-                              alt={`Cover image for "${post.title}"`}
-                              width={64}
-                              height={64}
-                              loading="lazy"
-                              decoding="async"
-                              className="hidden size-16 shrink-0 rounded-lg object-cover sm:block"
-                            />
-                          )}
-                          <div className="min-w-0 flex-1">
-                            <h2 className="font-semibold text-white transition-colors group-hover:text-[#10D8BE] truncate">
-                              {post.title}
-                            </h2>
-                            {post.excerpt && (
-                              <p className="mt-1 text-sm text-[#888] line-clamp-1">
-                                {post.excerpt}
-                              </p>
-                            )}
-                          </div>
-                          <div className="hidden shrink-0 text-right text-sm text-[#555] sm:block">
-                            <div>{post.authorName}</div>
-                            <time>
-                              {post.publishedAt
-                                ? new Date(post.publishedAt).toLocaleDateString(
-                                    "en-US",
-                                    {
-                                      month: "short",
-                                      day: "numeric",
-                                    },
-                                  )
-                                : ""}
-                            </time>
-                          </div>
+                          <span className="truncate">{c.name}</span>
+                          <span className="shrink-0 text-[#555]">{c.count}</span>
                         </Link>
-                      ))}
-                    </div>
-                  )}
-                </>
-              );
-            })()}
-          </div>
-        )}
+                      );
+                    })}
+                  </nav>
+                </div>
+              )}
 
-        {/* Pagination */}
-        {totalPages > 1 &&
-          (() => {
-            const qs = (p: number) => {
-              const params = new URLSearchParams();
-              if (p > 1) params.set("page", String(p));
-              if (query) params.set("q", query);
-              const str = params.toString();
-              return str ? `/blog?${str}` : "/blog";
-            };
-            return (
+              {tagCloud.length > 0 && (
+                <div className={categories.length > 0 ? "mt-8" : ""}>
+                  <h2 className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-[#888]">
+                    Topics
+                  </h2>
+                  <div className="flex flex-wrap gap-2">
+                    {tagCloud.map((t) => {
+                      const active = t.name === tag;
+                      const w = tagWeight(t.count);
+                      return (
+                        <Link
+                          key={t.name}
+                          href={makeHref({ q: query, category, tag: t.name })}
+                          className={`rounded-full border px-2.5 py-1 leading-none transition-colors ${
+                            TAG_SIZE[w]
+                          } ${
+                            active
+                              ? "border-[#10D8BE]/40 bg-[#10D8BE]/10 text-[#10D8BE]"
+                              : `border-white/[0.08] ${TAG_TONE[w]} hover:border-white/[0.15] hover:text-white`
+                          }`}
+                        >
+                          {t.name}
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </aside>
+          )}
+
+          <div className="min-w-0">
+            {(category || tag) && (
+              <div className="mb-6 flex flex-wrap items-center gap-2 text-sm">
+                <span className="text-[#555]">Filtered by</span>
+                {category && (
+                  <span className="rounded-full border border-[#10D8BE]/30 bg-[#10D8BE]/10 px-2.5 py-1 text-[#10D8BE]">
+                    {category}
+                  </span>
+                )}
+                {tag && (
+                  <span className="rounded-full border border-[#10D8BE]/30 bg-[#10D8BE]/10 px-2.5 py-1 text-[#10D8BE]">
+                    #{tag}
+                  </span>
+                )}
+                <Link
+                  href={makeHref({ q: query })}
+                  className="inline-flex items-center gap-1 text-[#555] transition-colors hover:text-white"
+                >
+                  <IconX className="size-3.5" />
+                  clear
+                </Link>
+              </div>
+            )}
+
+            {query && (
+              <p className="mb-6 text-sm text-[#555]">
+                {totalCount} result{totalCount !== 1 ? "s" : ""} for &ldquo;
+                {query}&rdquo;
+              </p>
+            )}
+
+            {posts.length === 0 ? (
+              <p className="text-[#555]">
+                {query || category || tag
+                  ? "No posts found."
+                  : "No posts yet. Check back soon."}
+              </p>
+            ) : (
+              <div>
+                {/* Featured post (first one) */}
+                {(() => {
+                  const featured = posts[0];
+                  const rest = posts.slice(1);
+                  return (
+                    <>
+                      <Link
+                        href={`/blog/${featured.slug}`}
+                        className="group block rounded-xl border border-white/[0.06] p-6 transition-colors hover:border-white/[0.12] hover:bg-white/[0.02]"
+                      >
+                        {featured.coverImageUrl && (
+                          <img
+                            src={featured.coverImageUrl}
+                            alt={`Cover image for "${featured.title}"`}
+                            width={1200}
+                            height={630}
+                            loading="eager"
+                            fetchPriority="high"
+                            decoding="async"
+                            className="mb-4 aspect-[1200/630] w-full rounded-lg object-cover"
+                          />
+                        )}
+                        <h2 className="mb-2 text-2xl font-semibold text-white group-hover:text-[#10D8BE] transition-colors">
+                          {featured.title}
+                        </h2>
+                        {featured.excerpt && (
+                          <p className="mb-3 text-[#888] line-clamp-2">
+                            {featured.excerpt}
+                          </p>
+                        )}
+                        <div className="flex items-center gap-3 text-sm text-[#555]">
+                          <span>{featured.authorName}</span>
+                          <span>·</span>
+                          <time>
+                            {featured.publishedAt
+                              ? new Date(
+                                  featured.publishedAt,
+                                ).toLocaleDateString("en-US", {
+                                  year: "numeric",
+                                  month: "long",
+                                  day: "numeric",
+                                })
+                              : ""}
+                          </time>
+                          {featured.readingTime != null && (
+                            <>
+                              <span>·</span>
+                              <span>{featured.readingTime} min read</span>
+                            </>
+                          )}
+                        </div>
+                      </Link>
+
+                      {/* Compact list for the rest */}
+                      {rest.length > 0 && (
+                        <div className="mt-8 divide-y divide-white/[0.06] rounded-xl border border-white/[0.06]">
+                          {rest.map((post) => (
+                            <Link
+                              key={post.slug}
+                              href={`/blog/${post.slug}`}
+                              className="group flex items-center gap-5 px-6 py-5 transition-colors hover:bg-white/[0.02]"
+                            >
+                              {post.coverImageUrl && (
+                                <img
+                                  src={post.coverImageUrl}
+                                  alt={`Cover image for "${post.title}"`}
+                                  width={64}
+                                  height={64}
+                                  loading="lazy"
+                                  decoding="async"
+                                  className="hidden size-16 shrink-0 rounded-lg object-cover sm:block"
+                                />
+                              )}
+                              <div className="min-w-0 flex-1">
+                                <h2 className="font-semibold text-white transition-colors group-hover:text-[#10D8BE] truncate">
+                                  {post.title}
+                                </h2>
+                                {post.excerpt && (
+                                  <p className="mt-1 text-sm text-[#888] line-clamp-1">
+                                    {post.excerpt}
+                                  </p>
+                                )}
+                              </div>
+                              <div className="hidden shrink-0 text-right text-sm text-[#555] sm:block">
+                                <div>{post.authorName}</div>
+                                <time>
+                                  {post.publishedAt
+                                    ? new Date(
+                                        post.publishedAt,
+                                      ).toLocaleDateString("en-US", {
+                                        month: "short",
+                                        day: "numeric",
+                                      })
+                                    : ""}
+                                  {post.readingTime != null &&
+                                    ` · ${post.readingTime} min read`}
+                                </time>
+                              </div>
+                            </Link>
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  );
+                })()}
+              </div>
+            )}
+
+            {/* Pagination */}
+            {totalPages > 1 && (
               <div className="mt-12 flex items-center justify-center gap-2">
                 {page > 1 ? (
                   <Link
-                    href={qs(page - 1)}
+                    href={makeHref({ q: query, category, tag, page: page - 1 })}
                     className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-[#888] transition-colors hover:border-white/[0.15] hover:text-white"
                   >
                     <IconChevronLeft className="size-4" />
@@ -241,7 +414,7 @@ export default async function BlogPage({
 
                 {page < totalPages ? (
                   <Link
-                    href={qs(page + 1)}
+                    href={makeHref({ q: query, category, tag, page: page + 1 })}
                     className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.08] px-4 py-2 text-sm text-[#888] transition-colors hover:border-white/[0.15] hover:text-white"
                   >
                     Next
@@ -254,8 +427,9 @@ export default async function BlogPage({
                   </span>
                 )}
               </div>
-            );
-          })()}
+            )}
+          </div>
+        </div>
       </main>
 
       <LandingFooter />

--- a/apps/web/app/(landing)/blog/page.tsx
+++ b/apps/web/app/(landing)/blog/page.tsx
@@ -9,8 +9,44 @@ import { LandingDesktopNav } from "@/components/landing-desktop-nav";
 import { IconChevronLeft, IconChevronRight, IconX } from "@tabler/icons-react";
 import { BlogSearch } from "@/components/blog-search";
 import { ScrollToTop } from "@/components/scroll-to-top";
+import { unstable_cache } from "next/cache";
 
 const POSTS_PER_PAGE = 10;
+
+// Sidebar taxonomy (categories + tag cloud) is identical across every /blog
+// request and changes only when posts change, so cache it (revalidated hourly)
+// instead of scanning every published post on each request. A short window is
+// fine for a blog sidebar; new posts show up within the hour.
+const getBlogTaxonomy = unstable_cache(
+  async () => {
+    const where = { status: "published" as const, deletedAt: null };
+    const [categoryGroups, tagRows] = await Promise.all([
+      prisma.blogPost.groupBy({
+        by: ["category"],
+        where,
+        _count: { _all: true },
+      }),
+      prisma.blogPost.findMany({ where, select: { tags: true } }),
+    ]);
+
+    const categories = categoryGroups
+      .map((g) => ({ name: g.category, count: g._count._all }))
+      .filter((c): c is { name: string; count: number } => c.name != null)
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+
+    const tagFreq = new Map<string, number>();
+    for (const row of tagRows) {
+      for (const t of row.tags) tagFreq.set(t, (tagFreq.get(t) ?? 0) + 1);
+    }
+    const tagCloud = [...tagFreq.entries()]
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+
+    return { categories, tagCloud };
+  },
+  ["blog-taxonomy"],
+  { revalidate: 3600 },
+);
 
 export const metadata: Metadata = {
   title: "Blog — Octopus",
@@ -78,7 +114,7 @@ export default async function BlogPage({
     ...(tag ? { tags: { has: tag } } : {}),
   };
 
-  const [posts, totalCount, categoryGroups, tagRows] = await Promise.all([
+  const [posts, totalCount] = await Promise.all([
     prisma.blogPost.findMany({
       where,
       orderBy: { publishedAt: "desc" },
@@ -95,30 +131,11 @@ export default async function BlogPage({
       },
     }),
     prisma.blogPost.count({ where }),
-    prisma.blogPost.groupBy({
-      by: ["category"],
-      where: baseWhere,
-      _count: { _all: true },
-    }),
-    prisma.blogPost.findMany({ where: baseWhere, select: { tags: true } }),
   ]);
 
   const totalPages = Math.ceil(totalCount / POSTS_PER_PAGE);
 
-  // Distinct categories + counts across all published posts (null ignored).
-  const categories = categoryGroups
-    .map((g) => ({ name: g.category, count: g._count._all }))
-    .filter((c): c is { name: string; count: number } => c.name != null)
-    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
-
-  // Tag frequency across all published posts, for the weighted tag cloud.
-  const tagFreq = new Map<string, number>();
-  for (const row of tagRows) {
-    for (const t of row.tags) tagFreq.set(t, (tagFreq.get(t) ?? 0) + 1);
-  }
-  const tagCloud = [...tagFreq.entries()]
-    .map(([name, count]) => ({ name, count }))
-    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+  const { categories, tagCloud } = await getBlogTaxonomy();
   const maxTagCount = tagCloud.length ? tagCloud[0].count : 0;
   const minTagCount = tagCloud.length ? tagCloud[tagCloud.length - 1].count : 0;
 

--- a/apps/web/app/api/blog/route.ts
+++ b/apps/web/app/api/blog/route.ts
@@ -34,6 +34,18 @@ function slugify(text: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+// Canonical blog categories. Author- and LLM-supplied values are matched
+// case-insensitively against this allowlist; anything else becomes null so the
+// sidebar only ever shows known categories.
+const BLOG_CATEGORIES = ["Engineering", "Product", "Company", "Security", "Guides"] as const;
+function normalizeCategory(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const match = BLOG_CATEGORIES.find(
+    (c) => c.toLowerCase() === value.trim().toLowerCase(),
+  );
+  return match ?? null;
+}
+
 export async function GET(request: NextRequest) {
   const token = await authenticateBlogToken(request);
   if (!token) {
@@ -146,7 +158,7 @@ export async function POST(request: NextRequest) {
     let finalTags = Array.isArray(tags)
       ? [...new Set(tags.map((t) => String(t).trim().toLowerCase()).filter(Boolean))].slice(0, 6)
       : [];
-    let finalCategory = category?.trim() ? category.trim() : null;
+    let finalCategory = normalizeCategory(category);
 
     // Generate SEO metadata (excerpt / category / tags) if requested and any
     // piece is missing. One Anthropic call fills ONLY the gaps; generation
@@ -176,15 +188,15 @@ export async function POST(request: NextRequest) {
           if (!finalExcerpt && typeof parsed.excerpt === "string" && parsed.excerpt.trim()) {
             finalExcerpt = parsed.excerpt.trim();
           }
-          if (finalCategory === null && typeof parsed.category === "string" && parsed.category.trim()) {
-            finalCategory = parsed.category.trim();
+          if (finalCategory === null && typeof parsed.category === "string") {
+            finalCategory = normalizeCategory(parsed.category);
           }
           if (finalTags.length === 0 && Array.isArray(parsed.tags)) {
             finalTags = [...new Set(parsed.tags.map((t) => String(t).trim().toLowerCase()).filter(Boolean))].slice(0, 6);
           }
         } catch {
-          // Not valid JSON — fall back to the original excerpt-only behavior.
-          if (!finalExcerpt && text) finalExcerpt = text;
+          // Model didn't return valid JSON — skip generated metadata rather
+          // than storing raw model output as the excerpt.
         }
       } catch {
         // SEO generation failed, continue without generated metadata

--- a/apps/web/app/api/blog/route.ts
+++ b/apps/web/app/api/blog/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@octopus/db";
 import { createHash } from "crypto";
 import { revalidatePath } from "next/cache";
 import Anthropic from "@anthropic-ai/sdk";
+import { readingTimeMinutes } from "@/lib/blog-reading";
 
 async function authenticateBlogToken(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
@@ -108,6 +109,8 @@ export async function POST(request: NextRequest) {
       authorName = "Octopus Team",
       status = "draft",
       generateSeo = false,
+      tags,
+      category,
     } = body as {
       title?: string;
       slug?: string;
@@ -117,6 +120,8 @@ export async function POST(request: NextRequest) {
       authorName?: string;
       status?: string;
       generateSeo?: boolean;
+      tags?: string[];
+      category?: string;
     };
 
     if (!title || !content) {
@@ -137,29 +142,57 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Generate SEO excerpt if requested and not provided
+    // Sanitize taxonomy inputs (author-provided values win over generation)
+    let finalTags = Array.isArray(tags)
+      ? [...new Set(tags.map((t) => String(t).trim().toLowerCase()).filter(Boolean))].slice(0, 6)
+      : [];
+    let finalCategory = category?.trim() ? category.trim() : null;
+
+    // Generate SEO metadata (excerpt / category / tags) if requested and any
+    // piece is missing. One Anthropic call fills ONLY the gaps; generation
+    // failures must never block post creation.
     let finalExcerpt = excerpt;
-    if (generateSeo && !excerpt) {
+    if (generateSeo && (!finalExcerpt || finalTags.length === 0 || finalCategory === null)) {
       try {
         const client = new Anthropic();
         const response = await client.messages.create({
           model: "claude-sonnet-4-6",
-          max_tokens: 200,
+          max_tokens: 300,
           messages: [
             {
               role: "user",
-              content: `Write a concise SEO-friendly excerpt (max 150 characters) for this blog post. Return ONLY the excerpt text, nothing else.\n\n${content.slice(0, 4000)}`,
+              content: `Generate SEO metadata for this blog post. Return ONLY minified JSON, no prose or code fences, of the exact shape: {"excerpt": string (<=150 chars), "category": one of ["Engineering","Product","Company","Security","Guides"], "tags": 3-6 short lowercase topic strings}.\n\n${content.slice(0, 4000)}`,
             },
           ],
         });
         const text = response.content[0].type === "text" ? response.content[0].text.trim() : "";
-        if (text) finalExcerpt = text;
+        const cleaned = text.replace(/```(?:json)?/gi, "").trim();
+        try {
+          const parsed = JSON.parse(cleaned) as {
+            excerpt?: string;
+            category?: string;
+            tags?: string[];
+          };
+          if (!finalExcerpt && typeof parsed.excerpt === "string" && parsed.excerpt.trim()) {
+            finalExcerpt = parsed.excerpt.trim();
+          }
+          if (finalCategory === null && typeof parsed.category === "string" && parsed.category.trim()) {
+            finalCategory = parsed.category.trim();
+          }
+          if (finalTags.length === 0 && Array.isArray(parsed.tags)) {
+            finalTags = [...new Set(parsed.tags.map((t) => String(t).trim().toLowerCase()).filter(Boolean))].slice(0, 6);
+          }
+        } catch {
+          // Not valid JSON — fall back to the original excerpt-only behavior.
+          if (!finalExcerpt && text) finalExcerpt = text;
+        }
       } catch {
-        // SEO generation failed, continue without excerpt
+        // SEO generation failed, continue without generated metadata
       }
     }
 
     const isPublished = status === "published";
+    const readingTime = readingTimeMinutes(content);
 
     const post = await prisma.blogPost.create({
       data: {
@@ -172,6 +205,9 @@ export async function POST(request: NextRequest) {
         publishedAt: isPublished ? new Date() : null,
         authorId: "api",
         authorName,
+        tags: finalTags,
+        category: finalCategory,
+        readingTime,
       },
     });
 
@@ -184,6 +220,8 @@ export async function POST(request: NextRequest) {
       slug: post.slug,
       status: post.status,
       excerpt: post.excerpt,
+      tags: post.tags,
+      category: post.category,
       url: `/blog/${post.slug}`,
     });
   } catch {

--- a/apps/web/scripts/backfill-blog-taxonomy.ts
+++ b/apps/web/scripts/backfill-blog-taxonomy.ts
@@ -21,6 +21,16 @@ import { readingTimeMinutes } from "@/lib/blog-reading";
 
 const APPLY = process.argv.includes("--apply");
 
+// Keep in sync with the allowlist in app/api/blog/route.ts.
+const BLOG_CATEGORIES = ["Engineering", "Product", "Company", "Security", "Guides"] as const;
+function normalizeCategory(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const match = BLOG_CATEGORIES.find(
+    (c) => c.toLowerCase() === value.trim().toLowerCase(),
+  );
+  return match ?? null;
+}
+
 interface GeneratedSeo {
   category: string | null;
   tags: string[];
@@ -46,8 +56,7 @@ async function generateSeo(content: string): Promise<GeneratedSeo> {
     const text = response.content[0].type === "text" ? response.content[0].text.trim() : "";
     const cleaned = text.replace(/```(?:json)?/gi, "").trim();
     const parsed = JSON.parse(cleaned) as { category?: string; tags?: string[] };
-    const category =
-      typeof parsed.category === "string" && parsed.category.trim() ? parsed.category.trim() : null;
+    const category = normalizeCategory(parsed.category);
     const tags = Array.isArray(parsed.tags)
       ? [...new Set(parsed.tags.map((t) => String(t).trim().toLowerCase()).filter(Boolean))].slice(0, 6)
       : [];

--- a/apps/web/scripts/backfill-blog-taxonomy.ts
+++ b/apps/web/scripts/backfill-blog-taxonomy.ts
@@ -1,0 +1,143 @@
+/**
+ * Backfill script: populate the new BlogPost taxonomy fields
+ * (`readingTime`, `category`, `tags`) on existing published posts.
+ *
+ * For each published, non-deleted post:
+ *   - readingTime: recomputed deterministically from content when null.
+ *   - category / tags: generated with ONE Anthropic call (same minified-JSON
+ *     shape as the authoring API) only when missing; existing values are kept.
+ *
+ * Fully-populated posts are skipped (idempotent). Generating category/tags
+ * requires ANTHROPIC_API_KEY; readingTime never does.
+ *
+ * Usage:
+ *   Dry run (default):  bun run --cwd apps/web scripts/backfill-blog-taxonomy.ts
+ *   Apply changes:      bun run --cwd apps/web scripts/backfill-blog-taxonomy.ts --apply
+ */
+
+import { prisma } from "@octopus/db";
+import Anthropic from "@anthropic-ai/sdk";
+import { readingTimeMinutes } from "@/lib/blog-reading";
+
+const APPLY = process.argv.includes("--apply");
+
+interface GeneratedSeo {
+  category: string | null;
+  tags: string[];
+}
+
+/**
+ * Ask Claude for SEO metadata as minified JSON and return the parsed
+ * category/tags. Returns null/[] on any failure so callers degrade gracefully.
+ */
+async function generateSeo(content: string): Promise<GeneratedSeo> {
+  try {
+    const client = new Anthropic();
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 300,
+      messages: [
+        {
+          role: "user",
+          content: `Generate SEO metadata for this blog post. Return ONLY minified JSON, no prose or code fences, of the exact shape: {"excerpt": string (<=150 chars), "category": one of ["Engineering","Product","Company","Security","Guides"], "tags": 3-6 short lowercase topic strings}.\n\n${content.slice(0, 4000)}`,
+        },
+      ],
+    });
+    const text = response.content[0].type === "text" ? response.content[0].text.trim() : "";
+    const cleaned = text.replace(/```(?:json)?/gi, "").trim();
+    const parsed = JSON.parse(cleaned) as { category?: string; tags?: string[] };
+    const category =
+      typeof parsed.category === "string" && parsed.category.trim() ? parsed.category.trim() : null;
+    const tags = Array.isArray(parsed.tags)
+      ? [...new Set(parsed.tags.map((t) => String(t).trim().toLowerCase()).filter(Boolean))].slice(0, 6)
+      : [];
+    return { category, tags };
+  } catch {
+    return { category: null, tags: [] };
+  }
+}
+
+async function main() {
+  console.log(`[backfill] Mode: ${APPLY ? "APPLY" : "DRY RUN"}`);
+
+  const posts = await prisma.blogPost.findMany({
+    where: { status: "published", deletedAt: null },
+    select: {
+      id: true,
+      slug: true,
+      content: true,
+      tags: true,
+      category: true,
+      readingTime: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  console.log(`[backfill] Loaded ${posts.length} published posts\n`);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const post of posts) {
+    const needsReadingTime = post.readingTime == null;
+    const needsSeo = post.tags.length === 0 || post.category === null;
+
+    if (!needsReadingTime && !needsSeo) {
+      skipped++;
+      continue;
+    }
+
+    const data: { readingTime?: number; tags?: string[]; category?: string } = {};
+
+    if (needsReadingTime) {
+      data.readingTime = readingTimeMinutes(post.content);
+    }
+
+    if (needsSeo) {
+      const seo = await generateSeo(post.content);
+      if (post.tags.length === 0 && seo.tags.length > 0) {
+        data.tags = seo.tags;
+      }
+      if (post.category === null && seo.category) {
+        data.category = seo.category;
+      }
+    }
+
+    if (Object.keys(data).length === 0) {
+      skipped++;
+      console.log(`[backfill] ${post.slug.padEnd(50)} nothing to write (generation returned nothing)`);
+      continue;
+    }
+
+    const summary = [
+      data.readingTime != null ? `readingTime=${data.readingTime}` : null,
+      data.category != null ? `category=${data.category}` : null,
+      data.tags != null ? `tags=[${data.tags.join(", ")}]` : null,
+    ]
+      .filter(Boolean)
+      .join(" ");
+
+    console.log(`[backfill] ${post.slug.padEnd(50)} ${APPLY ? "->" : "(dry-run)"} ${summary}`);
+
+    if (APPLY) {
+      await prisma.blogPost.update({ where: { id: post.id }, data });
+      updated++;
+    }
+  }
+
+  console.log(`\n[backfill] Done.`);
+  console.log(`  Posts scanned:     ${posts.length}`);
+  console.log(`  Skipped (no-op):   ${skipped}`);
+  if (APPLY) {
+    console.log(`  Updated:           ${updated}`);
+  } else {
+    console.log(`\n[backfill] Dry run complete. Re-run with --apply to persist changes.`);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error("[backfill] Fatal error:", err);
+  process.exit(1);
+});

--- a/packages/db/prisma/migrations/20260705170000_add_blog_taxonomy/migration.sql
+++ b/packages/db/prisma/migrations/20260705170000_add_blog_taxonomy/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "blog_posts" ADD COLUMN     "category" TEXT,
+ADD COLUMN     "readingTime" INTEGER,
+ADD COLUMN     "tags" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- CreateIndex
+CREATE INDEX "blog_posts_status_category_idx" ON "blog_posts"("status", "category");
+

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -927,11 +927,15 @@ model BlogPost {
   publishedAt   DateTime?
   authorId      String
   authorName    String
+  tags          String[]  @default([])
+  category      String?
+  readingTime   Int? // whole minutes, precomputed on write
   deletedAt     DateTime?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
   @@index([status, publishedAt])
+  @@index([status, category])
   @@map("blog_posts")
 }
 


### PR DESCRIPTION
Phase 2 of 3 (Phase 1 shipped in #605/v1.0.33). Adds tags & categories with a left-sidebar categories list + tag cloud.

## What
- **Migration (expand-only):** `BlogPost.tags String[] @default([])`, `category String?`, `readingTime Int?`, `@@index([status, category])`. `migrate-check` should pass (ADD COLUMN nullable/default + CREATE INDEX only).
- **API** (`POST /api/blog`): accepts `tags`/`category`; computes + stores `readingTime`; extends `generateSeo` to also auto-produce a **category** (one of Engineering/Product/Company/Security/Guides) + **3–6 tags** in one Anthropic JSON call, filling only missing fields (resilient — failure never blocks creation).
- **Blog list:** fluid 2-column with a **left sidebar** — Categories (with counts) + a frequency-weighted **Topics tag cloud**; `?category=`/`?tag=` filtering preserved across search + pagination; **"X min read"** on cards from the stored `readingTime` column (no more full-content fetch — resolves the Phase 1 perf note). Sections hide gracefully when there's no taxonomy yet.
- **Post page:** category eyebrow + tag chips (link to the filtered list); `keywords` + `articleSection` added to metadata + `BlogPosting` JSON-LD.
- **Backfill:** `scripts/backfill-blog-taxonomy.ts` — **dry-run by default** (`--apply` to write); deterministic `readingTime` + LLM `tags`/`category` for existing posts.

## Rollout note
The tag cloud / categories are empty until posts have taxonomy. New posts get it via the API; existing posts get it by running the backfill **on the prod box** (has DB + `ANTHROPIC_API_KEY`) — I'll run it dry-run first and confirm the proposed tags before `--apply`.

## Test plan
- `typecheck` clean · `lint` 0 errors (1 pre-existing warning) · `build` ✓ (145/145) · migration is expand-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)