### PR TITLE
feat(admin): incident comms — failed-review emails + goodwill credits

### DIFF
--- a/apps/cli/src/commands/admin.ts
+++ b/apps/cli/src/commands/admin.ts
@@ -1,0 +1,334 @@
+import { createInterface } from "node:readline";
+import { loadCredentials } from "../lib/credentials.js";
+import { getJson, postJson } from "../lib/api.js";
+
+/**
+ * `octp admin` — operator-only commands against the /api/admin/* endpoints.
+ *
+ * Auth is deliberately NOT the customer device-flow token (that is org-scoped):
+ * these endpoints are gated by the server's ADMIN_API_SECRET, supplied here
+ * via OCTOPUS_ADMIN_SECRET (or ADMIN_API_SECRET) in the environment. The base
+ * URL falls back to the signed-in credentials' baseUrl so self-hosted
+ * operators get the right default without extra flags.
+ *
+ * Subcommands:
+ *   octp admin incidents [--since 3h] [--match 429]
+ *   octp admin incidents notify --incident-key <key> [--since 3h] [--match 429]
+ *        [--credits 5] [--summary "…"] [--template slug] [--send] [--yes] [--force]
+ *   octp admin credits grant --org <slug|id> --amount 10 --reason "…" [--yes] [--force]
+ *
+ * `incidents notify` is dry-run unless --send is passed, and --send asks for
+ * an interactive confirmation unless --yes is passed. The server enforces the
+ * same dry-run default and the per-org credit cap independently.
+ */
+
+const NOTIFY_TIMEOUT_MS = 5 * 60_000; // bulk email sends can be slow
+
+interface AdminContext {
+  baseUrl: string;
+  secret: string;
+}
+
+type Recipient = { email: string; name: string };
+
+interface AffectedOrg {
+  orgId: string;
+  orgSlug: string;
+  orgName: string;
+  failedCount: number;
+  firstFailureAt: string;
+  lastFailureAt: string;
+  repositories: string[];
+  errors: string[];
+  recipients: Recipient[];
+}
+
+interface FailedReviewsResponse {
+  since: string;
+  until: string;
+  match: string | null;
+  totals: { orgs: number; failedReviews: number };
+  orgs: AffectedOrg[];
+}
+
+interface OrgOutcome {
+  orgSlug: string;
+  orgName: string;
+  failedCount: number;
+  recipients: string[];
+  creditUsd: number;
+  action: "planned" | "sent" | "skipped" | "error";
+  reason?: string;
+}
+
+interface NotifyResponse {
+  dryRun: boolean;
+  incidentKey: string;
+  orgs: OrgOutcome[];
+  totals: { orgs: number; emails: number; creditUsd: number };
+}
+
+interface GrantResponse {
+  org: { id: string; slug: string; name: string };
+  granted: number;
+  balance: { free: number; purchased: number; total: number };
+}
+
+function printAdminHelp(): void {
+  console.log(`octp admin — operator commands (requires OCTOPUS_ADMIN_SECRET)
+
+Usage:
+  octp admin incidents [--since 3h] [--match 429]
+      List orgs with failed reviews in the window, with admin recipients.
+
+  octp admin incidents notify --incident-key <key> [options]
+      Email affected orgs' owners/admins + optionally grant free credits.
+      Dry-run by default; add --send to execute (asks to confirm).
+      --since <3h|45m|2d|ISO>   window (default 3h, max 30d)
+      --match <text>            only failures whose error contains <text>
+      --credits <usd>           free credits per org (default 0, cap $50)
+      --summary <text>          one-line cause shown in the email
+      --template <slug>         email template (default incident-resolved)
+      --send                    actually send (otherwise dry-run)
+      --yes                     skip the interactive confirmation
+      --force                   allow credits above the cap
+
+  octp admin credits grant --org <slug|id> --amount <usd> --reason <text> [--yes] [--force]
+      One-off goodwill grant to a single org's free-credit balance.
+
+Common flags:
+  --url <base>                  API base (default: OCTOPUS_ADMIN_URL, then your
+                                signed-in baseUrl from ~/.octopus/credentials)
+`);
+}
+
+function getFlag(argv: string[], name: string): string | undefined {
+  const i = argv.indexOf(name);
+  if (i === -1) return undefined;
+  const value = argv[i + 1];
+  if (value === undefined || value.startsWith("--")) return undefined;
+  return value;
+}
+
+async function resolveContext(argv: string[]): Promise<AdminContext | null> {
+  const secret = process.env.OCTOPUS_ADMIN_SECRET || process.env.ADMIN_API_SECRET;
+  if (!secret) {
+    console.error("No admin secret. Set OCTOPUS_ADMIN_SECRET to the server's ADMIN_API_SECRET.");
+    return null;
+  }
+
+  let baseUrl = getFlag(argv, "--url") || process.env.OCTOPUS_ADMIN_URL;
+  if (!baseUrl) {
+    const creds = await loadCredentials();
+    baseUrl = creds?.baseUrl;
+  }
+  if (!baseUrl) {
+    console.error("No API base URL. Pass --url, set OCTOPUS_ADMIN_URL, or sign in with `octp` first.");
+    return null;
+  }
+
+  return { baseUrl: baseUrl.replace(/\/+$/, ""), secret };
+}
+
+async function confirm(prompt: string): Promise<boolean> {
+  if (!process.stdin.isTTY) {
+    console.error("Refusing to send without a TTY confirmation — pass --yes to override.");
+    return false;
+  }
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((resolve) => rl.question(prompt, resolve));
+  rl.close();
+  return answer.trim() === "SEND";
+}
+
+function formatWindow(startIso: string, endIso: string): string {
+  const fmt = (iso: string) => iso.replace("T", " ").slice(0, 16);
+  return `${fmt(startIso)} → ${fmt(endIso)} UTC`;
+}
+
+function printOrgTable(orgs: AffectedOrg[]): void {
+  for (const org of orgs) {
+    console.log(`\n  ${org.orgName} (${org.orgSlug})`);
+    console.log(`    failed reviews : ${org.failedCount}  [${formatWindow(org.firstFailureAt, org.lastFailureAt)}]`);
+    console.log(`    repositories   : ${org.repositories.join(", ")}`);
+    console.log(`    recipients     : ${org.recipients.map((r) => r.email).join(", ") || "(none — would be skipped)"}`);
+    for (const err of org.errors) {
+      console.log(`    error          : ${err}`);
+    }
+  }
+}
+
+function printOutcomes(result: NotifyResponse): void {
+  for (const org of result.orgs) {
+    const credit = org.creditUsd > 0 ? ` +$${org.creditUsd.toFixed(2)}` : "";
+    const reason = org.reason ? ` — ${org.reason}` : "";
+    console.log(`  [${org.action.toUpperCase().padEnd(7)}] ${org.orgSlug} (${org.failedCount} failed, ${org.recipients.length} recipient(s)${credit})${reason}`);
+  }
+  console.log(
+    `\n  Totals: ${result.totals.orgs} org(s), ${result.totals.emails} email(s), $${result.totals.creditUsd.toFixed(2)} credits${result.dryRun ? "  [DRY RUN]" : ""}`,
+  );
+}
+
+async function incidentsList(argv: string[], ctx: AdminContext): Promise<number> {
+  const since = getFlag(argv, "--since") ?? "3h";
+  const match = getFlag(argv, "--match");
+  const qs = new URLSearchParams({ since });
+  if (match) qs.set("match", match);
+
+  const res = await getJson<FailedReviewsResponse>(
+    `${ctx.baseUrl}/api/admin/incidents/failed-reviews?${qs}`,
+    { headers: { authorization: `Bearer ${ctx.secret}` } },
+  );
+  if (!res.ok) {
+    console.error(`Failed (HTTP ${res.status}): ${res.error}`);
+    return 1;
+  }
+
+  const { totals, orgs } = res.data;
+  console.log(
+    `Failed reviews since ${res.data.since}${match ? ` matching "${match}"` : ""}: ${totals.failedReviews} across ${totals.orgs} org(s)`,
+  );
+  if (orgs.length > 0) printOrgTable(orgs);
+  return 0;
+}
+
+async function incidentsNotify(argv: string[], ctx: AdminContext): Promise<number> {
+  const incidentKey = getFlag(argv, "--incident-key");
+  if (!incidentKey) {
+    console.error("Missing --incident-key (e.g. openai-429-2026-07-11). It is the idempotency key: re-runs with the same key never re-email an org.");
+    return 2;
+  }
+
+  const creditsRaw = getFlag(argv, "--credits");
+  const creditUsd = creditsRaw === undefined ? 0 : Number(creditsRaw);
+  if (Number.isNaN(creditUsd) || creditUsd < 0) {
+    console.error(`Invalid --credits value: ${creditsRaw}`);
+    return 2;
+  }
+
+  const payload = {
+    incidentKey,
+    since: getFlag(argv, "--since") ?? "3h",
+    match: getFlag(argv, "--match"),
+    template: getFlag(argv, "--template"),
+    summary: getFlag(argv, "--summary"),
+    creditUsd,
+    force: argv.includes("--force"),
+  };
+
+  // Always dry-run first so the operator sees the exact blast radius.
+  const dry = await postJson<NotifyResponse>(
+    `${ctx.baseUrl}/api/admin/incidents/notify`,
+    { ...payload, dryRun: true },
+    ctx.secret,
+    { timeoutMs: NOTIFY_TIMEOUT_MS },
+  );
+  if (!dry.ok) {
+    console.error(`Dry run failed (HTTP ${dry.status}): ${dry.error}`);
+    return 1;
+  }
+
+  console.log(`Incident "${incidentKey}" — plan:\n`);
+  printOutcomes(dry.data);
+
+  if (!argv.includes("--send")) {
+    console.log("\nDry run only. Re-run with --send to execute.");
+    return 0;
+  }
+  if (dry.data.totals.orgs === 0) {
+    console.log("\nNothing to send.");
+    return 0;
+  }
+
+  if (!argv.includes("--yes")) {
+    const ok = await confirm(
+      `\nSend ${dry.data.totals.emails} email(s) and grant $${dry.data.totals.creditUsd.toFixed(2)} across ${dry.data.totals.orgs} org(s)? Type SEND to proceed: `,
+    );
+    if (!ok) {
+      console.log("Aborted.");
+      return 1;
+    }
+  }
+
+  const live = await postJson<NotifyResponse>(
+    `${ctx.baseUrl}/api/admin/incidents/notify`,
+    { ...payload, dryRun: false },
+    ctx.secret,
+    { timeoutMs: NOTIFY_TIMEOUT_MS },
+  );
+  if (!live.ok) {
+    console.error(`Send failed (HTTP ${live.status}): ${live.error}`);
+    return 1;
+  }
+
+  console.log("\nResult:\n");
+  printOutcomes(live.data);
+  return live.data.orgs.some((o) => o.action === "error") ? 1 : 0;
+}
+
+async function creditsGrant(argv: string[], ctx: AdminContext): Promise<number> {
+  const org = getFlag(argv, "--org");
+  const amountRaw = getFlag(argv, "--amount");
+  const reason = getFlag(argv, "--reason");
+  if (!org || !amountRaw || !reason) {
+    console.error("Usage: octp admin credits grant --org <slug|id> --amount <usd> --reason <text> [--yes] [--force]");
+    return 2;
+  }
+  const amountUsd = Number(amountRaw);
+  if (Number.isNaN(amountUsd) || amountUsd <= 0) {
+    console.error(`Invalid --amount value: ${amountRaw}`);
+    return 2;
+  }
+
+  if (!argv.includes("--yes")) {
+    const ok = await confirm(
+      `Grant $${amountUsd.toFixed(2)} free credits to "${org}" (${reason})? Type SEND to proceed: `,
+    );
+    if (!ok) {
+      console.log("Aborted.");
+      return 1;
+    }
+  }
+
+  const res = await postJson<GrantResponse>(
+    `${ctx.baseUrl}/api/admin/credits/grant`,
+    { org, amountUsd, reason, force: argv.includes("--force") },
+    ctx.secret,
+  );
+  if (!res.ok) {
+    console.error(`Grant failed (HTTP ${res.status}): ${res.error}`);
+    return 1;
+  }
+
+  const { balance } = res.data;
+  console.log(
+    `Granted $${res.data.granted.toFixed(2)} to ${res.data.org.slug}. Balance: $${balance.free.toFixed(2)} free + $${balance.purchased.toFixed(2)} purchased = $${balance.total.toFixed(2)}.`,
+  );
+  return 0;
+}
+
+export async function adminCommand(argv: string[]): Promise<number> {
+  if (argv.length === 0 || argv.includes("--help") || argv.includes("-h")) {
+    printAdminHelp();
+    return argv.length === 0 ? 2 : 0;
+  }
+
+  const ctx = await resolveContext(argv);
+  if (!ctx) return 2;
+
+  const sub = argv[0];
+  if (sub === "incidents") {
+    if (argv[1] === "notify") return await incidentsNotify(argv.slice(2), ctx);
+    return await incidentsList(argv.slice(1), ctx);
+  }
+  if (sub === "credits") {
+    if (argv[1] === "grant") return await creditsGrant(argv.slice(2), ctx);
+    console.error(`Unknown credits subcommand: ${argv[1] ?? "(none)"}`);
+    console.error("Try: octp admin credits grant --help");
+    return 2;
+  }
+
+  console.error(`Unknown admin subcommand: ${sub}`);
+  printAdminHelp();
+  return 2;
+}

