### PR TITLE
feat(review): inject past reviews on similar code into review context (#645)

### DIFF
--- a/apps/web/lib/__tests__/review-helpers.test.ts
+++ b/apps/web/lib/__tests__/review-helpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "bun:test";
+import { formatPastReviews, type PastReviewHit } from "@/lib/review-helpers";
+
+describe("formatPastReviews", () => {
+  const hit = (o: Partial<PastReviewHit> = {}): PastReviewHit => ({
+    text: "Flagged an N+1 query in the loader.",
+    prTitle: "Add loader",
+    prNumber: 10,
+    repoFullName: "org/repo",
+    author: "alice",
+    reviewDate: "2026-07-01T12:00:00.000Z",
+    score: 0.8,
+    ...o,
+  });
+
+  it("returns empty string when there are no hits", () => {
+    expect(formatPastReviews([], 5, "org/repo")).toBe("");
+  });
+
+  it("excludes the current PR's own prior review", () => {
+    const out = formatPastReviews([hit({ prNumber: 5, repoFullName: "org/repo" })], 5, "org/repo");
+    expect(out).toBe("");
+  });
+
+  it("keeps a same-numbered PR from a different repo", () => {
+    const out = formatPastReviews([hit({ prNumber: 5, repoFullName: "org/other" })], 5, "org/repo");
+    expect(out).toContain("org/other#5");
+  });
+
+  it("drops low-score and empty-text hits", () => {
+    expect(formatPastReviews([hit({ score: 0.1 })], 1, "org/repo")).toBe("");
+    expect(formatPastReviews([hit({ text: "   " })], 1, "org/repo")).toBe("");
+  });
+
+  it("caps to max and truncates long bodies", () => {
+    const many = Array.from({ length: 9 }, (_, i) => hit({ prNumber: 100 + i }));
+    const out = formatPastReviews(many, 5, "org/repo", { max: 3 });
+    expect(out.match(/^### /gm)?.length).toBe(3);
+    const longOut = formatPastReviews([hit({ text: "x".repeat(2000) })], 5, "org/repo", { maxCharsPerHit: 50 });
+    expect(longOut.includes("x".repeat(51))).toBe(false);
+  });
+
+  it("renders repo#pr — title with a date", () => {
+    const out = formatPastReviews([hit()], 5, "org/repo");
+    expect(out).toContain("### org/repo#10 — Add loader (2026-07-01)");
+  });
+});

--- a/apps/web/lib/review-core.ts
+++ b/apps/web/lib/review-core.ts
@@ -12,6 +12,7 @@ import {
   searchKnowledgeChunks,
   searchFeedbackPatterns,
   ensureFeedbackCollection,
+  searchReviewChunks,
 } from "@/lib/qdrant";
 import { createEmbeddings } from "@/lib/embeddings";
 import { rerankDocuments } from "@/lib/reranker";
@@ -25,7 +26,7 @@ import {
   parseFindingsFromJson,
   parseFindingsFromMarkdown,
 } from "@/lib/review-dedup";
-import { extractCrossFileQueries, generateVerificationQueries, normalizeScoreDenominators } from "@/lib/review-helpers";
+import { extractCrossFileQueries, generateVerificationQueries, normalizeScoreDenominators, formatPastReviews } from "@/lib/review-helpers";
 import { gatherCrossFileContext, gatherVerificationContext, validateFindings } from "@/lib/review-validation";
 import { logAiUsage } from "@/lib/ai-usage";
 import { getReviewModel } from "@/lib/ai-client";
@@ -259,6 +260,14 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
     `[review-core] Context: ${contextChunks.length}/${rawCodeChunks.length} code chunks, ${knowledgeChunks.length} knowledge chunks (${alwaysIncludeKnowledge.length} pinned + ${similarityKnowledgeChunks.length}/${rawKnowledgeChunks.length} from search)`,
   );
 
+  // Past reviews on similar code — reuses the query vector already computed
+  // (one extra Qdrant query, no extra embedding/LLM cost). Never blocks review.
+  const pastReviewsContext = formatPastReviews(
+    await searchReviewChunks(org.id, queryVector, 6, rerankQuery).catch(() => []),
+    params.prNumber ?? 0,
+    repo.fullName,
+  );
+
   // Step 2: Build false positive context from past feedback
   let falsePositiveContext = "";
   try {
@@ -343,6 +352,7 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
     CODEBASE_CONTEXT: codebaseContext,
     FILE_TREE: fileTreeStr,
     KNOWLEDGE_CONTEXT: knowledgeContext,
+    PAST_REVIEWS_CONTEXT: pastReviewsContext,
     PR_NUMBER: String(params.prNumber ?? 0),
     USER_INSTRUCTION: "",
     PROVIDER: "local",

--- a/apps/web/lib/review-core.ts
+++ b/apps/web/lib/review-core.ts
@@ -223,10 +223,12 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
 
   const rerankQuery = `${title ?? "Local Review"}\n${diff.slice(0, 2000)}`;
 
-  const [rawCodeChunks, rawKnowledgeChunks, alwaysIncludeKnowledge] = await Promise.all([
+  const [rawCodeChunks, rawKnowledgeChunks, alwaysIncludeKnowledge, rawPastReviews] = await Promise.all([
     searchSimilarChunks(repo.id, queryVector, 50, rerankQuery),
     searchKnowledgeChunks(org.id, queryVector, 25, rerankQuery).catch(() => [] as { title: string; text: string; score: number }[]),
     getAlwaysIncludeKnowledge(org.id).catch(() => []),
+    // Past reviews on similar code — reuses the query vector, runs in parallel.
+    searchReviewChunks(org.id, queryVector, 6, rerankQuery).catch(() => []),
   ]);
 
   const [contextChunks, similarityKnowledgeChunks] = await Promise.all([
@@ -260,13 +262,8 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
     `[review-core] Context: ${contextChunks.length}/${rawCodeChunks.length} code chunks, ${knowledgeChunks.length} knowledge chunks (${alwaysIncludeKnowledge.length} pinned + ${similarityKnowledgeChunks.length}/${rawKnowledgeChunks.length} from search)`,
   );
 
-  // Past reviews on similar code — reuses the query vector already computed
-  // (one extra Qdrant query, no extra embedding/LLM cost). Never blocks review.
-  const pastReviewsContext = formatPastReviews(
-    await searchReviewChunks(org.id, queryVector, 6, rerankQuery).catch(() => []),
-    params.prNumber ?? 0,
-    repo.fullName,
-  );
+  // Format the past reviews retrieved above (in the parallel batch).
+  const pastReviewsContext = formatPastReviews(rawPastReviews, params.prNumber ?? 0, repo.fullName);
 
   // Step 2: Build false positive context from past feedback
   let falsePositiveContext = "";

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -712,3 +712,50 @@ export function shouldFailReviewCheck(
       (threshold === "medium" && sev.hasMedium))
   );
 }
+
+/** One hit from `searchReviewChunks` (past review summaries in Qdrant). */
+export interface PastReviewHit {
+  text: string;
+  prTitle: string;
+  prNumber: number;
+  repoFullName: string;
+  author: string;
+  reviewDate: string;
+  score: number;
+}
+
+/**
+ * Format past reviews on similar code into a compact prompt block. Grounds a
+ * review in what Octopus already concluded on related PRs so it stops
+ * relitigating settled findings. Pure so it is unit-testable; the caller does
+ * the Qdrant query and passes the current PR's identity so we never inject the
+ * PR's own prior review back into it (that is the separate re-review context).
+ * Returns "" when there is nothing usable, so the placeholder empties cleanly.
+ */
+export function formatPastReviews(
+  hits: PastReviewHit[],
+  currentPrNumber: number,
+  currentRepoFullName: string,
+  opts: { max?: number; minScore?: number; maxCharsPerHit?: number } = {},
+): string {
+  const { max = 5, minScore = 0.3, maxCharsPerHit = 800 } = opts;
+  const usable = hits
+    .filter((h) => h.text?.trim())
+    .filter((h) => h.score >= minScore)
+    // Never echo the current PR's own prior review back at it.
+    .filter(
+      (h) =>
+        !(h.prNumber === currentPrNumber && h.repoFullName === currentRepoFullName),
+    )
+    .slice(0, max);
+
+  if (usable.length === 0) return "";
+
+  return usable
+    .map((h) => {
+      const body = h.text.trim().slice(0, maxCharsPerHit);
+      const date = h.reviewDate ? ` (${h.reviewDate.slice(0, 10)})` : "";
+      return `### ${h.repoFullName}#${h.prNumber} — ${h.prTitle}${date}\n${body}`;
+    })
+    .join("\n\n---\n\n");
+}

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -13,6 +13,7 @@ import {
   searchFeedbackPatterns,
   ensureFeedbackCollection,
   upsertFeedbackPattern,
+  searchReviewChunks,
 } from "@/lib/qdrant";
 import { extractAllMermaidBlocks, extractNodeLabels, DIAGRAM_TYPE_LABELS, sanitizeMermaidInMarkdown } from "@/lib/mermaid-utils";
 import { loadQueueConfig, computeStaleReclaimMs, enqueue, enqueueAfter } from "@/lib/queue";
@@ -68,6 +69,7 @@ import {
   resolveIndexClaimWait,
   normalizeScoreDenominators,
   shouldFailReviewCheck,
+  formatPastReviews,
 } from "@/lib/review-helpers";
 import type { ReviewConfig } from "@/lib/review-helpers";
 import { getCategoryConfidenceThreshold } from "@/lib/review-categories";
@@ -1354,6 +1356,15 @@ export async function processReview(pullRequestId: string): Promise<void> {
       ? knowledgeChunks.map((c) => c.text).join("\n\n---\n\n")
       : "";
 
+    // Past reviews on similar code — highest-signal grounding, reuses the query
+    // vector already computed (one extra Qdrant query, no extra embedding/LLM
+    // cost). Never blocks a review on failure.
+    const pastReviewsContext = formatPastReviews(
+      await searchReviewChunks(org.id, queryVector, 6, rerankQuery).catch(() => []),
+      pr.number,
+      repo.fullName,
+    );
+
     await emitReviewStatus(org.id, {
       ...baseEvent,
       status: "reviewing",
@@ -1662,6 +1673,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
       CODEBASE_CONTEXT: codebaseContext,
       FILE_TREE: fileTree,
       KNOWLEDGE_CONTEXT: knowledgeContext,
+      PAST_REVIEWS_CONTEXT: pastReviewsContext,
       PR_NUMBER: String(pr.number),
       USER_INSTRUCTION: userInstruction,
       PROVIDER: isGitHub ? "GitHub" : isBitbucket ? "Bitbucket" : isGitlab ? "GitLab" : repo.provider,

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1320,10 +1320,13 @@ export async function processReview(pullRequestId: string): Promise<void> {
     // Over-fetch from Qdrant, then rerank with Cohere
     const rerankQuery = `${pr.title}\n${diff.slice(0, 2000)}`;
 
-    const [rawCodeChunks, rawKnowledgeChunks, alwaysIncludeKnowledge] = await Promise.all([
+    const [rawCodeChunks, rawKnowledgeChunks, alwaysIncludeKnowledge, rawPastReviews] = await Promise.all([
       searchSimilarChunks(repo.id, queryVector, 50, rerankQuery),
       searchKnowledgeChunks(org.id, queryVector, 25, rerankQuery).catch(() => [] as { title: string; text: string; score: number }[]),
       getAlwaysIncludeKnowledge(org.id).catch(() => []),
+      // Past reviews on similar code — reuses the query vector (no extra
+      // embedding/LLM cost) and runs in parallel with the other retrievals.
+      searchReviewChunks(org.id, queryVector, 6, rerankQuery).catch(() => []),
     ]);
 
     const [contextChunks, similarityKnowledgeChunks] = await Promise.all([
@@ -1356,14 +1359,9 @@ export async function processReview(pullRequestId: string): Promise<void> {
       ? knowledgeChunks.map((c) => c.text).join("\n\n---\n\n")
       : "";
 
-    // Past reviews on similar code — highest-signal grounding, reuses the query
-    // vector already computed (one extra Qdrant query, no extra embedding/LLM
-    // cost). Never blocks a review on failure.
-    const pastReviewsContext = formatPastReviews(
-      await searchReviewChunks(org.id, queryVector, 6, rerankQuery).catch(() => []),
-      pr.number,
-      repo.fullName,
-    );
+    // Format past reviews retrieved above (in the parallel batch) into the
+    // prompt block; excludes this PR's own prior review, caps and score-floors.
+    const pastReviewsContext = formatPastReviews(rawPastReviews, pr.number, repo.fullName);
 
     await emitReviewStatus(org.id, {
       ...baseEvent,

--- a/apps/web/prompts/SYSTEM_PROMPT.md
+++ b/apps/web/prompts/SYSTEM_PROMPT.md
@@ -116,6 +116,17 @@ Team-specific standards take precedence over general best practices.
 If no knowledge context is provided, skip this section.
 </knowledge_context>
 
+<past_reviews_context>
+{{PAST_REVIEWS_CONTEXT}}
+
+The above are summaries of past Octopus reviews on similar code in this organization.
+Use them for continuity: do NOT relitigate findings already settled there, stay
+consistent with conclusions previously reached on related code, and treat recurring
+issues as higher-confidence. These are prior context, NOT ground truth about the current
+diff — verify against the actual diff before repeating a past finding.
+If no past reviews are provided, skip this section.
+</past_reviews_context>
+
 <feedback_context>
 {{FALSE_POSITIVE_CONTEXT}}
 

--- a/apps/web/scripts/review-simulator.ts
+++ b/apps/web/scripts/review-simulator.ts
@@ -91,6 +91,7 @@ function loadSystemPrompt(fileTree: string, priorContext: string, userInstructio
   template = template.replace("{{CODEBASE_CONTEXT}}", "(Not available in simulation mode — no Qdrant context)");
   template = template.replace("{{FILE_TREE}}", fileTree);
   template = template.replace("{{KNOWLEDGE_CONTEXT}}", "");
+  template = template.replace("{{PAST_REVIEWS_CONTEXT}}", "");
   template = template.replace("{{PR_NUMBER}}", "0");
   template = template.replace("{{USER_INSTRUCTION}}", userInstruction);
   template = template.replace("{{PROVIDER}}", "GitHub");


### PR DESCRIPTION
Closes #645.

## What
`searchReviewChunks` populated `review_chunks` on every review but was never read at review time. This wires past reviews on similar code into both review paths as a `{{PAST_REVIEWS_CONTEXT}}` prompt block, reusing the query vector already computed — **one extra Qdrant query, no extra embedding or LLM cost**.

## How
- `formatPastReviews()` in `review-helpers.ts` — pure, unit-tested. Excludes the PR's own prior review (that's the separate re-review context), applies a score floor, caps to 5, truncates each hit; returns `""` when nothing is usable so the placeholder empties cleanly.
- Called in `reviewer.ts` and `review-core.ts` right after the knowledge context is built; added to both `substitutePromptVars` maps.
- New `<past_reviews_context>` section in `SYSTEM_PROMPT.md` instructing the model to use it for continuity but verify against the actual diff (not ground truth).

## Validation
- 6 new unit tests for `formatPastReviews` (own-PR exclusion, cross-repo same number, score/empty filtering, cap+truncate, render format) — all pass. tsc clean.
- **Security:** retrieval is `orgId`-scoped (`searchReviewChunks` filter) — no cross-tenant leak; no secrets; no new endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)