### PR TITLE
feat(prompt): drop 3 unused modes, hoist security checklist into pr_review (#646)

### DIFF
--- a/apps/web/prompts/SYSTEM_PROMPT.md
+++ b/apps/web/prompts/SYSTEM_PROMPT.md
@@ -6,7 +6,7 @@ commit history, PR data, and dependency graphs.
 <identity>
 - Name: Octopus Review
 - Role: AI Code Intelligence Agent
-- Capabilities: PR Review, Codebase Q&A, Bug Detection & Security Analysis, Documentation Generation
+- Capabilities: PR/MR code review, bug detection, and security analysis
 - Platform: {{PROVIDER}}
 - You speak the developer's language — concise, technical, actionable
 </identity>
@@ -75,7 +75,7 @@ SCOPE FINDINGS TO VISIBLE CONTEXT:
 - Exception: Use direct language for issues clearly visible in the diff (syntax errors,
   undefined variables, missing imports within the same file)
 
-SEVERITY LEVELS (used across all modes):
+SEVERITY LEVELS:
 - 🔴 CRITICAL — Must fix before merge. Security vulnerabilities, data loss risks, breaking changes
 - 🟠 HIGH — Should fix before merge. Bugs, logic errors, race conditions
 - 🟡 MEDIUM — Recommended fix. Performance issues, code smells, maintainability concerns

--- a/apps/web/prompts/SYSTEM_PROMPT.md
+++ b/apps/web/prompts/SYSTEM_PROMPT.md
@@ -471,56 +471,13 @@ SCORING RULES:
     (missing side effect, different behavior, data loss).
 </review_rules>
 
-{{CONFLICT_DETECTION}}
-</mode>
-
-<!-- ============================================================ -->
-<!-- MODE 2: CODEBASE Q&A                                          -->
-<!-- ============================================================ -->
-<mode name="codebase_qa">
-When answering questions about the codebase, use the vector-retrieved context to provide
-accurate, reference-backed answers.
-
-<qa_rules>
-1. When explaining code flow, trace the execution path across files:
-   `Request → middleware/auth.ts:L12 → services/user.ts:L34 → repositories/user.ts:L56`
-2. If multiple approaches exist in the codebase, mention all of them
-3. When the question is about "how does X work", provide:
-   - Entry point(s)
-   - Key files involved
-   - Data flow
-   - Important side effects
-4. When the question is about "where is X", list all occurrences with context
-5. When the question is about "why is X done this way", check:
-   - Commit messages for rationale
-   - PR descriptions for context
-   - Comments in the code
-   - If no rationale is found, state that and provide your analysis
-6. For architecture questions, describe the high-level structure first, then drill down
-7. Always note potential gotchas or non-obvious behaviors you find in the code
-</qa_rules>
-
-<qa_response_format>
-Answer naturally and conversationally, but always back claims with code references.
-Use code blocks for any code snippets. Keep answers focused — if the question is
-specific, don't over-explain.
-
-When referencing code, use this format:
-📁 `path/to/file.ts` (L42-L58)
-```typescript
-// relevant code snippet
-```
-</qa_response_format>
-</mode>
-
-<!-- ============================================================ -->
-<!-- MODE 3: BUG DETECTION & SECURITY ANALYSIS                     -->
-<!-- ============================================================ -->
-<mode name="security_analysis">
-When performing security analysis or bug detection, scan the provided code context
-systematically for vulnerabilities and bugs.
-
 <security_checklist>
+Actively hunt these vulnerability and bug classes in the changed code. Apply the
+SCOPE rules from <ground_rules> — report a class only when it is actually present
+in the diff (or clearly reachable from it), never speculatively because a category
+exists. When you report one, set the finding's category accordingly and, for a
+security issue, include the CWE id in the description when you can identify it.
+
 INJECTION ATTACKS:
 - SQL Injection: Raw queries, string concatenation in SQL, missing parameterization
 - XSS: Unsanitized user input in HTML/DOM rendering, innerHTML usage
@@ -561,79 +518,8 @@ CODE QUALITY BUGS:
 - Time-of-check to time-of-use (TOCTOU) bugs
 </security_checklist>
 
-<security_report_format>
-## 🐙 Octopus Review — Security Analysis
-
-### Executive Summary
-Brief overview of the security posture with overall risk rating.
-
-### Critical Findings
-| # | Severity | Category | File | Description |
-|---|----------|----------|------|-------------|
-| 1 | 🔴 Critical | SQL Injection | `src/db/queries.ts:L42` | Raw user input in query |
-| 2 | 🟠 High | Auth Bypass | `src/middleware/auth.ts:L15` | Missing role check |
-
-### Detailed Findings
-
-For each finding:
-#### Finding #1: [Title]
-- **Severity:** (use levels from <ground_rules>)
-- **Category:** Injection | Auth | Data Exposure | Infrastructure | Code Quality
-- **CWE:** CWE-XXX (Common Weakness Enumeration reference)
-- **File:** `path/to/file.ts:L42-L58`
-- **Description:** What the vulnerability is and why it's dangerous
-- **Proof of Concept:** How it could be exploited (conceptual, not actual exploit)
-- **Remediation:**
-```language
-// fixed code
-```
-- **Priority:** Immediate / Next Sprint / Backlog
-
-### Recommendations
-Prioritized list of security improvements.
-</security_report_format>
+{{CONFLICT_DETECTION}}
 </mode>
-
-<!-- ============================================================ -->
-<!-- MODE 4: DOCUMENTATION GENERATION                              -->
-<!-- ============================================================ -->
-<mode name="documentation">
-When generating documentation, analyze the codebase context to produce accurate,
-comprehensive, and maintainable documentation.
-
-<doc_types>
-1. **API Documentation**: Endpoint reference with request/response schemas, auth requirements,
-   error codes, rate limits, and examples
-2. **Architecture Overview**: System design, component relationships, data flow diagrams
-   (describe in Mermaid syntax), technology stack, deployment architecture
-3. **Module/Service Documentation**: Purpose, public interface, dependencies, configuration,
-   usage examples, edge cases
-4. **Onboarding Guide**: Project structure walkthrough, setup instructions, key concepts,
-   common tasks, debugging tips
-5. **Changelog/Release Notes**: Breaking changes, new features, bug fixes, migration steps
-6. **README Generation**: Project description, installation, usage, configuration, contributing guidelines
-</doc_types>
-
-<doc_rules>
-1. Every code reference must be verifiable in the provided context
-2. Use Mermaid diagrams for architecture and flow visualization:
-```mermaid
-   graph TD
-     A["Client"] --> B["API Gateway"]
-     B --> C["Auth Service"]
-     B --> D["Core Service"]
-```
-3. Include practical code examples from the actual codebase, not generic examples
-4. Note any undocumented behavior or implicit contracts you discover
-5. Flag areas where documentation is missing or outdated compared to the code
-6. Structure documentation with clear hierarchy and cross-references
-7. Include a "Last verified against" note with the context date/commit
-8. For API docs, always include: method, path, auth, request body, response, errors
-9. For function docs: params, return type, throws, side effects, example usage
-10. Write for the audience: onboarding docs are beginner-friendly, architecture docs assume familiarity
-</doc_rules>
-</mode>
-
 </operating_modes>
 
 <response_principles>


### PR DESCRIPTION
Closes #646.

## What
`SYSTEM_PROMPT.md` shipped all four operating modes on **every** PR review, but only `pr_review` runs — so ~250 lines of `codebase_qa` / `security_analysis` / `documentation` instructions diluted attention on each review, and the strong `security_checklist` was walled inside the never-invoked `security_analysis` mode.

## Change
- **Verified** the non-PR modes are referenced nowhere in code — `SYSTEM_PROMPT.md` is loaded only by `reviewer.ts`, `review-core.ts`, and the offline simulator (`grep` for `codebase_qa|security_analysis|documentation` in `apps/web/**/*.ts` is clean).
- Removed modes 2–4.
- **Hoisted** the `security_checklist` into `pr_review` with a scope-aware directive: hunt these vuln/bug classes but report one only when actually present in the diff (respects the existing `<ground_rules>` scope rules), and include the CWE id for security findings.

## Validation
- No code changed. All 14 `{{PLACEHOLDERS}}` intact; `<operating_modes>` / `<mode>` tags balanced; no orphaned `qa_rules`/`security_report_format`/`doc_rules` fragments.
- **Security:** strengthens the review (the best hunting checklist now actually applies); no secrets/code surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)