--- a/apps/cli/src/commands/admin.ts
+++ b/apps/cli/src/commands/admin.ts
@@ -1,6 +1,7 @@
 import { createInterface } from "node:readline";
 import { loadCredentials } from "../lib/credentials.js";
-import { getJson, postJson } from "../lib/api.js";
+import { getJson, isTransportSafe, postJson } from "../lib/api.js";
+import { sanitizeTerminal } from "../lib/output.js";
 
 /**
  * `octp admin` — operator-only commands against the /api/admin/* endpoints.
@@ -64,6 +65,8 @@ interface OrgOutcome {
 interface NotifyResponse {
   dryRun: boolean;
   incidentKey: string;
+  /** The window start the server resolved, as ISO — reused verbatim for the live send. */
+  since: string;
   orgs: OrgOutcome[];
   totals: { orgs: number; emails: number; creditUsd: number };
 }
@@ -99,6 +102,8 @@ Usage:
 Common flags:
   --url <base>                  API base (default: OCTOPUS_ADMIN_URL, then your
                                 signed-in baseUrl from ~/.octopus/credentials)
+  --insecure                    Allow sending the admin secret over cleartext
+                                HTTP to a non-local host (not recommended)
 `);
 }
 
@@ -127,7 +132,16 @@ async function resolveContext(argv: string[]): Promise<AdminContext | null> {
     return null;
   }
 
-  return { baseUrl: baseUrl.replace(/\/+$/, ""), secret };
+  const cleanBase = baseUrl.replace(/\/+$/, "");
+  // The admin secret is strictly more sensitive than a customer token (it
+  // grants mass-email + credit-granting) — same cleartext guard as login.ts.
+  if (!isTransportSafe(cleanBase) && !argv.includes("--insecure")) {
+    console.error("Refusing to send the admin secret over cleartext HTTP to a non-local host.");
+    console.error("Use an https URL (or a loopback / private-LAN host), or pass --insecure to override.");
+    return null;
+  }
+
+  return { baseUrl: cleanBase, secret };
 }
 
 async function confirm(prompt: string): Promise<boolean> {
@@ -146,14 +160,16 @@ function formatWindow(startIso: string, endIso: string): string {
   return `${fmt(startIso)} → ${fmt(endIso)} UTC`;
 }
 
+// All org/repo/error strings below are server-provided (and error text can
+// echo upstream API responses) — sanitize before they reach the terminal.
 function printOrgTable(orgs: AffectedOrg[]): void {
   for (const org of orgs) {
-    console.log(`\n  ${org.orgName} (${org.orgSlug})`);
+    console.log(`\n  ${sanitizeTerminal(org.orgName)} (${sanitizeTerminal(org.orgSlug)})`);
     console.log(`    failed reviews : ${org.failedCount}  [${formatWindow(org.firstFailureAt, org.lastFailureAt)}]`);
-    console.log(`    repositories   : ${org.repositories.join(", ")}`);
-    console.log(`    recipients     : ${org.recipients.map((r) => r.email).join(", ") || "(none — would be skipped)"}`);
+    console.log(`    repositories   : ${sanitizeTerminal(org.repositories.join(", "))}`);
+    console.log(`    recipients     : ${sanitizeTerminal(org.recipients.map((r) => r.email).join(", ")) || "(none — would be skipped)"}`);
     for (const err of org.errors) {
-      console.log(`    error          : ${err}`);
+      console.log(`    error          : ${sanitizeTerminal(err)}`);
     }
   }
 }
@@ -161,8 +177,8 @@ function printOrgTable(orgs: AffectedOrg[]): void {
 function printOutcomes(result: NotifyResponse): void {
   for (const org of result.orgs) {
     const credit = org.creditUsd > 0 ? ` +$${org.creditUsd.toFixed(2)}` : "";
-    const reason = org.reason ? ` — ${org.reason}` : "";
-    console.log(`  [${org.action.toUpperCase().padEnd(7)}] ${org.orgSlug} (${org.failedCount} failed, ${org.recipients.length} recipient(s)${credit})${reason}`);
+    const reason = org.reason ? ` — ${sanitizeTerminal(org.reason)}` : "";
+    console.log(`  [${org.action.toUpperCase().padEnd(7)}] ${sanitizeTerminal(org.orgSlug)} (${org.failedCount} failed, ${org.recipients.length} recipient(s)${credit})${reason}`);
   }
   console.log(
     `\n  Totals: ${result.totals.orgs} org(s), ${result.totals.emails} email(s), $${result.totals.creditUsd.toFixed(2)} credits${result.dryRun ? "  [DRY RUN]" : ""}`,
@@ -250,9 +266,12 @@ async function incidentsNotify(argv: string[], ctx: AdminContext): Promise<numbe
     }
   }
 
+  // Pin the live send to the exact window the operator just approved — a
+  // relative --since would re-resolve at send time and could pull in orgs
+  // that failed after the plan was printed.
   const live = await postJson<NotifyResponse>(
     `${ctx.baseUrl}/api/admin/incidents/notify`,
-    { ...payload, dryRun: false },
+    { ...payload, since: dry.data.since, dryRun: false },
     ctx.secret,
     { timeoutMs: NOTIFY_TIMEOUT_MS },
   );
@@ -302,7 +321,7 @@ async function creditsGrant(argv: string[], ctx: AdminContext): Promise<number> 
 
   const { balance } = res.data;
   console.log(
-    `Granted $${res.data.granted.toFixed(2)} to ${res.data.org.slug}. Balance: $${balance.free.toFixed(2)} free + $${balance.purchased.toFixed(2)} purchased = $${balance.total.toFixed(2)}.`,
+    `Granted $${res.data.granted.toFixed(2)} to ${sanitizeTerminal(res.data.org.slug)}. Balance: $${balance.free.toFixed(2)} free + $${balance.purchased.toFixed(2)} purchased = $${balance.total.toFixed(2)}.`,
   );
   return 0;
 }

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { renderWizard } from "./OnboardWizard.js";
 import { isOnboarded, loadConfig } from "./lib/config.js";
+import { adminCommand } from "./commands/admin.js";
 import { agentServeCommand } from "./commands/agent-serve.js";
 import { agentWatchCommand } from "./commands/agent-watch.js";
 import { doctorCommand } from "./commands/doctor.js";
@@ -86,6 +87,8 @@ Agent & ops:
   octp agent watch [path]    Watch a repo dir so cloud chat can search it locally
   octp config <get|set|list> Manage ~/.octopus/config.json
   octp skills <list|install|update|remove>       Manage AI-agent skills
+  octp admin <subcommand>    Operator ops: incident emails + goodwill credits
+                             (see \`octp admin --help\`; needs OCTOPUS_ADMIN_SECRET)
   octp doctor                Environment + auth health check
   octp update [--check]      Update the CLI
 
@@ -209,6 +212,8 @@ async function main(rawArgv: string[]): Promise<number> {
     case "account":
     case "profile":
       return await accountCommand(rest);
+    case "admin":
+      return await adminCommand(rest);
     case "agent": {
       const sub = argv[1];
       if (sub === "serve") return await agentServeCommand(argv.slice(2));

--- a/apps/web/app/api/admin/credits/grant/route.ts
+++ b/apps/web/app/api/admin/credits/grant/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@octopus/db";
+import { addFreeCredits, getOrgBalance } from "@/lib/credits";
+import { writeAuditLog } from "@/lib/audit";
+import { MAX_CREDIT_USD } from "@/lib/incidents";
+
+function isAuthorized(request: NextRequest): boolean {
+  const expected = process.env.ADMIN_API_SECRET;
+  if (!expected) return false;
+  const header = request.headers.get("authorization");
+  if (!header) return false;
+  const token = header.startsWith("Bearer ") ? header.slice(7) : header;
+  return token === expected;
+}
+
+interface GrantBody {
+  org?: unknown;
+  amountUsd?: unknown;
+  reason?: unknown;
+  force?: unknown;
+}
+
+/**
+ * POST /api/admin/credits/grant — standalone goodwill grant to one org's
+ * free-credit balance (the incident flow grants in bulk; this is the manual
+ * follow-up / one-off path). `org` accepts a slug or an id.
+ */
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: GrantBody;
+  try {
+    body = (await request.json()) as GrantBody;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const orgRef = typeof body.org === "string" ? body.org.trim() : "";
+  if (!orgRef) {
+    return NextResponse.json({ error: "org (slug or id) is required" }, { status: 400 });
+  }
+
+  const amountUsd = Number(body.amountUsd);
+  if (!Number.isFinite(amountUsd) || amountUsd <= 0) {
+    return NextResponse.json({ error: "amountUsd must be a positive number" }, { status: 400 });
+  }
+  if (amountUsd > MAX_CREDIT_USD && body.force !== true) {
+    return NextResponse.json(
+      { error: `amountUsd ${amountUsd} exceeds the $${MAX_CREDIT_USD} cap — pass force:true if intentional` },
+      { status: 400 },
+    );
+  }
+
+  const reason = typeof body.reason === "string" ? body.reason.trim() : "";
+  if (!reason) {
+    return NextResponse.json({ error: "reason is required" }, { status: 400 });
+  }
+
+  const org = await prisma.organization.findFirst({
+    where: {
+      OR: [{ slug: orgRef }, { id: orgRef }],
+      deletedAt: null,
+    },
+    select: { id: true, slug: true, name: true, bannedAt: true },
+  });
+  if (!org) {
+    return NextResponse.json({ error: `organization "${orgRef}" not found` }, { status: 404 });
+  }
+  if (org.bannedAt) {
+    return NextResponse.json({ error: `organization "${org.slug}" is banned` }, { status: 400 });
+  }
+
+  await addFreeCredits(org.id, amountUsd, `Goodwill credit — ${reason}`);
+
+  await writeAuditLog({
+    action: "admin.credits.grant",
+    category: "admin",
+    organizationId: org.id,
+    metadata: { amountUsd, reason },
+  });
+
+  const balance = await getOrgBalance(org.id);
+
+  return NextResponse.json({
+    org: { id: org.id, slug: org.slug, name: org.name },
+    granted: amountUsd,
+    balance,
+  });
+}

--- a/apps/web/app/api/admin/credits/grant/route.ts
+++ b/apps/web/app/api/admin/credits/grant/route.ts
@@ -1,17 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@octopus/db";
+import { isAdminApiAuthorized } from "@/lib/admin-auth";
 import { addFreeCredits, getOrgBalance } from "@/lib/credits";
 import { writeAuditLog } from "@/lib/audit";
 import { MAX_CREDIT_USD } from "@/lib/incidents";
-
-function isAuthorized(request: NextRequest): boolean {
-  const expected = process.env.ADMIN_API_SECRET;
-  if (!expected) return false;
-  const header = request.headers.get("authorization");
-  if (!header) return false;
-  const token = header.startsWith("Bearer ") ? header.slice(7) : header;
-  return token === expected;
-}
 
 interface GrantBody {
   org?: unknown;
@@ -26,7 +18,7 @@ interface GrantBody {
  * follow-up / one-off path). `org` accepts a slug or an id.
  */
 export async function POST(request: NextRequest) {
-  if (!isAuthorized(request)) {
+  if (!isAdminApiAuthorized(request)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/apps/web/app/api/admin/incidents/failed-reviews/route.ts
+++ b/apps/web/app/api/admin/incidents/failed-reviews/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { findAffectedOrgs, parseSince } from "@/lib/incidents";
+
+function isAuthorized(request: NextRequest): boolean {
+  const expected = process.env.ADMIN_API_SECRET;
+  if (!expected) return false;
+  const header = request.headers.get("authorization");
+  if (!header) return false;
+  const token = header.startsWith("Bearer ") ? header.slice(7) : header;
+  return token === expected;
+}
+
+/**
+ * GET /api/admin/incidents/failed-reviews?since=3h&match=429
+ *
+ * Failed reviews inside the window, grouped per organization with the
+ * owner/admin recipients an incident notification would go to. Read-only —
+ * the write side is POST /api/admin/incidents/notify.
+ */
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(request.url);
+  const sinceRaw = url.searchParams.get("since") ?? "3h";
+  const match = url.searchParams.get("match") ?? undefined;
+
+  const since = parseSince(sinceRaw);
+  if (!since) {
+    return NextResponse.json(
+      { error: `invalid since "${sinceRaw}" — use 45m / 3h / 2d (max 30d) or an ISO date` },
+      { status: 400 },
+    );
+  }
+
+  const orgs = await findAffectedOrgs(since, match);
+
+  return NextResponse.json({
+    since: since.toISOString(),
+    until: new Date().toISOString(),
+    match: match ?? null,
+    totals: {
+      orgs: orgs.length,
+      failedReviews: orgs.reduce((sum, o) => sum + o.failedCount, 0),
+    },
+    orgs,
+  });
+}

--- a/apps/web/app/api/admin/incidents/failed-reviews/route.ts
+++ b/apps/web/app/api/admin/incidents/failed-reviews/route.ts
@@ -1,14 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { isAdminApiAuthorized } from "@/lib/admin-auth";
 import { findAffectedOrgs, parseSince } from "@/lib/incidents";
-
-function isAuthorized(request: NextRequest): boolean {
-  const expected = process.env.ADMIN_API_SECRET;
-  if (!expected) return false;
-  const header = request.headers.get("authorization");
-  if (!header) return false;
-  const token = header.startsWith("Bearer ") ? header.slice(7) : header;
-  return token === expected;
-}
 
 /**
  * GET /api/admin/incidents/failed-reviews?since=3h&match=429
@@ -18,7 +10,7 @@ function isAuthorized(request: NextRequest): boolean {
  * the write side is POST /api/admin/incidents/notify.
  */
 export async function GET(request: NextRequest) {
-  if (!isAuthorized(request)) {
+  if (!isAdminApiAuthorized(request)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/apps/web/app/api/admin/incidents/notify/route.ts
+++ b/apps/web/app/api/admin/incidents/notify/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { isAdminApiAuthorized } from "@/lib/admin-auth";
 import {
   INCIDENT_KEY_RE,
   IncidentNotifyError,
@@ -6,15 +7,6 @@ import {
   notifyAffectedOrgs,
   parseSince,
 } from "@/lib/incidents";
-
-function isAuthorized(request: NextRequest): boolean {
-  const expected = process.env.ADMIN_API_SECRET;
-  if (!expected) return false;
-  const header = request.headers.get("authorization");
-  if (!header) return false;
-  const token = header.startsWith("Bearer ") ? header.slice(7) : header;
-  return token === expected;
-}
 
 interface NotifyBody {
   incidentKey?: unknown;
@@ -35,7 +27,7 @@ interface NotifyBody {
  * explicitly false. Idempotent per (incidentKey, org) — see lib/incidents.ts.
  */
 export async function POST(request: NextRequest) {
-  if (!isAuthorized(request)) {
+  if (!isAdminApiAuthorized(request)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/apps/web/app/api/admin/incidents/notify/route.ts
+++ b/apps/web/app/api/admin/incidents/notify/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  INCIDENT_KEY_RE,
+  IncidentNotifyError,
+  MAX_CREDIT_USD,
+  notifyAffectedOrgs,
+  parseSince,
+} from "@/lib/incidents";
+
+function isAuthorized(request: NextRequest): boolean {
+  const expected = process.env.ADMIN_API_SECRET;
+  if (!expected) return false;
+  const header = request.headers.get("authorization");
+  if (!header) return false;
+  const token = header.startsWith("Bearer ") ? header.slice(7) : header;
+  return token === expected;
+}
+
+interface NotifyBody {
+  incidentKey?: unknown;
+  since?: unknown;
+  match?: unknown;
+  template?: unknown;
+  creditUsd?: unknown;
+  summary?: unknown;
+  dryRun?: unknown;
+  force?: unknown;
+}
+
+/**
+ * POST /api/admin/incidents/notify
+ *
+ * Emails owner/admin members of every org with failed reviews in the window
+ * and optionally grants goodwill free credits. Dry-run unless `dryRun` is
+ * explicitly false. Idempotent per (incidentKey, org) — see lib/incidents.ts.
+ */
+export async function POST(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: NotifyBody;
+  try {
+    body = (await request.json()) as NotifyBody;
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const incidentKey = typeof body.incidentKey === "string" ? body.incidentKey : "";
+  if (!INCIDENT_KEY_RE.test(incidentKey)) {
+    return NextResponse.json(
+      { error: "incidentKey is required: 3-64 chars of lowercase letters, digits, dashes (e.g. openai-429-2026-07-11)" },
+      { status: 400 },
+    );
+  }
+
+  const sinceRaw = typeof body.since === "string" ? body.since : "3h";
+  const since = parseSince(sinceRaw);
+  if (!since) {
+    return NextResponse.json(
+      { error: `invalid since "${sinceRaw}" — use 45m / 3h / 2d (max 30d) or an ISO date` },
+      { status: 400 },
+    );
+  }
+
+  const creditUsd = body.creditUsd === undefined ? 0 : Number(body.creditUsd);
+  if (!Number.isFinite(creditUsd) || creditUsd < 0) {
+    return NextResponse.json({ error: "creditUsd must be a non-negative number" }, { status: 400 });
+  }
+  if (creditUsd > MAX_CREDIT_USD && body.force !== true) {
+    return NextResponse.json(
+      { error: `creditUsd ${creditUsd} exceeds the $${MAX_CREDIT_USD} per-org cap — pass force:true if intentional` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await notifyAffectedOrgs({
+      incidentKey,
+      since,
+      match: typeof body.match === "string" && body.match ? body.match : undefined,
+      templateSlug:
+        typeof body.template === "string" && body.template ? body.template : "incident-resolved",
+      creditUsd,
+      summary: typeof body.summary === "string" && body.summary ? body.summary : undefined,
+      // Live send requires an explicit opt-out of the default dry-run.
+      dryRun: body.dryRun !== false,
+    });
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof IncidentNotifyError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
+    throw err;
+  }
+}

--- a/apps/web/lib/__tests__/incidents.test.ts
+++ b/apps/web/lib/__tests__/incidents.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import {
+  INCIDENT_KEY_RE,
+  MAX_CREDIT_USD,
+  buildCreditNote,
+  parseSince,
+} from "../incidents";
+
+const NOW = new Date("2026-07-11T12:00:00.000Z");
+
+describe("parseSince", () => {
+  test("parses minute/hour/day shorthands relative to now", () => {
+    expect(parseSince("45m", NOW)?.toISOString()).toBe("2026-07-11T11:15:00.000Z");
+    expect(parseSince("3h", NOW)?.toISOString()).toBe("2026-07-11T09:00:00.000Z");
+    expect(parseSince("2d", NOW)?.toISOString()).toBe("2026-07-09T12:00:00.000Z");
+  });
+
+  test("parses an ISO date inside the window", () => {
+    expect(parseSince("2026-07-10T00:00:00Z", NOW)?.toISOString()).toBe(
+      "2026-07-10T00:00:00.000Z",
+    );
+  });
+
+  test("rejects zero, garbage, and unknown units", () => {
+    expect(parseSince("0h", NOW)).toBeNull();
+    expect(parseSince("xyz", NOW)).toBeNull();
+    expect(parseSince("3w", NOW)).toBeNull();
+    expect(parseSince("", NOW)).toBeNull();
+  });
+
+  test("rejects windows beyond the 30-day ceiling (typo guard)", () => {
+    expect(parseSince("31d", NOW)).toBeNull();
+    expect(parseSince("300d", NOW)).toBeNull();
+    expect(parseSince("2026-01-01T00:00:00Z", NOW)).toBeNull();
+    expect(parseSince("30d", NOW)).not.toBeNull();
+  });
+
+  test("rejects future dates", () => {
+    expect(parseSince("2026-07-12T00:00:00Z", NOW)).toBeNull();
+  });
+});
+
+describe("buildCreditNote", () => {
+  test("empty when no credit is granted", () => {
+    expect(buildCreditNote(0)).toBe("");
+    expect(buildCreditNote(-1)).toBe("");
+  });
+
+  test("formats the amount as USD with two decimals", () => {
+    expect(buildCreditNote(5)).toContain("$5.00");
+    expect(buildCreditNote(12.5)).toContain("$12.50");
+  });
+});
+
+describe("INCIDENT_KEY_RE", () => {
+  test("accepts kebab-case incident keys", () => {
+    expect(INCIDENT_KEY_RE.test("openai-429-2026-07-11")).toBe(true);
+    expect(INCIDENT_KEY_RE.test("abc")).toBe(true);
+  });
+
+  test("rejects uppercase, leading dash, too short, too long", () => {
+    expect(INCIDENT_KEY_RE.test("OpenAI-429")).toBe(false);
+    expect(INCIDENT_KEY_RE.test("-leading")).toBe(false);
+    expect(INCIDENT_KEY_RE.test("ab")).toBe(false);
+    expect(INCIDENT_KEY_RE.test("x".repeat(65))).toBe(false);
+  });
+});
+
+describe("MAX_CREDIT_USD", () => {
+  test("cap is a sane positive ceiling", () => {
+    expect(MAX_CREDIT_USD).toBeGreaterThan(0);
+    expect(MAX_CREDIT_USD).toBeLessThanOrEqual(100);
+  });
+});

--- a/apps/web/lib/email-template-seeds.ts
+++ b/apps/web/lib/email-template-seeds.ts
@@ -285,6 +285,28 @@ Let us know how your first review goes!`,
     buttonUrl: "{{appUrl}}/repositories",
     variables: ["firstName", "appUrl"],
   },
