### PR TITLE
feat(billing): monthly subscription plans with saved-card renewals

### DIFF
--- a/apps/web/app/(app)/settings/billing/actions.ts
+++ b/apps/web/app/(app)/settings/billing/actions.ts
@@ -5,7 +5,9 @@ import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
-import { createCheckoutSession, getStripe } from "@/lib/stripe";
+import { createCheckoutSession, createSubscriptionCheckoutSession, getStripe } from "@/lib/stripe";
+import { SUBSCRIPTION_PLANS, isPaidPlanTier } from "@/lib/plans";
+import { chargeSubscription, grantSubscriptionPeriod, addOneMonth } from "@/lib/subscription";
 
 async function getOwnerOrgId(): Promise<{ orgId: string } | { error: string }> {
   const session = await auth.api.getSession({ headers: await headers() });
@@ -48,6 +50,61 @@ export async function purchaseCredits(
   );
 
   return { url };
+}
+
+export async function subscribeToPlan(
+  tier: string,
+): Promise<{ url?: string; success?: boolean; error?: string }> {
+  if (!isPaidPlanTier(tier)) return { error: "Unknown plan." };
+
+  const result = await getOwnerOrgId();
+  if ("error" in result) return { error: result.error };
+
+  const org = await prisma.organization.findUnique({
+    where: { id: result.orgId },
+    select: { planTier: true },
+  });
+  if (org?.planTier === tier) return { error: "Already on this plan." };
+
+  // Saved card? Charge off-session right now; otherwise send to Checkout
+  // (which saves the card for renewals).
+  const chargeRef = await chargeSubscription(result.orgId, tier);
+  if (chargeRef) {
+    await grantSubscriptionPeriod(result.orgId, tier, chargeRef, addOneMonth(new Date()));
+    revalidatePath("/settings/billing");
+    return { success: true };
+  }
+
+  const plan = SUBSCRIPTION_PLANS[tier];
+  const url = await createSubscriptionCheckoutSession(
+    result.orgId,
+    tier,
+    plan.name,
+    plan.priceUsd,
+    `${process.env.BETTER_AUTH_URL || "http://localhost:3000"}/settings/billing`,
+  );
+  return { url };
+}
+
+export async function setSubscriptionCancel(
+  cancel: boolean,
+): Promise<{ success?: boolean; error?: string }> {
+  const result = await getOwnerOrgId();
+  if ("error" in result) return { error: result.error };
+
+  const org = await prisma.organization.findUnique({
+    where: { id: result.orgId },
+    select: { planTier: true },
+  });
+  if (!org || org.planTier === "free") return { error: "No active subscription." };
+
+  await prisma.organization.update({
+    where: { id: result.orgId },
+    data: { planCancelAtPeriodEnd: cancel },
+  });
+
+  revalidatePath("/settings/billing");
+  return { success: true };
 }
 
 export async function updateAutoReload(

--- a/apps/web/app/(app)/settings/billing/actions.ts
+++ b/apps/web/app/(app)/settings/billing/actions.ts
@@ -66,24 +66,35 @@ export async function subscribeToPlan(
   });
   if (org?.planTier === tier) return { error: "Already on this plan." };
 
