### PR TITLE
fix(billing): read Stripe publishable key at runtime, not build-time-inlined

### DIFF
--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -54,6 +54,10 @@ type Props = {
   billingEmail: string | null;
   monthlySpendLimitUsd: number | null;
   stripeCustomerId: string | null;
+  // Read server-side (runtime env) and passed down — NOT read from
+  // process.env in the client, where NEXT_PUBLIC_* is inlined at build time
+  // and the CI build has no Stripe key (would bake in an empty string).
+  stripePublishableKey: string;
   planTier: string;
   planRenewsAt: string | null;
   planCancelAtPeriodEnd: boolean;
@@ -117,6 +121,7 @@ export function BillingSettings({
   billingEmail,
   monthlySpendLimitUsd,
   stripeCustomerId,
+  stripePublishableKey,
   planTier,
   planRenewsAt,
   planCancelAtPeriodEnd,
@@ -811,7 +816,7 @@ export function BillingSettings({
       <CardSetupDialog
         open={cardOpen}
         onOpenChange={setCardOpen}
-        publishableKey={process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? ""}
+        publishableKey={stripePublishableKey}
         onSaved={() => router.refresh()}
       />
     </div>

--- a/apps/web/app/(app)/settings/billing/page.tsx
+++ b/apps/web/app/(app)/settings/billing/page.tsx
@@ -44,6 +44,13 @@ export default async function BillingPage() {
   const org = member.organization;
   const isOwner = member.role === "owner" || member.role === "admin";
 
+  // Bracket notation on purpose: Next inlines `process.env.NEXT_PUBLIC_*`
+  // dot-access at BUILD time (client and server), and the CI image is built
+  // without the Stripe key — dot-access would bake in an empty string.
+  // Computed access isn't inlined, so this reads the runtime value the box
+  // actually has. Passed to the client component as a prop.
+  const stripePublishableKey = process.env["NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY"] ?? "";
+
   const [autoReloadConfig, transactions, totalTransactions, monthlySpend, paymentMethods] = await Promise.all([
     prisma.autoReloadConfig.findUnique({
       where: { organizationId: org.id },
@@ -72,6 +79,7 @@ export default async function BillingPage() {
       billingEmail={org.billingEmail}
       monthlySpendLimitUsd={org.monthlySpendLimitUsd}
       stripeCustomerId={org.stripeCustomerId}
+      stripePublishableKey={stripePublishableKey}
       planTier={org.planTier}
       planRenewsAt={org.planRenewsAt ? org.planRenewsAt.toISOString() : null}
       planCancelAtPeriodEnd={org.planCancelAtPeriodEnd}


### PR DESCRIPTION
## Bug

The in-app card dialog (#625) failed in prod with `IntegrationError: Please call Stripe() with your publishable key. You used an empty string.`

**Root cause:** the client component read `process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`. Next inlines `NEXT_PUBLIC_*` **dot-access at build time**, and `release.yml` builds the hosted image without the Stripe key in its build args — so an empty string got compiled into the bundle. The key IS set in the box's runtime env, but that's too late for a build-time inline.

## Fix

Read the key in the billing **server component** (`page.tsx`) using computed access — `process.env["NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY"]` — which webpack's DefinePlugin does not inline, so it's the runtime value. Thread it to `CardSetupDialog` as a prop. No per-environment rebuild; self-host works the same way.

## Note

Depends on the runtime env having `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (documented in `.env.example`) — verifying on the box before/after deploy.

`tsc --noEmit` clean; 26/26 billing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)