+  {
+    slug: "incident-resolved",
+    name: "Incident Resolved",
+    category: "transactional",
+    fromType: "system",
+    subject: "Resolved: Octopus review failures in {{orgName}}",
+    body: `Hi {{orgName}} team,
+
+Between {{windowStart}} and {{windowEnd}}, {{failedCount}} pull request review(s) in your organization failed because of a problem on our side — not anything in your code or configuration. {{incidentSummary}}
+
+The issue is fixed and reviews are running normally again. You can re-run any affected review by re-triggering it on the pull request or from the repository page.{{creditNote}}
+
+Sorry for the disruption, and thank you for your patience.`,
+    variables: [
+      "orgName",
+      "windowStart",
+      "windowEnd",
+      "failedCount",
+      "incidentSummary",
+      "creditNote",
+    ],
+  },
 ];
 
 /**

--- a/apps/web/lib/events/observers/email.observer.ts
+++ b/apps/web/lib/events/observers/email.observer.ts
@@ -2,6 +2,7 @@ import { prisma } from "@octopus/db";
 import { sendEmail } from "@/lib/email";
 import { escapeHtml, sanitizeUrl } from "@/lib/html";
 import { renderEmailTemplate } from "@/lib/email-renderer";
+import { getAdminRecipients } from "@/lib/org-recipients";
 import { eventBus } from "../bus";
 import type {
   RepoIndexedEvent,
@@ -126,24 +127,6 @@ function onKnowledgeReady(event: KnowledgeReadyEvent): Promise<void> {
   });
 }
 
-async function getAdminRecipients(
-  orgId: string,
-): Promise<{ email: string; name: string }[]> {
-  const members = await prisma.organizationMember.findMany({
-    where: {
-      organizationId: orgId,
-      deletedAt: null,
-      role: { in: ["owner", "admin"] },
-    },
-    select: {
-      user: { select: { email: true, name: true } },
-    },
-  });
-
-  return members
-    .filter((m) => m.user.email)
-    .map((m) => ({ email: m.user.email, name: m.user.name }));
-}
 
 const CREDIT_LOW_COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24h
 

--- a/apps/web/lib/incidents.ts
+++ b/apps/web/lib/incidents.ts
@@ -1,0 +1,331 @@
+import { prisma } from "@octopus/db";
+import { sendEmail } from "./email";
+import { escapeHtml } from "./html";
+import { renderEmailTemplate } from "./email-renderer";
+import { addFreeCredits } from "./credits";
+import { writeAuditLog } from "./audit";
+import { getAdminRecipients } from "./org-recipients";
+
+/**
+ * Incident comms engine — powers the /api/admin/incidents/* endpoints behind
+ * `octp admin incidents`. Finds orgs whose reviews failed inside a time
+ * window, emails their owner/admin members from a DB template, and optionally
+ * grants goodwill free credits. Idempotent per (incidentKey, org) via the
+ * IncidentComm unique constraint: a claim row is created before any send and
+ * released only if that org's send fails before emails are recorded.
+ */
+
+// ---------- pure helpers (unit-tested in __tests__/incidents.test.ts) ----------
+
+const SINCE_RE = /^(\d+)([mhd])$/;
+// Window ceiling: a typo like `--since 300d` must not turn an incident email
+// into a mass mailing of everyone who ever had a failed review.
+export const MAX_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+// Per-org goodwill ceiling without an explicit force flag.
+export const MAX_CREDIT_USD = 50;
+
+export const INCIDENT_KEY_RE = /^[a-z0-9][a-z0-9-]{2,63}$/;
+
+/** Parse "45m" / "3h" / "2d" or an ISO date into a window start. Null = invalid. */
+export function parseSince(input: string, now: Date = new Date()): Date | null {
+  const m = SINCE_RE.exec(input.trim());
+  let start: Date | null = null;
+  if (m) {
+    const n = Number(m[1]);
+    if (n > 0) {
+      const ms = m[2] === "m" ? 60_000 : m[2] === "h" ? 3_600_000 : 86_400_000;
+      start = new Date(now.getTime() - n * ms);
+    }
+  } else {
+    const parsed = Date.parse(input);
+    if (!Number.isNaN(parsed)) start = new Date(parsed);
+  }
+  if (!start) return null;
+  if (start.getTime() > now.getTime()) return null;
+  if (now.getTime() - start.getTime() > MAX_WINDOW_MS) return null;
+  return start;
+}
+
+/** The optional goodwill paragraph appended to the incident email. */
+export function buildCreditNote(creditUsd: number): string {
+  if (creditUsd <= 0) return "";
+  return `\n\nAs a small thank-you for your patience, we've added $${creditUsd.toFixed(2)} in free credits to your account — no action needed.`;
+}
+
+function formatUtc(iso: string): string {
+  return `${iso.replace("T", " ").slice(0, 16)} UTC`;
+}
+
+// ---------- affected-org query ----------
+
+export interface AffectedOrg {
+  orgId: string;
+  orgSlug: string;
+  orgName: string;
+  failedCount: number;
+  firstFailureAt: string;
+  lastFailureAt: string;
+  repositories: string[];
+  /** Distinct error messages, truncated, max 5 — enough to see the pattern. */
+  errors: string[];
+  recipients: { email: string; name: string }[];
+}
+
+const MAX_DISTINCT_ERRORS = 5;
+
+export async function findAffectedOrgs(
+  since: Date,
+  match?: string,
+): Promise<AffectedOrg[]> {
+  const failed = await prisma.pullRequest.findMany({
+    where: {
+      status: "failed",
+      updatedAt: { gte: since },
+      ...(match
+        ? { errorMessage: { contains: match, mode: "insensitive" as const } }
+        : {}),
+      // Never email deleted or banned orgs.
+      repository: { organization: { deletedAt: null, bannedAt: null } },
+    },
+    select: {
+      updatedAt: true,
+      errorMessage: true,
+      repository: {
+        select: {
+          fullName: true,
+          organization: { select: { id: true, slug: true, name: true } },
+        },
+      },
+    },
+    orderBy: { updatedAt: "asc" },
+  });
+
+  const byOrg = new Map<string, AffectedOrg>();
+  for (const pr of failed) {
+    const org = pr.repository.organization;
+    let entry = byOrg.get(org.id);
+    if (!entry) {
+      entry = {
+        orgId: org.id,
+        orgSlug: org.slug,
+        orgName: org.name,
+        failedCount: 0,
+        firstFailureAt: pr.updatedAt.toISOString(),
+        lastFailureAt: pr.updatedAt.toISOString(),
+        repositories: [],
+        errors: [],
+        recipients: [],
+      };
+      byOrg.set(org.id, entry);
+    }
+    entry.failedCount++;
+    entry.lastFailureAt = pr.updatedAt.toISOString();
+    if (!entry.repositories.includes(pr.repository.fullName)) {
+      entry.repositories.push(pr.repository.fullName);
+    }
+    const msg = (pr.errorMessage ?? "unknown error").slice(0, 200);
+    if (entry.errors.length < MAX_DISTINCT_ERRORS && !entry.errors.includes(msg)) {
+      entry.errors.push(msg);
+    }
+  }
+
+  const orgs = [...byOrg.values()];
+  for (const org of orgs) {
+    org.recipients = await getAdminRecipients(org.orgId);
+  }
+  return orgs;
+}
+
+// ---------- notify executor ----------
+
+export class IncidentNotifyError extends Error {}
+
+export interface NotifyParams {
+  incidentKey: string;
+  since: Date;
+  match?: string;
+  templateSlug: string;
+  creditUsd: number;
+  summary?: string;
+  dryRun: boolean;
+}
+
+export interface OrgOutcome {
+  orgSlug: string;
+  orgName: string;
+  failedCount: number;
+  recipients: string[];
+  creditUsd: number;
+  action: "planned" | "sent" | "skipped" | "error";
+  reason?: string;
+}
+
+export interface NotifyResult {
+  dryRun: boolean;
+  incidentKey: string;
+  orgs: OrgOutcome[];
+  totals: { orgs: number; emails: number; creditUsd: number };
+}
+
+export async function notifyAffectedOrgs(params: NotifyParams): Promise<NotifyResult> {
+  const template = await prisma.emailTemplate.findUnique({
+    where: { slug: params.templateSlug },
+    select: { enabled: true },
+  });
+  if (!template?.enabled) {
+    throw new IncidentNotifyError(
+      `email template "${params.templateSlug}" not found or disabled — seed templates first`,
+    );
+  }
+
+  const affected = await findAffectedOrgs(params.since, params.match);
+  const outcomes: OrgOutcome[] = [];
+
+  for (const org of affected) {
+    const base: Omit<OrgOutcome, "action"> = {
+      orgSlug: org.orgSlug,
+      orgName: org.orgName,
+      failedCount: org.failedCount,
+      recipients: org.recipients.map((r) => r.email),
+      creditUsd: params.creditUsd,
+    };
+
+    const already = await prisma.incidentComm.findUnique({
+      where: {
+        incidentKey_organizationId: {
+          incidentKey: params.incidentKey,
+          organizationId: org.orgId,
+        },
+      },
+      select: { id: true },
+    });
+    if (already) {
+      outcomes.push({ ...base, action: "skipped", reason: "already notified for this incidentKey" });
+      continue;
+    }
+    if (org.recipients.length === 0) {
+      outcomes.push({ ...base, action: "skipped", reason: "no owner/admin recipients" });
+      continue;
+    }
+    if (params.dryRun) {
+      outcomes.push({ ...base, action: "planned" });
+      continue;
+    }
+
+    // Claim first — the unique constraint makes concurrent or repeated runs safe.
+    try {
+      await prisma.incidentComm.create({
+        data: { incidentKey: params.incidentKey, organizationId: org.orgId },
+      });
+    } catch {
+      outcomes.push({ ...base, action: "skipped", reason: "already notified (concurrent claim)" });
+      continue;
+    }
+
+    // Emails first, then record them on the claim, then credits. A failure
+    // BEFORE emails are recorded releases the claim so a retry re-attempts
+    // the org (worst case: one org's recipients get a duplicate email). A
+    // failure AFTER keeps the claim — no duplicate email is possible, and
+    // the outcome tells the operator to grant the missing credit manually.
+    let emailsRecorded = false;
+    try {
+      const rendered = await renderEmailTemplate(params.templateSlug, {
+        orgName: escapeHtml(org.orgName),
+        failedCount: String(org.failedCount),
+        windowStart: formatUtc(org.firstFailureAt),
+        windowEnd: formatUtc(org.lastFailureAt),
+        creditNote: buildCreditNote(params.creditUsd),
+        incidentSummary: escapeHtml(params.summary ?? ""),
+      });
+      if (!rendered) {
+        throw new Error(`template "${params.templateSlug}" failed to render`);
+      }
+
+      let emailsSent = 0;
+      for (const recipient of org.recipients) {
+        await sendEmail({ to: recipient.email, subject: rendered.subject, html: rendered.html });
+        emailsSent++;
+      }
+
+      await prisma.incidentComm.update({
+        where: {
+          incidentKey_organizationId: {
+            incidentKey: params.incidentKey,
+            organizationId: org.orgId,
+          },
+        },
+        data: { emailsSent },
+      });
+      emailsRecorded = true;
+
+      if (params.creditUsd > 0) {
+        await addFreeCredits(
+          org.orgId,
+          params.creditUsd,
+          `Goodwill credit — incident ${params.incidentKey}`,
+        );
+        await prisma.incidentComm.update({
+          where: {
+            incidentKey_organizationId: {
+              incidentKey: params.incidentKey,
+              organizationId: org.orgId,
+            },
+          },
+          data: { creditGrantedUsd: params.creditUsd },
+        });
+      }
+
+      await writeAuditLog({
+        action: "admin.incident.notify",
+        category: "admin",
+        organizationId: org.orgId,
+        metadata: {
+          incidentKey: params.incidentKey,
+          emailsSent,
+          creditUsd: params.creditUsd,
+          failedCount: org.failedCount,
+        },
+      });
+
+      outcomes.push({ ...base, action: "sent" });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!emailsRecorded) {
+        await prisma.incidentComm
+          .delete({
+            where: {
+              incidentKey_organizationId: {
+                incidentKey: params.incidentKey,
+                organizationId: org.orgId,
+              },
+            },
+          })
+          .catch(() => {});
+        outcomes.push({
+          ...base,
+          action: "error",
+          reason: `${msg} (claim released — a retry re-attempts this org)`,
+        });
+      } else {
+        outcomes.push({
+          ...base,
+          action: "error",
+          reason: `${msg} (emails already sent — grant credits manually with \`octp admin credits grant\`)`,
+        });
+      }
+    }
+  }
+
+  const sentOrPlanned = outcomes.filter((o) => o.action === "sent" || o.action === "planned");
+  return {
+    dryRun: params.dryRun,
+    incidentKey: params.incidentKey,
+    orgs: outcomes,
+    totals: {
+      orgs: sentOrPlanned.length,
+      emails: sentOrPlanned.reduce((sum, o) => sum + o.recipients.length, 0),
+      creditUsd: sentOrPlanned.reduce((sum, o) => sum + o.creditUsd, 0),
+    },
+  };
+}

