### PR TITLE
fix(docs): correct cloud/self-host boundary + page↔Ask-AI-index drift

### DIFF
--- a/apps/web/app/(landing)/docs/docs-sidebar.tsx
+++ b/apps/web/app/(landing)/docs/docs-sidebar.tsx
@@ -76,6 +76,15 @@ const sections: SidebarSection[] = [
       { href: "/docs/security", label: "Security & Bug Bounty" },
     ],
   },
+  {
+    title: "Compliance",
+    items: [
+      { href: "/docs/security-overview", label: "Security Overview" },
+      { href: "/docs/dpa", label: "Data Processing Addendum" },
+      { href: "/docs/sub-processors", label: "Sub-processors" },
+      { href: "/docs/data-retention", label: "Data Retention" },
+    ],
+  },
 ];
 
 export function DocsSidebar() {

--- a/apps/web/app/(landing)/docs/faq/page.tsx
+++ b/apps/web/app/(landing)/docs/faq/page.tsx
@@ -37,7 +37,7 @@ const generalFaqs = [
 const securityFaqs = [
   {
     q: "Is my code safe?",
-    a: "Yes. Your code is processed in-memory and never stored permanently on our servers. Embeddings are stored in your Qdrant instance for search, but the original source code is not retained. If you self-host, everything stays on your own infrastructure.",
+    a: "Yes. Your code is processed in-memory and never stored permanently on our servers. Embeddings are stored in a Qdrant vector database for search, but the original source code is not retained. If you self-host, the entire pipeline — including Qdrant — runs on your own infrastructure.",
   },
   {
     q: "Can I self-host Octopus?",
@@ -67,6 +67,10 @@ const integrationFaqs = [
     a: "Yes. You can connect Octopus to Linear to automatically create issues from review findings. This makes it easy to track and prioritize the issues Octopus discovers.",
   },
   {
+    q: "Does Octopus integrate with Jira?",
+    a: "Yes. Connect your Atlassian site to create Jira issues directly from review findings. Each issue is pre-filled with the finding details, severity, and a link back to the PR/MR.",
+  },
+  {
     q: "Can I use Octopus with a monorepo?",
     a: <>Yes. Octopus indexes the entire repository and understands cross-package dependencies. You can use <Link href="/docs/octopusignore" className="text-white underline decoration-white/30 underline-offset-2 hover:decoration-white">.octopusignore</Link> to exclude directories that shouldn&apos;t be reviewed (build outputs, vendor code, etc.).</>,
   },
@@ -87,7 +91,7 @@ const pricingFaqs = [
   },
   {
     q: "What are BYO (Bring Your Own) keys?",
-    a: "BYO keys let you use your own Anthropic or OpenAI API keys. This way, AI usage is billed directly to your provider account, and you only pay Octopus for the platform — not the AI tokens.",
+    a: "BYO keys let you use your own Anthropic, OpenAI, Google, or Cohere API keys. This way, AI usage is billed directly to your provider account, and you only pay Octopus for the platform — not the AI tokens.",
   },
   {
     q: "Can I set spend limits?",

--- a/apps/web/app/(landing)/docs/getting-started/page.tsx
+++ b/apps/web/app/(landing)/docs/getting-started/page.tsx
@@ -68,7 +68,7 @@ export default function GettingStartedPage() {
           <FeatureCard
             icon={<IconPlugConnected className="size-4" />}
             title="Works With Your Tools"
-            description="GitHub, GitLab, Bitbucket, Slack, Linear. Fits into your existing workflow."
+            description="GitHub, GitLab, Bitbucket, Slack, Linear, Jira. Fits into your existing workflow."
           />
         </div>
       </Section>
@@ -198,13 +198,13 @@ export default function GettingStartedPage() {
             icon={<IconCircleDot className="size-4" />}
             color="text-red-400"
             label="Critical"
-            description="Bugs, security vulnerabilities, data loss risks. Blocks merge."
+            description="Security vulnerabilities, data loss risks, broken functionality. Blocks merge."
           />
           <SeverityRow
             icon={<IconAlertTriangle className="size-4" />}
             color="text-orange-400"
             label="Major"
-            description="Logic errors, performance issues, potential edge cases."
+            description="Bugs, logic errors, performance issues, and missing error handling."
           />
           <SeverityRow
             icon={<IconAlertCircle className="size-4" />}
@@ -315,7 +315,7 @@ export default function GettingStartedPage() {
             href="/docs/integrations"
             icon={<IconPlugConnected className="size-4" />}
             title="Integrations"
-            description="Connect GitHub, GitLab, Bitbucket, Slack, and Linear"
+            description="Connect GitHub, GitLab, Bitbucket, Slack, Linear, and Jira"
           />
           <NextStepCard
             href="/docs/cli"

--- a/apps/web/app/(landing)/docs/glossary/page.tsx
+++ b/apps/web/app/(landing)/docs/glossary/page.tsx
@@ -69,7 +69,7 @@ const glossary: { term: string; definition: string }[] = [
   {
     term: "Severity Levels",
     definition:
-      "A rating system Octopus assigns to each review finding: 🔴 Critical (likely bug or security issue), 🟠 Major (significant concern), 🟡 Minor (style or minor issue), 🔵 Suggestion (improvement idea), 💡 Tip (informational note). Helps teams prioritize what to fix first.",
+      "A rating system Octopus assigns to each review finding: 🔴 Critical (security, data loss, or broken functionality — blocks merge), 🟠 Major (bugs, logic errors, performance), 🟡 Minor (code quality and maintainability), 🔵 Suggestion (optional improvement), 💡 Tip (informational note). Helps teams prioritize what to fix first.",
   },
   {
     term: "Spend Limit",

--- a/apps/web/app/(landing)/docs/glossary/page.tsx
+++ b/apps/web/app/(landing)/docs/glossary/page.tsx
@@ -14,7 +14,7 @@ const glossary: { term: string; definition: string }[] = [
   {
     term: "BYO Keys (Bring Your Own Keys)",
     definition:
-      "A configuration option that lets you use your own Anthropic or OpenAI API keys. AI token usage is billed directly to your provider account instead of consuming Octopus credits.",
+      "A configuration option that lets you use your own Anthropic, OpenAI, Google, or Cohere API keys. AI token usage is billed directly to your provider account instead of consuming Octopus credits.",
   },
   {
     term: "Codebase Indexing",
@@ -84,7 +84,7 @@ const glossary: { term: string; definition: string }[] = [
   {
     term: "Webhook",
     definition:
-      "An HTTP callback sent by GitHub or Bitbucket to Octopus when an event occurs — typically a pull request being opened or updated. This is how Octopus knows when to start a review automatically.",
+      "An HTTP callback sent by GitHub, GitLab, or Bitbucket to Octopus when an event occurs — typically a pull request or merge request being opened or updated. This is how Octopus knows when to start a review automatically.",
   },
 ];
 

--- a/apps/web/app/(landing)/docs/integrations/page.tsx
+++ b/apps/web/app/(landing)/docs/integrations/page.tsx
@@ -72,13 +72,6 @@ export default function IntegrationsPage() {
             description="Create GitHub issues directly from review findings for tracking and follow-up."
           />
         </FeatureGrid>
-        <EnvBlock
-          vars={[
-            { name: "GITHUB_APP_ID", description: "Your GitHub App ID" },
-            { name: "GITHUB_APP_PRIVATE_KEY", description: "RSA private key (PEM or base64-encoded)" },
-            { name: "GITHUB_WEBHOOK_SECRET", description: "Webhook secret for event verification" },
-          ]}
-        />
       </IntegrationSection>
 
       {/* GitLab */}
@@ -115,13 +108,6 @@ export default function IntegrationsPage() {
             description="One webhook per project is registered at sync time — no Premium tier required."
           />
         </FeatureGrid>
-        <EnvBlock
-          vars={[
-            { name: "GITLAB_CLIENT_ID", description: "OAuth application ID for gitlab.com" },
-            { name: "GITLAB_CLIENT_SECRET", description: "OAuth application secret for gitlab.com" },
-            { name: "GITLAB_REDIRECT_URI", description: "OAuth callback URL, e.g. https://octopus-review.ai/api/gitlab/callback" },
-          ]}
-        />
       </IntegrationSection>
 
       {/* Bitbucket */}
@@ -152,12 +138,6 @@ export default function IntegrationsPage() {
             description="Automatic webhook management for real-time PR event processing."
           />
         </FeatureGrid>
-        <EnvBlock
-          vars={[
-            { name: "BITBUCKET_CLIENT_ID", description: "OAuth consumer key" },
-            { name: "BITBUCKET_CLIENT_SECRET", description: "OAuth consumer secret" },
-          ]}
-        />
       </IntegrationSection>
 
       {/* Linear */}
@@ -216,13 +196,6 @@ export default function IntegrationsPage() {
             description="Track issue status directly from the Octopus dashboard without leaving the review."
           />
         </FeatureGrid>
-        <EnvBlock
-          vars={[
-            { name: "JIRA_CLIENT_ID", description: "Atlassian OAuth 2.0 (3LO) client ID" },
-            { name: "JIRA_CLIENT_SECRET", description: "Atlassian OAuth 2.0 (3LO) client secret" },
-            { name: "JIRA_REDIRECT_URI", description: "OAuth callback URL, e.g. https://octopus-review.ai/api/jira/callback" },
-          ]}
-        />
       </IntegrationSection>
 
       {/* Slack */}
@@ -338,31 +311,4 @@ function Feature({
 
 function P({ children }: { children: React.ReactNode }) {
   return <p className="mb-3 text-sm leading-relaxed text-[#888]">{children}</p>;
-}
-
-function EnvBlock({
-  vars,
-}: {
-  vars: { name: string; description: string }[];
-}) {
-  return (
-    <div className="mb-4">
-      <h3 className="mb-2 text-sm font-semibold text-[#ccc]">
-        Environment Variables
-      </h3>
-      <div className="space-y-1">
-        {vars.map((v) => (
-          <div
-            key={v.name}
-            className="rounded-lg border border-white/[0.04] bg-white/[0.01] px-3 py-2"
-          >
-            <code className="text-xs text-white sm:text-sm">{v.name}</code>
-            <span className="mt-1 block text-xs text-[#555]">
-              {v.description}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
 }

--- a/apps/web/app/(landing)/docs/oauth-setup/page.tsx
+++ b/apps/web/app/(landing)/docs/oauth-setup/page.tsx
@@ -23,7 +23,7 @@ export default function OauthSetupPage() {
         </h1>
         <p className="mt-3 text-sm text-[#888]">
           Octopus uses Better Auth for sign-in. Magic-link email works out of the box;
-          Google and GitHub need OAuth credentials. This page walks you through both.
+          Google, GitHub, and Microsoft need OAuth credentials. This page walks you through each.
         </p>
       </div>
 

--- a/apps/web/app/(landing)/docs/octopusignore/page.tsx
+++ b/apps/web/app/(landing)/docs/octopusignore/page.tsx
@@ -231,13 +231,21 @@ models/**/*.bin`}
       {/* Providers */}
       <Section title="Provider Support">
         <Paragraph>
-          <Mono>.octopusignore</Mono> works with both supported providers:
+          <Mono>.octopusignore</Mono> works across your connected code
+          providers:
         </Paragraph>
-        <div className="mb-4 grid gap-3 sm:grid-cols-2">
+        <div className="mb-4 grid gap-3 sm:grid-cols-3">
           <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
             <h4 className="text-sm font-medium text-white">GitHub</h4>
             <p className="mt-1 text-xs text-[#666]">
               Fetched via Contents API from the PR&apos;s base branch.
+            </p>
+          </div>
+          <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">
+            <h4 className="text-sm font-medium text-white">GitLab</h4>
+            <p className="mt-1 text-xs text-[#666]">
+              Fetched via the Repository Files API from the MR&apos;s target
+              branch.
             </p>
           </div>
           <div className="rounded-lg border border-white/[0.06] bg-white/[0.02] p-4">

--- a/apps/web/app/(landing)/docs/privacy/page.tsx
+++ b/apps/web/app/(landing)/docs/privacy/page.tsx
@@ -51,7 +51,7 @@ export default function PrivacyPage() {
         <H3>Repository Data</H3>
         <P>
           When you connect a repository, we access its contents through the
-          GitHub or Bitbucket API to create code embeddings and perform
+          GitHub, GitLab, or Bitbucket API to create code embeddings and perform
           reviews. We process pull request diffs, file contents, and
           repository metadata.
         </P>
@@ -100,7 +100,7 @@ export default function PrivacyPage() {
             reviews
           </li>
           <li>
-            <strong className="text-white">GitHub / Bitbucket</strong> for
+            <strong className="text-white">GitHub / GitLab / Bitbucket</strong> for
             repository access and webhook events
           </li>
           <li>
@@ -146,8 +146,9 @@ export default function PrivacyPage() {
           <li>Opt out of live team-telemetry visibility (from member settings)</li>
         </UL>
         <P>
-          For any privacy-related requests, open an issue on our GitHub
-          repository or contact us directly.
+          For any privacy-related request (access, export, deletion, or
+          opt-out), email privacy@octopus-review.ai from the address on your
+          account. See our Data Retention policy for details.
         </P>
       </Section>
 

--- a/apps/web/app/(landing)/docs/security-overview/page.tsx
+++ b/apps/web/app/(landing)/docs/security-overview/page.tsx
@@ -23,9 +23,9 @@ export default function SecurityOverviewPage() {
 
       <Section title="1. Data flow at a glance">
         <P>
-          Octopus reviews pull requests in five stages. Each stage runs inside the
-          customer&apos;s VPC tenancy (hosted Octopus) or the customer&apos;s own
-          infrastructure (self-hosted Octopus).
+          Octopus reviews pull requests in five stages. Each stage runs in
+          Octopus&apos;s managed cloud infrastructure (hosted Octopus) or in the
+          customer&apos;s own infrastructure (self-hosted Octopus).
         </P>
         <UL>
           <li><strong>Webhook</strong> — GitHub, GitLab, or Bitbucket POSTs a PR/MR event; we verify the HMAC signature before processing.</li>

--- a/apps/web/app/(landing)/docs/self-hosting/page.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/page.tsx
@@ -334,7 +334,7 @@ DATABASE_URL=postgresql://octopus:octopus@localhost:43332/octopus bunx prisma mi
         <div className="space-y-3">
           <TipCard
             title="Use connection pooling"
-            description="Use PgBouncer or Supabase pooler for PostgreSQL connections. Next.js serverless functions can exhaust connection limits quickly."
+            description="Use PgBouncer or Supabase pooler for PostgreSQL connections. Multiple app instances and pg-boss worker processes can otherwise exhaust Postgres connection limits."
           />
           <TipCard
             title="Secure Qdrant"

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -104,11 +104,11 @@ The review pipeline: Webhook receives PR event → Octopus fetches the diff → 
       {
         heading: "3. Understanding Findings",
         text: `Each finding includes a severity level to help you prioritize:
-🔴 Critical — Security vulnerabilities, data loss risks, breaking changes that must be fixed.
-🟠 Major — Bugs, logic errors, performance issues that should be addressed.
-🟡 Minor — Code quality issues, minor improvements, style concerns.
-🔵 Suggestion — Best practice recommendations, alternative approaches.
-💡 Tip — Educational insights, helpful context, nice-to-know information.`,
+🔴 Critical — Security vulnerabilities, data loss risks, broken functionality. Blocks merge.
+🟠 Major — Bugs, logic errors, performance issues, and missing error handling.
+🟡 Minor — Code quality, maintainability, and best-practice concerns.
+🔵 Suggestion — Optional improvements, alternative approaches, and ideas.
+💡 Tip — Informational notes about the code, documentation, or conventions.`,
       },
       {
         heading: "4. Use the CLI",
@@ -207,13 +207,15 @@ This is ideal for teams that already have API agreements with AI providers or wa
       },
       {
         heading: "Model Pricing",
-        text: `Octopus supports multiple AI models:
-Claude Sonnet 4.6 — Primary review model. High quality, fast.
-Claude Haiku — Used for lightweight tasks like title generation.
-OpenAI GPT-4o — Alternative review model.
-OpenAI text-embedding-3-large — Used for creating embeddings (3072 dimensions).
-Cohere rerank-v3.5 — Used for re-ranking search results.
-Prompt caching reduces costs: cached reads cost 10% of the normal input price.`,
+        text: `Octopus supports multiple AI models. A 20% platform fee is applied on top of provider costs. Base prices per 1M tokens:
+Claude Opus 4.6 and Claude Opus 4 — $15 input / $75 output. Highest-quality review models.
+Claude Sonnet 4.6 and Claude Sonnet 4 — $3 input / $15 output. Primary review models: high quality, fast.
+Claude Haiku 4.5 — $1 input / $5 output. Lightweight tasks like title generation.
+Gemini 2.5 Pro — $1.25 input / $10 output. Gemini 2.5 Flash — $0.15 input / $0.60 output.
+GPT-5.3 Codex — $1.75 input / $14 output.
+Embeddings: text-embedding-3-large ($0.13) and text-embedding-3-small ($0.02).
+Cohere rerank is used for re-ranking search results.
+Prompt caching reduces costs: cached reads are billed at 10% of the input price.`,
       },
       {
         heading: "Spend Limits & Billing",
@@ -287,22 +289,22 @@ Anthropic API key for Claude (reviews and chat).`,
 2. Create a .env file with your configuration (an auto-generator is provided on the docs page). Pin OCTOPUS_VERSION to the release tag you want to run.
 3. Pull the prebuilt self-host image: docker compose -f docker-compose.selfhost.yml pull
 4. Start the stack: docker compose -f docker-compose.selfhost.yml up -d
-5. Run database migrations from a checkout matching OCTOPUS_VERSION: docker compose -f docker-compose.selfhost.yml exec octopus bun run db:migrate
+5. Run database migrations from a repo checkout matching OCTOPUS_VERSION (the runtime image does not ship the Prisma CLI or migration files): cd packages/db && DATABASE_URL=postgresql://octopus:octopus@localhost:43332/octopus bunx prisma migrate deploy
 6. Access Octopus at http://localhost:43300 (set OCTOPUS_PORT to override the default 43300).
 The self-host compose file includes PostgreSQL and Qdrant containers.`,
       },
       {
         heading: "Environment Variables",
-        text: `Required: DATABASE_URL, QDRANT_URL, OPENAI_API_KEY, ANTHROPIC_API_KEY, BETTER_AUTH_SECRET, BETTER_AUTH_URL.
-Optional: COHERE_API_KEY (for re-ranking), GITHUB_APP_ID, GITHUB_PRIVATE_KEY, GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, SLACK_BOT_TOKEN, LINEAR_API_KEY, STRIPE_SECRET_KEY.
+        text: `Required: DATABASE_URL, QDRANT_URL, OPENAI_API_KEY, ANTHROPIC_API_KEY, BETTER_AUTH_SECRET, BETTER_AUTH_URL, GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, GITHUB_WEBHOOK_SECRET.
+Optional: GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET (for GitHub login), COHERE_API_KEY (for re-ranking), GOOGLE_API_KEY (Gemini models), STRIPE_SECRET_KEY (for billing).
 The self-hosting docs page includes an interactive env generator.`,
       },
       {
         heading: "GitHub App Setup",
         text: `Create a GitHub App for your self-hosted instance:
 Set the webhook URL to your instance's /api/github/webhook endpoint.
-Required permissions: Repository contents (read), Pull requests (read/write), Issues (read/write), Checks (read/write), Metadata (read).
-Subscribe to events: Pull request, Push, Installation.`,
+Required permissions: Contents (read), Pull requests (read/write), Checks (read/write), Metadata (read).
+Subscribe to events: Pull request, Pull request review.`,
       },
       {
         heading: "Production Tips",
@@ -465,9 +467,15 @@ Rules: Each file belongs to exactly one category. User confirms before proceedin
       {
         heading: "Octopus Fix",
         text: `The Octopus Fix skill discovers open PRs with review comments, presents a summary, and applies fixes.
-Workflow: 1) Discover open PRs 2) Check for review comments 3) Present summary to user 4) Apply fixes 5) Return to original branch 6) Report.
-Review handling: Thumbs up for valid suggestions, thumbs down for false positives.
-Rules: Never force-push. Show proposed fixes before applying. Make minimal changes. Ask on unclear comments. Handle merge conflicts. Preserve git history.`,
+Workflow: 1) Discover open PRs 2) Check reviews (fetch comments/threads; automatically skip PRs whose latest bot review shows 0 findings) 3) Present summary and get confirmation 4) Apply fixes (checkout branch, minimal changes, commit, push) 5) Report.
+Review handling: Thumbs up for valid suggestions (fixed with a reply describing the change), thumbs down for false positives (with an explanation). Review threads are resolved after fixes, and a final PR comment tags @octopusreview to signal updates are ready.
+Rules: Never force-push. Show proposed fixes and get confirmation before committing. Make minimal changes. Ask on unclear comments. Stop on merge conflicts. Preserve git history — no squash, rebase, or amend.`,
+      },
+      {
+        heading: "Octopus Changelog",
+        text: `The Octopus Changelog skill reads your git history since the last tag, categorizes commits using the Keep a Changelog standard, and updates CHANGELOG.md for a new release.
+Workflow: 1) Determine version (detect the latest git tag and suggest the next, or use the version you provide) 2) Gather commits since the last tag and parse conventional-commit prefixes 3) Categorize into Added, Fixed, Changed, Removed, Deprecated, Security (skipping dependency bumps and trivial changes) 4) Review draft — present the formatted entries for approval 5) Update file — insert the new version section into CHANGELOG.md with comparison links.
+Rules: Never commits or pushes — only updates the file. Always shows a draft and gets confirmation before writing. Skips dependency bumps, trivial refactors, and CI-only changes. Groups related commits into single entries.`,
       },
     ],
   },

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -348,7 +348,7 @@ Q: Can I self-host Octopus?
 A: Yes. Octopus is fully self-hostable with Docker. Your code never leaves your infrastructure.
 
 Q: Which AI models are used?
-A: Claude (Anthropic) and OpenAI GPT-4o for reviews and chat. OpenAI text-embedding-3-large for embeddings. Cohere rerank-v3.5 for search re-ranking.
+A: Claude (Anthropic) and OpenAI models for reviews and chat. OpenAI text-embedding-3-large for embeddings. Cohere Rerank for search re-ranking.
 
 Q: Is my code used for AI training?
 A: No. Neither Anthropic nor OpenAI use API inputs for training. Your code is never used to train AI models.`,
@@ -428,15 +428,15 @@ Embeddings: Numerical vector representations of text. Octopus uses OpenAI text-e
 
 Knowledge Base: Custom documents uploaded to an organization (coding guidelines, architecture decisions, style guides) that Octopus references during reviews.
 
-LLM (Large Language Model): AI models like Claude (Anthropic) and GPT-4o (OpenAI) that analyze code and generate review findings.
+LLM (Large Language Model): AI models like Claude (Anthropic) and GPT (OpenAI) that analyze code and generate review findings.
 
 .octopusignore: A file in your repository root (same syntax as .gitignore) that tells Octopus which files to skip during indexing and review.
 
 Qdrant: The vector database used by Octopus to store and search code embeddings. Collections: code_chunks, knowledge_chunks, review_chunks, chat_chunks, flowchart_chunks.
 
-Reranking: A second-pass ranking step using Cohere rerank-v3.5 that re-orders search results by relevance to the query, improving the quality of retrieved context.
+Reranking: A second-pass ranking step using Cohere Rerank that re-orders search results by relevance to the query, improving the quality of retrieved context.
 
-Severity Levels: Finding priority ratings — 🔴 Critical (must fix), 🟠 Major (should fix), 🟡 Minor (nice to fix), 🔵 Suggestion (consider), 💡 Tip (informational).
+Severity Levels: Finding priority ratings — 🔴 Critical (security, data loss, or broken functionality; blocks merge), 🟠 Major (bugs, logic errors, performance), 🟡 Minor (code quality, maintainability), 🔵 Suggestion (optional improvement), 💡 Tip (informational).
 
 Spend Limit: A monthly cost cap per organization. When reached, AI operations are paused until the next billing cycle or limit increase.
 


### PR DESCRIPTION
## What

A content audit across `/docs`, triggered by the **Integrations** page (filed under *Cloud Setup*) showing self-host environment-variable blocks. The audit found the same class of error — plus systematic page ↔ `docs-content.ts` (Ask-AI/search index) drift — across the docs. This fixes all confirmed findings. 11 files.

## Cloud vs self-host correctness

- **`integrations`** — remove the four `EnvBlock`s (GitHub `APP_ID`/`PRIVATE_KEY`/`WEBHOOK_SECRET`; GitLab/Bitbucket/Jira `CLIENT_ID`/`SECRET`/`REDIRECT_URI`). Cloud users connect via the in-app GitHub-App-install / OAuth flow and never set these — they're self-host operator config. The per-integration setup steps stay (they're correct for cloud). Removed the now-dead `EnvBlock` component; all icon imports still used.
- **`faq` "Is my code safe?"** — dropped "your Qdrant instance", which implied cloud users run their own Qdrant.
- **`security-overview`** — hosted Octopus is managed multi-tenant cloud, not per-customer "VPC tenancy" (confirmed with the maintainer). Reworded.

## Self-host docs that would misconfigure an operator (all in the Ask-AI index)

- Migration command named a **non-existent compose service** (`exec octopus`; it's `web`) and the wrong approach → the host-checkout `cd packages/db && … bunx prisma migrate deploy`.
- `GITHUB_PRIVATE_KEY` → `GITHUB_APP_PRIVATE_KEY`; moved the 3 GitHub App vars to **Required**; dropped the phantom `Issues` permission and `Push`/`Installation` events so the index matches the page **and the real webhook handler** (which consumes `pull_request`, `issue_comment`, `installation*`).
- `self-hosting` "connection pooling" tip: self-host runs a long-running standalone server, not serverless — fixed the rationale.

## Page ↔ index drift & provider undercounting

- Reconciled the finding-**severity taxonomy** to the review engine's own semantics (`knowledge-templates.ts`: bugs are **Major**, Critical = security/data-loss/broken-functionality) on both the page and the index.
- Synced the **pricing model catalog** in the index to the page (dropped stale GPT-4o / unversioned Haiku; added the 20% platform fee + current models).
- Added **GitLab** to `octopusignore` provider support, the glossary **Webhook** definition, and the privacy policy's repo-provider list — verified `reviewer.ts` fetches `.octopusignore` for GitLab.
- Added **Jira** to the getting-started tool lists + a FAQ entry; listed all four **BYOK** providers (Anthropic/OpenAI/Google/Cohere) in glossary + faq.
- Added the missing **"Octopus Changelog"** skill to the index and refreshed the stale **"Octopus Fix"** flow.
- `oauth-setup` covers **three** providers (Google/GitHub/Microsoft), not two.

## Navigation / legal

- Privacy requests now route to **privacy@octopus-review.ai** instead of a public GitHub issue (matches the DPA / Data Retention pages).
- Surfaced the orphaned compliance pages (Security Overview, DPA, Sub-processors, Data Retention) in a new sidebar **Compliance** group.

## Deliberately NOT changed (verified against code, not stale)

- **`github-action` free "community mode"** — verified live in `app/api/github-action/review/route.ts` (public repos → auto `community-<owner>` org, 5/day limit; private repos require `octopus-api-key`). Community-tier retirement is still pending, so the page is accurate today.
- **CLI name `octp`** — the native installer (`apps/cli/install/install.sh`) delivers the binary as `octp` (`BINARY_NAME="octp"`), so the docs' `octp …` commands are correct for the native-install path. (The npm package is invoked as `octopus`; the docs use native install.)

## Test plan

- `bun run typecheck` — clean
- `bun run lint` — 0 errors
- `bun run build` — succeeds; all `/docs/*` routes compile
- Manual: no self-host env-var blocks remain on Cloud Setup pages; sidebar shows the Compliance group

## Post-deploy note

`docs-content.ts` seeds the **Ask-Octopus** chat KB — re-run `POST /api/admin/seed-docs` after deploy for the index edits to take effect in Ask-AI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)