### PR TITLE
feat(gating): GitLab commit-status parity for merge gating (#618)

### DIFF
--- a/apps/web/lib/__tests__/merge-gating.test.ts
+++ b/apps/web/lib/__tests__/merge-gating.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { shouldFailReviewCheck } from "@/lib/review-helpers";
+
+const sev = (hasCritical: boolean, hasHigh: boolean, hasMedium: boolean) => ({
+  hasCritical,
+  hasHigh,
+  hasMedium,
+});
+
+describe("shouldFailReviewCheck (merge-gating decision)", () => {
+  it("never fails when threshold is 'none', regardless of severity", () => {
+    expect(shouldFailReviewCheck(sev(true, true, true), "none")).toBe(false);
+  });
+
+  it("'critical' fails only on a critical finding", () => {
+    expect(shouldFailReviewCheck(sev(true, false, false), "critical")).toBe(true);
+    expect(shouldFailReviewCheck(sev(false, true, true), "critical")).toBe(false);
+    expect(shouldFailReviewCheck(sev(false, false, false), "critical")).toBe(false);
+  });
+
+  it("'high' fails on critical or high, not medium-only", () => {
+    expect(shouldFailReviewCheck(sev(true, false, false), "high")).toBe(true);
+    expect(shouldFailReviewCheck(sev(false, true, false), "high")).toBe(true);
+    expect(shouldFailReviewCheck(sev(false, false, true), "high")).toBe(false);
+  });
+
+  it("'medium' fails on any of critical/high/medium", () => {
+    expect(shouldFailReviewCheck(sev(false, false, true), "medium")).toBe(true);
+    expect(shouldFailReviewCheck(sev(false, true, false), "medium")).toBe(true);
+    expect(shouldFailReviewCheck(sev(true, false, false), "medium")).toBe(true);
+    expect(shouldFailReviewCheck(sev(false, false, false), "medium")).toBe(false);
+  });
+});

--- a/apps/web/lib/gitlab.ts
+++ b/apps/web/lib/gitlab.ts
@@ -300,6 +300,50 @@ export async function createPullRequestComment(
   return data.id as number;
 }
 
+/**
+ * Set (post) a commit status on a GitLab commit. Shows on the MR as a
+ * pipeline/status check; a project can require it to pass before merge
+ * ("Merge checks → Pipelines must succeed" with an external status). This is
+ * the GitLab equivalent of a GitHub check-run — the merge-gating primitive.
+ * `state`: "running" | "success" | "failed" | "canceled".
+ */
+export async function setCommitStatus(
+  organizationId: string,
+  projectPath: string,
+  sha: string,
+  state: "running" | "success" | "failed" | "canceled",
+  name: string,
+  description: string,
+  targetUrl?: string,
+): Promise<void> {
+  const token = await getAccessToken(organizationId);
+  const host = await getHost(organizationId);
+  const res = await fetch(
+    `${apiBase(host)}/projects/${encodeURIComponent(projectPath)}/statuses/${sha}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        state,
+        name,
+        description: description.slice(0, 255), // GitLab caps the field
+        ...(targetUrl ? { target_url: targetUrl } : {}),
+      }),
+    },
+  );
+
+  if (!res.ok) {
+    // GitLab 400s when the same (sha, name, state) is posted twice — that's a
+    // benign no-op, not a failure worth throwing over.
+    const errBody = await res.text();
+    if (res.status === 400 && errBody.includes("Cannot transition status")) return;
+    throw new Error(`Failed to set GitLab commit status: ${res.status} ${errBody}`);
+  }
+}
+
 export async function updatePullRequestComment(
   organizationId: string,
   projectPath: string,

--- a/apps/web/lib/large-review-result.ts
+++ b/apps/web/lib/large-review-result.ts
@@ -12,6 +12,7 @@ import {
   buildLowSeveritySummary,
   stripDetailedFindings,
   countFindings,
+  shouldFailReviewCheck,
 } from "@/lib/review-helpers";
 import { eventBus } from "@/lib/events";
 
@@ -169,11 +170,10 @@ export async function handleLargeReviewResult(
   const hasHigh = findings.some((f) => f.severity === "🟠");
   const hasMedium = findings.some((f) => f.severity === "🟡");
   const threshold = org.checkFailureThreshold || "critical";
-  const shouldRequestChanges =
-    threshold !== "none" &&
-    (hasCritical ||
-      (threshold !== "critical" && hasHigh) ||
-      (threshold === "medium" && hasMedium));
+  const shouldRequestChanges = shouldFailReviewCheck(
+    { hasCritical, hasHigh, hasMedium },
+    threshold,
+  );
   const reviewEvent: "COMMENT" | "REQUEST_CHANGES" = shouldRequestChanges
     ? "REQUEST_CHANGES"
     : "COMMENT";

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -693,3 +693,22 @@ export function generateVerificationQueries(
 
   return queries.slice(0, 15);
 }
+
+/**
+ * The merge-gating decision: does a review fail its check given the findings'
+ * severities and the org's checkFailureThreshold? Single source of truth for
+ * both the GitHub check-run conclusion and the GitLab commit status (and the
+ * REQUEST_CHANGES review event), so the two providers can never drift.
+ * threshold: "none" | "critical" | "high" | "medium".
+ */
+export function shouldFailReviewCheck(
+  sev: { hasCritical: boolean; hasHigh: boolean; hasMedium: boolean },
+  threshold: string,
+): boolean {
+  return (
+    threshold !== "none" &&
+    (sev.hasCritical ||
+      (threshold !== "critical" && sev.hasHigh) ||
+      (threshold === "medium" && sev.hasMedium))
+  );
+}

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -67,6 +67,7 @@ import {
   generateVerificationQueries,
   resolveIndexClaimWait,
   normalizeScoreDenominators,
+  shouldFailReviewCheck,
 } from "@/lib/review-helpers";
 import type { ReviewConfig } from "@/lib/review-helpers";
 import { getCategoryConfidenceThreshold } from "@/lib/review-categories";
@@ -823,6 +824,16 @@ export async function processReview(pullRequestId: string): Promise<void> {
     }
   }
 
+  // GitLab: post a running commit status so the MR shows the review in flight.
+  // This is the merge-gating primitive — a project can require the "octopus"
+  // status to pass before merge. Best-effort; a status failure never blocks the
+  // review itself.
+  if (pr.headSha && isGitlab) {
+    await gitlab
+      .setCommitStatus(org.id, projectPath, pr.headSha, "running", "octopus", "Octopus review in progress")
+      .catch((err) => console.error("[reviewer] Failed to set GitLab running status:", err));
+  }
+
   // Pre-review: sync feedback from GitHub before generating new findings
   if (isGitHub && installationId) {
     try {
@@ -1217,6 +1228,12 @@ export async function processReview(pullRequestId: string): Promise<void> {
           title: "No reviewable changes",
           summary: "The diff is empty — there are no reviewable code changes.",
         });
+      }
+      // GitLab has no "neutral" — an empty diff shouldn't block a merge, so pass.
+      if (pr.headSha && isGitlab) {
+        await gitlab
+          .setCommitStatus(org.id, projectPath, pr.headSha, "success", "octopus", "No reviewable code changes.")
+          .catch((e) => console.error("[reviewer] Failed to set GitLab status:", e));
       }
 
       console.log(`[reviewer] Skipped PR #${pr.number} — empty diff`);
@@ -2043,12 +2060,10 @@ Rules:
     const hasMedium = findings.some((f) => f.severity === "🟡");
 
     const threshold = org.checkFailureThreshold || "critical";
-    const shouldRequestChanges =
-      threshold !== "none" && (
-        hasCritical ||
-        (threshold !== "critical" && hasHigh) ||
-        (threshold === "medium" && hasMedium)
-      );
+    const shouldRequestChanges = shouldFailReviewCheck(
+      { hasCritical, hasHigh, hasMedium },
+      threshold,
+    );
     const reviewEvent = shouldRequestChanges ? "REQUEST_CHANGES" : "COMMENT";
 
     // Track the actual number of findings visible to the user (inline + summary table)
@@ -2301,37 +2316,38 @@ Rules:
       },
     });
 
