### PR TITLE
fix: correct Ask-Octopus/docs to show Google Gemini is a supported BYOK review model

### DIFF
--- a/apps/web/app/(landing)/docs/faq/page.tsx
+++ b/apps/web/app/(landing)/docs/faq/page.tsx
@@ -18,7 +18,7 @@ const generalFaqs = [
   },
   {
     q: "How does Octopus review my code?",
-    a: "When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Claude or OpenAI) for analysis. The results are posted as PR comments with severity indicators: 🔴 Critical, 🟠 Major, 🟡 Minor, 🔵 Suggestion, 💡 Tip.",
+    a: "When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Claude, OpenAI, or Google Gemini) for analysis. The results are posted as PR comments with severity indicators: 🔴 Critical, 🟠 Major, 🟡 Minor, 🔵 Suggestion, 💡 Tip.",
   },
   {
     q: "Which programming languages does Octopus support?",
@@ -45,11 +45,11 @@ const securityFaqs = [
   },
   {
     q: "Which AI models process my code?",
-    a: "Octopus supports Anthropic Claude and OpenAI models. You can configure which model your organization uses, or bring your own API keys (BYO keys) so requests go directly to the provider without any intermediary.",
+    a: "Octopus supports Anthropic Claude, OpenAI (GPT), and Google Gemini as review models. You can configure which your organization uses, or bring your own API key (BYOK) for any of them — including a Google Gemini key — so requests go directly to the provider without any intermediary. (Embeddings use OpenAI, and Cohere is used for search re-ranking.)",
   },
   {
     q: "Does Octopus train AI models on my code?",
-    a: "No. Your code is never used for training. When using the cloud service, code is sent to Anthropic or OpenAI via their API, which does not use API inputs for model training. When self-hosting, you control the entire pipeline.",
+    a: "No. Your code is never used for training. When using the cloud service, code is sent to Anthropic, OpenAI, or Google via their API, which do not use API inputs for model training. When self-hosting, you control the entire pipeline.",
   },
 ];
 