-  // Saved card? Charge off-session right now; otherwise send to Checkout
-  // (which saves the card for renewals).
-  const chargeRef = await chargeSubscription(result.orgId, tier);
-  if (chargeRef) {
-    await grantSubscriptionPeriod(result.orgId, tier, chargeRef, addOneMonth(new Date()));
-    revalidatePath("/settings/billing");
-    return { success: true };
-  }
+  try {
+    // Saved card? Charge off-session right now; otherwise send to Checkout
+    // (which saves the card for renewals). The idempotency key is stable for
+    // the calendar day, so a double-clicked subscribe can't charge twice.
+    const day = new Date().toISOString().slice(0, 10);
+    const chargeRef = await chargeSubscription(
+      result.orgId,
+      tier,
+      `sub-start-${result.orgId}-${tier}-${day}`,
+    );
+    if (chargeRef) {
+      await grantSubscriptionPeriod(result.orgId, tier, chargeRef, addOneMonth(new Date()));
+      revalidatePath("/settings/billing");
+      return { success: true };
+    }
 
-  const plan = SUBSCRIPTION_PLANS[tier];
-  const url = await createSubscriptionCheckoutSession(
-    result.orgId,
-    tier,
-    plan.name,
-    plan.priceUsd,
-    `${process.env.BETTER_AUTH_URL || "http://localhost:3000"}/settings/billing`,
-  );
-  return { url };
+    const plan = SUBSCRIPTION_PLANS[tier];
+    const url = await createSubscriptionCheckoutSession(
+      result.orgId,
+      tier,
+      plan.name,
+      plan.priceUsd,
+      `${process.env.BETTER_AUTH_URL || "http://localhost:3000"}/settings/billing`,
+    );
+    return { url };
+  } catch (err) {
+    console.error("[billing] subscribeToPlan failed:", err);
+    return { error: "Could not start the subscription. Please try again or update your card." };
+  }
 }
 
 export async function setSubscriptionCancel(

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -263,8 +263,9 @@ export function BillingSettings({
                       <span className="text-sm font-normal text-muted-foreground">/month</span>
                     </p>
                     <p className="text-sm text-muted-foreground">
-                      ${plan.creditsUsd} in credits every month — $
-                      {plan.creditsUsd - plan.priceUsd} bonus over topping up.
+                      ${plan.creditsUsd} in credits every month (
+                      {Math.round(((plan.creditsUsd - plan.priceUsd) / plan.priceUsd) * 100)}%
+                      bonus over topping up).
                     </p>
                     {isOwner && !isCurrent && (
                       <Button
@@ -293,6 +294,23 @@ export function BillingSettings({
             )}
           </div>
           {planError && <p className="text-sm text-destructive mt-3">{planError}</p>}
+          {isOwner && stripeCustomerId && (
+            <div className="mt-4">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={portalLoading}
+                onClick={handlePortal}
+              >
+                {portalLoading ? (
+                  <IconLoader2 className="size-4 mr-1 animate-spin" />
+                ) : (
+                  <IconReceipt className="size-4 mr-1" />
+                )}
+                View invoices
+              </Button>
+            </div>
+          )}
           {isOwner && planTier !== "free" && (
             <div className="mt-4">
               {planCancelAtPeriodEnd ? (

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -24,11 +24,14 @@ import {
   IconChevronRight,
 } from "@tabler/icons-react";
 import { PurchaseDialog } from "./purchase-dialog";
+import { SUBSCRIPTION_PLANS } from "@/lib/plans";
 import {
   updateAutoReload,
   updateBillingEmail,
   updateSpendLimit,
   loadMoreTransactions,
+  subscribeToPlan,
+  setSubscriptionCancel,
   type TransactionDTO,
 } from "./actions";
 
@@ -49,6 +52,9 @@ type Props = {
   billingEmail: string | null;
   monthlySpendLimitUsd: number | null;
   stripeCustomerId: string | null;
+  planTier: string;
+  planRenewsAt: string | null;
+  planCancelAtPeriodEnd: boolean;
   autoReloadConfig: {
     enabled: boolean;
     thresholdAmount: number;
@@ -77,6 +83,8 @@ function typeBadgeVariant(type: string) {
       return "default" as const;
     case "coupon":
       return "outline" as const;
+    case "subscription":
+      return "default" as const;
     default:
       return "secondary" as const;
   }
@@ -92,6 +100,8 @@ function typeBadgeClass(type: string) {
       return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400 border-yellow-200 dark:border-yellow-800";
     case "coupon":
       return "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400 border-purple-200 dark:border-purple-800";
+    case "subscription":
+      return "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-400 border-indigo-200 dark:border-indigo-800";
     default:
       return "";
   }
@@ -105,6 +115,9 @@ export function BillingSettings({
   billingEmail,
   monthlySpendLimitUsd,
   stripeCustomerId,
+  planTier,
+  planRenewsAt,
+  planCancelAtPeriodEnd,
   autoReloadConfig,
   initialTransactions,
   totalTransactions,
@@ -130,6 +143,27 @@ export function BillingSettings({
   const [autoReloadEnabled, setAutoReloadEnabled] = useState(
     autoReloadConfig?.enabled ?? false,
   );
+
+  const [planPending, startPlanTransition] = useTransition();
+  const [planError, setPlanError] = useState<string | null>(null);
+
+  const handleSubscribe = (tier: string) => {
+    setPlanError(null);
+    startPlanTransition(async () => {
+      const res = await subscribeToPlan(tier);
+      if (res.error) setPlanError(res.error);
+      else if (res.url) window.location.href = res.url;
+      // On success the server action revalidates the page.
+    });
+  };
+
+  const handleCancelToggle = (cancel: boolean) => {
+    setPlanError(null);
+    startPlanTransition(async () => {
+      const res = await setSubscriptionCancel(cancel);
+      if (res.error) setPlanError(res.error);
+    });
+  };
 
   const total = creditBalance + freeCreditBalance;
 
@@ -198,6 +232,91 @@ export function BillingSettings({
               </Button>
             )}
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Card: Subscription */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Subscription</CardTitle>
+          <CardDescription>
+            Monthly plans charge your saved card and grant bonus credits into
+            your balance each month. Credits never expire.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {(Object.entries(SUBSCRIPTION_PLANS) as [string, { name: string; priceUsd: number; creditsUsd: number }][]).map(
+              ([tier, plan]) => {
+                const isCurrent = planTier === tier;
+                return (
+                  <div
+                    key={tier}
+                    className={`rounded-lg border p-4 space-y-2 ${isCurrent ? "border-primary bg-muted/20" : ""}`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="font-semibold">{plan.name}</p>
+                      {isCurrent && <Badge>Current plan</Badge>}
+                    </div>
+                    <p className="text-2xl font-semibold">
+                      ${plan.priceUsd}
+                      <span className="text-sm font-normal text-muted-foreground">/month</span>
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      ${plan.creditsUsd} in credits every month — $
+                      {plan.creditsUsd - plan.priceUsd} bonus over topping up.
+                    </p>
+                    {isOwner && !isCurrent && (
+                      <Button
+                        size="sm"
+                        disabled={planPending}
+                        onClick={() => handleSubscribe(tier)}
+                      >
+                        {planPending ? (
+                          <IconLoader2 className="size-4 mr-1 animate-spin" />
+                        ) : (
+                          <IconPlus className="size-4 mr-1" />
+                        )}
+                        {planTier === "free" ? "Subscribe" : "Switch"}
+                      </Button>
+                    )}
+                    {isCurrent && (
+                      <p className="text-xs text-muted-foreground">
+                        {planCancelAtPeriodEnd
+                          ? `Ends ${planRenewsAt ? new Date(planRenewsAt).toLocaleDateString() : "at period end"} — credits keep working.`
+                          : `Renews ${planRenewsAt ? new Date(planRenewsAt).toLocaleDateString() : "monthly"}.`}
+                      </p>
+                    )}
+                  </div>
+                );
+              },
+            )}
+          </div>
+          {planError && <p className="text-sm text-destructive mt-3">{planError}</p>}
+          {isOwner && planTier !== "free" && (
+            <div className="mt-4">
+              {planCancelAtPeriodEnd ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={planPending}
+                  onClick={() => handleCancelToggle(false)}
+                >
+                  Resume subscription
+                </Button>
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground"
+                  disabled={planPending}
+                  onClick={() => handleCancelToggle(true)}
+                >
+                  Cancel at period end
+                </Button>
+              )}
+            </div>
+          )}
         </CardContent>
       </Card>
 

--- a/apps/web/app/(app)/settings/billing/page.tsx
+++ b/apps/web/app/(app)/settings/billing/page.tsx
@@ -31,6 +31,9 @@ export default async function BillingPage() {
           billingEmail: true,
           monthlySpendLimitUsd: true,
           stripeCustomerId: true,
+          planTier: true,
+          planRenewsAt: true,
+          planCancelAtPeriodEnd: true,
         },
       },
     },
@@ -69,6 +72,9 @@ export default async function BillingPage() {
       billingEmail={org.billingEmail}
       monthlySpendLimitUsd={org.monthlySpendLimitUsd}
       stripeCustomerId={org.stripeCustomerId}
+      planTier={org.planTier}
+      planRenewsAt={org.planRenewsAt ? org.planRenewsAt.toISOString() : null}
+      planCancelAtPeriodEnd={org.planCancelAtPeriodEnd}
       autoReloadConfig={
         autoReloadConfig
           ? {

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { constructWebhookEvent, getStripe } from "@/lib/stripe";
 import { addCredits, deductCredits } from "@/lib/credits";
+import { grantSubscriptionPeriod, addOneMonth } from "@/lib/subscription";
+import { isPaidPlanTier } from "@/lib/plans";
 import { prisma } from "@octopus/db";
 
 async function getReceiptUrl(paymentIntentId: string | null): Promise<string | null> {
@@ -80,6 +82,19 @@ export async function POST(req: NextRequest) {
         } catch (err) {
           console.error("[stripe-webhook] Receipt URL backfill failed (non-fatal):", err);
         }
+      }
+    }
+
+    if (event.type === "checkout.session.completed") {
+      const session = event.data.object;
+      const orgId = session.metadata?.orgId;
+      const tier = session.metadata?.tier;
+
+      if (session.metadata?.type === "subscription_start" && orgId && tier && isPaidPlanTier(tier)) {
+        // Idempotent: the grant is keyed on session.id; a redelivery re-runs
+        // grantSubscriptionPeriod, which treats the duplicate ledger row as
+        // already-granted and re-stamps the same plan state.
+        await grantSubscriptionPeriod(orgId, tier, session.id, addOneMonth(new Date()));
       }
     }
 

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -50,7 +50,12 @@ export async function POST(req: NextRequest) {
       const type = session.metadata?.type;
       const amountUsd = Number(session.metadata?.amountUsd || 0);
 
-      if (orgId && type === "credit_purchase" && amountUsd > 0) {
+      // checkout.session.completed fires even when payment is still pending
+      // (async payment methods); only grant once Stripe reports it paid.
+      // Cards — the only method we accept — are always "paid" at completion.
+      const isPaid = session.payment_status === "paid";
+
+      if (isPaid && orgId && type === "credit_purchase" && amountUsd > 0) {
         try {
           await addCredits(
             orgId,
@@ -90,7 +95,9 @@ export async function POST(req: NextRequest) {
       const orgId = session.metadata?.orgId;
       const tier = session.metadata?.tier;
 
-      if (session.metadata?.type === "subscription_start" && orgId && tier && isPaidPlanTier(tier)) {
+      const isPaid = session.payment_status === "paid";
+
+      if (isPaid && session.metadata?.type === "subscription_start" && orgId && tier && isPaidPlanTier(tier)) {
         // Idempotent: the grant is keyed on session.id; a redelivery re-runs
         // grantSubscriptionPeriod, which treats the duplicate ledger row as
         // already-granted and re-stamps the same plan state.

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -49,6 +49,14 @@ export async function register() {
       if (process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true") {
         await boss.schedule("refresh-release-cache", "0 5 * * *");
       }
+
+      // Daily subscription renewals (06:00 UTC — offset from the jobs above).
+      // Cloud-only: self-hosted installs have no billing path. Charges due
+      // orgs' saved cards and grants the period's credits; failures retry
+      // daily inside a grace window (see lib/subscription.ts).
+      if (process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED !== "true") {
+        await boss.schedule("subscription-renewals", "0 6 * * *");
+      }
     }
 
     // Graceful shutdown: wait for active jobs (e.g. in-progress reviews) to finish

--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -347,6 +347,7 @@ describe("Stripe webhook route", () => {
       data: {
         object: {
           id: "cs_123",
+          payment_status: "paid",
           metadata: {
             orgId: "org_1",
             type: "credit_purchase",
@@ -515,6 +516,7 @@ describe("Stripe webhook route", () => {
       data: {
         object: {
           id: "cs_fail",
+          payment_status: "paid",
           metadata: { orgId: "org_1", type: "credit_purchase", amountUsd: "25" },
           payment_intent: "pi_fail",
         },
@@ -662,5 +664,74 @@ describe("subscription renewals", () => {
     expect(result).toEqual({ renewed: 1, canceled: 0, downgraded: 0, failed: 0 });
     expect(orgState.creditBalance).toBe(20); // rolled back, not re-granted
     expect(organizationUpdates).toEqual([]); // plan state untouched
+  });
+});
+
+describe("subscription webhook", () => {
+  it("grants the first period and stamps the plan for a paid subscription_start session", async () => {
+    currentEvent = {
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_sub_1",
+          payment_status: "paid",
+          metadata: { orgId: "org_1", type: "subscription_start", tier: "pro" },
+          payment_intent: "pi_sub_1",
+        },
+      },
+    };
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(orgState.creditBalance).toBe(20 + 54);
+    expect(createdTransactions).toHaveLength(1);
+    expect((createdTransactions[0] as { type: string; stripeSessionId: string }).type).toBe(
+      "subscription",
+    );
+    expect(
+      (createdTransactions[0] as { stripeSessionId: string }).stripeSessionId,
+    ).toBe("cs_sub_1");
+    const stamp = organizationUpdates[0] as { data: { planTier: string } };
+    expect(stamp.data.planTier).toBe("pro");
+  });
+
+  it("does not grant when the session is not paid yet", async () => {
+    currentEvent = {
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_sub_unpaid",
+          payment_status: "unpaid",
+          metadata: { orgId: "org_1", type: "subscription_start", tier: "pro" },
+        },
+      },
+    };
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(createdTransactions).toEqual([]);
+    expect(organizationUpdates).toEqual([]);
+    expect(orgState.creditBalance).toBe(20);
+  });
+
+  it("ignores unknown tiers without granting", async () => {
+    currentEvent = {
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_sub_bad",
+          payment_status: "paid",
+          metadata: { orgId: "org_1", type: "subscription_start", tier: "mega" },
+        },
+      },
+    };
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(createdTransactions).toEqual([]);
+    expect(organizationUpdates).toEqual([]);
   });
 });

--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -57,6 +57,12 @@ let mockCreditTransactionFindFirst = mock(() => Promise.resolve(null));
 let mockCreditTransactionUpdate = mock(() => Promise.resolve());
 let mockAutoReloadConfigFindUnique = mock(() => Promise.resolve(null));
 let mockOrganizationFindUnique = mock(() => Promise.resolve(null));
+let mockOrganizationFindMany = mock(() => Promise.resolve([] as unknown[]));
+let mockOrganizationUpdate = mock((args: unknown) => {
+  organizationUpdates.push(args);
+  return Promise.resolve({});
+});
+let organizationUpdates: unknown[];
 
 let mockConstructWebhookEvent = mock(() => currentEvent);
 let mockChargesList = mock(() =>
@@ -89,6 +95,8 @@ mock.module("@octopus/db", () => ({
     organization: {
       findUniqueOrThrow: (...args: unknown[]) => mockFindUniqueOrThrow(...args),
       findUnique: (...args: unknown[]) => mockOrganizationFindUnique(...args),
+      findMany: (...args: unknown[]) => mockOrganizationFindMany(...args),
+      update: (...args: unknown[]) => mockOrganizationUpdate(...args),
     },
     creditTransaction: {
       aggregate: (...args: unknown[]) => mockCreditAggregate(...args),
@@ -148,6 +156,7 @@ const {
   getOrgBalance,
 } = await import("@/lib/credits");
 const { POST } = await import("@/app/api/stripe/webhook/route");
+const { addOneMonth, renewDueSubscriptions } = await import("@/lib/subscription");
 
 function resetBillingMocks() {
   orgState = { creditBalance: 20, freeCreditBalance: 8 };
@@ -202,6 +211,12 @@ function resetBillingMocks() {
   mockCreditTransactionUpdate = mock(() => Promise.resolve());
   mockAutoReloadConfigFindUnique = mock(() => Promise.resolve(null));
   mockOrganizationFindUnique = mock(() => Promise.resolve(null));
+  organizationUpdates = [];
+  mockOrganizationFindMany = mock(() => Promise.resolve([] as unknown[]));
+  mockOrganizationUpdate = mock((args: unknown) => {
+    organizationUpdates.push(args);
+    return Promise.resolve({});
+  });
 
   mockConstructWebhookEvent = mock((body: string, signature: string) => {
     expect(body).toBe("{}");
@@ -525,5 +540,127 @@ describe("Stripe webhook route", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ received: true });
     expect(createdTransactions).toEqual([]);
+  });
+});
+
+describe("subscription renewals", () => {
+  it("addOneMonth clamps the day (Jan 31 → Feb 28)", () => {
+    expect(addOneMonth(new Date(Date.UTC(2026, 0, 31))).toISOString()).toBe(
+      new Date(Date.UTC(2026, 1, 28)).toISOString(),
+    );
+  });
+
+  it("renews a due org: charges, grants credits, advances from the due date", async () => {
+    const due = new Date(Date.UTC(2026, 6, 15));
+    mockOrganizationFindMany = mock(() =>
+      Promise.resolve([
+        { id: "org_1", planTier: "pro", planRenewsAt: due, planCancelAtPeriodEnd: false },
+      ]),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1" } as never),
+    );
+    mockPaymentIntentsCreate = mock(() =>
+      Promise.resolve({ id: "pi_sub_1", status: "succeeded", latest_charge: null } as never),
+    );
+
+    const result = await renewDueSubscriptions();
+
+    expect(result).toEqual({ renewed: 1, canceled: 0, downgraded: 0, failed: 0 });
+    expect(orgState.creditBalance).toBe(20 + 54); // Pro grants $54
+    expect(createdTransactions).toHaveLength(1);
+    expect((createdTransactions[0] as { type: string }).type).toBe("subscription");
+    const stamp = organizationUpdates.find(
+      (u) => (u as { data: { planTier?: string } }).data.planTier === "pro",
+    ) as { data: { planRenewsAt: Date } };
+    expect(stamp.data.planRenewsAt.toISOString()).toBe(
+      new Date(Date.UTC(2026, 7, 15)).toISOString(),
+    );
+  });
+
+  it("downgrades a cancel-at-period-end org without charging", async () => {
+    mockOrganizationFindMany = mock(() =>
+      Promise.resolve([
+        { id: "org_1", planTier: "pro", planRenewsAt: new Date(), planCancelAtPeriodEnd: true },
+      ]),
+    );
+
+    const result = await renewDueSubscriptions();
+
+    expect(result).toEqual({ renewed: 0, canceled: 1, downgraded: 0, failed: 0 });
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    expect(orgState.creditBalance).toBe(20);
+    expect(organizationUpdates).toEqual([
+      {
+        where: { id: "org_1" },
+        data: { planTier: "free", planRenewsAt: null, planCancelAtPeriodEnd: false },
+      },
+    ]);
+  });
+
+  it("keeps retrying a failed charge inside the grace window", async () => {
+    mockOrganizationFindMany = mock(() =>
+      Promise.resolve([
+        { id: "org_1", planTier: "pro", planRenewsAt: new Date(Date.now() - 24 * 60 * 60 * 1000), planCancelAtPeriodEnd: false },
+      ]),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1" } as never),
+    );
+    mockPaymentIntentsCreate = mock(() => Promise.reject(new Error("card_declined")));
+
+    const result = await renewDueSubscriptions();
+
+    expect(result).toEqual({ renewed: 0, canceled: 0, downgraded: 0, failed: 1 });
+    expect(orgState.creditBalance).toBe(20);
+    expect(organizationUpdates).toEqual([]);
+  });
+
+  it("downgrades after the grace window of failed charges", async () => {
+    mockOrganizationFindMany = mock(() =>
+      Promise.resolve([
+        { id: "org_1", planTier: "pro", planRenewsAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000), planCancelAtPeriodEnd: false },
+      ]),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1" } as never),
+    );
+    mockPaymentIntentsCreate = mock(() => Promise.reject(new Error("card_declined")));
+
+    const result = await renewDueSubscriptions();
+
+    expect(result).toEqual({ renewed: 0, canceled: 0, downgraded: 1, failed: 0 });
+    expect(organizationUpdates).toEqual([
+      {
+        where: { id: "org_1" },
+        data: { planTier: "free", planRenewsAt: null, planCancelAtPeriodEnd: false },
+      },
+    ]);
+  });
+
+  it("treats a duplicate grant (P2002) as already processed — no double credit, no re-stamp", async () => {
+    const due = new Date(Date.UTC(2026, 6, 15));
+    mockOrganizationFindMany = mock(() =>
+      Promise.resolve([
+        { id: "org_1", planTier: "pro", planRenewsAt: due, planCancelAtPeriodEnd: false },
+      ]),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1" } as never),
+    );
+    mockPaymentIntentsCreate = mock(() =>
+      Promise.resolve({ id: "pi_sub_dup", status: "succeeded", latest_charge: null } as never),
+    );
+    mockTxCreditTransactionCreate = mock(() => {
+      const err = new Error("unique") as Error & { code: string };
+      err.code = "P2002";
+      return Promise.reject(err);
+    });
+
+    const result = await renewDueSubscriptions();
+
+    expect(result).toEqual({ renewed: 1, canceled: 0, downgraded: 0, failed: 0 });
+    expect(orgState.creditBalance).toBe(20); // rolled back, not re-granted
+    expect(organizationUpdates).toEqual([]); // plan state untouched
   });
 });

--- a/apps/web/lib/entitlements.ts
+++ b/apps/web/lib/entitlements.ts
@@ -4,14 +4,15 @@ import { ORG_TYPE } from "@/lib/org-types";
 /**
  * Feature entitlements for paid-only features (currently: live telemetry).
  *
- * There is no subscription/plan model — billing is credit-based (one-time
- * Stripe top-ups). "Paid" is therefore defined monotonically so it can't
- * flicker as credits are spent, and so it doesn't wrongly lock the feature
- * for legitimate non-credit payers. An org is paid when ANY of:
+ * "Paid" is defined monotonically so it can't flicker as credits are spent,
+ * and so it doesn't wrongly lock the feature for legitimate non-credit
+ * payers. An org is paid when ANY of:
  *   1. self-hosted install (no billing path at all);
  *   2. FRIENDLY org type (comped / relationship tier);
  *   3. BYOK — the org runs on its own provider key(s);
- *   4. it has ever made a real purchase (purchase / auto_reload txn).
+ *   4. it has ever made a real purchase (purchase / auto_reload /
+ *      subscription txn);
+ *   5. it has an active subscription tier (planTier != "free").
  *
  * COMMUNITY orgs are intentionally excluded — that tier is rate-limited, not
  * credit-based, and live telemetry is a paid perk.
@@ -23,7 +24,7 @@ import { ORG_TYPE } from "@/lib/org-types";
 const IS_SELF_HOSTED = process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true";
 
 /** CreditTransaction.type values that represent a real (paid) purchase. */
-const PURCHASE_TXN_TYPES = ["purchase", "auto_reload"];
+const PURCHASE_TXN_TYPES = ["purchase", "auto_reload", "subscription"];
 
 /** True when the deployment is a self-hosted install (no billing path). */
 export function isSelfHosted(): boolean {
@@ -55,6 +56,8 @@ function hasOwnProviderKey(org: ProviderKeyFields): boolean {
 export type OrgEntitlements = {
   /** Entitled to paid-only features. */
   paid: boolean;
+  /** Current subscription tier ("free" | "pro" | "team") for tier-specific gates. */
+  planTier: string;
   /** Live telemetry is entitled AND the org owner has enabled it. */
   liveTelemetryActive: boolean;
   /** Org has opted in to letting vendor staff see member-level detail. */
@@ -72,10 +75,11 @@ export async function getOrgEntitlements(orgId: string): Promise<OrgEntitlements
     // self-host, where there is no vendor console — but kept consistent).
     const org = await prisma.organization.findUnique({
       where: { id: orgId },
-      select: { liveTelemetryEnabled: true, allowVendorMemberVisibility: true },
+      select: { liveTelemetryEnabled: true, allowVendorMemberVisibility: true, planTier: true },
     });
     return {
       paid: true,
+      planTier: org?.planTier ?? "free",
       liveTelemetryActive: Boolean(org?.liveTelemetryEnabled),
       allowVendorMemberVisibility: Boolean(org?.allowVendorMemberVisibility),
     };
@@ -94,13 +98,15 @@ export async function getOrgEntitlements(orgId: string): Promise<OrgEntitlements
       claudeCodeApiKey: true,
       liveTelemetryEnabled: true,
       allowVendorMemberVisibility: true,
+      planTier: true,
     },
   });
   if (!org) {
-    return { paid: false, liveTelemetryActive: false, allowVendorMemberVisibility: false };
+    return { paid: false, planTier: "free", liveTelemetryActive: false, allowVendorMemberVisibility: false };
   }
 
-  let paid = org.type === ORG_TYPE.FRIENDLY || hasOwnProviderKey(org);
+  let paid =
+    org.type === ORG_TYPE.FRIENDLY || hasOwnProviderKey(org) || org.planTier !== "free";
   if (!paid) {
     const purchase = await prisma.creditTransaction.findFirst({
       where: { organizationId: orgId, type: { in: PURCHASE_TXN_TYPES } },
@@ -111,6 +117,7 @@ export async function getOrgEntitlements(orgId: string): Promise<OrgEntitlements
 
   return {
     paid,
+    planTier: org.planTier,
     liveTelemetryActive: paid && Boolean(org.liveTelemetryEnabled),
     allowVendorMemberVisibility: Boolean(org.allowVendorMemberVisibility),
   };

--- a/apps/web/lib/plans.ts
+++ b/apps/web/lib/plans.ts
@@ -1,0 +1,17 @@
+/**
+ * Monthly subscription plans. Charged as off-session PaymentIntents against
+ * the org's saved card (same machinery as auto-reload) — deliberately NOT
+ * Stripe Billing subscriptions; see renewDueSubscriptions in subscription.ts.
+ * Each period grants non-expiring credits into the unified balance; the
+ * credit grant exceeds the price so subscribing beats one-off top-ups.
+ */
+export const SUBSCRIPTION_PLANS = {
+  pro: { name: "Pro", priceUsd: 49, creditsUsd: 54 },
+  team: { name: "Team", priceUsd: 99, creditsUsd: 115 },
+} as const;
+
+export type PaidPlanTier = keyof typeof SUBSCRIPTION_PLANS;
+
+export function isPaidPlanTier(tier: string): tier is PaidPlanTier {
+  return tier in SUBSCRIPTION_PLANS;
+}

--- a/apps/web/lib/queue-workers.ts
+++ b/apps/web/lib/queue-workers.ts
@@ -8,6 +8,7 @@ import {
 import { processCommunityReview, type CommunityReviewJobData } from "./community-review";
 import { enforceAuditLogRetention, enforceActivityEventRetention } from "./audit";
 import { refreshReleaseCache } from "./releases";
+import { renewDueSubscriptions } from "./subscription";
 import { runOllamaPull } from "./ollama-admin";
 import type { QueueConfig } from "./queue";
 
@@ -88,6 +89,23 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
         console.log(`[queue] enforce-audit-retention ${job.id}: deleted ${deleted} rows`);
       } catch (err) {
         console.error(`[queue] enforce-audit-retention failed (job ${job.id}):`, err);
+        throw err;
+      }
+    }
+  });
+
+  // Daily subscription renewals — scheduled in instrumentation.ts via
+  // boss.schedule() (cloud only). Idempotent: grants are keyed on the Stripe
+  // PaymentIntent id, so a re-run can never double-grant a period.
+  await boss.work("subscription-renewals", async (jobs) => {
+    for (const job of jobs) {
+      try {
+        const r = await renewDueSubscriptions();
+        console.log(
+          `[queue] subscription-renewals ${job.id}: renewed=${r.renewed} canceled=${r.canceled} downgraded=${r.downgraded} failed=${r.failed}`,
+        );
+      } catch (err) {
+        console.error(`[queue] subscription-renewals failed (job ${job.id}):`, err);
         throw err;
       }
     }

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -120,7 +120,48 @@ export async function createCheckoutSession(
       },
     ],
     metadata: { orgId, type: "credit_purchase", amountUsd: String(amountUsd) },
+    // Save the card for off-session use (auto-reload, subscription renewals).
+    payment_intent_data: { setup_future_usage: "off_session" },
     success_url: `${returnUrl}?success=true`,
+    cancel_url: `${returnUrl}?canceled=true`,
+  });
+
+  return session.url!;
+}
+
+/**
+ * First subscription payment via Checkout for orgs with no saved card.
+ * The webhook (metadata.type === "subscription_start") grants the period and
+ * stamps the plan; setup_future_usage saves the card so renewals can charge
+ * off-session.
+ */
+export async function createSubscriptionCheckoutSession(
+  orgId: string,
+  tier: string,
+  planName: string,
+  priceUsd: number,
+  returnUrl: string,
+): Promise<string> {
+  const customerId = await getOrCreateStripeCustomer(orgId);
+
+  const session = await getStripe().checkout.sessions.create({
+    mode: "payment",
+    customer: customerId,
+    line_items: [
+      {
+        price_data: {
+          currency: "usd",
+          unit_amount: Math.round(priceUsd * 100),
+          product_data: {
+            name: `Octopus ${planName} plan — first month`,
+          },
+        },
+        quantity: 1,
+      },
+    ],
+    metadata: { orgId, type: "subscription_start", tier },
+    payment_intent_data: { setup_future_usage: "off_session" },
+    success_url: `${returnUrl}?subscribed=true`,
     cancel_url: `${returnUrl}?canceled=true`,
   });
 

--- a/apps/web/lib/subscription.ts
+++ b/apps/web/lib/subscription.ts
@@ -86,6 +86,9 @@ export async function grantSubscriptionPeriod(
 
 /**
  * Charge the saved card off-session for one period of `tier`.
+ * `idempotencyKey` must be deterministic for the billing event (org + period)
+ * so concurrent callers — double-clicked subscribe, overlapping cron runs —
+ * collapse into ONE Stripe charge instead of two.
  * Returns the PaymentIntent id on success, null when the org has no saved
  * card or the charge fails (caller decides: fall back to Checkout, or leave
  * for the next daily retry).
@@ -93,6 +96,7 @@ export async function grantSubscriptionPeriod(
 export async function chargeSubscription(
   orgId: string,
   tier: PaidPlanTier,
+  idempotencyKey: string,
 ): Promise<string | null> {
   const org = await prisma.organization.findUnique({
     where: { id: orgId },
@@ -102,14 +106,17 @@ export async function chargeSubscription(
 
   const plan = SUBSCRIPTION_PLANS[tier];
   try {
-    const paymentIntent = await getStripe().paymentIntents.create({
-      amount: Math.round(plan.priceUsd * 100),
-      currency: "usd",
-      customer: org.stripeCustomerId,
-      off_session: true,
-      confirm: true,
-      metadata: { orgId, type: "subscription", tier, amountUsd: String(plan.priceUsd) },
-    });
+    const paymentIntent = await getStripe().paymentIntents.create(
+      {
+        amount: Math.round(plan.priceUsd * 100),
+        currency: "usd",
+        customer: org.stripeCustomerId,
+        off_session: true,
+        confirm: true,
+        metadata: { orgId, type: "subscription", tier, amountUsd: String(plan.priceUsd) },
+      },
+      { idempotencyKey },
+    );
     if (paymentIntent.status !== "succeeded") return null;
     return paymentIntent.id;
   } catch (err) {
@@ -158,7 +165,13 @@ export async function renewDueSubscriptions(): Promise<{
     }
 
     const tier = org.planTier as PaidPlanTier;
-    const chargeRef = await chargeSubscription(org.id, tier);
+    // Keyed on the due date: every retry of THIS period reuses the key (no
+    // double-charge from overlapping runs), while next period gets a new one.
+    const chargeRef = await chargeSubscription(
+      org.id,
+      tier,
+      `sub-renew-${org.id}-${(org.planRenewsAt ?? now).toISOString()}`,
+    );
     if (chargeRef) {
       // Advance from the DUE date (not now) so billing anchors don't drift.
       const base = org.planRenewsAt ?? now;

--- a/apps/web/lib/subscription.ts
+++ b/apps/web/lib/subscription.ts
@@ -1,0 +1,184 @@
+import { prisma } from "@octopus/db";
+import { addCredits } from "@/lib/credits";
+import { getStripe } from "@/lib/stripe";
+import { SUBSCRIPTION_PLANS, type PaidPlanTier } from "@/lib/plans";
+
+/**
+ * Monthly subscriptions WITHOUT Stripe Billing: each period we charge the
+ * org's saved card with an off-session PaymentIntent (exactly like
+ * auto-reload in credits.ts) and grant the plan's credits into the unified
+ * balance. The daily `subscription-renewals` cron (instrumentation.ts →
+ * queue-workers.ts) picks up orgs whose planRenewsAt has passed.
+ *
+ * Idempotency: the credit grant is keyed on the PaymentIntent id via the
+ * ledger's unique stripeSessionId, so a crash between charge and grant is
+ * healed on the next run (P2002 → treated as already-granted).
+ * ponytail: migrate to real Stripe Billing (invoices/proration/tax) only
+ * when MRR justifies the catalog build — tracked in #619.
+ */
+
+/** Days past the renewal date we keep retrying the card before downgrading. */
+const RENEWAL_GRACE_DAYS = 7;
+
+/** Add one calendar month, clamping the day (Jan 31 → Feb 28, not Mar 3). */
+export function addOneMonth(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getUTCDate();
+  d.setUTCDate(1);
+  d.setUTCMonth(d.getUTCMonth() + 1);
+  const daysInMonth = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0)).getUTCDate();
+  d.setUTCDate(Math.min(day, daysInMonth));
+  return d;
+}
+
+async function backfillReceipt(paymentIntentId: string): Promise<void> {
+  try {
+    const charges = await getStripe().charges.list({ payment_intent: paymentIntentId, limit: 1 });
+    const receiptUrl = charges.data[0]?.receipt_url;
+    if (receiptUrl) {
+      await prisma.creditTransaction.update({
+        where: { stripeSessionId: paymentIntentId },
+        data: { receiptUrl },
+      });
+    }
+  } catch {
+    /* non-critical */
+  }
+}
+
+function isDuplicateLedgerError(err: unknown): boolean {
+  return (err as { code?: string } | null)?.code === "P2002";
+}
+
+/**
+ * Grant a period's credits and stamp the plan state. `chargeRef` is the
+ * Stripe PaymentIntent (or Checkout session) id — the idempotency key.
+ * `renewsAt` is the NEXT renewal date to record.
+ */
+export async function grantSubscriptionPeriod(
+  orgId: string,
+  tier: PaidPlanTier,
+  chargeRef: string,
+  renewsAt: Date,
+): Promise<void> {
+  const plan = SUBSCRIPTION_PLANS[tier];
+  try {
+    await addCredits(
+      orgId,
+      plan.creditsUsd,
+      "subscription",
+      `${plan.name} plan — $${plan.creditsUsd} credits`,
+      chargeRef,
+    );
+  } catch (err) {
+    if (!isDuplicateLedgerError(err)) throw err;
+    // Already granted for this charge (webhook redelivery / crash recovery) —
+    // the plan state was stamped then too; recomputing renewsAt now would
+    // drift the billing anchor, so this is a full no-op.
+    return;
+  }
+  await prisma.organization.update({
+    where: { id: orgId },
+    data: { planTier: tier, planRenewsAt: renewsAt, planCancelAtPeriodEnd: false },
+  });
+  await backfillReceipt(chargeRef);
+}
+
+/**
+ * Charge the saved card off-session for one period of `tier`.
+ * Returns the PaymentIntent id on success, null when the org has no saved
+ * card or the charge fails (caller decides: fall back to Checkout, or leave
+ * for the next daily retry).
+ */
+export async function chargeSubscription(
+  orgId: string,
+  tier: PaidPlanTier,
+): Promise<string | null> {
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { stripeCustomerId: true },
+  });
+  if (!org?.stripeCustomerId) return null;
+
+  const plan = SUBSCRIPTION_PLANS[tier];
+  try {
+    const paymentIntent = await getStripe().paymentIntents.create({
+      amount: Math.round(plan.priceUsd * 100),
+      currency: "usd",
+      customer: org.stripeCustomerId,
+      off_session: true,
+      confirm: true,
+      metadata: { orgId, type: "subscription", tier, amountUsd: String(plan.priceUsd) },
+    });
+    if (paymentIntent.status !== "succeeded") return null;
+    return paymentIntent.id;
+  } catch (err) {
+    console.error(`[subscription] Charge failed for org ${orgId} (${tier}):`, err);
+    return null;
+  }
+}
+
+/**
+ * Daily cron body: renew every org whose period has lapsed.
+ * - cancel-at-period-end orgs are downgraded to free;
+ * - otherwise charge the saved card and grant the next period;
+ * - charge failures are retried daily until RENEWAL_GRACE_DAYS past due,
+ *   then the org drops to free (credits already granted are kept).
+ * Returns counts for the cron log.
+ */
+export async function renewDueSubscriptions(): Promise<{
+  renewed: number;
+  canceled: number;
+  downgraded: number;
+  failed: number;
+}> {
+  const now = new Date();
+  const due = await prisma.organization.findMany({
+    where: {
+      planTier: { not: "free" },
+      planRenewsAt: { lte: now },
+      deletedAt: null,
+    },
+    select: { id: true, planTier: true, planRenewsAt: true, planCancelAtPeriodEnd: true },
+  });
+
+  let renewed = 0;
+  let canceled = 0;
+  let downgraded = 0;
+  let failed = 0;
+
+  for (const org of due) {
+    if (org.planCancelAtPeriodEnd || !(org.planTier in SUBSCRIPTION_PLANS)) {
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { planTier: "free", planRenewsAt: null, planCancelAtPeriodEnd: false },
+      });
+      canceled++;
+      continue;
+    }
+
+    const tier = org.planTier as PaidPlanTier;
+    const chargeRef = await chargeSubscription(org.id, tier);
+    if (chargeRef) {
+      // Advance from the DUE date (not now) so billing anchors don't drift.
+      const base = org.planRenewsAt ?? now;
+      await grantSubscriptionPeriod(org.id, tier, chargeRef, addOneMonth(base));
+      renewed++;
+      continue;
+    }
+
+    const graceCutoff = new Date(now.getTime() - RENEWAL_GRACE_DAYS * 24 * 60 * 60 * 1000);
+    if (org.planRenewsAt && org.planRenewsAt < graceCutoff) {
+      await prisma.organization.update({
+        where: { id: org.id },
+        data: { planTier: "free", planRenewsAt: null, planCancelAtPeriodEnd: false },
+      });
+      downgraded++;
+      console.warn(`[subscription] Org ${org.id} downgraded after ${RENEWAL_GRACE_DAYS}d of failed renewals`);
+    } else {
+      failed++;
+    }
+  }
+
+  return { renewed, canceled, downgraded, failed };
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -133,6 +133,11 @@ model Organization {
   creditBalance           Decimal  @default(0) @db.Decimal(12, 4)
   freeCreditBalance       Decimal  @default(0) @db.Decimal(12, 4)
   billingEmail            String?
+  // Monthly subscription plan (charged off-session against the saved card;
+  // grants non-expiring credits each period). "free" | "pro" | "team".
+  planTier              String    @default("free")
+  planRenewsAt          DateTime?
+  planCancelAtPeriodEnd Boolean   @default(false)
   githubMarketplacePlanId   Int?
   githubMarketplacePlanName String?
   githubMarketplaceAccountId Int?     @unique


### PR DESCRIPTION
## What

Monthly **Pro ($49/mo → $54 credits)** and **Team ($99/mo → $115 credits)** subscription plans on top of the existing credit system (#619 Tier 1). Credits granted are non-expiring and land in the unified balance; the bonus makes subscribing strictly better than one-off top-ups.

## How — deliberately NOT Stripe Billing

Each period is an **off-session PaymentIntent against the saved card** — the exact machinery auto-reload already uses — swept by a daily `subscription-renewals` pg-boss cron (cloud-only). A real Stripe catalog (invoices/proration/tax) waits until MRR justifies it.

- **Schema**: `planTier`/`planRenewsAt`/`planCancelAtPeriodEnd` on Organization (migration `20260717210000`).
- **Idempotency**: grants keyed on the PaymentIntent/Checkout-session id via the ledger's unique `stripeSessionId` — cron re-runs and webhook redeliveries can never double-grant, and a redelivery never re-stamps the billing anchor.
- **Renewals**: advance from the due date (no anchor drift), calendar-month clamped (Jan 31 → Feb 28). Failed cards retry daily for 7 days, then downgrade to free (granted credits are kept).
- **Card saving**: checkout sessions now set `setup_future_usage: off_session` — also fixes the pre-existing gap where auto-reload could find no saved card. Subscribers without a card start via Checkout; the webhook (`subscription_start`) grants and stamps the plan.
- **Cancel**: cancel-at-period-end / resume, tier persists until the period lapses.
- **Entitlements**: `subscription` counts as a paid txn type; `planTier` exposed for future tier-specific gates.
- **UI**: Subscription card in billing settings (subscribe / switch / cancel / resume), subscription badge in the ledger.

## Verification

- `bun test`: 21/21 billing tests pass, including 5 new renewal tests (grant+advance, cancel-at-period-end, grace retry, post-grace downgrade, duplicate-grant idempotency). The 2 pre-existing nodemailer SMTP failures are unrelated.
- `tsc --noEmit` clean; `prisma generate` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)