### PR TITLE
fix(presence): middleware 307-hijacks /api/presence, breaking heartbeat auth contract

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -24,6 +24,7 @@ const publicPrefixes = [
   "/api/stripe",
   "/api/cli",
   "/api/agent",
+  "/api/presence",
   "/api/admin",
   "/api/newsletter",
   "/api/analyze-deps",


### PR DESCRIPTION
## Symptom
`POST /api/presence/heartbeat` (and `GET /api/presence`) return **`307 → /login`** for any request without a valid session cookie, instead of the JSON `401/403` the handlers are written to return. Confirmed on prod:

```
$ curl -i -X POST https://octopus-review.ai/api/presence/heartbeat -H 'Origin: https://octopus-review.ai' ...
HTTP 307  location: /login?callbackUrl=%2Fapi%2Fpresence%2Fheartbeat
```

## Root cause
`middleware.ts` redirects any non-public path lacking a session cookie to `/login`. `/api/presence` was missing from `publicPrefixes`, so the middleware pre-empted the route handler. The client (`presence-reporter.tsx`) has explicit auth-terminal handling — `if (res.status === 401 || 403) stop()` — but it's **dead code**: `fetch` transparently follows the 307 to the `/login` HTML page (a `200`), `res.json()` throws on HTML → caught → `data = null` → the reporter never stops and re-beats the login page every 30s for the life of the tab.

## Fix
Add `/api/presence` to the middleware `publicPrefixes` allowlist. Both presence handlers already enforce auth themselves (session → 401, org membership/role → 403, same-origin CSRF check on the POST), exactly like `/api/agent`, `/api/cli`, and `/api/admin` which are already exempt. "Public" here means "middleware doesn't gate it — the handler does."

## Verification
After deploy, re-run the curl above → expect `401 {"error":"Unauthorized"}`, not `307`. A logged-out long-open tab then stops heartbeating instead of hammering `/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)