--- a/apps/web/app/(landing)/docs/glossary/page.tsx
+++ b/apps/web/app/(landing)/docs/glossary/page.tsx
@@ -49,7 +49,7 @@ const glossary: { term: string; definition: string }[] = [
   {
     term: "LLM (Large Language Model)",
     definition:
-      "An AI model trained on large amounts of text, such as Anthropic Claude or OpenAI GPT. Octopus sends code context and diffs to an LLM, which performs the actual analysis and generates review findings.",
+      "An AI model trained on large amounts of text, such as Anthropic Claude, OpenAI GPT, or Google Gemini. Octopus sends code context and diffs to an LLM, which performs the actual analysis and generates review findings.",
   },
   {
     term: ".octopusignore",

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -37,7 +37,7 @@ const landingFaqs = [
   },
   {
     q: "How does the automated review work?",
-    a: "When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Claude or OpenAI) for analysis. Findings are posted directly on the PR with severity ratings: Critical, Major, Minor, Suggestion, and Tip.",
+    a: "When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Claude, OpenAI, or Google Gemini) for analysis. Findings are posted directly on the PR with severity ratings: Critical, Major, Minor, Suggestion, and Tip.",
   },
   {
     q: "Which programming languages are supported?",

--- a/apps/web/app/(landing)/vs-coderabbit/page.tsx
+++ b/apps/web/app/(landing)/vs-coderabbit/page.tsx
@@ -46,7 +46,7 @@ const faqs = [
   },
   {
     q: "How does pricing work with Octopus?",
-    a: "Octopus is credit-based and usage-only, so you pay for what the AI actually reviews. You can also bring your own Claude or OpenAI API key and pay the LLM provider directly. Self-hosted Octopus is free. See the pricing page for current rates.",
+    a: "Octopus is credit-based and usage-only, so you pay for what the AI actually reviews. You can also bring your own Claude, OpenAI, or Gemini API key and pay the LLM provider directly. Self-hosted Octopus is free. See the pricing page for current rates.",
   },
 ];
 
@@ -171,7 +171,7 @@ export default async function VsCodeRabbitPage() {
               </li>
               <li className="flex gap-3">
                 <IconCheck className="mt-0.5 size-4 shrink-0 text-[#10D8BE]" />
-                You want to bring your own Claude or OpenAI API keys.
+                You want to bring your own Claude, OpenAI, or Gemini API keys.
               </li>
               <li className="flex gap-3">
                 <IconCheck className="mt-0.5 size-4 shrink-0 text-[#10D8BE]" />

--- a/apps/web/app/(landing)/vs-greptile/page.tsx
+++ b/apps/web/app/(landing)/vs-greptile/page.tsx
@@ -50,7 +50,7 @@ const faqs = [
   },
   {
     q: "How does pricing work with Octopus?",
-    a: "Octopus is credit-based and usage-only, so you pay for what the AI actually reviews. You can also bring your own Claude or OpenAI API key and pay the LLM provider directly. Self-hosted Octopus is free. See the pricing page for current rates.",
+    a: "Octopus is credit-based and usage-only, so you pay for what the AI actually reviews. You can also bring your own Claude, OpenAI, or Gemini API key and pay the LLM provider directly. Self-hosted Octopus is free. See the pricing page for current rates.",
   },
 ];
 
@@ -178,7 +178,7 @@ export default async function VsGreptilePage() {
               </li>
               <li className="flex gap-3">
                 <IconCheck className="mt-0.5 size-4 shrink-0 text-[#10D8BE]" />
-                You want to bring your own Claude or OpenAI API keys.
+                You want to bring your own Claude, OpenAI, or Gemini API keys.
               </li>
               <li className="flex gap-3">
                 <IconCheck className="mt-0.5 size-4 shrink-0 text-[#10D8BE]" />

--- a/apps/web/app/api/ask-octopus/route.ts
+++ b/apps/web/app/api/ask-octopus/route.ts
@@ -59,9 +59,11 @@ const SYSTEM_PROMPT = `You are Octopus Assistant, a helpful AI that answers ques
 <octopus_overview>
 Octopus is a source-available, AI-powered code review tool available at https://octopus-review.ai. It connects to GitHub, GitLab, and Bitbucket, indexes your codebase using vector embeddings (OpenAI text-embedding-3-large, stored in Qdrant), and automatically reviews every pull request (and GitLab merge request). Findings are posted as inline PR comments with severity levels: 🔴 Critical, 🟠 Major, 🟡 Minor, 🔵 Suggestion, 💡 Tip.
 
-Key features: RAG Chat (ask questions about your codebase), CLI tool (octp — installed via a native one-liner), Codebase Indexing, Knowledge Base (custom review rules), shared team setup (org rules, repos, and reviewer settings stay aligned), Analytics, and integrations with Slack, Linear, and Jira (create Jira issues directly from review findings). Self-hostable with Docker (source-available, Modified MIT License). Supports Bring Your Own Keys (BYOK) for Anthropic, OpenAI, Google, Cohere. Credit-based pricing with free tier.
+Key features: RAG Chat (ask questions about your codebase), CLI tool (octp — installed via a native one-liner), Codebase Indexing, Knowledge Base (custom review rules), shared team setup (org rules, repos, and reviewer settings stay aligned), Analytics, and integrations with Slack, Linear, and Jira (create Jira issues directly from review findings). Self-hostable with Docker (source-available, Modified MIT License). Credit-based pricing with free tier.
 
-Tech stack: Next.js (App Router, React 19), Prisma + PostgreSQL, Qdrant vector DB, Claude & OpenAI, Tailwind CSS, TypeScript, Turborepo monorepo.
+Review/chat models: Anthropic Claude, OpenAI GPT, and Google Gemini are all supported review models, selectable per organization. Bring Your Own Keys (BYOK): an organization can bring its own Anthropic, OpenAI, OR Google/Gemini API key to run reviews and chat on its own account — yes, a Google Gemini API key works for reviews (it is not embeddings-only). Cohere keys are also supported, for search re-ranking. Embeddings use OpenAI text-embedding-3-large (or a local model when self-hosting).
+
+Tech stack: Next.js (App Router, React 19), Prisma + PostgreSQL, Qdrant vector DB, Claude / OpenAI / Gemini for reviews, Tailwind CSS, TypeScript, Turborepo monorepo.
 </octopus_overview>
 
 Use the documentation context provided with each question to give detailed, accurate answers. If context is provided, prefer it over the overview above. If no context is available, answer from the overview.

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -59,7 +59,7 @@ Self-Host Ready — Run Octopus on your own infrastructure with one Docker Compo
 A: Octopus is an AI-powered code review tool that connects to GitHub, GitLab, and Bitbucket, indexes your codebase for deep context, and automatically reviews every pull request (and GitLab merge request) — posting findings as inline comments with severity levels.
 
 Q: How does the automated review work?
-A: When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Claude or OpenAI) for analysis. Findings are posted directly on the PR with severity ratings: Critical, Major, Minor, Suggestion, and Tip.
+A: When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Claude, OpenAI, or Google Gemini) for analysis. Findings are posted directly on the PR with severity ratings: Critical, Major, Minor, Suggestion, and Tip.
 
 Q: Which programming languages are supported?
 A: Octopus is language-agnostic. It reviews any text-based code file — TypeScript, Python, Go, Rust, Java, C#, Ruby, PHP, Swift, Kotlin, and more.
@@ -118,7 +118,7 @@ Key commands: octp chat (chat with your codebase), octp review --pr <number> (re
       },
       {
         heading: "5. Customize Your Setup",
-        text: `AI Provider: Choose between Claude (Anthropic) and OpenAI for reviews and chat. Or bring your own API keys.
+        text: `AI Provider: Choose between Claude (Anthropic), OpenAI, and Google Gemini for reviews and chat. Or bring your own API keys.
 Knowledge Base: Upload documents, coding guidelines, and architecture decisions. Octopus references these during reviews.
 .octopusignore: Exclude files and directories from indexing and review (same syntax as .gitignore).
 Spend Limits: Set monthly spending caps per organization to control costs.
@@ -328,7 +328,7 @@ Running without Docker: Install Bun, set up PostgreSQL and Qdrant locally, run b
 A: Octopus is a source-available, AI-powered code review tool that indexes your codebase and automatically reviews pull requests with context-aware findings.
 
 Q: How does Octopus review code?
-A: When a PR is opened, Octopus fetches the diff, retrieves relevant code context via vector search, and uses an LLM (Claude or OpenAI) to analyze changes. Findings are posted as inline PR comments.
+A: When a PR is opened, Octopus fetches the diff, retrieves relevant code context via vector search, and uses an LLM (Claude, OpenAI, or Google Gemini) to analyze changes. Findings are posted as inline PR comments.
 
 Q: What languages does Octopus support?
 A: Octopus is language-agnostic. It supports TypeScript, JavaScript, Python, Go, Rust, Java, C#, Ruby, PHP, Swift, Kotlin, Scala, C, C++, Vue, Svelte, Astro, HTML, CSS, SQL, GraphQL, and more.
@@ -348,10 +348,10 @@ Q: Can I self-host Octopus?
 A: Yes. Octopus is fully self-hostable with Docker. Your code never leaves your infrastructure.
 
 Q: Which AI models are used?
-A: Claude (Anthropic) and OpenAI models for reviews and chat. OpenAI text-embedding-3-large for embeddings. Cohere Rerank for search re-ranking.
+A: Claude (Anthropic), OpenAI (GPT), and Google Gemini are all supported review/chat models, selectable per organization — and you can bring your own key for any of them (a Google Gemini API key works for reviews, not just embeddings). OpenAI text-embedding-3-large is used for embeddings. Cohere Rerank is used for search re-ranking.
 
 Q: Is my code used for AI training?
-A: No. Neither Anthropic nor OpenAI use API inputs for training. Your code is never used to train AI models.`,
+A: No. Anthropic, OpenAI, and Google do not use API inputs to train their models. Your code is never used to train AI models.`,
       },
       {
         heading: "Integrations",
@@ -428,7 +428,7 @@ Embeddings: Numerical vector representations of text. Octopus uses OpenAI text-e
 
 Knowledge Base: Custom documents uploaded to an organization (coding guidelines, architecture decisions, style guides) that Octopus references during reviews.
 
-LLM (Large Language Model): AI models like Claude (Anthropic) and GPT (OpenAI) that analyze code and generate review findings.
+LLM (Large Language Model): AI models like Claude (Anthropic), GPT (OpenAI), and Gemini (Google) that analyze code and generate review findings.
 
 .octopusignore: A file in your repository root (same syntax as .gitignore) that tells Octopus which files to skip during indexing and review.
 
@@ -502,7 +502,7 @@ Free to self-host: run the source-available core on your own infrastructure at n
         text: `Next.js (App Router, React 19) for the web application.
 Prisma with PostgreSQL for the database.
 Qdrant for vector storage and semantic search.
-Claude (Anthropic) and OpenAI for AI operations.
+Claude (Anthropic), OpenAI, and Google Gemini for AI operations.
 Tailwind CSS 4 for styling.
 TypeScript throughout.
 Turborepo for monorepo management.`,


### PR DESCRIPTION
## What

The public **Ask-Octopus** chat answered *"can I bring my own Gemini API key?"* with **"No, Octopus doesn't currently support Google Gemini API keys"** — then contradicted itself by listing Google under BYOK "(for embeddings)". That's wrong.

**Verified against code:** Google/Gemini is a first-class review provider with per-org BYOK — `lib/providers/google.ts` is registered in the provider registry, `lib/ai-router.ts` maps `gemini → google` and selects the org's decrypted `googleApiKey`. So a Google Gemini BYO key works for reviews/chat, not just embeddings.

**Root cause:** the docs + Ask-Octopus system prompt framed the review LLMs as "Claude or OpenAI" and Google as embeddings-only, so the model inferred Gemini wasn't a review option.

## Fix — corrected every place review models / BYOK are described

- **`api/ask-octopus/route.ts`** (`<octopus_overview>`): explicitly lists Claude / OpenAI / Gemini as review models and states a Google Gemini BYO key works for reviews (not embeddings-only); tech-stack line updated.
- **`lib/docs-content.ts`** (the Ask-Octopus KB): review-flow answers, "which AI models are used", BYOK/training answers, glossary LLM def, getting-started + about.
- **`/docs/faq`**: "Which AI models process my code?" now includes Gemini (the exact item the earlier docs audit *deliberately left* — revisited here per verified provider truth), plus the review-flow and training answers.
- **homepage FAQ, glossary LLM def, `vs-coderabbit`, `vs-greptile`** BYOK copy.

Left `self-hosting`'s "you'll need a provider key" note as-is — OpenAI is still required there for embeddings, so implying Gemini alone suffices would be inaccurate.

## Test plan

- `bun run typecheck` clean · `bun run lint` 0 errors · no residual "Claude or OpenAI" review/BYOK framing.

## Post-deploy

`docs-content.ts` seeds the Ask-Octopus KB — re-run `seed-docs-wdc` after deploy so the chat serves the corrected answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)