### PR TITLE
fix(review): shared confidence filter on the large-PR path (#652)

### DIFF
--- a/apps/web/lib/__tests__/review-helpers.test.ts
+++ b/apps/web/lib/__tests__/review-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { formatPastReviews, formatPrIntent, buildRetrievalQuery, cappedConfidence, UNCITED_HIGH_SEV_CAP, type PastReviewHit } from "@/lib/review-helpers";
+import { formatPastReviews, formatPrIntent, buildRetrievalQuery, cappedConfidence, UNCITED_HIGH_SEV_CAP, filterByConfidence, type PastReviewHit } from "@/lib/review-helpers";
 
 describe("formatPastReviews", () => {
   const hit = (o: Partial<PastReviewHit> = {}): PastReviewHit => ({
@@ -129,5 +129,24 @@ describe("cappedConfidence (adversarial validation #654)", () => {
   });
   it("leaves an already-low uncited high-severity score untouched", () => {
     expect(cappedConfidence("🔴", 40, false)).toBe(40);
+  });
+});
+
+describe("filterByConfidence (#652 shared filter)", () => {
+  const f = (o: Partial<import("@/lib/review-dedup").InlineFinding>) => ({
+    severity: "🟡", title: "t", description: "d", category: "Style",
+    filePath: "a.ts", startLine: 1, endLine: 1, confidence: 80, ...o,
+  }) as import("@/lib/review-dedup").InlineFinding;
+
+  it("drops findings below the base threshold", () => {
+    const out = filterByConfidence([f({ confidence: 80 }), f({ confidence: 50 })], 70);
+    expect(out).toHaveLength(1);
+    expect(out[0].confidence).toBe(80);
+  });
+
+  it("keeps a high-risk category at a relaxed threshold", () => {
+    // Security is relaxed below the base 70, so a 60-confidence security finding survives.
+    const out = filterByConfidence([f({ category: "Security", confidence: 60 })], 70);
+    expect(out).toHaveLength(1);
   });
 });

--- a/apps/web/lib/__tests__/review-helpers.test.ts
+++ b/apps/web/lib/__tests__/review-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { formatPastReviews, formatPrIntent, buildRetrievalQuery, cappedConfidence, UNCITED_HIGH_SEV_CAP, filterByConfidence, type PastReviewHit } from "@/lib/review-helpers";
+import { formatPastReviews, formatPrIntent, buildRetrievalQuery, cappedConfidence, UNCITED_HIGH_SEV_CAP, filterByConfidence, resolveConfidenceThreshold, type PastReviewHit } from "@/lib/review-helpers";
 
 describe("formatPastReviews", () => {
   const hit = (o: Partial<PastReviewHit> = {}): PastReviewHit => ({
@@ -148,5 +148,15 @@ describe("filterByConfidence (#652 shared filter)", () => {
     // Security is relaxed below the base 70, so a 60-confidence security finding survives.
     const out = filterByConfidence([f({ category: "Security", confidence: 60 })], 70);
     expect(out).toHaveLength(1);
+  });
+});
+
+describe("resolveConfidenceThreshold (#652)", () => {
+  it("uses an explicit numeric threshold", () => {
+    expect(resolveConfidenceThreshold({ confidenceThreshold: 82 })).toBe(82);
+  });
+  it("maps HIGH to 85 and default to 70", () => {
+    expect(resolveConfidenceThreshold({ confidenceThreshold: "HIGH" })).toBe(85);
+    expect(resolveConfidenceThreshold({})).toBe(70);
   });
 });

--- a/apps/web/lib/large-review-result.ts
+++ b/apps/web/lib/large-review-result.ts
@@ -11,7 +11,9 @@ import { findingSignature, mergeFindingsBySignature, inheritReviewIssueTriage } 
 import {
   buildLowSeveritySummary,
   stripDetailedFindings,
-  countFindings,
+  filterByConfidence,
+  sortAndCapFindings,
+  MAX_FINDINGS_PER_REVIEW,
   shouldFailReviewCheck,
 } from "@/lib/review-helpers";
 import { eventBus } from "@/lib/events";
@@ -111,11 +113,19 @@ export async function handleLargeReviewResult(
 
   const reviewBody = data.reviewBody;
 
-  // 1. Parse findings out of the markdown
-  const findings = parseFindings(reviewBody);
-  const findingsCount = countFindings(reviewBody);
+  // 1. Parse findings out of the markdown, then apply the SAME per-category
+  // confidence filter + severity cap as the standard path (#652) so the largest,
+  // most bug-prone PRs no longer get raw model output straight to comments.
+  // (Diff-dependent validateFindings + semantic suppression require the diff,
+  // which this job payload doesn't carry — tracked as a follow-up.)
+  const parsedFindings = parseFindings(reviewBody);
+  const { kept: findings, truncatedCount } = sortAndCapFindings(
+    filterByConfidence(parsedFindings),
+    MAX_FINDINGS_PER_REVIEW,
+  );
+  const findingsCount = findings.length;
   console.log(
-    `[large-review-result] PR #${pr.number}: ${reviewBody.length} chars, ${findings.length} findings parsed`,
+    `[large-review-result] PR #${pr.number}: ${reviewBody.length} chars, ${parsedFindings.length} parsed → ${findings.length} after confidence filter${truncatedCount ? ` (capped ${truncatedCount})` : ""}`,
   );
 
   // 2. Update placeholder comment with main body (findings JSON stripped — they go inline/summary)

--- a/apps/web/lib/large-review-result.ts
+++ b/apps/web/lib/large-review-result.ts
@@ -12,9 +12,13 @@ import {
   buildLowSeveritySummary,
   stripDetailedFindings,
   filterByConfidence,
+  resolveConfidenceThreshold,
   sortAndCapFindings,
+  parseReviewConfig,
+  mergeReviewConfigs,
   MAX_FINDINGS_PER_REVIEW,
   shouldFailReviewCheck,
+  type ReviewConfig,
 } from "@/lib/review-helpers";
 import { eventBus } from "@/lib/events";
 
@@ -118,10 +122,24 @@ export async function handleLargeReviewResult(
   // most bug-prone PRs no longer get raw model output straight to comments.
   // (Diff-dependent validateFindings + semantic suppression require the diff,
   // which this job payload doesn't carry — tracked as a follow-up.)
+  // Resolve the repo/org-configured threshold + max via the same 3-tier merge as
+  // the standard path so the two never diverge on configuration.
+  let systemConfig: ReviewConfig = {};
+  try {
+    const sysRow = await prisma.systemConfig.findUnique({ where: { id: "singleton" } });
+    if (sysRow) systemConfig = parseReviewConfig(sysRow.defaultReviewConfig);
+  } catch {
+    // SystemConfig unavailable — fall back to org/repo config only.
+  }
+  const reviewConfig = mergeReviewConfigs(
+    systemConfig,
+    parseReviewConfig(org.defaultReviewConfig),
+    parseReviewConfig(repo.reviewConfig),
+  );
   const parsedFindings = parseFindings(reviewBody);
   const { kept: findings, truncatedCount } = sortAndCapFindings(
-    filterByConfidence(parsedFindings),
-    MAX_FINDINGS_PER_REVIEW,
+    filterByConfidence(parsedFindings, resolveConfidenceThreshold(reviewConfig)),
+    reviewConfig.maxFindings ?? MAX_FINDINGS_PER_REVIEW,
   );
   const findingsCount = findings.length;
   console.log(

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -11,6 +11,7 @@ import {
   parseFindingsFromJson,
   extractDiffFiles,
 } from "@/lib/review-dedup";
+import { getCategoryConfidenceThreshold } from "@/lib/review-categories";
 // Re-define the type locally to avoid importing from github.ts (which has side effects in some envs)
 export type ReviewComment = {
   path: string;
@@ -891,4 +892,17 @@ export function cappedConfidence(severity: string, confidence: number, hasCitati
     return UNCITED_HIGH_SEV_CAP;
   }
   return confidence;
+}
+
+/**
+ * Per-category confidence filter — the single source of truth for "does this
+ * finding clear the bar", shared by the standard review path (reviewer.ts) and
+ * the large-PR path (large-review-result.ts) so the two can't drift (#652).
+ * High-risk categories (Security/Bug) get a relaxed threshold via
+ * getCategoryConfidenceThreshold. Pure/testable.
+ */
+export function filterByConfidence(findings: InlineFinding[], baseThreshold = 70): InlineFinding[] {
+  return findings.filter(
+    (f) => f.confidence >= getCategoryConfidenceThreshold(f.category, baseThreshold),
+  );
 }

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -906,3 +906,14 @@ export function filterByConfidence(findings: InlineFinding[], baseThreshold = 70
     (f) => f.confidence >= getCategoryConfidenceThreshold(f.category, baseThreshold),
   );
 }
+
+/**
+ * Resolve the numeric base confidence threshold from a review config. Shared by
+ * the standard and large-PR paths so both honor the repo/org-configured value
+ * ("HIGH" → 85, an explicit number as-is, else the 70 default). Pure.
+ */
+export function resolveConfidenceThreshold(cfg: { confidenceThreshold?: number | string }): number {
+  if (typeof cfg.confidenceThreshold === "number") return cfg.confidenceThreshold;
+  if (cfg.confidenceThreshold === "HIGH") return 85;
+  return 70;
+}

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -73,9 +73,9 @@ import {
   formatPastReviews,
   formatPrIntent,
   buildRetrievalQuery,
+  filterByConfidence,
 } from "@/lib/review-helpers";
 import type { ReviewConfig } from "@/lib/review-helpers";
-import { getCategoryConfidenceThreshold } from "@/lib/review-categories";
 import {
   gatherCrossFileContext,
   gatherVerificationContext,
@@ -1946,9 +1946,7 @@ Rules:
     // finding the validator/threshold would drop. Inline vs summary is derived
     // from this single validated set further below.
     const beforeConfidence = allParsedFindings.length;
-    allParsedFindings = allParsedFindings.filter(
-      (f) => f.confidence >= getCategoryConfidenceThreshold(f.category, confidenceThreshold),
-    );
+    allParsedFindings = filterByConfidence(allParsedFindings, confidenceThreshold);
     if (beforeConfidence !== allParsedFindings.length) {
       console.log(`[reviewer] Filtered out ${beforeConfidence - allParsedFindings.length} findings below per-category confidence threshold (base ${confidenceThreshold})`);
     }

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -74,6 +74,7 @@ import {
   formatPrIntent,
   buildRetrievalQuery,
   filterByConfidence,
+  resolveConfidenceThreshold,
 } from "@/lib/review-helpers";
 import type { ReviewConfig } from "@/lib/review-helpers";
 import {
@@ -1934,12 +1935,7 @@ Rules:
     // Filter out findings below confidence threshold (per-category: high-risk
     // categories like Security/Bug get a relaxed threshold so genuine issues
     // are not silently dropped — see review-categories.ts).
-    const confidenceThreshold =
-      typeof reviewConfig.confidenceThreshold === "number"
-        ? reviewConfig.confidenceThreshold
-        : reviewConfig.confidenceThreshold === "HIGH"
-          ? 85
-          : 70;
+    const confidenceThreshold = resolveConfidenceThreshold(reviewConfig);
     // #647: run confidence filter, category filter, suppression AND validation on
     // the FULL parsed union — not just the inline subset — so the summary table
     // and persisted DB rows carry post-validation confidence and never show a


### PR DESCRIPTION
Closes #652.

## Problem
The large-PR handler (`large-review-result.ts`) did `parseFindings → buildLowSeveritySummary → persist` with **none** of the standard path's quality steps — the biggest, most bug-prone PRs got raw model output straight to comments, and the two paths drifted.

## Change
Extracted the per-category confidence filter into a shared, pure, unit-tested `filterByConfidence()` (in `review-helpers.ts`) and call it from **both** `reviewer.ts` (replacing its inline filter) and `large-review-result.ts` (which also now applies the shared `sortAndCapFindings`). Same function → the two paths can't drift on filtering.

## Scope (transparent)
Diff-dependent `validateFindings` and semantic FP-suppression are **not** added to the large path yet: its pg-boss job payload (`LargeReviewResultJob`) carries only `reviewBody`, **no diff**, and re-fetching a >30k diff defeats the purpose of the large path. Plumbing the diff through the payload is a follow-up. This PR lands the **diff-free parity** — confidence filter + severity cap — which is the step the large path most lacked (it had zero filtering).

## Acceptance
- ✅ Both entry points call the same post-parse function (`filterByConfidence`), with a test asserting its filtering behaviour (base threshold + relaxed high-risk).
- ✅ Large-PR results now pass through confidence filtering (+ cap).
- ⚠️ Validation + suppression on the large path: follow-up (needs the diff plumbed through the job).
- ✅ Large-PR persisted findings reflect the filter.

## Validation
21 helper tests pass (2 new for `filterByConfidence`); tsc clean. **Security:** pure shared filter; the large path now shows *fewer* (filtered) findings — more conservative; no secrets/endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)