### PR TITLE
chore: remove FUNDING.yml (drop sponsor links)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,0 @@
-patreon: octopusreview
-open_collective: octopusreview
-ko_fi: octopusreview
-buy_me_a_coffee: octopusreview


### PR DESCRIPTION
Removes the Sponsor-this-project sidebar (patreon / opencollective / ko-fi / buymeacoffee) per maintainer decision. Docs-ops only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)