### PR TITLE
fix(billing): explicit welcome-credit grant + env-configurable markup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,9 @@ STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 
+# Billing: multiplier over provider list price when charging credits (default 1.2)
+PLATFORM_MARKUP=1.2
+
 # Cohere (Reranking)
 COHERE_API_KEY=
 

--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -14,7 +14,7 @@ import { createAbortController, abortIndexing } from "@/lib/indexing-abort";
 import { runIndexingInBackground } from "@/lib/indexing-runner";
 import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
 import { canUserCreateOrg } from "@/lib/org-limits";
-import { MAX_OWNED_ORGS_PER_USER } from "@/lib/constants";
+import { MAX_OWNED_ORGS_PER_USER, WELCOME_FREE_CREDITS } from "@/lib/constants";
 import { encryptString } from "@/lib/crypto";
 import { writeAuditLog } from "@/lib/audit";
 import { canUseLiveTelemetry } from "@/lib/entitlements";
@@ -119,13 +119,13 @@ export async function createOrganization(
             },
           },
           ...(firstOrg && {
-            freeCreditBalance: 150,
+            freeCreditBalance: WELCOME_FREE_CREDITS,
             creditTransactions: {
               create: {
-                amount: 150,
+                amount: WELCOME_FREE_CREDITS,
                 type: "free_credit",
-                description: "Welcome bonus — $150 free credits",
-                balanceAfter: 150,
+                description: `Welcome bonus — $${WELCOME_FREE_CREDITS} free credits`,
+                balanceAfter: WELCOME_FREE_CREDITS,
               },
             },
           }),

--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -119,6 +119,7 @@ export async function createOrganization(
             },
           },
           ...(firstOrg && {
+            freeCreditBalance: 150,
             creditTransactions: {
               create: {
                 amount: 150,

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -1,2 +1,4 @@
 export const DISCORD_INVITE_URL = "https://discord.gg/qyuWTXghbS";
 export const MAX_OWNED_ORGS_PER_USER = 3;
+// Welcome credits granted once, on a user's first organization (USD).
+export const WELCOME_FREE_CREDITS = 150;

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -53,9 +53,15 @@ export async function getModelPricing(): Promise<Map<string, ModelPricing>> {
 // Multiplier applied to provider list price when charging credits.
 // Overridable per deployment via PLATFORM_MARKUP; guarded so a bad value
 // can never zero out or invert billing.
-const parsedMarkup = Number(process.env.PLATFORM_MARKUP);
-export const PLATFORM_MARKUP =
-  Number.isFinite(parsedMarkup) && parsedMarkup >= 1 ? parsedMarkup : 1.2;
+const rawMarkup = process.env.PLATFORM_MARKUP;
+const parsedMarkup = Number(rawMarkup);
+const markupValid = Number.isFinite(parsedMarkup) && parsedMarkup >= 1;
+if (rawMarkup !== undefined && rawMarkup !== "" && !markupValid) {
+  console.warn(
+    `Invalid PLATFORM_MARKUP ${JSON.stringify(rawMarkup)} (must be a number >= 1) — using default 1.2`,
+  );
+}
+export const PLATFORM_MARKUP = markupValid ? parsedMarkup : 1.2;
 
 export function calcCost(
   pricing: Map<string, ModelPricing>,

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -50,6 +50,13 @@ export async function getModelPricing(): Promise<Map<string, ModelPricing>> {
   return map;
 }
 
+// Multiplier applied to provider list price when charging credits.
+// Overridable per deployment via PLATFORM_MARKUP; guarded so a bad value
+// can never zero out or invert billing.
+const parsedMarkup = Number(process.env.PLATFORM_MARKUP);
+export const PLATFORM_MARKUP =
+  Number.isFinite(parsedMarkup) && parsedMarkup >= 1 ? parsedMarkup : 1.2;
+
 export function calcCost(
   pricing: Map<string, ModelPricing>,
   model: string,
@@ -60,7 +67,6 @@ export function calcCost(
 ): number {
   const p = pricing.get(model);
   if (!p) return 0;
-  const PLATFORM_MARKUP = 1.2; // 20% markup
   const plainInput = Math.max(inputTokens - cacheReadTokens - cacheWriteTokens, 0);
   const baseCost =
     (plainInput * p.input +

--- a/apps/web/lib/org-create.ts
+++ b/apps/web/lib/org-create.ts
@@ -63,6 +63,7 @@ export async function createOrgForUser(userId: string, userName: string) {
           },
         },
         ...(firstOrg && {
+          freeCreditBalance: 150,
           creditTransactions: {
             create: {
               amount: 150,

--- a/apps/web/lib/org-create.ts
+++ b/apps/web/lib/org-create.ts
@@ -1,7 +1,7 @@
 import { prisma } from "@octopus/db";
 import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
 import { canUserCreateOrg } from "@/lib/org-limits";
-import { MAX_OWNED_ORGS_PER_USER } from "@/lib/constants";
+import { MAX_OWNED_ORGS_PER_USER, WELCOME_FREE_CREDITS } from "@/lib/constants";
 
 /**
  * Creates an organization for a user. Pure DB operation — no cookie setting,
@@ -63,13 +63,13 @@ export async function createOrgForUser(userId: string, userName: string) {
           },
         },
         ...(firstOrg && {
-          freeCreditBalance: 150,
+          freeCreditBalance: WELCOME_FREE_CREDITS,
           creditTransactions: {
             create: {
-              amount: 150,
+              amount: WELCOME_FREE_CREDITS,
               type: "free_credit",
-              description: "Welcome bonus — $150 free credits",
-              balanceAfter: 150,
+              description: `Welcome bonus — $${WELCOME_FREE_CREDITS} free credits`,
+              balanceAfter: WELCOME_FREE_CREDITS,
             },
           },
         }),

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -131,7 +131,7 @@ model Organization {
   reviewLanguage          String   @default("en") // BCP-47 code; review prose output language
   stripeCustomerId        String?  @unique
   creditBalance           Decimal  @default(0) @db.Decimal(12, 4)
-  freeCreditBalance       Decimal  @default(150) @db.Decimal(12, 4)
+  freeCreditBalance       Decimal  @default(0) @db.Decimal(12, 4)
   billingEmail            String?
   githubMarketplacePlanId   Int?
   githubMarketplacePlanName String?


### PR DESCRIPTION
## What

Two small billing-config hardening changes:

1. **Welcome credits granted explicitly.** The first-org creation paths (`lib/org-create.ts`, `app/(app)/actions.ts`) now set `freeCreditBalance: 150` alongside the existing `free_credit` ledger row, and the `organizations.freeCreditBalance` column default drops from 150 to 0 (migration `20260717200000_default_free_credits_zero`). Balance changes now always originate from an explicit grant with a matching ledger entry — the community-org path already worked this way.

2. **`PLATFORM_MARKUP` configurable via env** (#620, first half). Moves the constant out of `calcCost` to a module-level export read from `process.env.PLATFORM_MARKUP`, guarded to finite ≥ 1 with fallback 1.2 so a bad value can never zero out or invert billing. Documented in `.env.example`.

## Verification

- `bun test` in apps/web: all billing tests pass (2 pre-existing nodemailer transport failures are unrelated — they attempt a real SMTP connection).
- `tsc --noEmit` clean.
- Migration is a bare `ALTER COLUMN ... SET DEFAULT`; no data change, reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)