### PR TITLE
feat(billing): success toast + confetti on credit purchase

### DIFF
--- a/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
+++ b/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import confetti from "canvas-confetti";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -41,7 +43,12 @@ export function PurchaseDialog({
       if (result.error) {
         setError(result.error);
       } else if (result.success) {
-        // Charged the saved card in-app — close and refresh the balance.
+        // Charged the saved card in-app — celebrate, close, and refresh the balance.
+        const total = amount + volumeBonusUsd(amount);
+        toast.success("Credits added", {
+          description: `$${total.toFixed(2)} in credits added to your balance.`,
+        });
+        confetti({ particleCount: 120, spread: 70, origin: { y: 0.7 } });
         onOpenChange(false);
         router.refresh();
       } else if (result.url) {

--- a/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
+++ b/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
@@ -48,7 +48,10 @@ export function PurchaseDialog({
         toast.success("Credits added", {
           description: `$${total.toFixed(2)} in credits added to your balance.`,
         });
-        confetti({ particleCount: 120, spread: 70, origin: { y: 0.7 } });
+        // Honor reduced-motion: the toast already confirms success; skip the burst.
+        if (!window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+          confetti({ particleCount: 120, spread: 70, origin: { y: 0.7 } });
+        }
         onOpenChange(false);
         router.refresh();
       } else if (result.url) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@stripe/stripe-js": "^9.10.0",
     "@tabler/icons-react": "^3.44.0",
     "better-auth": "^1.4.18",
+    "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -64,6 +65,7 @@
   "devDependencies": {
     "@octopus/tsconfig": "workspace:*",
     "@tailwindcss/postcss": "^4",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "^25",
     "@types/nodemailer": "^8.0.1",
     "@types/pdfkit": "^0.17.6",

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@stripe/stripe-js": "^9.10.0",
         "@tabler/icons-react": "^3.44.0",
         "better-auth": "^1.4.18",
+        "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -81,6 +82,7 @@
       "devDependencies": {
         "@octopus/tsconfig": "workspace:*",
         "@tailwindcss/postcss": "^4",
+        "@types/canvas-confetti": "^1.9.0",
         "@types/node": "^25",
         "@types/nodemailer": "^8.0.1",
         "@types/pdfkit": "^0.17.6",
@@ -949,6 +951,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/canvas-confetti": ["@types/canvas-confetti@1.9.0", "", {}, "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg=="],
+
     "@types/command-line-args": ["@types/command-line-args@5.2.3", "", {}, "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw=="],
 
     "@types/command-line-usage": ["@types/command-line-usage@5.0.4", "", {}, "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="],
@@ -1254,6 +1258,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001778", "", {}, "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg=="],
 
     "canvas-color-tracker": ["canvas-color-tracker@1.3.2", "", { "dependencies": { "tinycolor2": "^1.6.0" } }, "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg=="],
+
+    "canvas-confetti": ["canvas-confetti@1.9.4", "", {}, "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw=="],
 
     "canvas-renderer": ["canvas-renderer@2.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-RrBgVL5qCEDIXpJ6NrzyRNoTnXxYarqm/cS/W6ERhUJts5UQtt/XPEosGN3rqUkZ4fjBArlnCbsISJ+KCFnIAg=="],
 


### PR DESCRIPTION
## What
When a credit purchase succeeds via the saved-card in-app path, show a success toast (crediting the total incl. any volume bonus) and a confetti burst — previously the dialog just closed silently and the balance updated with no acknowledgement.

## Why
User feedback: "when purchase credit successful, add a feedback successfully added credit message not only just update the credit balance, perhaps a confetti would be nice too."

## Changes
- `purchase-dialog.tsx`: on `result.success`, fire `toast.success("Credits added", …)` + `confetti(...)` before closing/refreshing.
- Added `canvas-confetti` (~6 KB, zero transitive deps) + its types.

## Scope
Only the in-app saved-card path (the silent one). The Stripe Checkout redirect path acknowledges on its own return page and is unchanged.

tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)