### PR TITLE
feat(billing): volume bonus on credit top-ups (#619 Tier 0)

### DIFF
--- a/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
+++ b/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { purchaseCredits } from "./actions";
+import { volumeBonusUsd } from "@/lib/plans";
 
 const PRESETS = [10, 25, 50, 100];
 
@@ -94,6 +95,13 @@ export function PurchaseDialog({
             </div>
             <p className="text-xs text-muted-foreground">Min $5, max $1,000</p>
           </div>
+
+          {typeof amount === "number" && volumeBonusUsd(amount) > 0 && (
+            <p className="text-sm text-emerald-600 dark:text-emerald-400">
+              +${volumeBonusUsd(amount)} bonus credits — you&apos;ll get $
+              {(amount + volumeBonusUsd(amount)).toFixed(2)} total.
+            </p>
+          )}
 
           {error && <p className="text-sm text-destructive">{error}</p>}
         </div>

--- a/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
+++ b/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
@@ -98,7 +98,7 @@ export function PurchaseDialog({
 
           {typeof amount === "number" && volumeBonusUsd(amount) > 0 && (
             <p className="text-sm text-emerald-600 dark:text-emerald-400">
-              +${volumeBonusUsd(amount)} bonus credits — you&apos;ll get $
+              +${volumeBonusUsd(amount).toFixed(2)} bonus credits — you&apos;ll get $
               {(amount + volumeBonusUsd(amount)).toFixed(2)} total.
             </p>
           )}

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { constructWebhookEvent, getStripe } from "@/lib/stripe";
-import { addCredits, deductCredits } from "@/lib/credits";
+import { addCredits, addFreeCredits, deductCredits } from "@/lib/credits";
 import { grantSubscriptionPeriod, addOneMonth } from "@/lib/subscription";
-import { isPaidPlanTier } from "@/lib/plans";
+import { isPaidPlanTier, volumeBonusUsd } from "@/lib/plans";
 import { prisma } from "@octopus/db";
 
 async function getReceiptUrl(paymentIntentId: string | null): Promise<string | null> {
@@ -70,6 +70,21 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ received: true });
           }
           throw err;
+        }
+
+        // Volume bonus on top of the paid amount (separate free_credit row so
+        // it never inflates the "purchased"/revenue figure). Reached only on
+        // the first, non-duplicate delivery — a redelivery returns early above.
+        // Best-effort: the purchase is already committed, so a bonus failure
+        // must not 500 and re-drive the purchase (which would then skip the
+        // bonus on retry). A rare lost bonus is logged, not double-granted.
+        const bonusUsd = volumeBonusUsd(amountUsd);
+        if (bonusUsd > 0) {
+          try {
+            await addFreeCredits(orgId, bonusUsd, `Volume bonus — $${bonusUsd} on $${amountUsd} purchase`);
+          } catch (err) {
+            console.error("[stripe-webhook] Volume bonus grant failed (non-fatal):", err);
+          }
         }
 
         // Best-effort receipt backfill — the credits are already committed, so a

--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -171,6 +171,7 @@ const {
 } = await import("@/lib/credits");
 const { POST } = await import("@/app/api/stripe/webhook/route");
 const { addOneMonth, renewDueSubscriptions } = await import("@/lib/subscription");
+const { volumeBonusUsd } = await import("@/lib/plans");
 
 function resetBillingMocks() {
   orgState = { creditBalance: 20, freeCreditBalance: 8 };
@@ -836,5 +837,66 @@ describe("off-session payment method resolution", () => {
 
     expect(result).toEqual({ renewed: 0, canceled: 0, downgraded: 0, failed: 1 });
     expect(orgState.creditBalance).toBe(20);
+  });
+});
+
+
+describe("volume purchase bonus", () => {
+  it("computes tiered bonus (0 below $100, 5% at $100+, 10% at $500+)", () => {
+    expect(volumeBonusUsd(25)).toBe(0);
+    expect(volumeBonusUsd(99)).toBe(0);
+    expect(volumeBonusUsd(100)).toBe(5);
+    expect(volumeBonusUsd(250)).toBe(12.5);
+    expect(volumeBonusUsd(500)).toBe(50);
+    expect(volumeBonusUsd(1000)).toBe(100);
+    expect(volumeBonusUsd(0)).toBe(0);
+    expect(volumeBonusUsd(-5)).toBe(0);
+  });
+
+  it("grants purchase + a separate free_credit bonus row on a $100 top-up", async () => {
+    currentEvent = {
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_bonus",
+          payment_status: "paid",
+          metadata: { orgId: "org_1", type: "credit_purchase", amountUsd: "100" },
+          payment_intent: "pi_bonus",
+        },
+      },
+    };
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    // free 8 + purchased 20, then +100 purchased, +5 free bonus.
+    expect(orgState).toEqual({ creditBalance: 120, freeCreditBalance: 13 });
+    const types = createdTransactions.map((t) => (t as { type: string }).type);
+    expect(types).toContain("purchase");
+    expect(types).toContain("free_credit");
+    const bonus = createdTransactions.find(
+      (t) => (t as { type: string }).type === "free_credit",
+    ) as { amount: number };
+    expect(bonus.amount).toBe(5); // NOT part of the purchase/revenue row
+  });
+
+  it("grants no bonus row for a sub-$100 top-up", async () => {
+    currentEvent = {
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_nobonus",
+          payment_status: "paid",
+          metadata: { orgId: "org_1", type: "credit_purchase", amountUsd: "50" },
+          payment_intent: "pi_nobonus",
+        },
+      },
+    };
+
+    await POST(stripeRequest() as never);
+
+    const types = createdTransactions.map((t) => (t as { type: string }).type);
+    expect(types).toContain("purchase");
+    expect(types).not.toContain("free_credit");
   });
 });

