### PR TITLE
feat(billing): add cards in-app via embedded Stripe Payment Element

### DIFF
--- a/apps/web/app/(app)/settings/billing/actions.ts
+++ b/apps/web/app/(app)/settings/billing/actions.ts
@@ -119,6 +119,25 @@ export async function finalizeCardSetup(
       invoice_settings: { default_payment_method: intent.payment_method },
     });
 
+    // One card per customer: detach every previously-attached card so a
+    // "Replace card" leaves exactly the new one (matches the UI copy, and
+    // stops stale cards being reachable for off-session charges). Best-effort
+    // — the new default is already set, so a detach failure must not fail the
+    // save.
+    try {
+      const existing = await getStripe().paymentMethods.list({
+        customer: org.stripeCustomerId,
+        type: "card",
+      });
+      await Promise.all(
+        existing.data
+          .filter((pm) => pm.id !== intent.payment_method)
+          .map((pm) => getStripe().paymentMethods.detach(pm.id)),
+      );
+    } catch (err) {
+      console.error("[billing] finalizeCardSetup: detaching old cards failed (non-fatal):", err);
+    }
+
     revalidatePath("/settings/billing");
     return { success: true };
   } catch (err) {

--- a/apps/web/app/(app)/settings/billing/actions.ts
+++ b/apps/web/app/(app)/settings/billing/actions.ts
@@ -5,7 +5,12 @@ import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
-import { createCheckoutSession, createSubscriptionCheckoutSession, getStripe } from "@/lib/stripe";
+import {
+  createCheckoutSession,
+  createSubscriptionCheckoutSession,
+  getOrCreateStripeCustomer,
+  getStripe,
+} from "@/lib/stripe";
 import { SUBSCRIPTION_PLANS, isPaidPlanTier } from "@/lib/plans";
 import { chargeSubscription, grantSubscriptionPeriod, addOneMonth } from "@/lib/subscription";
 
@@ -50,6 +55,76 @@ export async function purchaseCredits(
   );
 
   return { url };
+}
+
+/**
+ * In-app card capture: create a SetupIntent whose client_secret the billing
+ * page feeds to an embedded Stripe Payment Element — no redirect to Stripe.
+ */
+export async function createCardSetupIntent(): Promise<{
+  clientSecret?: string;
+  error?: string;
+}> {
+  const result = await getOwnerOrgId();
+  if ("error" in result) return { error: result.error };
+
+  try {
+    const customerId = await getOrCreateStripeCustomer(result.orgId);
+    const intent = await getStripe().setupIntents.create({
+      customer: customerId,
+      payment_method_types: ["card"],
+      usage: "off_session",
+      metadata: { orgId: result.orgId },
+    });
+    if (!intent.client_secret) return { error: "Could not start card setup." };
+    return { clientSecret: intent.client_secret };
+  } catch (err) {
+    console.error("[billing] createCardSetupIntent failed:", err);
+    return { error: "Could not start card setup. Please try again." };
+  }
+}
+
+/**
+ * After the Payment Element confirms the SetupIntent client-side, make the
+ * new card the customer's default so off-session charges (auto-reload,
+ * subscription renewals) use it. Verifies the intent belongs to THIS org's
+ * customer — the id comes from the browser.
+ */
+export async function finalizeCardSetup(
+  setupIntentId: string,
+): Promise<{ success?: boolean; error?: string }> {
+  if (typeof setupIntentId !== "string" || !setupIntentId.startsWith("seti_")) {
+    return { error: "Invalid card setup reference." };
+  }
+
+  const result = await getOwnerOrgId();
+  if ("error" in result) return { error: result.error };
+
+  try {
+    const org = await prisma.organization.findUnique({
+      where: { id: result.orgId },
+      select: { stripeCustomerId: true },
+    });
+    if (!org?.stripeCustomerId) return { error: "No billing account for this organization." };
+
+    const intent = await getStripe().setupIntents.retrieve(setupIntentId);
+    if (intent.customer !== org.stripeCustomerId) {
+      return { error: "Card setup doesn't belong to this organization." };
+    }
+    if (intent.status !== "succeeded" || typeof intent.payment_method !== "string") {
+      return { error: "Card setup hasn't completed." };
+    }
+
+    await getStripe().customers.update(org.stripeCustomerId, {
+      invoice_settings: { default_payment_method: intent.payment_method },
+    });
+
+    revalidatePath("/settings/billing");
+    return { success: true };
+  } catch (err) {
+    console.error("[billing] finalizeCardSetup failed:", err);
+    return { error: "Could not save the card. Please try again." };
+  }
 }
 
 export async function subscribeToPlan(

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -23,7 +23,9 @@ import {
   IconChevronLeft,
   IconChevronRight,
 } from "@tabler/icons-react";
+import { useRouter } from "next/navigation";
 import { PurchaseDialog } from "./purchase-dialog";
+import { CardSetupDialog } from "./card-setup-dialog";
 import { SUBSCRIPTION_PLANS } from "@/lib/plans";
 import {
   updateAutoReload,
@@ -124,7 +126,9 @@ export function BillingSettings({
   monthlySpend,
   paymentMethods,
 }: Props) {
+  const router = useRouter();
   const [purchaseOpen, setPurchaseOpen] = useState(false);
+  const [cardOpen, setCardOpen] = useState(false);
   const [transactions, setTransactions] = useState(initialTransactions);
   const [hasMore, setHasMore] = useState(initialTransactions.length < totalTransactions);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -149,6 +153,13 @@ export function BillingSettings({
 
   const handleSubscribe = (tier: string) => {
     setPlanError(null);
+    // No saved card yet — capture one in-app first, then they subscribe with
+    // the card on file (a saved card makes subscribeToPlan charge directly,
+    // no Stripe redirect).
+    if (paymentMethods.length === 0) {
+      setCardOpen(true);
+      return;
+    }
     startPlanTransition(async () => {
       const res = await subscribeToPlan(tier);
       if (res.error) setPlanError(res.error);
@@ -402,58 +413,63 @@ export function BillingSettings({
         <CardHeader>
           <CardTitle>Payment Methods</CardTitle>
           <CardDescription>
-            Manage your payment methods through Stripe.
+            One card for your subscription, top-ups, and auto-refill.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          {!stripeCustomerId ? (
-            <p className="text-sm text-muted-foreground">
-              Purchase credits to set up billing.
-            </p>
-          ) : (
-            <div className="space-y-3">
-              {paymentMethods.length > 0 ? (
-                <div className="space-y-2">
-                  {paymentMethods.map((pm, i) => (
-                    <div
-                      key={i}
-                      className="flex items-center gap-3 rounded-md border bg-muted/20 px-3 py-2.5"
-                    >
-                      <IconCreditCard className="size-5 text-muted-foreground" />
-                      <div className="flex-1">
-                        <span className="text-sm font-medium capitalize">
-                          {pm.brand}
-                        </span>
-                        <span className="text-sm text-muted-foreground">
-                          {" "}•••• {pm.last4}
-                        </span>
-                      </div>
-                      <span className="text-xs text-muted-foreground">
-                        {String(pm.expMonth).padStart(2, "0")}/{pm.expYear}
+          <div className="space-y-3">
+            {paymentMethods.length > 0 ? (
+              <div className="space-y-2">
+                {paymentMethods.map((pm, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center gap-3 rounded-md border bg-muted/20 px-3 py-2.5"
+                  >
+                    <IconCreditCard className="size-5 text-muted-foreground" />
+                    <div className="flex-1">
+                      <span className="text-sm font-medium capitalize">
+                        {pm.brand}
+                      </span>
+                      <span className="text-sm text-muted-foreground">
+                        {" "}•••• {pm.last4}
                       </span>
                     </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">
-                  No saved payment methods.
-                </p>
-              )}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handlePortal}
-                disabled={portalLoading || !isOwner}
-              >
-                {portalLoading ? (
-                  <IconLoader2 className="size-4 animate-spin mr-1" />
-                ) : (
-                  <IconExternalLink className="size-4 mr-1" />
+                    <span className="text-xs text-muted-foreground">
+                      {String(pm.expMonth).padStart(2, "0")}/{pm.expYear}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No saved payment methods.
+              </p>
+            )}
+            {isOwner && (
+              <div className="flex flex-wrap gap-2">
+                <Button variant="outline" size="sm" onClick={() => setCardOpen(true)}>
+                  <IconCreditCard className="size-4 mr-1" />
+                  {paymentMethods.length > 0 ? "Replace card" : "Add card"}
+                </Button>
+                {stripeCustomerId && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-muted-foreground"
+                    onClick={handlePortal}
+                    disabled={portalLoading}
+                  >
+                    {portalLoading ? (
+                      <IconLoader2 className="size-4 animate-spin mr-1" />
+                    ) : (
+                      <IconExternalLink className="size-4 mr-1" />
+                    )}
+                    Manage on Stripe
+                  </Button>
                 )}
-                Manage Payment Methods
-              </Button>
-            </div>
-          )}
+              </div>
+            )}
+          </div>
         </CardContent>
       </Card>
 
@@ -792,6 +808,12 @@ export function BillingSettings({
       </Card>
 
       <PurchaseDialog open={purchaseOpen} onOpenChange={setPurchaseOpen} />
+      <CardSetupDialog
+        open={cardOpen}
+        onOpenChange={setCardOpen}
+        publishableKey={process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? ""}
+        onSaved={() => router.refresh()}
+      />
     </div>
   );
 }

--- a/apps/web/app/(app)/settings/billing/card-setup-dialog.tsx
+++ b/apps/web/app/(app)/settings/billing/card-setup-dialog.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { loadStripe, type Stripe, type StripeElements } from "@stripe/stripe-js";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { IconLoader2 } from "@tabler/icons-react";
+import { createCardSetupIntent, finalizeCardSetup } from "./actions";
+
+/**
+ * In-app card capture via Stripe's embedded Payment Element on a SetupIntent —
+ * the card form renders inside our dialog (Stripe-hosted iframe, so card data
+ * never touches our servers) and there is no redirect to Stripe.
+ */
+export function CardSetupDialog({
+  open,
+  onOpenChange,
+  publishableKey,
+  onSaved,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  publishableKey: string;
+  onSaved: () => void;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const stripeRef = useRef<Stripe | null>(null);
+  const elementsRef = useRef<StripeElements | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setReady(false);
+      setError(null);
+      elementsRef.current = null;
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      const res = await createCardSetupIntent();
+      if (cancelled) return;
+      if (res.error || !res.clientSecret) {
+        setError(res.error ?? "Could not start card setup.");
+        return;
+      }
+      const stripe = await loadStripe(publishableKey);
+      if (cancelled) return;
+      if (!stripe) {
+        setError("Could not load the payment form.");
+        return;
+      }
+      stripeRef.current = stripe;
+      const elements = stripe.elements({
+        clientSecret: res.clientSecret,
+        appearance: { theme: "night", variables: { colorPrimary: "#22c55e" } },
+      });
+      elementsRef.current = elements;
+      const paymentElement = elements.create("payment");
+      if (mountRef.current) {
+        paymentElement.mount(mountRef.current);
+        paymentElement.on("ready", () => {
+          if (!cancelled) setReady(true);
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, publishableKey]);
+
+  const handleSave = async () => {
+    const stripe = stripeRef.current;
+    const elements = elementsRef.current;
+    if (!stripe || !elements) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      const { error: confirmError, setupIntent } = await stripe.confirmSetup({
+        elements,
+        redirect: "if_required",
+      });
+      if (confirmError) {
+        setError(confirmError.message ?? "Card could not be saved.");
+        return;
+      }
+      if (!setupIntent || setupIntent.status !== "succeeded") {
+        setError("Card setup did not complete. Please try again.");
+        return;
+      }
+      const res = await finalizeCardSetup(setupIntent.id);
+      if (res.error) {
+        setError(res.error);
+        return;
+      }
+      onOpenChange(false);
+      onSaved();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add card</DialogTitle>
+          <DialogDescription>
+            Saved for subscriptions, top-ups, and auto-reload. Card details go
+            directly to Stripe — they never touch our servers.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-24">
+          <div ref={mountRef} />
+          {!ready && !error && (
+            <div className="flex items-center justify-center py-6 text-muted-foreground">
+              <IconLoader2 className="size-5 animate-spin" />
+            </div>
+          )}
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!ready || saving}>
+            {saving && <IconLoader2 className="size-4 mr-1 animate-spin" />}
+            Save card
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/app/(app)/settings/billing/card-setup-dialog.tsx
+++ b/apps/web/app/(app)/settings/billing/card-setup-dialog.tsx
@@ -72,7 +72,11 @@ export function CardSetupDialog({
           if (!cancelled) setReady(true);
         });
       }
-    })();
+    })().catch((err) => {
+      if (cancelled) return;
+      console.error("[billing] card setup failed to initialize:", err);
+      setError("Could not load the payment form. Please try again.");
+    });
 
     return () => {
       cancelled = true;

--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -128,8 +128,11 @@ mock.module("@octopus/db", () => ({
   },
 }));
 
+let mockOffSessionPaymentMethodId = mock(() => Promise.resolve("pm_default" as string | null));
+
 mock.module("@/lib/stripe", () => ({
   constructWebhookEvent: (...args: unknown[]) => mockConstructWebhookEvent(...args),
+  getOffSessionPaymentMethodId: (...args: unknown[]) => mockOffSessionPaymentMethodId(...args),
   getStripe: () => ({
     charges: {
       list: (...args: unknown[]) => mockChargesList(...args),
@@ -212,6 +215,7 @@ function resetBillingMocks() {
   mockAutoReloadConfigFindUnique = mock(() => Promise.resolve(null));
   mockOrganizationFindUnique = mock(() => Promise.resolve(null));
   organizationUpdates = [];
+  mockOffSessionPaymentMethodId = mock(() => Promise.resolve("pm_default" as string | null));
   mockOrganizationFindMany = mock(() => Promise.resolve([] as unknown[]));
   mockOrganizationUpdate = mock((args: unknown) => {
     organizationUpdates.push(args);
@@ -735,3 +739,24 @@ describe("subscription webhook", () => {
     expect(organizationUpdates).toEqual([]);
   });
 });
+
+describe("off-session payment method resolution", () => {
+  it("does not charge a renewal when the org has no saved card", async () => {
+    mockOrganizationFindMany = mock(() =>
+      Promise.resolve([
+        { id: "org_1", planTier: "pro", planRenewsAt: new Date(), planCancelAtPeriodEnd: false },
+      ]),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1" } as never),
+    );
+    mockOffSessionPaymentMethodId = mock(() => Promise.resolve(null));
+
+    const result = await renewDueSubscriptions();
+
+    // No card → charge returns null → treated as a failed charge (grace retry).
+    expect(result).toEqual({ renewed: 0, canceled: 0, downgraded: 0, failed: 1 });
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    expect(orgState.creditBalance).toBe(20);
+  });
+})

--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -759,4 +759,23 @@ describe("off-session payment method resolution", () => {
     expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
     expect(orgState.creditBalance).toBe(20);
   });
-})
+
+  it("does not downgrade on a Stripe API error resolving the card (transient)", async () => {
+    mockOrganizationFindMany = mock(() =>
+      Promise.resolve([
+        { id: "org_1", planTier: "pro", planRenewsAt: new Date(), planCancelAtPeriodEnd: false },
+      ]),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1" } as never),
+    );
+    // A Stripe outage must NOT read as "no card" — it should count as a failed
+    // charge (grace retry), never a downgrade.
+    mockOffSessionPaymentMethodId = mock(() => Promise.reject(new Error("stripe down")));
+
+    const result = await renewDueSubscriptions();
+
+    expect(result).toEqual({ renewed: 0, canceled: 0, downgraded: 0, failed: 1 });
+    expect(orgState.creditBalance).toBe(20);
+  });
+});

--- a/apps/web/lib/credits.ts
+++ b/apps/web/lib/credits.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@octopus/db";
-import { getStripe } from "./stripe";
+import { getStripe, getOffSessionPaymentMethodId } from "./stripe";
 import { eventBus } from "./events/bus";
 
 export async function getOrgBalance(orgId: string) {
@@ -218,12 +218,18 @@ async function triggerAutoReloadIfNeeded(
 
   if (recentReload) return;
 
+  // Cards saved via Checkout are attached but not the customer default, and
+  // an off-session confirm does not fall back to attached cards — resolve the
+  // payment method explicitly or the reload silently no-ops.
+  const paymentMethod = await getOffSessionPaymentMethodId(org.stripeCustomerId);
+  if (!paymentMethod) return;
+
   try {
-    // Create a PaymentIntent and confirm immediately using the customer's default payment method
     const paymentIntent = await getStripe().paymentIntents.create({
       amount: Math.round(reloadAmount * 100),
       currency: "usd",
       customer: org.stripeCustomerId,
+      payment_method: paymentMethod,
       off_session: true,
       confirm: true,
       metadata: {

--- a/apps/web/lib/credits.ts
+++ b/apps/web/lib/credits.ts
@@ -218,13 +218,13 @@ async function triggerAutoReloadIfNeeded(
 
   if (recentReload) return;
 
-  // Cards saved via Checkout are attached but not the customer default, and
-  // an off-session confirm does not fall back to attached cards — resolve the
-  // payment method explicitly or the reload silently no-ops.
-  const paymentMethod = await getOffSessionPaymentMethodId(org.stripeCustomerId);
-  if (!paymentMethod) return;
-
   try {
+    // Cards saved via Checkout are attached but not the customer default, and
+    // an off-session confirm does not fall back to attached cards — resolve
+    // the payment method explicitly or the reload silently no-ops.
+    const paymentMethod = await getOffSessionPaymentMethodId(org.stripeCustomerId);
+    if (!paymentMethod) return;
+
     const paymentIntent = await getStripe().paymentIntents.create({
       amount: Math.round(reloadAmount * 100),
       currency: "usd",

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -174,28 +174,25 @@ export async function createSubscriptionCheckoutSession(
  * ATTACHED to the customer but not made the default, and a PaymentIntent
  * confirmed without an explicit payment_method does not fall back to attached
  * cards — so we prefer the customer's default and fall back to the most
- * recently attached card. Returns null when the customer has no card at all.
+ * recently attached card. Returns null ONLY when the customer genuinely has
+ * no card; a Stripe API error propagates so callers don't mistake an outage
+ * for "no card" (which would wrongly count as a failed renewal / downgrade).
  */
 export async function getOffSessionPaymentMethodId(
   stripeCustomerId: string,
 ): Promise<string | null> {
-  try {
-    const customer = await getStripe().customers.retrieve(stripeCustomerId);
-    if (!customer.deleted) {
-      const def = customer.invoice_settings?.default_payment_method;
-      if (typeof def === "string") return def;
-      if (def && typeof def === "object") return def.id;
-    }
-    const methods = await getStripe().paymentMethods.list({
-      customer: stripeCustomerId,
-      type: "card",
-      limit: 1,
-    });
-    return methods.data[0]?.id ?? null;
-  } catch (err) {
-    console.error("[stripe] Failed to resolve off-session payment method:", err);
-    return null;
+  const customer = await getStripe().customers.retrieve(stripeCustomerId);
+  if (!customer.deleted) {
+    const def = customer.invoice_settings?.default_payment_method;
+    if (typeof def === "string") return def;
+    if (def && typeof def === "object") return def.id;
   }
+  const methods = await getStripe().paymentMethods.list({
+    customer: stripeCustomerId,
+    type: "card",
+    limit: 1,
+  });
+  return methods.data[0]?.id ?? null;
 }
 
 export async function createPortalSession(

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -168,6 +168,36 @@ export async function createSubscriptionCheckoutSession(
   return session.url!;
 }
 
+/**
+ * Resolve the payment method to use for off-session charges (auto-reload,
+ * subscription renewals). Cards saved via Checkout's setup_future_usage are
+ * ATTACHED to the customer but not made the default, and a PaymentIntent
+ * confirmed without an explicit payment_method does not fall back to attached
+ * cards — so we prefer the customer's default and fall back to the most
+ * recently attached card. Returns null when the customer has no card at all.
+ */
+export async function getOffSessionPaymentMethodId(
+  stripeCustomerId: string,
+): Promise<string | null> {
+  try {
+    const customer = await getStripe().customers.retrieve(stripeCustomerId);
+    if (!customer.deleted) {
+      const def = customer.invoice_settings?.default_payment_method;
+      if (typeof def === "string") return def;
+      if (def && typeof def === "object") return def.id;
+    }
+    const methods = await getStripe().paymentMethods.list({
+      customer: stripeCustomerId,
+      type: "card",
+      limit: 1,
+    });
+    return methods.data[0]?.id ?? null;
+  } catch (err) {
+    console.error("[stripe] Failed to resolve off-session payment method:", err);
+    return null;
+  }
+}
+
 export async function createPortalSession(
   orgId: string,
   returnUrl: string,

--- a/apps/web/lib/subscription.ts
+++ b/apps/web/lib/subscription.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@octopus/db";
 import { addCredits } from "@/lib/credits";
-import { getStripe } from "@/lib/stripe";
+import { getStripe, getOffSessionPaymentMethodId } from "@/lib/stripe";
 import { SUBSCRIPTION_PLANS, type PaidPlanTier } from "@/lib/plans";
 
 /**
@@ -104,6 +104,9 @@ export async function chargeSubscription(
   });
   if (!org?.stripeCustomerId) return null;
 
+  const paymentMethod = await getOffSessionPaymentMethodId(org.stripeCustomerId);
+  if (!paymentMethod) return null;
+
   const plan = SUBSCRIPTION_PLANS[tier];
   try {
     const paymentIntent = await getStripe().paymentIntents.create(
@@ -111,6 +114,7 @@ export async function chargeSubscription(
         amount: Math.round(plan.priceUsd * 100),
         currency: "usd",
         customer: org.stripeCustomerId,
+        payment_method: paymentMethod,
         off_session: true,
         confirm: true,
         metadata: { orgId, type: "subscription", tier, amountUsd: String(plan.priceUsd) },

--- a/apps/web/lib/subscription.ts
+++ b/apps/web/lib/subscription.ts
@@ -104,11 +104,11 @@ export async function chargeSubscription(
   });
   if (!org?.stripeCustomerId) return null;
 
-  const paymentMethod = await getOffSessionPaymentMethodId(org.stripeCustomerId);
-  if (!paymentMethod) return null;
-
   const plan = SUBSCRIPTION_PLANS[tier];
   try {
+    const paymentMethod = await getOffSessionPaymentMethodId(org.stripeCustomerId);
+    if (!paymentMethod) return null;
+
     const paymentIntent = await getStripe().paymentIntents.create(
       {
         amount: Math.round(plan.priceUsd * 100),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@react-email/components": "^1.0.12",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
+    "@stripe/stripe-js": "^9.10.0",
     "@tabler/icons-react": "^3.44.0",
     "better-auth": "^1.4.18",
     "class-variance-authority": "^0.7.1",

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "@react-email/components": "^1.0.12",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
+        "@stripe/stripe-js": "^9.10.0",
         "@tabler/icons-react": "^3.44.0",
         "better-auth": "^1.4.18",
         "class-variance-authority": "^0.7.1",
@@ -900,6 +901,8 @@
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
+    "@stripe/stripe-js": ["@stripe/stripe-js@9.10.0", "", {}, "sha512-rxkKgWLAWtjvJhqEynPJ5zPXoKx5cK4eIUunnMGxwUJDRHKv3MlpA1mCCXdeiXzui5YZNWJKUJBTpe7m30jhOA=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 


### PR DESCRIPTION
## What

Save a card **without leaving the app**. The Payment Methods section now has an **Add card** button that opens a dialog with Stripe's embedded Payment Element (card form in a Stripe-hosted iframe — card data never touches our servers) on a SetupIntent. On confirm, the card becomes the customer's default for off-session charges. No redirect to Stripe.

Subscribing with no saved card now opens this dialog instead of bouncing to Checkout.

## Also fixes a latent off-session bug

Cards saved via Checkout's `setup_future_usage` are *attached* to the customer but not made the *default*, and an off-session PaymentIntent confirmed without an explicit `payment_method` does **not** fall back to attached cards. So auto-reload and subscription renewals would have silently no-op'd. Added `getOffSessionPaymentMethodId` (customer default, else most-recently-attached card) and now pass `payment_method` explicitly on every off-session charge; both paths no-op cleanly only when there is genuinely no card.

## Security

`finalizeCardSetup` verifies the SetupIntent (id comes from the browser) belongs to the calling org's Stripe customer before making it default; both new actions are owner/admin gated via the existing `getOwnerOrgId`.

## Verification

- `bun test`: 25/25 billing tests (added a no-card renewal no-op test); 2 unrelated pre-existing nodemailer failures.
- `tsc --noEmit` clean.
- Note: the card form needs `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (already set in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)