### PR TITLE
feat(billing): notify org owner when auto-reload payment fails (#506)

### DIFF
--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -130,6 +130,17 @@ mock.module("@octopus/db", () => ({
 
 let mockOffSessionPaymentMethodId = mock(() => Promise.resolve("pm_default" as string | null));
 
+// Capture emitted events; mocking the bus also stops the real observers (which
+// hit prisma methods this harness doesn't stub) from registering on import.
+let emittedEvents: Array<{ type: string; [k: string]: unknown }> = [];
+mock.module("@/lib/events/bus", () => ({
+  eventBus: {
+    emit: (e: { type: string }) => emittedEvents.push(e as never),
+    on: () => {},
+    off: () => {},
+  },
+}));
+
 mock.module("@/lib/stripe", () => ({
   constructWebhookEvent: (...args: unknown[]) => mockConstructWebhookEvent(...args),
   getOffSessionPaymentMethodId: (...args: unknown[]) => mockOffSessionPaymentMethodId(...args),
@@ -164,6 +175,7 @@ const { addOneMonth, renewDueSubscriptions } = await import("@/lib/subscription"
 function resetBillingMocks() {
   orgState = { creditBalance: 20, freeCreditBalance: 8 };
   createdTransactions = [];
+  emittedEvents = [];
   currentEvent = { type: "unhandled.event", data: { object: {} } };
   shouldRejectSignature = false;
 
@@ -318,6 +330,53 @@ describe("credits ledger", () => {
     expect(mockTxQueryRaw).not.toHaveBeenCalled();
     expect(mockTxOrganizationUpdate).not.toHaveBeenCalled();
     expect(mockTxCreditTransactionCreate).not.toHaveBeenCalled();
+  });
+
+  it("records a truthful negative balance when usage exceeds the balance (post-paid)", async () => {
+    // free 8 + purchased 20 = 28; a $30 deduction (tokens already spent) must
+    // record the real overage, not clamp to zero.
+    await deductCredits("org_1", 30, "Expensive review");
+
+    expect(orgState).toEqual({ creditBalance: -2, freeCreditBalance: 0 });
+    expect(createdTransactions).toEqual([
+      {
+        amount: -30,
+        type: "usage",
+        description: "Expensive review",
+        balanceAfter: -2,
+        organizationId: "org_1",
+      },
+    ]);
+  });
+});
+
+describe("auto-reload failure notification", () => {
+  it("emits auto-reload-failed when the reload charge is declined", async () => {
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: true, thresholdAmount: 25, reloadAmount: 50 } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1" } as never),
+    );
+    mockCreditTransactionFindFirst = mock(() => Promise.resolve(null)); // no recent reload
+    mockOffSessionPaymentMethodId = mock(() => Promise.resolve("pm_1"));
+    const declined = new Error("Your card was declined.") as Error & { code: string };
+    declined.code = "card_declined";
+    mockPaymentIntentsCreate = mock(() => Promise.reject(declined));
+
+    // Deduct into the auto-reload threshold; the fire-and-forget reload runs.
+    await deductCredits("org_1", 6, "Review run");
+    // Let the fire-and-forget triggerAutoReloadIfNeeded settle.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const failed = emittedEvents.find((e) => e.type === "auto-reload-failed");
+    expect(failed).toBeTruthy();
+    expect(failed).toMatchObject({
+      type: "auto-reload-failed",
+      orgId: "org_1",
+      reloadAmount: 50,
+      reason: "card_declined",
+    });
   });
 });
 

--- a/apps/web/lib/activity.ts
+++ b/apps/web/lib/activity.ts
@@ -61,6 +61,7 @@ export function projectActivity(event: AppEvent): ProjectedActivity | null {
       });
     // Not surfaced in the activity feed:
     case "credit-low": // billing alert
+    case "auto-reload-failed": // billing alert
     case "org-type-changed": // admin/audit concern
       return null;
     default:

--- a/apps/web/lib/credits.ts
+++ b/apps/web/lib/credits.ts
@@ -265,8 +265,22 @@ async function triggerAutoReloadIfNeeded(
       console.log(`[credits] Auto-reload $${reloadAmount} for org ${orgId}`);
     }
   } catch (err) {
-    // Payment failed (no default payment method, card declined, etc.)
+    // Payment failed (card declined, expired, etc.). Post-paid metering means
+    // the in-flight review already spent the tokens; the actionable signal is
+    // to the owner — their card failed and reviews will stop once the balance
+    // is exhausted. A silent console.error left them blind (#506).
     console.error("[credits] Auto-reload payment failed:", err);
+    const reason =
+      err && typeof err === "object" && "code" in err
+        ? String((err as { code?: unknown }).code)
+        : undefined;
+    eventBus.emit({
+      type: "auto-reload-failed",
+      orgId,
+      reloadAmount,
+      remainingBalance: currentBalance,
+      reason,
+    });
   }
 }
 

--- a/apps/web/lib/credits.ts
+++ b/apps/web/lib/credits.ts
@@ -270,10 +270,8 @@ async function triggerAutoReloadIfNeeded(
     // to the owner — their card failed and reviews will stop once the balance
     // is exhausted. A silent console.error left them blind (#506).
     console.error("[credits] Auto-reload payment failed:", err);
-    const reason =
-      err && typeof err === "object" && "code" in err
-        ? String((err as { code?: unknown }).code)
-        : undefined;
+    const code = (err as { code?: unknown } | null)?.code;
+    const reason = typeof code === "string" ? code : undefined;
     eventBus.emit({
       type: "auto-reload-failed",
       orgId,

--- a/apps/web/lib/email-template-seeds.ts
+++ b/apps/web/lib/email-template-seeds.ts
@@ -194,6 +194,21 @@ When credits run out, PR reviews and other AI-powered features will stop working
     buttonUrl: "{{appUrl}}/settings/billing",
     variables: ["balance", "paceLine", "appUrl"],
   },
+  {
+    slug: "auto-reload-failed",
+    name: "Auto-Reload Payment Failed",
+    category: "transactional",
+    fromType: "system",
+    subject: "Action needed: auto-reload payment failed",
+    body: `We tried to automatically top up your organization's credits by **{{reloadAmount}}**, but the payment did not go through.{{reasonLine}}
+
+Your balance is currently **{{balance}}**. Once it runs out, PR reviews and other AI-powered features will stop working.
+
+Please update your card to keep automatic top-ups running.`,
+    buttonText: "Update payment method",
+    buttonUrl: "{{appUrl}}/settings/billing",
+    variables: ["reloadAmount", "reasonLine", "balance", "appUrl"],
+  },
 
   // ── Marketing templates (for Send Email) ──────────────────────────────
 

--- a/apps/web/lib/events/observers/email.observer.ts
+++ b/apps/web/lib/events/observers/email.observer.ts
@@ -12,6 +12,7 @@ import type {
   ReviewFailedEvent,
   KnowledgeReadyEvent,
   CreditLowEvent,
+  AutoReloadFailedEvent,
 } from "../types";
 
 async function getEligibleRecipients(
@@ -231,6 +232,72 @@ async function onCreditLow(event: CreditLowEvent): Promise<void> {
   );
 }
 
+// Cooldown so a burst of failed auto-reloads (each low-balance deduction
+// re-attempts) can't spam the owner — one card-failure email per day.
+const AUTO_RELOAD_FAILED_COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24h
+
+async function onAutoReloadFailed(event: AutoReloadFailedEvent): Promise<void> {
+  // Same atomic cooldown-claim as onCreditLow: a marker ledger row under
+  // Serializable isolation ensures at most one email per window even when
+  // concurrent deductions each fail their reload.
+  let claimed = false;
+  try {
+    claimed = await prisma.$transaction(
+      async (tx) => {
+        const recent = await tx.creditTransaction.findFirst({
+          where: {
+            organizationId: event.orgId,
+            type: "auto_reload_failed_email",
+            createdAt: { gte: new Date(Date.now() - AUTO_RELOAD_FAILED_COOLDOWN_MS) },
+          },
+          select: { id: true },
+        });
+        if (recent) return false;
+        await tx.creditTransaction.create({
+          data: {
+            amount: 0,
+            type: "auto_reload_failed_email",
+            description: "Auto-reload failure notification sent",
+            balanceAfter: event.remainingBalance,
+            organizationId: event.orgId,
+          },
+        });
+        return true;
+      },
+      { isolationLevel: "Serializable" },
+    );
+  } catch (err) {
+    console.error("[email-observer] auto-reload-failed cooldown claim lost:", err);
+    return;
+  }
+
+  if (!claimed) return;
+
+  const recipients = await getAdminRecipients(event.orgId);
+  if (recipients.length === 0) return;
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://octopus-review.ai";
+  const reasonLine = event.reason
+    ? ` (reason: ${escapeHtml(event.reason)})`
+    : "";
+
+  const result = await renderEmailTemplate("auto-reload-failed", {
+    reloadAmount: `$${event.reloadAmount.toFixed(2)}`,
+    reasonLine,
+    balance: `$${event.remainingBalance.toFixed(2)}`,
+    appUrl,
+  });
+  if (!result) return;
+
+  await Promise.allSettled(
+    recipients.map((r) =>
+      sendEmail({ to: r.email, subject: result.subject, html: result.html }).catch((err) =>
+        console.error(`[email-observer] Failed to send auto-reload-failed to ${r.email}:`, err),
+      ),
+    ),
+  );
+}
+
 export function registerEmailObserver(): void {
   console.log("[email-observer] Registering Email observer");
 
@@ -241,4 +308,5 @@ export function registerEmailObserver(): void {
   eventBus.on<ReviewFailedEvent>("review-failed", onReviewFailed);
   eventBus.on<KnowledgeReadyEvent>("knowledge-ready", onKnowledgeReady);
   eventBus.on<CreditLowEvent>("credit-low", onCreditLow);
+  eventBus.on<AutoReloadFailedEvent>("auto-reload-failed", onAutoReloadFailed);
 }

--- a/apps/web/lib/events/types.ts
+++ b/apps/web/lib/events/types.ts
@@ -61,6 +61,17 @@ export type CreditLowEvent = {
   runwayMinutes?: number;
 };
 
+export type AutoReloadFailedEvent = {
+  type: "auto-reload-failed";
+  orgId: string;
+  /** The reload amount we tried to charge. */
+  reloadAmount: number;
+  /** Balance at the time the reload was attempted. */
+  remainingBalance: number;
+  /** Stripe's decline reason, when available. */
+  reason?: string;
+};
+
 export type OrgTypeChangedEvent = {
   type: "org-type-changed";
   orgId: string;
@@ -88,6 +99,7 @@ export type AppEvent =
   | ReviewFailedEvent
   | KnowledgeReadyEvent
   | CreditLowEvent
+  | AutoReloadFailedEvent
   | OrgTypeChangedEvent
   | CommunityReviewEvent;
 


### PR DESCRIPTION
## What

Closes the actionable half of #506: a declined auto-reload used to be a silent `console.error`, so an org owner had no idea their card failed until reviews stopped. Now the decline emits an `auto-reload-failed` event and the email observer sends the owner an actionable *"update your card"* email.

## How

- New `auto-reload-failed` event (types.ts) emitted from `triggerAutoReloadIfNeeded`'s catch, carrying the reload amount, current balance, and Stripe decline code.
- Email observer handler with the **same 24h Serializable cooldown-claim** as `credit-low` — a burst of concurrently-failing reloads can't spam the owner (one email per window).
- New `auto-reload-failed` email template seed.
- Billing alert, so it's excluded from the activity feed (parity with `credit-low`).

## Post-paid model, now tested

Two tests lock in behavior the audit flagged:
- **Usage exceeding balance records a truthful negative balance**, not clamped to zero — the tokens are already spent; the ledger must reflect the real overage.
- **Declined reload emits `auto-reload-failed`** with the decline code.

## Deliberately not in scope

The full **reservation model** from #506 (hold estimated cost at admission, settle on completion) is a review-lifecycle change with its own orphaned-hold failure modes on crash. Given metering is post-paid, that's a design decision — not built speculatively on the money path. This PR ships the concrete, safe win; the reservation piece stays open on #506 for a separate design pass. #501's test asks are already covered by `billing.test.ts` (now 28 cases).

## Verification

- `bun test`: 28/28 billing tests; 2 unrelated pre-existing nodemailer failures.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)