+    // Merge-gating result, computed once and applied to whichever provider
+    // supports a status check (GitHub check-run, GitLab commit status).
+    const checkShouldFail = shouldFailReviewCheck(
+      { hasCritical, hasHigh, hasMedium },
+      threshold,
+    );
+    const summaryText = checkShouldFail
+      ? hasCritical
+        ? "Critical issues found that must be fixed before merge."
+        : hasHigh
+          ? "High severity issues found that should be fixed before merge."
+          : "Medium severity issues found that should be fixed before merge."
+      : effectiveFindingsCount > 0
+        ? "Review complete. No issues above the configured threshold."
+        : "Review complete. No issues found.";
+    const checkTitle = `${filesChanged} file${filesChanged !== 1 ? "s" : ""} reviewed, ${effectiveFindingsCount} finding${effectiveFindingsCount !== 1 ? "s" : ""}`;
+
     if (checkRunId && isGitHub && installationId) {
-      const checkShouldFail =
-        threshold !== "none" && (
-          hasCritical ||
-          (threshold !== "critical" && hasHigh) ||
-          (threshold === "medium" && hasMedium)
-        );
       const conclusion = checkShouldFail ? "failure" : "success";
-
-      const summaryText = checkShouldFail
-        ? hasCritical
-          ? "Critical issues found that must be fixed before merge."
-          : hasHigh
-            ? "High severity issues found that should be fixed before merge."
-            : "Medium severity issues found that should be fixed before merge."
-        : effectiveFindingsCount > 0
-          ? "Review complete. No issues above the configured threshold."
-          : "Review complete. No issues found.";
-
-      await ghUpdateCheckRun(
-        installationId,
-        owner,
-        repoName,
-        checkRunId,
-        conclusion,
-        {
-          title: `${filesChanged} file${filesChanged !== 1 ? "s" : ""} reviewed, ${effectiveFindingsCount} finding${effectiveFindingsCount !== 1 ? "s" : ""}`,
-          summary: summaryText,
-        },
-      );
+      await ghUpdateCheckRun(installationId, owner, repoName, checkRunId, conclusion, {
+        title: checkTitle,
+        summary: summaryText,
+      });
       console.log(`[reviewer] Check run updated — conclusion: ${conclusion} (threshold: ${threshold})`);
+    }
+
+    if (pr.headSha && isGitlab) {
+      const state = checkShouldFail ? "failed" : "success";
+      await gitlab
+        .setCommitStatus(org.id, projectPath, pr.headSha, state, "octopus", summaryText)
+        .catch((err) => console.error("[reviewer] Failed to set GitLab commit status:", err));
+      console.log(`[reviewer] GitLab commit status set — state: ${state} (threshold: ${threshold})`);
     }
 
     // Step 7: Store review in vector DB for timeline/search
