### PR TITLE
feat(blog): Phase 3 — ElevenLabs read-aloud (player + CI pipeline)

### DIFF
--- a/.github/workflows/blog-audio.yml
+++ b/.github/workflows/blog-audio.yml
@@ -1,0 +1,49 @@
+name: Generate blog read-aloud audio
+
+# Generates an MP3 per published blog post via ElevenLabs TTS, uploads it to
+# Cloudflare R2, and writes the audioUrl back through the public authenticated
+# blog API. Manual trigger only; dry-run unless `apply` is checked.
+#
+# Runs in the cloud (not the VPN-only prod box) because it needs the monorepo
+# ELEVENLABS_API_KEY secret; it reaches the DB only indirectly, through the
+# public octopus-review.ai blog API.
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Generate + upload + write back (unchecked = dry run)"
+        type: boolean
+        default: false
+
+jobs:
+  generate:
+    name: Generate + publish audio
+    runs-on: ubuntu-latest
+    steps:
+      # Third-party actions pinned to full commit SHAs (supply-chain
+      # mitigation; matches .github/workflows/octp-release.yml). The trailing
+      # comment is the tag the SHA was resolved from at pin time.
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        with:
+          bun-version: 1.3.4
+
+      - name: Install dependencies (root workspace)
+        run: bun install --frozen-lockfile
+
+      - name: Generate blog audio
+        run: bun run --cwd apps/web scripts/generate-blog-audio.ts ${{ inputs.apply && '--apply' || '' }}
+        env:
+          OCTOPUS_API_URL: https://octopus-review.ai
+          BLOG_API_TOKEN: ${{ secrets.BLOG_API_TOKEN }}
+          ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+          ELEVENLABS_VOICE_ID: ${{ secrets.ELEVENLABS_VOICE_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}

--- a/apps/web/app/(landing)/blog/[slug]/page.tsx
+++ b/apps/web/app/(landing)/blog/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { LandingFooter } from "@/components/landing-footer";
 import { LandingMobileNav } from "@/components/landing-mobile-nav";
 import { LandingDesktopNav } from "@/components/landing-desktop-nav";
 import { BlogContent } from "@/components/blog-content";
+import { BlogAudioPlayer } from "@/components/blog-audio-player";
 import { BlogToc } from "@/components/blog-toc";
 import { ScrollToTop } from "@/components/scroll-to-top";
 import { IconArrowLeft } from "@tabler/icons-react";
@@ -186,6 +187,12 @@ export default async function BlogPostPage({
               </time>
               <span aria-hidden="true">·</span>
               <span>{minutes} min read</span>
+              {post.audioUrl && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <BlogAudioPlayer src={post.audioUrl} />
+                </>
+              )}
             </div>
 
             {headings.length >= 2 && (

--- a/apps/web/app/api/blog/route.ts
+++ b/apps/web/app/api/blog/route.ts
@@ -83,7 +83,9 @@ export async function GET(request: NextRequest) {
         title: true,
         slug: true,
         excerpt: true,
+        content: true,
         coverImageUrl: true,
+        audioUrl: true,
         status: true,
         authorName: true,
         publishedAt: true,
@@ -239,6 +241,77 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json(
       { error: "Failed to create blog post" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  const token = await authenticateBlogToken(request);
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { id, audioUrl, tags, category } = body as {
+      id?: string;
+      audioUrl?: string | null;
+      tags?: string[];
+      category?: string;
+    };
+
+    if (!id) {
+      return NextResponse.json({ error: "id is required" }, { status: 400 });
+    }
+
+    const post = await prisma.blogPost.findFirst({ where: { id, deletedAt: null } });
+    if (!post) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    // Update ONLY the fields the caller provided. `audioUrl` may be set to a
+    // string or explicitly cleared with null; tags/category reuse the same
+    // sanitization as POST.
+    const data: { audioUrl?: string | null; tags?: string[]; category?: string | null } = {};
+
+    if ("audioUrl" in body) {
+      data.audioUrl = typeof audioUrl === "string" ? audioUrl : null;
+    }
+    if ("tags" in body && Array.isArray(tags)) {
+      data.tags = [...new Set(tags.map((t) => String(t).trim().toLowerCase()).filter(Boolean))].slice(0, 6);
+    }
+    if ("category" in body) {
+      data.category = normalizeCategory(category);
+    }
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json(
+        { error: "No updatable fields provided" },
+        { status: 400 },
+      );
+    }
+
+    const updated = await prisma.blogPost.update({
+      where: { id: post.id },
+      data,
+      select: { id: true, slug: true, audioUrl: true, tags: true, category: true },
+    });
+
+    revalidatePath("/blog");
+    revalidatePath(`/blog/${updated.slug}`);
+
+    return NextResponse.json({
+      success: true,
+      id: updated.id,
+      slug: updated.slug,
+      audioUrl: updated.audioUrl,
+      tags: updated.tags,
+      category: updated.category,
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to update blog post" },
       { status: 500 },
     );
   }

--- a/apps/web/app/api/blog/route.ts
+++ b/apps/web/app/api/blog/route.ts
@@ -46,6 +46,25 @@ function normalizeCategory(value: string | null | undefined): string | null {
   return match ?? null;
 }
 
+// audioUrl is rendered as <audio src> on the public blog, so only accept null
+// (clear) or an https URL under the configured R2 public base — never an
+// arbitrary origin (guards against a leaked token pointing audio elsewhere).
+function normalizeAudioUrl(
+  value: unknown,
+): { ok: true; value: string | null } | { ok: false } {
+  if (value === null || value === undefined) return { ok: true, value: null };
+  if (typeof value !== "string") return { ok: false };
+  try {
+    const u = new URL(value);
+    if (u.protocol !== "https:") return { ok: false };
+    const base = process.env.R2_PUBLIC_URL?.replace(/\/$/, "");
+    if (base && !value.startsWith(`${base}/`)) return { ok: false };
+    return { ok: true, value };
+  } catch {
+    return { ok: false };
+  }
+}
+
 export async function GET(request: NextRequest) {
   const token = await authenticateBlogToken(request);
   if (!token) {
@@ -57,6 +76,9 @@ export async function GET(request: NextRequest) {
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10) || 1);
   const limit = Math.min(50, Math.max(1, parseInt(searchParams.get("limit") ?? "10", 10) || 10));
   const status = searchParams.get("status") || undefined;
+  // Full post bodies are opt-in (the audio generator needs them); the default
+  // list response stays lean.
+  const includeContent = searchParams.get("includeContent") === "true";
 
   const where = {
     deletedAt: null,
@@ -83,7 +105,7 @@ export async function GET(request: NextRequest) {
         title: true,
         slug: true,
         excerpt: true,
-        content: true,
+        ...(includeContent ? { content: true } : {}),
         coverImageUrl: true,
         audioUrl: true,
         status: true,
@@ -276,7 +298,14 @@ export async function PATCH(request: NextRequest) {
     const data: { audioUrl?: string | null; tags?: string[]; category?: string | null } = {};
 
     if ("audioUrl" in body) {
-      data.audioUrl = typeof audioUrl === "string" ? audioUrl : null;
+      const result = normalizeAudioUrl(audioUrl);
+      if (!result.ok) {
+        return NextResponse.json(
+          { error: "audioUrl must be null or an https URL under the configured audio host" },
+          { status: 400 },
+        );
+      }
+      data.audioUrl = result.value;
     }
     if ("tags" in body && Array.isArray(tags)) {
       data.tags = [...new Set(tags.map((t) => String(t).trim().toLowerCase()).filter(Boolean))].slice(0, 6);

--- a/apps/web/components/blog-audio-player.tsx
+++ b/apps/web/components/blog-audio-player.tsx
@@ -9,13 +9,10 @@ export function BlogAudioPlayer({ src }: { src: string }) {
   function toggle() {
     const audio = audioRef.current;
     if (!audio) return;
-    if (audio.paused) {
-      audio.play().catch(() => setPlaying(false));
-      setPlaying(true);
-    } else {
-      audio.pause();
-      setPlaying(false);
-    }
+    // Drive state from the audio element's own play/pause/ended events (below)
+    // so the button always reflects real playback, even if play() is blocked.
+    if (audio.paused) audio.play().catch(() => {});
+    else audio.pause();
   }
 
   return (
@@ -34,6 +31,8 @@ export function BlogAudioPlayer({ src }: { src: string }) {
         ref={audioRef}
         src={src}
         preload="none"
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
         onEnded={() => setPlaying(false)}
         className="hidden"
       />

--- a/apps/web/components/blog-audio-player.tsx
+++ b/apps/web/components/blog-audio-player.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+export function BlogAudioPlayer({ src }: { src: string }) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+
+  function toggle() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (audio.paused) {
+      audio.play().catch(() => setPlaying(false));
+      setPlaying(true);
+    } else {
+      audio.pause();
+      setPlaying(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-label={playing ? "Pause article audio" : "Listen to this article"}
+        aria-pressed={playing}
+        className="inline-flex items-center gap-1.5 rounded-full border border-[#10D8BE]/30 px-3 py-1 text-xs font-medium text-[#10D8BE] transition-colors hover:border-[#10D8BE]/60 hover:bg-[#10D8BE]/10"
+      >
+        <span aria-hidden="true">{playing ? "⏸" : "▶"}</span>
+        {playing ? "Pause" : "Listen"}
+      </button>
+      <audio
+        ref={audioRef}
+        src={src}
+        preload="none"
+        onEnded={() => setPlaying(false)}
+        className="hidden"
+      />
+    </>
+  );
+}

--- a/apps/web/scripts/generate-blog-audio.ts
+++ b/apps/web/scripts/generate-blog-audio.ts
@@ -79,7 +79,7 @@ async function fetchPublishedPosts(): Promise<BlogPost[]> {
 
   do {
     const res = await fetch(
-      `${API_URL}/api/blog?status=published&limit=50&page=${page}`,
+      `${API_URL}/api/blog?status=published&includeContent=true&limit=50&page=${page}`,
       { headers: { authorization: `Bearer ${BLOG_API_TOKEN}` } },
     );
     if (!res.ok) {

--- a/apps/web/scripts/generate-blog-audio.ts
+++ b/apps/web/scripts/generate-blog-audio.ts
@@ -1,0 +1,262 @@
+/**
+ * Generate read-aloud audio for published blog posts.
+ *
+ * Standalone script for cloud CI (GitHub Actions) — it has NO database access
+ * and MUST NOT import prisma. It talks to the public authenticated blog API
+ * (octopus-review.ai) over `fetch`, synthesizes speech with ElevenLabs, uploads
+ * the MP3 to Cloudflare R2 with `@aws-sdk/client-s3`, and writes the resulting
+ * `audioUrl` back through the API.
+ *
+ * For each published post WITHOUT an audioUrl:
+ *   - strip Markdown to plain prose (truncated to a safe length for TTS)
+ *   - ElevenLabs TTS  -> MP3 buffer
+ *   - upload to R2     -> public URL  (key: blog-audio/<slug>.mp3)
+ *   - PATCH /api/blog  -> persist audioUrl
+ *
+ * Per-post failures are isolated: one bad post never aborts the run.
+ *
+ * Env:
+ *   OCTOPUS_API_URL        (default "https://octopus-review.ai")
+ *   BLOG_API_TOKEN         Bearer token for the blog API (read + PATCH)
+ *   ELEVENLABS_API_KEY     ElevenLabs API key
+ *   ELEVENLABS_VOICE_ID    ElevenLabs voice id
+ *   R2_ACCOUNT_ID / R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_BUCKET
+ *   R2_PUBLIC_URL     public base for uploaded objects
+ *
+ * Usage:
+ *   Dry run (default):  bun run --cwd apps/web scripts/generate-blog-audio.ts
+ *   Apply changes:      bun run --cwd apps/web scripts/generate-blog-audio.ts --apply
+ */
+
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+
+const APPLY = process.argv.includes("--apply");
+
+const API_URL = (process.env.OCTOPUS_API_URL || "https://octopus-review.ai").replace(/\/$/, "");
+const BLOG_API_TOKEN = process.env.BLOG_API_TOKEN;
+const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const ELEVENLABS_VOICE_ID = process.env.ELEVENLABS_VOICE_ID;
+const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID;
+const R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID;
+const R2_SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY;
+const R2_BUCKET = process.env.R2_BUCKET;
+const R2_PUBLIC_URL = (process.env.R2_PUBLIC_URL || "").replace(/\/$/, "");
+
+const ELEVENLABS_MODEL_ID = "eleven_turbo_v2_5";
+// ElevenLabs caps a single request; keep well under it and log when we clip.
+const MAX_TTS_CHARS = 9000;
+
+interface BlogPost {
+  id: string;
+  slug: string;
+  content: string;
+  audioUrl: string | null;
+}
+
+/**
+ * Strip Markdown to readable prose for TTS. Mirrors the stripping in
+ * lib/blog-reading.ts (fenced/inline code, images, links) but preserves
+ * sentence text instead of reducing to a word count.
+ */
+function markdownToPlainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ") // fenced code (backtick)
+    .replace(/~~~[\s\S]*?~~~/g, " ") // fenced code (tilde)
+    .replace(/`[^`]*`/g, " ") // inline code
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ") // images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // links -> keep text
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "") // heading markers
+    .replace(/[*_~>|]/g, " ") // residual md punctuation
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** GET every published post, following pagination. */
+async function fetchPublishedPosts(): Promise<BlogPost[]> {
+  const posts: BlogPost[] = [];
+  let page = 1;
+  let totalPages = 1;
+
+  do {
+    const res = await fetch(
+      `${API_URL}/api/blog?status=published&limit=50&page=${page}`,
+      { headers: { authorization: `Bearer ${BLOG_API_TOKEN}` } },
+    );
+    if (!res.ok) {
+      throw new Error(`GET /api/blog failed: ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as {
+      posts: BlogPost[];
+      pagination: { totalPages: number };
+    };
+    posts.push(...data.posts);
+    totalPages = data.pagination.totalPages;
+    page++;
+  } while (page <= totalPages);
+
+  return posts;
+}
+
+/** ElevenLabs TTS via REST -> MP3 buffer. */
+async function synthesizeSpeech(text: string): Promise<Buffer> {
+  const res = await fetch(
+    `https://api.elevenlabs.io/v1/text-to-speech/${ELEVENLABS_VOICE_ID}`,
+    {
+      method: "POST",
+      headers: {
+        "xi-api-key": ELEVENLABS_API_KEY!,
+        "content-type": "application/json",
+        accept: "audio/mpeg",
+      },
+      body: JSON.stringify({ text, model_id: ELEVENLABS_MODEL_ID }),
+    },
+  );
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(
+      `ElevenLabs TTS failed: ${res.status} ${res.statusText} ${detail.slice(0, 200)}`,
+    );
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+let r2Client: S3Client | null = null;
+function getR2Client(): S3Client {
+  if (!r2Client) {
+    r2Client = new S3Client({
+      region: "auto",
+      endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+      credentials: {
+        accessKeyId: R2_ACCESS_KEY_ID!,
+        secretAccessKey: R2_SECRET_ACCESS_KEY!,
+      },
+    });
+  }
+  return r2Client;
+}
+
+/** Upload an MP3 to R2 and return its public URL. */
+async function uploadMp3(key: string, body: Buffer): Promise<string> {
+  await getR2Client().send(
+    new PutObjectCommand({
+      Bucket: R2_BUCKET,
+      Key: key,
+      Body: body,
+      ContentType: "audio/mpeg",
+      CacheControl: "public, max-age=31536000, immutable",
+    }),
+  );
+  return `${R2_PUBLIC_URL}/${key}`;
+}
+
+/** PATCH the post's audioUrl through the authenticated blog API. */
+async function patchAudioUrl(id: string, audioUrl: string): Promise<void> {
+  const res = await fetch(`${API_URL}/api/blog`, {
+    method: "PATCH",
+    headers: {
+      authorization: `Bearer ${BLOG_API_TOKEN}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ id, audioUrl }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(
+      `PATCH /api/blog failed: ${res.status} ${res.statusText} ${detail.slice(0, 200)}`,
+    );
+  }
+}
+
+async function main() {
+  console.log(`[blog-audio] Mode: ${APPLY ? "APPLY" : "DRY RUN"}`);
+  console.log(`[blog-audio] API: ${API_URL}`);
+
+  // Reading posts requires the token in every mode.
+  if (!BLOG_API_TOKEN) {
+    console.error("[blog-audio] BLOG_API_TOKEN is required.");
+    process.exit(1);
+  }
+  // Generation/upload/write-back credentials are only needed with --apply.
+  if (APPLY) {
+    const missing = Object.entries({
+      ELEVENLABS_API_KEY,
+      ELEVENLABS_VOICE_ID,
+      R2_ACCOUNT_ID,
+      R2_ACCESS_KEY_ID,
+      R2_SECRET_ACCESS_KEY,
+      R2_BUCKET,
+      R2_PUBLIC_URL,
+    })
+      .filter(([, v]) => !v)
+      .map(([k]) => k);
+    if (missing.length > 0) {
+      console.error(`[blog-audio] Missing required env for --apply: ${missing.join(", ")}`);
+      process.exit(1);
+    }
+  }
+
+  const posts = await fetchPublishedPosts();
+  const pending = posts.filter((p) => !p.audioUrl);
+  const skipped = posts.length - pending.length;
+  console.log(
+    `[blog-audio] ${posts.length} published, ${skipped} already have audio, ${pending.length} to process\n`,
+  );
+
+  let generated = 0;
+  let failed = 0;
+
+  for (const post of pending) {
+    try {
+      const key = `blog-audio/${post.slug}.mp3`;
+      const text = markdownToPlainText(post.content);
+      const truncated = text.length > MAX_TTS_CHARS;
+      const finalText = truncated ? text.slice(0, MAX_TTS_CHARS) : text;
+      if (truncated) {
+        console.log(
+          `[blog-audio] ${post.slug}: content ${text.length} chars, truncated to ${MAX_TTS_CHARS}`,
+        );
+      }
+
+      if (!APPLY) {
+        console.log(
+          `[blog-audio] ${post.slug}: (dry-run) would synthesize ${finalText.length} chars -> ${key} -> PATCH audioUrl`,
+        );
+        continue;
+      }
+
+      console.log(`[blog-audio] ${post.slug}: synthesizing ${finalText.length} chars...`);
+      const mp3 = await synthesizeSpeech(finalText);
+      const url = await uploadMp3(key, mp3);
+      await patchAudioUrl(post.id, url);
+      console.log(`[blog-audio] ${post.slug}: done -> ${url}`);
+      generated++;
+    } catch (err) {
+      failed++;
+      console.error(
+        `[blog-audio] ${post.slug}: FAILED -`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  console.log(`\n[blog-audio] Done.`);
+  console.log(`  Published:         ${posts.length}`);
+  console.log(`  Already had audio: ${skipped}`);
+  if (APPLY) {
+    console.log(`  Generated:         ${generated}`);
+    console.log(`  Failed:            ${failed}`);
+  } else {
+    console.log(`  Would process:     ${pending.length}`);
+    console.log(`\n[blog-audio] Dry run complete. Re-run with --apply to generate audio.`);
+  }
+
+  // Surface partial failures to CI without having aborted the loop.
+  if (APPLY && failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("[blog-audio] Fatal error:", err);
+  process.exit(1);
+});

--- a/packages/db/prisma/migrations/20260705180000_add_blog_audio_url/migration.sql
+++ b/packages/db/prisma/migrations/20260705180000_add_blog_audio_url/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "blog_posts" ADD COLUMN     "audioUrl" TEXT;
+

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -930,6 +930,7 @@ model BlogPost {
   tags          String[]  @default([])
   category      String?
   readingTime   Int? // whole minutes, precomputed on write
+  audioUrl      String? // read-aloud MP3 (R2), generated in CI
   deletedAt     DateTime?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt


### PR DESCRIPTION
Final blog-revamp phase (1 & 2 shipped in v1.0.33/v1.0.34). Read-aloud audio for posts.

## Architecture (decided)
The prod DB is VPN-only, but octopus-review.ai is public — so a **cloud GitHub Actions job** (which can see the monorepo `ELEVENLABS_API_KEY` secret) generates audio and writes it back through the **public authenticated blog API**. No self-hosted runner / VPN needed. Matches the "Actions secret" setup.

## What
- **Migration (expand-only):** `BlogPost.audioUrl String?`.
- **API:** `GET /api/blog` now returns `content` + `audioUrl`; new **authenticated `PATCH /api/blog`** (Bearer `BlogApiToken`) sets `audioUrl`/`tags`/`category` on an existing post (allowlisted category, sanitized tags). This is the audio write-back **and** reusable for the taxonomy backfill.
- **UI:** `blog-audio-player.tsx` — a play/pause "Listen" control shown on the post byline when `audioUrl` is set.
- **Generation:** `scripts/generate-blog-audio.ts` — cloud-CI script (fetch, no prisma): reads published posts via the public API, ElevenLabs TTS → MP3 → R2 (`blog-audio/<slug>.mp3`) → PATCH `audioUrl`. **Dry-run by default** (`--apply` for real work); per-post isolation; never logs secrets.
- **Workflow:** `.github/workflows/blog-audio.yml` (`workflow_dispatch`, `apply` input; cloud runner; actions pinned to SHAs).

## Activation checklist (post-merge — inert until done)
Add these **repo Actions secrets** (octopusreview/octopus): `BLOG_API_TOKEN` (mint via the BlogApiToken flow), `ELEVENLABS_VOICE_ID` (pick a voice), and `R2_ACCOUNT_ID`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`/`R2_BUCKET`/`R2_PUBLIC_URL`. (`ELEVENLABS_API_KEY` already set.) Then run the workflow dry-run → `apply=true`. The player renders only when a post has `audioUrl`, so this ships safely with nothing configured yet.

## Test plan
- `typecheck` clean · `lint` 0 errors (1 pre-existing warning) · `build` ✓ (145/145) · migration expand-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)