### PR TITLE
feat(retrieval): compose RAG query from paths/hunks/identifiers (#651)

### DIFF
--- a/apps/web/lib/__tests__/review-helpers.test.ts
+++ b/apps/web/lib/__tests__/review-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { formatPastReviews, formatPrIntent, type PastReviewHit } from "@/lib/review-helpers";
+import { formatPastReviews, formatPrIntent, buildRetrievalQuery, type PastReviewHit } from "@/lib/review-helpers";
 
 describe("formatPastReviews", () => {
   const hit = (o: Partial<PastReviewHit> = {}): PastReviewHit => ({
@@ -81,5 +81,36 @@ describe("formatPrIntent parenthesised refs", () => {
     const linked = out.split("\n").find((l) => l.startsWith("Linked issues:")) ?? "";
     expect(linked).toContain("#42");
     expect(linked).toContain("#7");
+  });
+});
+
+describe("buildRetrievalQuery", () => {
+  const bigDiff = Array.from({ length: 20 }, (_, i) =>
+    `diff --git a/src/mod${i}/file${i}.ts b/src/mod${i}/file${i}.ts\n--- a/src/mod${i}/file${i}.ts\n+++ b/src/mod${i}/file${i}.ts\n@@ -1,3 +1,4 @@ export function handler${i}() {\n+  const paymentProcessor${i} = new Stripe();\n`,
+  ).join("\n");
+
+  it("includes later-file identifiers, not just the first ~8k chars", () => {
+    const q = buildRetrievalQuery(bigDiff, "Refactor payments");
+    // file19 appears well beyond 8000 chars of raw diff — must still be represented
+    expect(q).toContain("Refactor payments");
+    expect(q).toContain("file19.ts");
+    expect(q).toContain("paymentProcessor19");
+  });
+
+  it("does NOT embed raw +/- diff markers", () => {
+    const q = buildRetrievalQuery("diff --git a/a.ts b/a.ts\n+++ b/a.ts\n@@ -1 +1 @@\n+const payload = 1;\n", "t");
+    expect(q.includes("+const")).toBe(false);
+    expect(q.includes("+++")).toBe(false);
+  });
+
+  it("is bounded in size", () => {
+    const q = buildRetrievalQuery(bigDiff, "t", { maxChars: 300 });
+    expect(q.length).toBeLessThanOrEqual(300);
+  });
+
+  it("strips language keywords from identifiers", () => {
+    const q = buildRetrievalQuery("+++ b/a.ts\n@@ @@\n+  const function return await;\n", "t");
+    expect(q).not.toContain("const");
+    expect(q).not.toContain("function");
   });
 });

--- a/apps/web/lib/review-core.ts
+++ b/apps/web/lib/review-core.ts
@@ -26,7 +26,7 @@ import {
   parseFindingsFromJson,
   parseFindingsFromMarkdown,
 } from "@/lib/review-dedup";
-import { extractCrossFileQueries, generateVerificationQueries, normalizeScoreDenominators, formatPastReviews } from "@/lib/review-helpers";
+import { extractCrossFileQueries, generateVerificationQueries, normalizeScoreDenominators, formatPastReviews, buildRetrievalQuery } from "@/lib/review-helpers";
 import { gatherCrossFileContext, gatherVerificationContext, validateFindings } from "@/lib/review-validation";
 import { logAiUsage } from "@/lib/ai-usage";
 import { resolveReviewModel } from "@/lib/review-routing";
@@ -218,15 +218,17 @@ export async function generateLocalReview(params: LocalReviewParams): Promise<Lo
   });
   console.log(`[review-core] Using model: ${reviewModel}`);
 
-  // Step 1: Embed diff → semantic search for codebase context
-  const searchText = diff.slice(0, 8000);
+  // Step 1: Embed a composed retrieval query (title + changed paths + hunk
+  // headers + identifiers, not raw +/- churn) so every changed file is
+  // represented regardless of diff size (#651). Bounded (<=4000 chars).
+  const searchText = buildRetrievalQuery(diff, title ?? "Local Review");
   const [queryVector] = await createEmbeddings([searchText], {
     organizationId: org.id,
     operation: "embedding",
     repositoryId: repo.id,
   });
 
-  const rerankQuery = `${title ?? "Local Review"}\n${diff.slice(0, 2000)}`;
+  const rerankQuery = searchText;
 
   const [rawCodeChunks, rawKnowledgeChunks, alwaysIncludeKnowledge, rawPastReviews] = await Promise.all([
     searchSimilarChunks(repo.id, queryVector, 50, rerankQuery),

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -801,8 +801,8 @@ export function formatPrIntent(
 // retrieval query is weighted toward domain identifiers, not syntax.
 const QUERY_STOPWORDS = new Set([
   "const", "let", "var", "function", "return", "import", "export", "from", "class",
-  "interface", "type", "async", "await", "if", "else", "for", "while", "switch",
-  "case", "break", "continue", "new", "this", "true", "false", "null", "undefined",
+  "interface", "type", "async", "await", "else", "while", "switch",
+  "case", "break", "continue", "new", "true", "false", "null", "undefined",
   "void", "public", "private", "protected", "static", "extends", "implements",
   "the", "and", "for", "with", "that", "this",
 ]);
@@ -855,12 +855,22 @@ export function buildRetrievalQuery(
     .slice(0, maxIdentifiers)
     .map(([id]) => id);
 
+  // Budget each section independently so a path/hunk-heavy diff can't consume the
+  // whole char budget and starve the identifiers (the strongest semantic signal).
+  // Caps sum to maxChars; identifiers get the largest guaranteed share.
+  const identifierBudget = Math.floor(maxChars * 0.55);
+  const pathBudget = Math.floor(maxChars * 0.2);
+  const hunkBudget = Math.floor(maxChars * 0.2);
+  // Leave a small margin for the newline separators so the total stays <= maxChars.
+  const titleBudget = Math.max(0, maxChars - identifierBudget - pathBudget - hunkBudget - 4);
   const parts = [
-    title,
-    [...new Set(paths)].join(" "),
-    hunkContexts.join(" "),
-    topIdentifiers.join(" "),
+    title.slice(0, titleBudget),
+    [...new Set(paths)].join(" ").slice(0, pathBudget),
+    hunkContexts.join(" ").slice(0, hunkBudget),
+    topIdentifiers.join(" ").slice(0, identifierBudget),
   ].filter((p) => p && p.trim());
 
+  // Per-section budgets already guarantee identifiers their share; the final
+  // clamp only trims trailing newline overhead, never a whole section.
   return parts.join("\n").slice(0, maxChars);
 }

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -796,3 +796,71 @@ export function formatPrIntent(
   if (linked.size > 0) parts.push(`Linked issues: ${[...linked].join(", ")}`);
   return parts.join("\n\n");
 }
+
+// Common language keywords/stopwords stripped from identifier extraction so the
+// retrieval query is weighted toward domain identifiers, not syntax.
+const QUERY_STOPWORDS = new Set([
+  "const", "let", "var", "function", "return", "import", "export", "from", "class",
+  "interface", "type", "async", "await", "if", "else", "for", "while", "switch",
+  "case", "break", "continue", "new", "this", "true", "false", "null", "undefined",
+  "void", "public", "private", "protected", "static", "extends", "implements",
+  "the", "and", "for", "with", "that", "this",
+]);
+
+/**
+ * Build a semantic retrieval query for a diff WITHOUT embedding the raw +/-
+ * churn (which dilutes the embedding and drops files past the old 8k slice).
+ * Composes: PR title + every changed file path + `@@` hunk-header context +
+ * de-duplicated identifiers from changed lines across the WHOLE diff, bounded so
+ * every file is represented regardless of diff size. Pure/testable.
+ */
+export function buildRetrievalQuery(
+  diff: string,
+  title: string,
+  opts: { maxIdentifiers?: number; maxChars?: number } = {},
+): string {
+  const { maxIdentifiers = 60, maxChars = 4000 } = opts;
+  const lines = diff.split("\n");
+
+  const paths: string[] = [];
+  const hunkContexts: string[] = [];
+  const identifierCounts = new Map<string, number>();
+
+  for (const line of lines) {
+    // New-side file path.
+    const fileMatch = line.match(/^\+\+\+ b\/(.+)$/);
+    if (fileMatch) {
+      paths.push(fileMatch[1]);
+      continue;
+    }
+    // Hunk header: keep the trailing context (usually the enclosing signature).
+    const hunkMatch = line.match(/^@@[^@]*@@\s*(.*)$/);
+    if (hunkMatch) {
+      if (hunkMatch[1].trim()) hunkContexts.push(hunkMatch[1].trim());
+      continue;
+    }
+    // Changed content lines (added/removed), excluding the file headers.
+    if ((line.startsWith("+") || line.startsWith("-")) && !line.startsWith("+++") && !line.startsWith("---")) {
+      for (const m of line.slice(1).matchAll(/[A-Za-z_][A-Za-z0-9_]{2,}/g)) {
+        const id = m[0];
+        if (QUERY_STOPWORDS.has(id.toLowerCase())) continue;
+        identifierCounts.set(id, (identifierCounts.get(id) ?? 0) + 1);
+      }
+    }
+  }
+
+  // Most frequent identifiers first — domain terms that recur across the change.
+  const topIdentifiers = [...identifierCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxIdentifiers)
+    .map(([id]) => id);
+
+  const parts = [
+    title,
+    [...new Set(paths)].join(" "),
+    hunkContexts.join(" "),
+    topIdentifiers.join(" "),
+  ].filter((p) => p && p.trim());
+
+  return parts.join("\n").slice(0, maxChars);
+}

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -72,6 +72,7 @@ import {
   shouldFailReviewCheck,
   formatPastReviews,
   formatPrIntent,
+  buildRetrievalQuery,
 } from "@/lib/review-helpers";
 import type { ReviewConfig } from "@/lib/review-helpers";
 import { getCategoryConfidenceThreshold } from "@/lib/review-categories";
@@ -1330,16 +1331,20 @@ export async function processReview(pullRequestId: string): Promise<void> {
       step: "searching-context",
     });
 
-    // Take first 8000 chars of diff as search query
-    const searchText = diff.slice(0, 8000);
+    // Retrieval query composed from title + changed paths + hunk headers +
+    // identifiers (not raw +/- churn), so every changed file is represented
+    // regardless of diff size (#651). Bounded (<=4000 chars) — no cost increase
+    // vs the old 8000-char slice.
+    const searchText = buildRetrievalQuery(diff, pr.title);
+    console.log(`[reviewer] Retrieval query: ${searchText.length} chars from ${diffFiles.size} changed files`);
     const [queryVector] = await createEmbeddings([searchText], {
       organizationId: org.id,
       operation: "embedding",
       repositoryId: repo.id,
     });
 
-    // Over-fetch from Qdrant, then rerank with Cohere
-    const rerankQuery = `${pr.title}\n${diff.slice(0, 2000)}`;
+    // Over-fetch from Qdrant, then rerank with Cohere (same composed query).
+    const rerankQuery = searchText;
 
     const [rawCodeChunks, rawKnowledgeChunks, alwaysIncludeKnowledge, rawPastReviews, prBody] = await Promise.all([
       searchSimilarChunks(repo.id, queryVector, 50, rerankQuery),


### PR DESCRIPTION
Closes #651.

## Problem
The retrieval query was `diff.slice(0, 8000)` — raw `+/-` churn diluted the embedding and any file appearing past ~8k chars retrieved **no** codebase context, degrading exactly the large multi-file case.

## Change
`buildRetrievalQuery(diff, title)` (pure, unit-tested) composes the query from: PR title + every changed file path + `@@` hunk-header context + de-duplicated, frequency-ranked identifiers from changed lines **across the whole diff** — no raw `+/-` markers. Bounded to 4000 chars so every file is represented regardless of diff size. Used for both the embedding and the rerank query in `reviewer.ts` and `review-core.ts`.

## Acceptance
- ✅ Query no longer embeds raw `+/-` diff lines (test asserts).
- ✅ A 20-file diff represents later files — test asserts `file19` / `paymentProcessor19` appear (they sit far beyond the old 8k slice).
- ✅ Bounded (4000 chars, ≤60 identifiers) and query length logged. Embedding cost is *lower* than the old 8000-char slice.
- ✅ Rerank thresholds unchanged (`rerankQuery = searchText`).
- ⚠️ Per-file parallel sub-queries for very large PRs: deferred follow-up — the single composed query already represents all files, so later-file coverage (the core problem) is fixed without N embeddings.

## Validation
4 new `buildRetrievalQuery` tests + existing suite (15 pass); tsc clean. **Security:** pure string composition, no secrets/endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)