### PR TITLE
feat(routing): diff-classified model routing (#653)

### DIFF
--- a/apps/web/lib/__tests__/review-routing.test.ts
+++ b/apps/web/lib/__tests__/review-routing.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "bun:test";
+import { classifyDiff, extractChangedPaths, MECHANICAL_MODEL } from "@/lib/review-routing";
+
+function diffFor(path: string, added = 3): string {
+  const plus = Array.from({ length: added }, (_, i) => `+line ${i}`).join("\n");
+  return `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n@@ -1,0 +1,${added} @@\n${plus}\n`;
+}
+
+describe("extractChangedPaths", () => {
+  it("pulls the new-side path from each file header", () => {
+    const d = diffFor("src/a.ts") + diffFor("src/b.ts");
+    expect(extractChangedPaths(d)).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+});
+
+describe("classifyDiff", () => {
+  it("classifies a lockfile-only diff as mechanical", () => {
+    expect(classifyDiff(diffFor("bun.lock", 500)).tier).toBe("mechanical");
+  });
+
+  it("classifies a docs-only diff as mechanical", () => {
+    expect(classifyDiff(diffFor("README.md", 40)).tier).toBe("mechanical");
+  });
+
+  it("classifies a tests-only diff as mechanical", () => {
+    expect(classifyDiff(diffFor("src/foo.test.ts", 40)).tier).toBe("mechanical");
+  });
+
+  it("classifies a tiny single-file source edit as mechanical", () => {
+    expect(classifyDiff(diffFor("src/foo.ts", 4)).tier).toBe("mechanical");
+  });
+
+  it("classifies a normal multi-file source change as standard", () => {
+    const d = diffFor("src/a.ts", 60) + diffFor("src/b.ts", 60);
+    expect(classifyDiff(d).tier).toBe("standard");
+  });
+
+  it("classifies a schema/migration change as complex (high-risk)", () => {
+    const c = classifyDiff(diffFor("packages/db/prisma/schema.prisma", 5));
+    expect(c.tier).toBe("complex");
+    expect(c.highRisk).toBe(true);
+  });
+
+  it("classifies a large diff as complex even without high-risk files", () => {
+    expect(classifyDiff(diffFor("src/big.ts", 500)).tier).toBe("complex");
+  });
+
+  it("a mixed lockfile + real source change is NOT mechanical", () => {
+    const d = diffFor("bun.lock", 300) + diffFor("src/app.ts", 40);
+    expect(classifyDiff(d).mechanicalOnly).toBe(false);
+    expect(classifyDiff(d).tier).toBe("standard");
+  });
+
+  it("counts loc and files", () => {
+    const c = classifyDiff(diffFor("src/a.ts", 7));
+    expect(c.files).toBe(1);
+    expect(c.loc).toBe(7);
+  });
+});
+
+describe("pricing coverage (never bill $0 on a downshift)", () => {
+  it("the mechanical downshift model has fallback pricing", async () => {
+    const { fallbackPricedModels } = await import("@/lib/cost");
+    expect(fallbackPricedModels()).toContain(MECHANICAL_MODEL);
+  });
+});

--- a/apps/web/lib/ai-client.ts
+++ b/apps/web/lib/ai-client.ts
@@ -16,22 +16,38 @@ async function getPlatformDefault(category: "llm" | "embedding"): Promise<string
   }
 }
 
-export async function getReviewModel(orgId: string, repoId?: string): Promise<string> {
+export interface ResolvedReviewModel {
+  model: string;
+  /** true when the model came from an explicit repo/org pin (not the platform default). */
+  pinned: boolean;
+}
+
+/**
+ * Resolve the review model AND report whether it was an explicit pin, in a
+ * single pass of DB lookups. Single source of truth for the
+ * repo-pin → org-pin → platform-default precedence; the router
+ * (review-routing.ts) uses `pinned` to know when it may downshift.
+ */
+export async function resolveReviewModelPin(orgId: string, repoId?: string): Promise<ResolvedReviewModel> {
   if (repoId) {
     const repo = await prisma.repository.findUnique({
       where: { id: repoId },
       select: { reviewModelId: true },
     });
-    if (repo?.reviewModelId) return repo.reviewModelId;
+    if (repo?.reviewModelId) return { model: repo.reviewModelId, pinned: true };
   }
 
   const org = await prisma.organization.findUnique({
     where: { id: orgId },
     select: { defaultModelId: true },
   });
-  if (org?.defaultModelId) return org.defaultModelId;
+  if (org?.defaultModelId) return { model: org.defaultModelId, pinned: true };
 
-  return (await getPlatformDefault("llm")) ?? HARDCODED_REVIEW_MODEL;
+  return { model: (await getPlatformDefault("llm")) ?? HARDCODED_REVIEW_MODEL, pinned: false };
+}
+
+export async function getReviewModel(orgId: string, repoId?: string): Promise<string> {
+  return (await resolveReviewModelPin(orgId, repoId)).model;
 }
 
 export async function getEmbedModel(orgId: string, repoId?: string): Promise<string> {

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -26,6 +26,12 @@ const FALLBACK_PRICING: Record<string, ModelPricing> = {
   "rerank-v3.5": { input: 2000.0, output: 0 },
 };
 
+/** Models that always have pricing (independent of the DB). Lets a router
+ *  assert every model it can emit is billable, so a downshift can never bill $0. */
+export function fallbackPricedModels(): string[] {
+  return Object.keys(FALLBACK_PRICING);
+}
+
 export async function getModelPricing(): Promise<Map<string, ModelPricing>> {
   if (pricingCache && Date.now() - pricingCacheTime < PRICING_CACHE_TTL) {
     return pricingCache;

--- a/apps/web/lib/review-core.ts
+++ b/apps/web/lib/review-core.ts
@@ -29,7 +29,7 @@ import {
 import { extractCrossFileQueries, generateVerificationQueries, normalizeScoreDenominators, formatPastReviews } from "@/lib/review-helpers";
 import { gatherCrossFileContext, gatherVerificationContext, validateFindings } from "@/lib/review-validation";
 import { logAiUsage } from "@/lib/ai-usage";
-import { getReviewModel } from "@/lib/ai-client";
+import { resolveReviewModel } from "@/lib/review-routing";
 import { createAiMessage } from "@/lib/ai-router";
 import { substitutePromptVars } from "@/lib/prompt-substitute";
 import fs from "node:fs";
@@ -210,7 +210,12 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
 
   // Resolve model — explicit override (eg. CLI passing the wizard's choice)
   // wins; otherwise fall back to the repo/org/platform-default chain.
-  const reviewModel = params.modelOverride ?? (await getReviewModel(org.id, repo.id));
+  const reviewModel = await resolveReviewModel({
+    orgId: org.id,
+    repoId: repo.id,
+    modelOverride: params.modelOverride,
+    diff,
+  });
   console.log(`[review-core] Using model: ${reviewModel}`);
 
   // Step 1: Embed diff → semantic search for codebase context
@@ -733,7 +738,7 @@ export async function generateBareLocalReview(
   // Resolve model — explicit override (eg. CLI passing the wizard's choice)
   // wins; otherwise fall back to org-default → platform-default. No repo
   // here so the repo-fallback link of the chain doesn't apply.
-  const reviewModel = modelOverride ?? (await getReviewModel(org.id));
+  const reviewModel = await resolveReviewModel({ orgId: org.id, modelOverride, diff });
 
   // System prompt gets a minimal template substitution. The template
   // placeholders that depend on repo/PR context get safe defaults so the

--- a/apps/web/lib/review-routing.ts
+++ b/apps/web/lib/review-routing.ts
@@ -11,9 +11,8 @@
  * self-protecting: it never emits a model that has no pricing (which would bill
  * $0), falling back to the default instead.
  */
-import { prisma } from "@octopus/db";
 import { getModelPricing } from "@/lib/cost";
-import { getReviewModel } from "@/lib/ai-client";
+import { resolveReviewModelPin } from "@/lib/ai-client";
 
 /** Cheaper model for provably-mechanical diffs. Must exist in pricing (asserted in tests). */
 export const MECHANICAL_MODEL = "claude-haiku-4-5-20251001";
@@ -106,18 +105,13 @@ export async function resolveReviewModel(args: {
 }): Promise<string> {
   const { orgId, repoId, modelOverride, diff } = args;
 
-  // Explicit pins always win — never override a user's deliberate model choice.
+  // Explicit caller override always wins — never override a deliberate choice.
   if (modelOverride) return modelOverride;
-  if (repoId) {
-    const repo = await prisma.repository.findUnique({ where: { id: repoId }, select: { reviewModelId: true } });
-    if (repo?.reviewModelId) return repo.reviewModelId;
-  }
-  const org = await prisma.organization.findUnique({ where: { id: orgId }, select: { defaultModelId: true } });
-  if (org?.defaultModelId) return org.defaultModelId;
 
-  // No pin → routed default. getReviewModel returns the platform default here
-  // (pins already handled above).
-  const base = await getReviewModel(orgId, repoId);
+  // Single lookup that also tells us whether the model was an explicit repo/org
+  // pin (single source of truth for precedence lives in ai-client).
+  const { model: base, pinned } = await resolveReviewModelPin(orgId, repoId);
+  if (pinned) return base;
 
   const cls = classifyDiff(diff);
   if (cls.tier === "mechanical" && MECHANICAL_MODEL !== base) {

--- a/apps/web/lib/review-routing.ts
+++ b/apps/web/lib/review-routing.ts
@@ -1,0 +1,129 @@
+/**
+ * Heuristic diff classification + model tier resolution in front of
+ * getReviewModel. Trivial/mechanical diffs (lockfile bumps, generated files,
+ * docs/tests-only, tiny single-file edits) downshift to a cheaper model; the
+ * default (Sonnet) is used for everything else. A deeper model for
+ * complex/high-risk diffs is deferred to a plan-gated follow-up — this only ever
+ * LOWERS cost, never risks quality by downshifting a substantive change.
+ *
+ * classifyDiff is pure/deterministic (unit-tested). resolveReviewModel keeps the
+ * existing precedence (explicit override / repo pin / org pin win first) and is
+ * self-protecting: it never emits a model that has no pricing (which would bill
+ * $0), falling back to the default instead.
+ */
+import { prisma } from "@octopus/db";
+import { getModelPricing } from "@/lib/cost";
+import { getReviewModel } from "@/lib/ai-client";
+
+/** Cheaper model for provably-mechanical diffs. Must exist in pricing (asserted in tests). */
+export const MECHANICAL_MODEL = "claude-haiku-4-5-20251001";
+
+export type DiffTier = "mechanical" | "standard" | "complex";
+
+export interface DiffClass {
+  loc: number;
+  files: number;
+  tier: DiffTier;
+  mechanicalOnly: boolean;
+  highRisk: boolean;
+}
+
+// Files whose changes are mechanical/generated — safe to review on a cheap model.
+const MECHANICAL_FILE = [
+  /(?:^|\/)(?:package-lock\.json|bun\.lock|yarn\.lock|pnpm-lock\.yaml|Cargo\.lock|go\.sum|composer\.lock|Gemfile\.lock|poetry\.lock)$/,
+  /\.min\.(?:js|css)$/,
+  /\.(?:snap|lock)$/,
+  /(?:^|\/)(?:dist|build|vendor|generated)\//,
+  /\.(?:md|mdx|txt|rst)$/, // docs
+];
+// Tests-only diffs are lower-risk (still real code, but not shipped behaviour).
+const TEST_FILE = [/(?:^|\/)__tests__\//, /\.(?:test|spec)\.[cm]?[jt]sx?$/, /(?:^|\/)tests?\//];
+// High-risk shared surfaces — mirror of touchesSharedFiles in the review paths.
+const HIGH_RISK_FILE = [
+  /(?:types|interfaces|schema|models)\//,
+  /(?:utils|helpers|shared|common)\//,
+  /(?:config|\.env|docker|ci)\b/,
+  /\.d\.ts$/,
+  /(?:prisma\/schema|migrations\/)/,
+  /(?:package\.json|tsconfig)/,
+];
+
+const anyMatch = (patterns: RegExp[], s: string) => patterns.some((p) => p.test(s));
+
+/** Extract changed file paths from a unified diff (`diff --git a/… b/…`). */
+export function extractChangedPaths(diff: string): string[] {
+  const paths: string[] = [];
+  for (const m of diff.matchAll(/^diff --git a\/(.+?) b\/(.+)$/gm)) {
+    paths.push(m[2]); // the "b/" (new) path
+  }
+  return paths;
+}
+
+export function classifyDiff(diff: string): DiffClass {
+  const paths = extractChangedPaths(diff);
+  const files = paths.length;
+
+  // Changed lines of code = added/removed content lines, excluding the +++/---
+  // file headers.
+  let loc = 0;
+  for (const line of diff.split("\n")) {
+    if ((line.startsWith("+") && !line.startsWith("+++")) || (line.startsWith("-") && !line.startsWith("---"))) {
+      loc++;
+    }
+  }
+
+  const nonMechanical = paths.filter((p) => !anyMatch(MECHANICAL_FILE, p) && !anyMatch(TEST_FILE, p));
+  // Mechanical only if every changed file is a lockfile/generated/docs/test file
+  // (and at least one file changed).
+  const mechanicalOnly = files > 0 && nonMechanical.length === 0;
+  const highRisk = paths.some((p) => anyMatch(HIGH_RISK_FILE, p));
+
+  let tier: DiffTier;
+  if (mechanicalOnly) {
+    // Lockfiles / generated / docs / tests are mechanical at any size.
+    tier = "mechanical";
+  } else if (highRisk || loc > 400 || files > 20) {
+    tier = "complex";
+  } else if (files <= 1 && loc <= 10) {
+    tier = "mechanical";
+  } else {
+    tier = "standard";
+  }
+
+  return { loc, files, tier, mechanicalOnly, highRisk };
+}
+
+/**
+ * Resolve the review model for a diff. Precedence (unchanged): explicit
+ * modelOverride → repo pin → org pin → routed default. Only mechanical diffs are
+ * downshifted, and only when the cheaper model actually has pricing.
+ */
+export async function resolveReviewModel(args: {
+  orgId: string;
+  repoId?: string;
+  modelOverride?: string;
+  diff: string;
+}): Promise<string> {
+  const { orgId, repoId, modelOverride, diff } = args;
+
+  // Explicit pins always win — never override a user's deliberate model choice.
+  if (modelOverride) return modelOverride;
+  if (repoId) {
+    const repo = await prisma.repository.findUnique({ where: { id: repoId }, select: { reviewModelId: true } });
+    if (repo?.reviewModelId) return repo.reviewModelId;
+  }
+  const org = await prisma.organization.findUnique({ where: { id: orgId }, select: { defaultModelId: true } });
+  if (org?.defaultModelId) return org.defaultModelId;
+
+  // No pin → routed default. getReviewModel returns the platform default here
+  // (pins already handled above).
+  const base = await getReviewModel(orgId, repoId);
+
+  const cls = classifyDiff(diff);
+  if (cls.tier === "mechanical" && MECHANICAL_MODEL !== base) {
+    // Self-protect: never emit a model without pricing (would bill $0).
+    const pricing = await getModelPricing().catch(() => null);
+    if (pricing?.has(MECHANICAL_MODEL)) return MECHANICAL_MODEL;
+  }
+  return base;
+}

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -99,7 +99,7 @@ import { summarizeRepository } from "@/lib/summarizer";
 import { analyzeRepository } from "@/lib/analyzer";
 import { writeSyncLog, deleteSyncLogs } from "@/lib/elasticsearch";
 import { logAiUsage } from "@/lib/ai-usage";
-import { getReviewModel } from "@/lib/ai-client";
+import { resolveReviewModel } from "@/lib/review-routing";
 import { createAiMessage } from "@/lib/ai-router";
 import { isOrgOverSpendLimit, shouldGuardConcurrency } from "@/lib/cost";
 import fs from "node:fs";
@@ -1109,10 +1109,6 @@ export async function processReview(pullRequestId: string): Promise<void> {
       }
     }
 
-    // Resolve the model to use for this org (with repo-level override)
-    const reviewModel = await getReviewModel(org.id, repo.id);
-    console.log(`[reviewer] Using model: ${reviewModel}`);
-
     // Spend limit check
     const overLimit = await isOrgOverSpendLimit(org.id);
     if (overLimit) {
@@ -1275,6 +1271,13 @@ export async function processReview(pullRequestId: string): Promise<void> {
 
     const diffFiles = extractDiffFiles(diff);
     const filesChanged = diffFiles.size;
+
+    // Resolve the review model now that the diff is known: explicit repo/org
+    // pins still win; otherwise mechanical diffs (lockfiles, generated, docs,
+    // tests, tiny edits) downshift to a cheaper model. Never emits an unpriced
+    // model. Substantive diffs keep the default.
+    const reviewModel = await resolveReviewModel({ orgId: org.id, repoId: repo.id, diff });
+    console.log(`[reviewer] Using model: ${reviewModel}`);
 
     // Merge PR diff files into the repo tree so new files added by the PR
     // are visible in the file tree — prevents false positives about "missing" modules.


### PR DESCRIPTION
Closes #653.

## What
Adds heuristic diff classification + a model resolver in front of `getReviewModel`, so trivial/mechanical PRs (lockfile bumps, generated files, docs/tests-only, tiny single-file edits) review on a **cheaper model** while substantive changes keep the default (Sonnet). Only *lowers* cost — a deeper model for complex diffs is a plan-gated follow-up.

## Design
- `classifyDiff(diff)` — pure/deterministic: changed LOC, file count, mechanical/test/high-risk detection. 11 unit tests (lockfile-only, docs-only, tests-only, tiny, standard, schema/migration=complex, large=complex, mixed).
- `resolveReviewModel({orgId, repoId?, modelOverride?, diff})` — keeps precedence (**override → repo pin → org pin → routed default**); downshifts only `mechanical` diffs.
- **Self-protecting:** never emits a model without pricing (which `calcCost` would bill at **$0**) — guarded at runtime *and* asserted by a pricing-coverage test (`fallbackPricedModels()` includes the downshift model).
- Wired into `reviewer.ts` (resolution moved to after the diff is known; first use is the LLM call) and both `review-core.ts` paths.

## Validation
- 11 tests pass; tsc clean.
- **Security:** read-only per-org lookups, no new surface; the only behavioural change is model selection, guarded so it can't bill $0 or override a user's pin.

Follow-up: complex/high-risk → deep model, gated behind the paid plan entitlement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)