### PR TITLE
feat(review): evidence-citing adversarial validation (#654)

### DIFF
--- a/apps/web/lib/__tests__/review-helpers.test.ts
+++ b/apps/web/lib/__tests__/review-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { formatPastReviews, formatPrIntent, buildRetrievalQuery, type PastReviewHit } from "@/lib/review-helpers";
+import { formatPastReviews, formatPrIntent, buildRetrievalQuery, cappedConfidence, UNCITED_HIGH_SEV_CAP, type PastReviewHit } from "@/lib/review-helpers";
 
 describe("formatPastReviews", () => {
   const hit = (o: Partial<PastReviewHit> = {}): PastReviewHit => ({
@@ -112,5 +112,22 @@ describe("buildRetrievalQuery", () => {
     const q = buildRetrievalQuery("+++ b/a.ts\n@@ @@\n+  const function return await;\n", "t");
     expect(q).not.toContain("const");
     expect(q).not.toContain("function");
+  });
+});
+
+describe("cappedConfidence (adversarial validation #654)", () => {
+  it("caps an uncited high-severity finding to the ceiling", () => {
+    expect(cappedConfidence("🔴", 95, false)).toBe(UNCITED_HIGH_SEV_CAP);
+    expect(cappedConfidence("🟠", 88, false)).toBe(UNCITED_HIGH_SEV_CAP);
+  });
+  it("does NOT cap a cited high-severity finding", () => {
+    expect(cappedConfidence("🔴", 95, true)).toBe(95);
+  });
+  it("does NOT cap non-high severities", () => {
+    expect(cappedConfidence("🟡", 95, false)).toBe(95);
+    expect(cappedConfidence("🔵", 90, false)).toBe(90);
+  });
+  it("leaves an already-low uncited high-severity score untouched", () => {
+    expect(cappedConfidence("🔴", 40, false)).toBe(40);
   });
 });

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -874,3 +874,21 @@ export function buildRetrievalQuery(
   // clamp only trims trailing newline overhead, never a whole section.
   return parts.join("\n").slice(0, maxChars);
 }
+
+/** High severities that must be tied to a concrete diff line to keep a high score. */
+const HIGH_SEVERITY = new Set(["🔴", "🟠"]);
+/** Ceiling for an uncited high-severity finding after adversarial validation (#654). */
+export const UNCITED_HIGH_SEV_CAP = 60;
+
+/**
+ * A high-severity finding the adversarial validator could not tie to a concrete
+ * diff line is suspect — cap its confidence so an uncited 🔴/🟠 can't ride a high
+ * self-reported score into the review. All other findings keep the validator's
+ * score. Pure so it is unit-testable without the server-only validation module.
+ */
+export function cappedConfidence(severity: string, confidence: number, hasCitation: boolean): number {
+  if (HIGH_SEVERITY.has(severity) && !hasCitation && confidence > UNCITED_HIGH_SEV_CAP) {
+    return UNCITED_HIGH_SEV_CAP;
+  }
+  return confidence;
+}

--- a/apps/web/lib/review-validation.ts
+++ b/apps/web/lib/review-validation.ts
@@ -383,7 +383,9 @@ Output ONLY the JSON array, nothing else.`,
     const validated = findings
       .map((f, i) => {
         const score = scoreMap.get(i);
-        if (!score) return f; // unscored → keep original confidence (never a silent drop)
+        // Unscored, or a score with no numeric confidence → keep the finding's
+        // original confidence. Never let a malformed entry silently drop it.
+        if (!score || typeof score.confidence !== "number") return f;
         const hasCitation = Boolean(score.citation && score.citation.trim());
         const confidence = cappedConfidence(f.severity, score.confidence, hasCitation);
         // Emit refutation reasons for offline false-positive analysis.
@@ -397,7 +399,7 @@ Output ONLY the JSON array, nothing else.`,
     console.log(`${logPrefix} Adversarial validation: ${validated.length}/${findings.length} findings kept (base threshold: ${confidenceThreshold}, per-category)`);
     return validated;
   } catch {
-    console.warn(`${logPrefix} Failed to parse two-pass validation response, keeping all findings`);
+    console.warn(`${logPrefix} Failed to parse adversarial validation response, keeping all findings`);
     return findings;
   }
 }

--- a/apps/web/lib/review-validation.ts
+++ b/apps/web/lib/review-validation.ts
@@ -9,6 +9,7 @@ import { logAiUsage } from "@/lib/ai-usage";
 import { createAiMessage } from "@/lib/ai-router";
 import type { InlineFinding } from "@/lib/review-dedup";
 import type { CrossFileQuery, VerificationQuery } from "@/lib/review-helpers";
+import { cappedConfidence } from "@/lib/review-helpers";
 import { getCategoryConfidenceThreshold } from "@/lib/review-categories";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -271,11 +272,13 @@ export async function validateFindings(
   const response = await createAiMessage(
     {
       model: VALIDATION_MODEL,
-      maxTokens: 2048,
+      // Raised from 2048 to fit per-finding citations/refutations without the
+      // validator truncating its own JSON.
+      maxTokens: 4096,
       messages: [
         {
           role: "user",
-          content: `You are a senior code reviewer validating findings from an automated review. For each finding, assign a confidence score (0-100) based on whether it is a genuine issue supported by the diff.
+          content: `You are a senior code reviewer running an ADVERSARIAL check on findings from an automated review. Your default stance is skepticism: for each finding, actively try to REFUTE it using the diff and the provided context. A finding survives with high confidence ONLY if you cannot refute it and can point to the concrete evidence that proves it. Assign a confidence score (0-100); a finding you can refute, or cannot tie to concrete evidence, gets a LOW score.
 
 FINDINGS:
 ${findingsSummary}
@@ -342,8 +345,11 @@ When a finding flags storage/column size concerns:
 - If the column type is TEXT, JSONB, or similar unbounded type, assign confidence 10-20
 - Only keep size findings when there is evidence the column has a restrictive type (VARCHAR with small limit)
 
-For each finding, respond with ONLY a JSON array:
-[{"index": 0, "confidence": 92}, {"index": 1, "confidence": 35}, ...]
+For each finding, respond with ONLY a JSON array. For a finding you KEEP (high
+confidence), include a one-line "citation" with the concrete diff location
+(\`file:Lnn\`) that proves it. For a finding you REFUTE or doubt (low confidence),
+include a short "refutation" saying why:
+[{"index": 0, "confidence": 92, "citation": "src/db.ts:L42"}, {"index": 1, "confidence": 15, "refutation": "the null guard already exists 3 lines above"}, ...]
 
 Output ONLY the JSON array, nothing else.`,
         },
@@ -365,21 +371,30 @@ Output ONLY the JSON array, nothing else.`,
 
   try {
     const jsonMatch = response.text.match(/\[[\s\S]*\]/);
-    if (!jsonMatch) return findings;
-    const scores = JSON.parse(jsonMatch[0]) as { index: number; confidence: number }[];
-    const scoreMap = new Map(scores.map((s) => [s.index, s.confidence]));
+    if (!jsonMatch) return findings; // fail-open ONLY on parse error
+    const scores = JSON.parse(jsonMatch[0]) as {
+      index: number;
+      confidence: number;
+      citation?: string;
+      refutation?: string;
+    }[];
+    const scoreMap = new Map(scores.map((s) => [s.index, s]));
 
     const validated = findings
       .map((f, i) => {
-        const newConfidence = scoreMap.get(i);
-        if (newConfidence !== undefined) {
-          return { ...f, confidence: newConfidence };
+        const score = scoreMap.get(i);
+        if (!score) return f; // unscored → keep original confidence (never a silent drop)
+        const hasCitation = Boolean(score.citation && score.citation.trim());
+        const confidence = cappedConfidence(f.severity, score.confidence, hasCitation);
+        // Emit refutation reasons for offline false-positive analysis.
+        if (score.refutation && score.refutation.trim()) {
+          console.log(`${logPrefix} refuted "${f.title}" (${f.filePath}:L${f.startLine}) → ${confidence}: ${score.refutation.trim()}`);
         }
-        return f;
+        return { ...f, confidence };
       })
       .filter((f) => f.confidence >= getCategoryConfidenceThreshold(f.category, confidenceThreshold));
 
-    console.log(`${logPrefix} Two-pass validation: ${validated.length}/${findings.length} findings kept (base threshold: ${confidenceThreshold}, per-category)`);
+    console.log(`${logPrefix} Adversarial validation: ${validated.length}/${findings.length} findings kept (base threshold: ${confidenceThreshold}, per-category)`);
     return validated;
   } catch {
     console.warn(`${logPrefix} Failed to parse two-pass validation response, keeping all findings`);


### PR DESCRIPTION
Closes #654.

## What
`validateFindings` re-scored confidence with a "is this supported?" prompt on the same model family — which tends to agree with itself, letting genuine false positives survive. Reframed to an **adversarial refute-or-survive** check with an evidence requirement.

## Change
- **Prompt**: default-skeptic framing — try to refute each finding; it keeps high confidence only if you can't refute it and can point to the concrete diff line proving it.
- **Output**: now `[{index, confidence, citation?, refutation?}]` — a `citation` (`file:Lnn`) for kept findings, a `refutation` reason for doubted ones.
- **Uncited high-severity cap**: a 🔴/🟠 finding the validator can't tie to a diff line is capped at 60 via pure `cappedConfidence()` (in `review-helpers.ts` so it's unit-testable — `review-validation.ts` is server-only). 4 tests.
- **Logging**: refutation reasons logged for offline FP tuning.
- `maxTokens` 2048→4096 so the JSON doesn't truncate.
- **Fail-open only on parse error** — a missing citation caps confidence, it does not fail open. Unscored findings keep their original score (no silent drop).

## Deferred / notes
- Running validation on a *different* model family (to further cut self-agreement) needs multi-provider config — deferred; the framing change lands the bulk of the benefit and degrades gracefully to same-family.
- Precision/recall to be confirmed via the #648 eval harness before wide rollout.

## Validation
19 helper tests pass (incl. 4 for the cap); tsc clean. **Security:** prompt/parse only; the cap only *lowers* confidence (more conservative); refutation logs carry finding metadata already logged elsewhere, no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)