--- a/apps/web/lib/plans.ts
+++ b/apps/web/lib/plans.ts
@@ -15,3 +15,21 @@ export type PaidPlanTier = keyof typeof SUBSCRIPTION_PLANS;
 export function isPaidPlanTier(tier: string): tier is PaidPlanTier {
   return tier in SUBSCRIPTION_PLANS;
 }
+
+/**
+ * Volume bonus on one-off credit top-ups: pay $N, get bonus credits on top.
+ * Rates are kept below the subscription per-dollar bonus (10–16%) so a
+ * recurring plan stays the better deal. Highest matching tier wins.
+ */
+export const VOLUME_BONUS_TIERS = [
+  { minUsd: 500, rate: 0.1 },
+  { minUsd: 100, rate: 0.05 },
+] as const;
+
+/** Bonus credits (USD, rounded to cents) granted for a top-up of `amountUsd`. */
+export function volumeBonusUsd(amountUsd: number): number {
+  if (!Number.isFinite(amountUsd) || amountUsd <= 0) return 0;
+  const tier = VOLUME_BONUS_TIERS.find((t) => amountUsd >= t.minUsd);
+  if (!tier) return 0;
+  return Math.round(amountUsd * tier.rate * 100) / 100;
+}


### PR DESCRIPTION
## What

The smallest revenue lever from the tier-ladder epic (#619): larger one-off top-ups grant bonus credits. **$100+ → 5%, $500+ → 10%.** Rates deliberately stay below the subscription per-dollar bonus (Pro 10% / Team ~16%) so subscribing remains the better deal.

## How

- `volumeBonusUsd(amountUsd)` — pure tiered function in `plans.ts`, single source of truth shared by the dialog and the webhook (highest matching tier wins, rounded to cents, guards non-positive input).
- **Bonus is a separate `free_credit` ledger row**, not added to the purchase amount — so it never inflates the revenue dashboard's "purchased"/revenue figure (which sums purchase+auto_reload). Granted only on the first, non-duplicate webhook delivery, best-effort (a bonus failure logs but can't 500 and re-drive the purchase, which would then skip the bonus).
- Purchase dialog shows "+$X bonus — you'll get $Y total" live as the amount changes.

## Verification

- `bun test`: 31/31 billing tests (tier math, $100 → purchase + $5 bonus row, sub-$100 → no bonus); 2 unrelated pre-existing nodemailer failures.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)