@@ -2456,6 +2472,13 @@ Rules:
           summary: `Octopus Review encountered an error: ${errorMessage}`,
         },
       ).catch((e) => console.error("[reviewer] Failed to update check run:", e));
+    }
+    // GitLab: mark the status failed on a review error so a gated MR isn't left
+    // hanging on a "running" status forever.
+    if (pr.headSha && isGitlab) {
+      await gitlab
+        .setCommitStatus(org.id, projectPath, pr.headSha, "failed", "octopus", `Review error: ${errorMessage}`.slice(0, 255))
+        .catch((e) => console.error("[reviewer] Failed to set GitLab failed status:", e));
     }
 
     // If indexing was in progress, mark it as failed (check current DB state, not stale in-memory value)

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -156,6 +156,11 @@ async function emitReviewStatus(orgId: string, event: ReviewEvent) {
 
 const FEEDBACK_CLASSIFICATION_MODEL = "claude-sonnet-4-6";
 
+// GitLab commit-status context name — the merge-gating check GitLab MRs can
+// require. Kept as one constant so every finalize path uses the same name
+// (GitLab keys statuses by name; a mismatch would leave a stale "running" one).
+const GITLAB_STATUS_NAME = "octopus";
+
 type ReplyIntent = "dismissed" | "accepted" | "unclear";
 
 /**
@@ -830,7 +835,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
   // review itself.
   if (pr.headSha && isGitlab) {
     await gitlab
-      .setCommitStatus(org.id, projectPath, pr.headSha, "running", "octopus", "Octopus review in progress")
+      .setCommitStatus(org.id, projectPath, pr.headSha, "running", GITLAB_STATUS_NAME, "Octopus review in progress")
       .catch((err) => console.error("[reviewer] Failed to set GitLab running status:", err));
   }
 
@@ -915,6 +920,13 @@ export async function processReview(pullRequestId: string): Promise<void> {
                 reviewCommentId,
                 "> 🐙 **Octopus Review** — Repository indexing failed and could not be recovered.\n>\n> Please re-trigger the review by commenting `@octopusreview`.",
               );
+            }
+            // Terminal — the review won't run, so finalize the GitLab status
+            // (leaving "running" would strand the MR).
+            if (pr.headSha && isGitlab) {
+              await gitlab
+                .setCommitStatus(org.id, projectPath, pr.headSha, "failed", GITLAB_STATUS_NAME, "Repository indexing failed.")
+                .catch((e) => console.error("[reviewer] Failed to set GitLab status:", e));
             }
             return;
           }
@@ -1095,6 +1107,14 @@ export async function processReview(pullRequestId: string): Promise<void> {
         where: { id: pr.id },
         data: { status: "failed", errorMessage: "Monthly spend limit reached" },
       });
+      // Finalize the GitLab status as success — a billing limit is not a code
+      // problem, so it must not block the MR merge (and leaving "running" would
+      // strand it). GitHub uses no check here for the same reason.
+      if (pr.headSha && isGitlab) {
+        await gitlab
+          .setCommitStatus(org.id, projectPath, pr.headSha, "success", GITLAB_STATUS_NAME, "Review skipped — monthly usage limit reached.")
+          .catch((e) => console.error("[reviewer] Failed to set GitLab status:", e));
+      }
       return;
     }
 
@@ -1232,7 +1252,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
       // GitLab has no "neutral" — an empty diff shouldn't block a merge, so pass.
       if (pr.headSha && isGitlab) {
         await gitlab
-          .setCommitStatus(org.id, projectPath, pr.headSha, "success", "octopus", "No reviewable code changes.")
+          .setCommitStatus(org.id, projectPath, pr.headSha, "success", GITLAB_STATUS_NAME, "No reviewable code changes.")
           .catch((e) => console.error("[reviewer] Failed to set GitLab status:", e));
       }
 
@@ -2345,7 +2365,7 @@ Rules:
     if (pr.headSha && isGitlab) {
       const state = checkShouldFail ? "failed" : "success";
       await gitlab
-        .setCommitStatus(org.id, projectPath, pr.headSha, state, "octopus", summaryText)
+        .setCommitStatus(org.id, projectPath, pr.headSha, state, GITLAB_STATUS_NAME, summaryText)
         .catch((err) => console.error("[reviewer] Failed to set GitLab commit status:", err));
       console.log(`[reviewer] GitLab commit status set — state: ${state} (threshold: ${threshold})`);
     }
@@ -2477,7 +2497,7 @@ Rules:
     // hanging on a "running" status forever.
     if (pr.headSha && isGitlab) {
       await gitlab
-        .setCommitStatus(org.id, projectPath, pr.headSha, "failed", "octopus", `Review error: ${errorMessage}`.slice(0, 255))
+        .setCommitStatus(org.id, projectPath, pr.headSha, "failed", GITLAB_STATUS_NAME, `Review error: ${errorMessage}`.slice(0, 255))
         .catch((e) => console.error("[reviewer] Failed to set GitLab failed status:", e));
     }
 


### PR DESCRIPTION
## What

Closes the real gap in #618. **GitHub merge-gating already works** — the reviewer publishes an `Octopus Review` check-run that a repo can mark as a required status check. This brings **GitLab MRs to parity**: the reviewer now posts an `octopus` commit status (running → success/failed by severity vs `checkFailureThreshold`), which a GitLab project can require to pass before merge.

Directly unblocks the one real external customer (#515, self-hosted GitLab) who asked for the bot to **block the MR**.

## How

- **`gitlab.setCommitStatus()`** → `POST /projects/:id/statuses/:sha` (running/success/failed), mirroring `createPullRequestComment`; tolerates GitLab's benign duplicate-transition 400.
- **`reviewer.ts`** — posts `running` at start; the pass/fail decision + summary are hoisted out of the GitHub-only block and applied to **both** providers at the end; `failed` on the review-error path, `success` on empty-diff (GitLab has no `neutral`). Best-effort — a status failure never blocks the review.
- **`shouldFailReviewCheck()`** in review-helpers.ts — single source of truth for the gating decision, collapsing the severity/threshold logic that was **duplicated in 3 places** (reviewer.ts ×2, large-review-result.ts) so GitHub and GitLab can't drift.

## Scope

- GitHub gating unchanged. `large-review-result.ts` is GitHub-only by design (early-returns for other providers) so it only adopts the shared helper.
- **No app-level on/off toggle** — gating is already opt-in via the provider's required-check setting, so parity doesn't need one.

## Verification

- `bun test`: new merge-gating test covers the full threshold × severity matrix; reviewer tests still green (541 pass, 2 unrelated nodemailer fails).
- `bun run build` compiles; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)