### PR TITLE
docs(legal): name SC Technology Limited as the operating entity

### DIFF
--- a/apps/web/app/(landing)/docs/dpa/page.tsx
+++ b/apps/web/app/(landing)/docs/dpa/page.tsx
@@ -24,8 +24,11 @@ export default function DpaPage() {
       <Section title="In plain language">
         <P>
           A Data Processing Addendum (DPA) is the legal document that
-          formalises Octopus&apos;s role as a data processor and your role as
-          a data controller under GDPR / UK GDPR / CCPA. It complements (does
+          formalises the role of SC Technology Limited — the company that
+          operates Octopus, registered in England &amp; Wales under company no.
+          09579805 at 3rd Floor, 86-90 Paul Street, London EC2A 4NE — as a data
+          processor, and your role as a data controller under GDPR / UK GDPR /
+          CCPA. It complements (does
           not replace) our <a href="/docs/terms" className="text-cyan-400 underline">Terms of Service</a>{" "}
           and <a href="/docs/privacy" className="text-cyan-400 underline">Privacy Policy</a>.
         </P>

--- a/apps/web/app/(landing)/docs/privacy/page.tsx
+++ b/apps/web/app/(landing)/docs/privacy/page.tsx
@@ -25,7 +25,9 @@ export default function PrivacyPage() {
 
       <Section title="1. Introduction">
         <P>
-          Octopus (&quot;we&quot;, &quot;our&quot;, &quot;us&quot;) is a
+          Octopus (&quot;we&quot;, &quot;our&quot;, &quot;us&quot;), operated by
+          SC Technology Limited (registered in England &amp; Wales, company no.
+          09579805, 3rd Floor, 86-90 Paul Street, London EC2A 4NE), is a
           source-available, AI-powered code review platform. This Privacy Policy
           explains how we collect, use, and protect your information when you
           use our cloud-hosted service. If you self-host Octopus, your own

--- a/apps/web/app/(landing)/docs/terms/page.tsx
+++ b/apps/web/app/(landing)/docs/terms/page.tsx
@@ -26,7 +26,9 @@ export default function TermsPage() {
 
       <Section title="1. Acceptance of Terms">
         <P>
-          By accessing or using Octopus (&quot;the Service&quot;), you agree
+          By accessing or using Octopus (&quot;the Service&quot;), operated by
+          SC Technology Limited (registered in England &amp; Wales, company no.
+          09579805, 3rd Floor, 86-90 Paul Street, London EC2A 4NE), you agree
           to be bound by these Terms and Conditions. If you do not agree to
           these terms, please do not use the Service.
         </P>

--- a/apps/web/components/landing-footer.tsx
+++ b/apps/web/components/landing-footer.tsx
@@ -419,8 +419,12 @@ export function LandingFooter() {
         <div className="mt-10 flex flex-col items-center gap-3 border-t border-white/[0.06] pt-6 sm:flex-row sm:justify-between">
           <div className="flex flex-col gap-1">
             <span className="text-xs text-[#333]">
-              &copy; {new Date().getFullYear()} Octopus. Source-available code review
-              automation.
+              &copy; {new Date().getFullYear()} SC Technology Limited. Octopus is
+              source-available code review automation.
+            </span>
+            <span className="text-xs text-[#333]">
+              SC Technology Limited · registered in England &amp; Wales, company no.
+              09579805 · 3rd Floor, 86-90 Paul Street, London EC2A 4NE
             </span>
             <span className="text-xs text-[#333]">
               3D model{" "}


### PR DESCRIPTION
Closes #635.

## What
Names **SC Technology Limited** (UK company 09579805, 3rd Floor 86-90 Paul Street, London EC2A 4NE) as the operating entity across the footer, DPA, Privacy Policy, and Terms — keeping `Octopus`/`Octopus Review` as the product name throughout.

## Why
The site previously identified the operator only as the brand "Octopus," with no registered legal entity or address in the footer or any legal doc. That is (a) a legal weakness — a DPA/Privacy Policy should identify the actual controller/processor under GDPR — and (b) inconsistent with external records and the Claude Marketplace partner application, which name SC Technology Limited as the company behind Octopus. An enterprise buyer's legal team (or an Anthropic reviewer) cross-referencing the entity would otherwise find no link between "SC Technology Limited" and the product.

## Scope
Legal/identity **copy only** — no functional or behavioural change.

- Footer: entity + registered address line.
- DPA: processor identified as SC Technology Limited (operating Octopus) + address.
- Privacy Policy: 'we/us' defined as Octopus, operated by SC Technology Limited + address.
- Terms: contracting party named.

## Verification
`tsc --noEmit` clean; `bun run build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PejbYUsyvGodrxtzAp9CxP