### PR TITLE
feat(billing): low-balance concurrency guard against overspend (#506)

### DIFF
--- a/apps/web/lib/__tests__/concurrency-guard.test.ts
+++ b/apps/web/lib/__tests__/concurrency-guard.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { concurrencyGuardApplies } from "@/lib/cost";
+
+describe("concurrencyGuardApplies (#506 low-balance guard)", () => {
+  it("never guards a fully-BYOK org (no platform spend)", () => {
+    expect(concurrencyGuardApplies(true, 5)).toBe(false);
+    expect(concurrencyGuardApplies(true, 0.5)).toBe(false);
+  });
+
+  it("guards a platform-billed org only inside the (0, threshold) window", () => {
+    expect(concurrencyGuardApplies(false, 5)).toBe(true); // low → serialize
+    expect(concurrencyGuardApplies(false, 9.99)).toBe(true);
+    expect(concurrencyGuardApplies(false, 10)).toBe(false); // comfortable → no cap
+    expect(concurrencyGuardApplies(false, 100)).toBe(false);
+  });
+
+  it("does not guard at or below zero — the spend-limit block already handles that", () => {
+    expect(concurrencyGuardApplies(false, 0)).toBe(false);
+    expect(concurrencyGuardApplies(false, -1)).toBe(false);
+  });
+});

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -166,6 +166,42 @@ export async function isOrgOverSpendLimit(orgId: string): Promise<boolean> {
   return status.blocked;
 }
 
+// Balance below which we serialize a platform-billed org's reviews. Metering
+// is post-paid, so N reviews admitted at the same instant can each pass the
+// balance check and collectively overspend. This bounds that overspend to a
+// single review once the balance is nearly gone. Comfortable balances are
+// unaffected — concurrency is only capped inside this danger window.
+const CONCURRENCY_GUARD_BALANCE_USD = 10;
+
+/**
+ * Pure guard decision: serialize when the org is platform-billed (not fully
+ * BYOK) AND its balance is in the (0, threshold) danger window. At or below 0
+ * the spend-limit check already blocks admission, so the guard only covers the
+ * narrow window above it.
+ */
+export function concurrencyGuardApplies(fullyBYOK: boolean, totalBalanceUsd: number): boolean {
+  if (fullyBYOK) return false;
+  return totalBalanceUsd > 0 && totalBalanceUsd < CONCURRENCY_GUARD_BALANCE_USD;
+}
+
+/** True when an org's reviews should be serialized to prevent concurrent overspend. */
+export async function shouldGuardConcurrency(orgId: string): Promise<boolean> {
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: {
+      anthropicApiKey: true,
+      openaiApiKey: true,
+      googleApiKey: true,
+      creditBalance: true,
+      freeCreditBalance: true,
+    },
+  });
+  if (!org) return false;
+  const fullyBYOK = Boolean(org.anthropicApiKey && org.openaiApiKey && org.googleApiKey);
+  const total = Number(org.creditBalance) + Number(org.freeCreditBalance);
+  return concurrencyGuardApplies(fullyBYOK, total);
+}
+
 export function formatUsd(n: number): string {
   if (n < 0.01) return `$${n.toFixed(4)}`;
   return `$${n.toFixed(2)}`;

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -189,6 +189,7 @@ export async function shouldGuardConcurrency(orgId: string): Promise<boolean> {
   const org = await prisma.organization.findUnique({
     where: { id: orgId },
     select: {
+      type: true,
       anthropicApiKey: true,
       openaiApiKey: true,
       googleApiKey: true,
@@ -197,6 +198,10 @@ export async function shouldGuardConcurrency(orgId: string): Promise<boolean> {
     },
   });
   if (!org) return false;
+  // Community orgs are rate-limited (communityDailyReviewLimit), not credit-
+  // billed — same exemption getOrgSpendLimitStatus applies. No credit spend to
+  // serialize.
+  if (org.type === ORG_TYPE.COMMUNITY) return false;
   const fullyBYOK = Boolean(org.anthropicApiKey && org.openaiApiKey && org.googleApiKey);
   const total = Number(org.creditBalance) + Number(org.freeCreditBalance);
   return concurrencyGuardApplies(fullyBYOK, total);

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1127,16 +1127,27 @@ export async function processReview(pullRequestId: string): Promise<void> {
     // spend-limit block above once credits hit zero; stale reviews are reclaimed
     // by the existing stuck-review sweeper.
     if (await shouldGuardConcurrency(org.id)) {
-      const inFlight = await prisma.pullRequest.count({
-        where: {
-          repository: { organizationId: org.id },
-          status: "reviewing",
-          id: { not: pr.id },
-        },
+      // Admission must be ATOMIC — a plain count-then-mark is check-then-act:
+      // N parallel workers each see 0 in-flight (none marked yet) and all admit.
+      // A transaction-scoped advisory lock keyed on the org serializes the
+      // count+mark so exactly one review per org is admitted at a time. The
+      // lock is held only for this fast count/update, not the whole review.
+      const admitted = await prisma.$transaction(async (tx) => {
+        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${org.id}))`;
+        const inFlight = await tx.pullRequest.count({
+          where: {
+            repository: { organizationId: org.id },
+            status: "reviewing",
+            id: { not: pr.id },
+          },
+        });
+        if (inFlight > 0) return false;
+        await tx.pullRequest.update({ where: { id: pr.id }, data: { status: "reviewing" } });
+        return true;
       });
-      if (inFlight > 0) {
+      if (!admitted) {
         console.log(
-          `[reviewer] Low balance + ${inFlight} in-flight review(s) for org ${org.id} — re-queuing PR ${pr.id}`,
+          `[reviewer] Low balance + in-flight review for org ${org.id} — re-queuing PR ${pr.id}`,
         );
         await prisma.pullRequest.update({
           where: { id: pr.id },
@@ -1147,7 +1158,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
       }
     }
 
-    // Step 1: Mark as reviewing
+    // Step 1: Mark as reviewing (idempotent — the guard may have set it already)
     await prisma.pullRequest.update({
       where: { id: pr.id },
       data: { status: "reviewing" },

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -15,7 +15,7 @@ import {
   upsertFeedbackPattern,
 } from "@/lib/qdrant";
 import { extractAllMermaidBlocks, extractNodeLabels, DIAGRAM_TYPE_LABELS, sanitizeMermaidInMarkdown } from "@/lib/mermaid-utils";
-import { loadQueueConfig, computeStaleReclaimMs, enqueue } from "@/lib/queue";
+import { loadQueueConfig, computeStaleReclaimMs, enqueue, enqueueAfter } from "@/lib/queue";
 import { createEmbeddings } from "@/lib/embeddings";
 import { generateSparseVector } from "@/lib/sparse-vector";
 import { substitutePromptVars } from "@/lib/prompt-substitute";
@@ -97,7 +97,7 @@ import { writeSyncLog, deleteSyncLogs } from "@/lib/elasticsearch";
 import { logAiUsage } from "@/lib/ai-usage";
 import { getReviewModel } from "@/lib/ai-client";
 import { createAiMessage } from "@/lib/ai-router";
-import { isOrgOverSpendLimit } from "@/lib/cost";
+import { isOrgOverSpendLimit, shouldGuardConcurrency } from "@/lib/cost";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -1116,6 +1116,35 @@ export async function processReview(pullRequestId: string): Promise<void> {
           .catch((e) => console.error("[reviewer] Failed to set GitLab status:", e));
       }
       return;
+    }
+
+    // Low-balance concurrency guard (#506): post-paid metering means N reviews
+    // admitted at once can each pass the balance check and collectively
+    // overspend. When a nearly-empty platform-billed org already has a review
+    // in flight, re-queue this one to run after that finishes (and the balance
+    // is re-checked), serializing spend down to one review at a time. Bounded:
+    // the in-flight review completes → this retries and either runs or hits the
+    // spend-limit block above once credits hit zero; stale reviews are reclaimed
+    // by the existing stuck-review sweeper.
+    if (await shouldGuardConcurrency(org.id)) {
+      const inFlight = await prisma.pullRequest.count({
+        where: {
+          repository: { organizationId: org.id },
+          status: "reviewing",
+          id: { not: pr.id },
+        },
+      });
+      if (inFlight > 0) {
+        console.log(
+          `[reviewer] Low balance + ${inFlight} in-flight review(s) for org ${org.id} — re-queuing PR ${pr.id}`,
+        );
+        await prisma.pullRequest.update({
+          where: { id: pr.id },
+          data: { status: "queued", updatedAt: new Date() },
+        });
+        await enqueueAfter("process-review", { pullRequestId: pr.id }, 30);
+        return;
+      }
     }
 
     // Step 1: Mark as reviewing


### PR DESCRIPTION
## What

The lightweight guard for #506. Post-paid metering means several reviews admitted in the same instant can each pass the balance check and collectively push an org past zero. When a **platform-billed org's balance is low** (in the `(0, $10)` danger window) and a review is **already in flight**, the next review is re-queued to run 30s later — serializing spend down to one review at a time in exactly the window where it matters. Comfortable balances and fully-BYOK orgs are untouched.

## Why not the full reservation model

#506 proposes hold-at-admission / settle-on-completion. That's a review-lifecycle change with a new failure mode (orphaned holds needing a sweeper), on the money path. The concurrent overspend it prevents is **bounded** (~one review's cost near empty) and partly self-correcting (admission already blocks at zero). This guard closes the same gap for a fraction of the risk. Chosen deliberately (confirmed with the owner).

## How

- `cost.ts`: `concurrencyGuardApplies(fullyBYOK, totalBalance)` (pure) + `shouldGuardConcurrency(orgId)`.
- `reviewer.ts`: after the spend-limit check, if guarded and another review is in flight, set the PR back to `queued` and `enqueueAfter("process-review", …, 30)`.
- Bounded termination: the in-flight review finishes → this retries and either runs or hits the spend-limit block once credits reach zero; the existing stale-review sweeper frees stuck reviews.

## Verification

- `bun test`: guard decision matrix (BYOK, window bounds, ≤0); reviewer tests green (555 pass, 2 unrelated nodemailer fails).
- `bun run build` compiles; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)