--- a/apps/web/lib/incidents.ts
+++ b/apps/web/lib/incidents.ts
@@ -164,6 +164,8 @@ export interface OrgOutcome {
 export interface NotifyResult {
   dryRun: boolean;
   incidentKey: string;
+  /** Resolved window start (ISO) — clients pin the live send to the dry-run's window with this. */
+  since: string;
   orgs: OrgOutcome[];
   totals: { orgs: number; emails: number; creditUsd: number };
 }
@@ -321,6 +323,7 @@ export async function notifyAffectedOrgs(params: NotifyParams): Promise<NotifyRe
   return {
     dryRun: params.dryRun,
     incidentKey: params.incidentKey,
+    since: params.since.toISOString(),
     orgs: outcomes,
     totals: {
       orgs: sentOrPlanned.length,

--- a/apps/web/lib/org-recipients.ts
+++ b/apps/web/lib/org-recipients.ts
@@ -1,0 +1,26 @@
+import { prisma } from "@octopus/db";
+
+/**
+ * Owner/admin member emails for an organization — the recipient set for
+ * org-level operational email (event notifications, admin incident comms).
+ * Excludes soft-deleted memberships; notification preferences do NOT apply
+ * here (these are account-level operational messages, not per-event opt-ins).
+ */
+export async function getAdminRecipients(
+  orgId: string,
+): Promise<{ email: string; name: string }[]> {
+  const members = await prisma.organizationMember.findMany({
+    where: {
+      organizationId: orgId,
+      deletedAt: null,
+      role: { in: ["owner", "admin"] },
+    },
+    select: {
+      user: { select: { email: true, name: true } },
+    },
+  });
+
+  return members
+    .filter((m) => m.user.email)
+    .map((m) => ({ email: m.user.email, name: m.user.name }));
+}

--- a/packages/db/prisma/migrations/20260711160000_add_incident_comms/migration.sql
+++ b/packages/db/prisma/migrations/20260711160000_add_incident_comms/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "incident_comms" (
+    "id" TEXT NOT NULL,
+    "incidentKey" TEXT NOT NULL,
+    "emailsSent" INTEGER NOT NULL DEFAULT 0,
+    "creditGrantedUsd" DOUBLE PRECISION NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "organizationId" TEXT NOT NULL,
+
+    CONSTRAINT "incident_comms_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "incident_comms_incidentKey_idx" ON "incident_comms"("incidentKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "incident_comms_incidentKey_organizationId_key" ON "incident_comms"("incidentKey", "organizationId");
+
+-- AddForeignKey
+ALTER TABLE "incident_comms" ADD CONSTRAINT "incident_comms_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -173,8 +173,29 @@ model Organization {
   couponRedemptions     CouponRedemption[]
   userPresences         UserPresence[]
   activityEvents        ActivityEvent[]
+  incidentComms         IncidentComm[]
 
   @@map("organizations")
+}
+
+// One row per (incident, organization) admin communication — the idempotency
+// spine for `octp admin incidents notify`: the unique constraint guarantees a
+// re-run of the same incidentKey can never re-email or re-grant an org. Rows
+// are created as a claim before sending and deleted if that org's send fails,
+// so a partial run can be safely retried.
+model IncidentComm {
+  id               String   @id @default(cuid())
+  incidentKey      String
+  emailsSent       Int      @default(0)
+  creditGrantedUsd Float    @default(0)
+  createdAt        DateTime @default(now())
+
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([incidentKey, organizationId])
+  @@index([incidentKey])
+  @@map("incident_comms")
 }
 
 model OrganizationMember {


### PR DESCRIPTION
Replaces #615, which was accidentally based on a stale local master and bundled ~160 unrelated commits into the diff — this PR contains exactly one feature commit rebased onto current master.

Operator tooling for provider outages (motivated by the OpenAI embedding-quota 429s on 2026-07-11, which failed customer reviews with no way to find or compensate affected orgs beyond hand-written SQL).

## What this adds

**`octp admin incidents --since 3h [--match 429]`** — lists every org with failed reviews in the window: counts, repos, distinct errors, and the owner/admin emails a notification would reach. Backed by `GET /api/admin/incidents/failed-reviews` (data already existed: `PullRequest.status="failed"` + `errorMessage`).

**`octp admin incidents notify --incident-key openai-429-2026-07-11 --since 3h --credits 5 --send`** — emails each affected org's owners/admins from the new `incident-resolved` DB template and grants goodwill free credits. Backed by `POST /api/admin/incidents/notify`.

**`octp admin credits grant --org <slug> --amount 10 --reason "…"`** — one-off goodwill grant (`POST /api/admin/credits/grant`). First caller of the previously-unused `addFreeCredits()`.

## Safety rails

- **Dry-run by default** at both layers: the endpoint requires `dryRun:false` explicitly; the CLI always prints the dry-run plan first and only executes with `--send` plus a typed `SEND` confirmation (or `--yes`).
- **Idempotent per (incidentKey, org)** via the new `IncidentComm` unique constraint — claim-first before any send; re-runs and concurrent runs can never re-email or re-grant an org. The claim is released only when a send fails *before* emails are recorded, so retries are safe (failure ordering documented in `lib/incidents.ts`).
- **Caps**: 30-day window ceiling on `since` (a `--since 300d` typo must not become a mass mailing) and a $50/org credit cap, both overridable only with an explicit force flag.
- Deleted/banned orgs excluded; orgs with no owner/admin recipients skipped; every send and grant audit-logged (`admin.incident.notify`, `admin.credits.grant`).
- Admin auth follows the existing `ADMIN_API_SECRET` bearer pattern (CLI: `OCTOPUS_ADMIN_SECRET`) — deliberately not the org-scoped device-flow token.

## Notes for review

- `getAdminRecipients` moved from `email.observer.ts` (private) to `lib/org-recipients.ts` — now shared with the incidents engine; observer behavior unchanged.
- `prisma/migrations` is gitignored ("managed manually") but the baseline `migration.sql` is tracked — the new migration follows that convention (force-added `.sql` only).
- The `incident-resolved` template seed requires a `seedEmailTemplates()` run on deploy (it has no automatic caller); the notify endpoint fails safe with a clear error until then.

## Verification (against current master)

- 10 new unit tests (`lib/__tests__/incidents.test.ts`): window parser, credit-note builder, incident-key validation — all pass.
- Full web suite: 516/518 pass — the 2 failures (`email transporter (nodemailer v9 surface)`) fail identically on clean master (pre-existing, unrelated).
- CLI: 106/106 tests pass, builds clean, `admin --help` + missing-secret guard smoke-tested.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)