### PR TITLE
feat(blog): blog-publish workflow + markdown publisher CLI

### DIFF
--- a/.github/workflows/blog-publish.yml
+++ b/.github/workflows/blog-publish.yml
@@ -1,0 +1,41 @@
+name: Publish blog post
+
+# Publishes a committed markdown post (apps/web/scripts/data/blog-posts/*.md) via
+# the authenticated POST /api/blog (public API — no DB access needed). Manual
+# dispatch; DRY RUN unless `status` is set to draft or published.
+
+on:
+  workflow_dispatch:
+    inputs:
+      file:
+        description: "Path to the post markdown"
+        type: string
+        default: apps/web/scripts/data/blog-posts/claude-opus-5.md
+      status:
+        description: "dry = preview only · draft = create hidden · published = go live"
+        type: choice
+        options:
+          - dry
+          - draft
+          - published
+        default: dry
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      # Pinned to full commit SHAs (see octp-release.yml for rationale).
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.4
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Publish post
+        env:
+          BLOG_API_TOKEN: ${{ secrets.BLOG_API_TOKEN }}
+          OCTOPUS_API_URL: https://octopus-review.ai
+        run: |
+          bun run apps/web/scripts/publish-blog-post.ts "${{ inputs.file }}" --status=${{ inputs.status }}

--- a/.github/workflows/blog-publish.yml
+++ b/.github/workflows/blog-publish.yml
@@ -37,5 +37,9 @@ jobs:
         env:
           BLOG_API_TOKEN: ${{ secrets.BLOG_API_TOKEN }}
           OCTOPUS_API_URL: https://octopus-review.ai
+          # Pass dispatch inputs through the environment, never interpolated into
+          # the shell line — `${{ inputs.file }}` inline is a command-injection sink.
+          POST_FILE: ${{ inputs.file }}
+          POST_STATUS: ${{ inputs.status }}
         run: |
-          bun run apps/web/scripts/publish-blog-post.ts "${{ inputs.file }}" --status=${{ inputs.status }}
+          bun run apps/web/scripts/publish-blog-post.ts "$POST_FILE" --status="$POST_STATUS"

--- a/apps/web/scripts/__tests__/publish-blog-post.test.ts
+++ b/apps/web/scripts/__tests__/publish-blog-post.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "bun:test";
+import { parseFrontmatter } from "../publish-blog-post";
+
+describe("parseFrontmatter", () => {
+  it("parses scalar fields, an inline tags array, and the body", () => {
+    const raw = `---
+title: Hello World
+slug: hello-world
+tags: [Claude, Models, Code Review]
+---
+
+First paragraph.
+
+## A heading
+
+Second paragraph.`;
+    const { data, content } = parseFrontmatter(raw);
+    expect(data.title).toBe("Hello World");
+    expect(data.slug).toBe("hello-world");
+    expect(data.tags).toEqual(["Claude", "Models", "Code Review"]);
+    expect(content.startsWith("First paragraph.")).toBe(true);
+    expect(content).toContain("## A heading");
+    expect(content).not.toContain("---");
+  });
+
+  it("returns the whole text as content when there is no frontmatter", () => {
+    const { data, content } = parseFrontmatter("Just a body, no frontmatter.");
+    expect(data).toEqual({});
+    expect(content).toBe("Just a body, no frontmatter.");
+  });
+});

--- a/apps/web/scripts/data/blog-posts/claude-opus-5.md
+++ b/apps/web/scripts/data/blog-posts/claude-opus-5.md
@@ -1,0 +1,34 @@
+---
+title: Claude Opus 5 is now available in Octopus
+slug: claude-opus-5-now-available
+excerpt: Anthropic's new top coding model is now a review option in Octopus. It's an opt-in premium tier, not the new default, and here's why.
+category: Product
+tags: [Claude, Models, Code Review]
+authorName: Octopus Team
+---
+
+Anthropic released Claude Opus 5 today, and it's already available as a review model in Octopus.
+
+The short version: Opus 5 is Anthropic's new top model for coding. On their published numbers it lands close to Fable 5, their frontier model, at half the price, and it's a step up from Opus 4.8 on software engineering. For something whose entire job is reading your code and finding what's wrong with it, that's the number worth caring about.
+
+Octopus has let you choose your review model since day one, and you can run it on your own key. Opus 5 fits straight into that. You can select it for a single repository or your whole org.
+
+## Why it's a premium option and not the new default
+
+We didn't switch everyone over. The default reviewer stays on the faster Sonnet-class model, which does a good job on most pull requests and keeps credit spend low. Opus 5 costs more per review, $5/$25 per million tokens against $3/$15 for the default, so making it the blanket default would raise everyone's bill whether they asked for it or not. That's not an upgrade. That's a surprise invoice.
+
+So Opus 5 is there for the reviews where you want the deepest read: gnarly concurrency, a security-sensitive change, a big refactor, the kind of pull request where a missed bug is the expensive kind. Point a repo at it and every review on that repo runs on it.
+
+If you want the absolute frontier, Fable 5 is selectable too, at the top of the range ($10/$50 per million tokens). Most teams won't reach for it on everyday review, but it's there for the rare change where you want the strongest read Anthropic ships.
+
+## What it changes for a review
+
+Better reasoning on the subtle stuff, mostly. The logic error that only shows up on the third read. A race condition. The bug that's technically two functions away from the diff. Anthropic also reports Opus 5 as their most-aligned model so far, and for a reviewer that shows up as fewer confidently-wrong findings, which is the failure mode developers actually hate.
+
+It also builds on the review work we shipped over the last few weeks: per-language rule packs, checks that read the pull request's stated intent, and a validation pass that makes each finding defend itself with evidence. Hand a stronger model that much structure and you get a better review, not just a pricier one.
+
+## Turning it on
+
+Open settings, pick your repository, and set the review model to Claude Opus 5. That's the whole setup. Prefer your own Anthropic key? That works too.
+
+The default doesn't move. Opus 5 is there for the changes that earn the deeper look.

--- a/apps/web/scripts/publish-blog-post.ts
+++ b/apps/web/scripts/publish-blog-post.ts
@@ -1,0 +1,127 @@
+/**
+ * Publish a markdown blog post to Octopus via the authenticated POST /api/blog
+ * endpoint (public API — no DB access needed; prod DB is VPN-only).
+ *
+ *   Dry run (default, no write — prints the parsed payload):
+ *     BLOG_API_TOKEN=... bun run apps/web/scripts/publish-blog-post.ts <file.md>
+ *   Create as draft:
+ *     BLOG_API_TOKEN=... bun run apps/web/scripts/publish-blog-post.ts <file.md> --status=draft
+ *   Create and publish:
+ *     BLOG_API_TOKEN=... bun run apps/web/scripts/publish-blog-post.ts <file.md> --status=published
+ *
+ * The file is markdown with a simple `---` frontmatter block:
+ *   title, slug, excerpt, category, authorName, coverImageUrl (scalars)
+ *   tags (inline array: [A, B, C])
+ *
+ * Env: BLOG_API_TOKEN (required), OCTOPUS_API_URL (default https://octopus-review.ai).
+ */
+import { readFileSync } from "node:fs";
+
+type Frontmatter = {
+  title?: string;
+  slug?: string;
+  excerpt?: string;
+  category?: string;
+  authorName?: string;
+  coverImageUrl?: string;
+  tags?: string[];
+};
+
+/** Parse a leading `---` frontmatter block. Returns the fields + the remaining body. */
+export function parseFrontmatter(raw: string): { data: Frontmatter; content: string } {
+  const text = raw.replace(/^﻿/, "");
+  if (!text.startsWith("---")) return { data: {}, content: text.trim() };
+  // Match the block between the first pair of --- fences.
+  const end = text.indexOf("\n---", 3);
+  if (end === -1) return { data: {}, content: text.trim() };
+  const block = text.slice(3, end).trim();
+  const content = text.slice(text.indexOf("\n", end + 1) + 1).trim();
+
+  const data: Frontmatter = {};
+  for (const line of block.split("\n")) {
+    const m = line.match(/^([A-Za-z]+):\s*(.*)$/);
+    if (!m) continue;
+    const [, key, rawVal] = m;
+    const val = rawVal.trim();
+    if (key === "tags") {
+      data.tags = val
+        .replace(/^\[|\]$/g, "")
+        .split(",")
+        .map((t) => t.trim().replace(/^["']|["']$/g, ""))
+        .filter(Boolean);
+    } else {
+      (data as Record<string, string>)[key] = val.replace(/^["']|["']$/g, "");
+    }
+  }
+  return { data, content };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const file = args.find((a) => !a.startsWith("--"));
+  const status = args.find((a) => a.startsWith("--status="))?.split("=")[1] ?? "dry";
+
+  if (!file) {
+    console.error("Usage: publish-blog-post.ts <file.md> [--status=dry|draft|published]");
+    process.exit(1);
+  }
+  if (!["dry", "draft", "published"].includes(status)) {
+    console.error(`Invalid --status=${status} (expected dry | draft | published)`);
+    process.exit(1);
+  }
+
+  const { data, content } = parseFrontmatter(readFileSync(file, "utf8"));
+  if (!data.title || !content) {
+    console.error("Post needs a `title` in frontmatter and a non-empty body.");
+    process.exit(1);
+  }
+
+  const payload = {
+    title: data.title,
+    slug: data.slug,
+    content,
+    excerpt: data.excerpt,
+    coverImageUrl: data.coverImageUrl ?? null,
+    authorName: data.authorName ?? "Octopus Team",
+    tags: data.tags,
+    category: data.category,
+    generateSeo: true,
+    status: status === "dry" ? "draft" : status,
+  };
+
+  const API_URL = (process.env.OCTOPUS_API_URL ?? "https://octopus-review.ai").replace(/\/$/, "");
+  console.log(`[publish-blog] Mode: ${status === "dry" ? "DRY RUN (no write)" : status.toUpperCase()} · ${API_URL}`);
+  console.log(`  title: ${payload.title}`);
+  console.log(`  slug:  ${payload.slug ?? "(auto from title)"}`);
+  console.log(`  tags:  ${payload.tags?.join(", ") ?? "(none)"} · category: ${payload.category ?? "(none)"}`);
+  console.log(`  body:  ${content.length} chars`);
+
+  if (status === "dry") {
+    console.log("Dry run — nothing posted. Re-run with --status=draft or --status=published to write.");
+    return;
+  }
+
+  const TOKEN = process.env.BLOG_API_TOKEN;
+  if (!TOKEN) {
+    console.error("BLOG_API_TOKEN is required to write.");
+    process.exit(1);
+  }
+
+  const res = await fetch(`${API_URL}/api/blog`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const bodyText = await res.text();
+  if (!res.ok) {
+    console.error(`POST /api/blog failed: ${res.status} ${res.statusText}\n${bodyText}`);
+    process.exit(1);
+  }
+  const created = JSON.parse(bodyText) as { slug?: string; status?: string };
+  console.log(`✓ ${created.status ?? status}: ${API_URL}/blog/${created.slug ?? payload.slug}`);
+}
+
+// Only run when executed directly (not when imported by the test).
+if (import.meta.main) {
+  main();
+}

--- a/apps/web/scripts/publish-blog-post.ts
+++ b/apps/web/scripts/publish-blog-post.ts
@@ -106,10 +106,41 @@ async function main() {
     console.error("BLOG_API_TOKEN is required to write.");
     process.exit(1);
   }
+  const headers = { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" };
+
+  // Upsert by slug: a POST with an existing slug 409s, so re-running (e.g. draft
+  // then published, the documented promote flow) must PATCH the existing post
+  // instead. Look across all statuses so a hidden draft is found too.
+  const existingId = payload.slug ? await findPostIdBySlug(API_URL, headers, payload.slug) : null;
+
+  if (existingId) {
+    const res = await fetch(`${API_URL}/api/blog`, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({
+        id: existingId,
+        title: payload.title,
+        content,
+        excerpt: payload.excerpt,
+        coverImageUrl: payload.coverImageUrl,
+        tags: payload.tags,
+        category: payload.category,
+        status: payload.status,
+      }),
+    });
+    const t = await res.text();
+    if (!res.ok) {
+      console.error(`PATCH /api/blog failed: ${res.status} ${res.statusText}\n${t}`);
+      process.exit(1);
+    }
+    const updated = JSON.parse(t) as { slug?: string; status?: string };
+    console.log(`✓ updated → ${updated.status ?? payload.status}: ${API_URL}/blog/${updated.slug ?? payload.slug}`);
+    return;
+  }
 
   const res = await fetch(`${API_URL}/api/blog`, {
     method: "POST",
-    headers: { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+    headers,
     body: JSON.stringify(payload),
   });
   const bodyText = await res.text();
@@ -118,10 +149,34 @@ async function main() {
     process.exit(1);
   }
   const created = JSON.parse(bodyText) as { slug?: string; status?: string };
-  console.log(`✓ ${created.status ?? status}: ${API_URL}/blog/${created.slug ?? payload.slug}`);
+  console.log(`✓ created → ${created.status ?? status}: ${API_URL}/blog/${created.slug ?? payload.slug}`);
+}
+
+/** Find a post id by exact slug across all statuses (drafts included); null if none. */
+async function findPostIdBySlug(
+  apiUrl: string,
+  headers: Record<string, string>,
+  slug: string,
+): Promise<string | null> {
+  for (let page = 1; page <= 500; page++) {
+    const res = await fetch(`${apiUrl}/api/blog?limit=50&page=${page}`, { headers });
+    if (!res.ok) throw new Error(`GET /api/blog failed: ${res.status} ${res.statusText}`);
+    const data = (await res.json()) as {
+      posts?: Array<{ id: string; slug: string }>;
+      pagination?: { totalPages?: number };
+    };
+    const hit = data.posts?.find((p) => p.slug === slug);
+    if (hit) return hit.id;
+    const totalPages = Number(data?.pagination?.totalPages);
+    if (!Number.isFinite(totalPages) || page >= totalPages) break;
+  }
+  return null;
 }
 
 // Only run when executed directly (not when imported by the test).
 if (import.meta.main) {
-  main();
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
Adds a one-click path to publish a committed markdown post to the blog, so posts live in the repo and ship via workflow dispatch (no manual API calls, no DB/SSH).

## What
- **`apps/web/scripts/publish-blog-post.ts`** — reads a markdown file with a simple `---` frontmatter block (`title`, `slug`, `excerpt`, `category`, `tags`, `authorName`, `coverImageUrl`) and POSTs the body to the authenticated `POST /api/blog`. **Dry-run by default**; `--status=draft|published` to write. Same `BLOG_API_TOKEN` + `OCTOPUS_API_URL` convention as `apply-blog-taxonomy.ts`.
- **`.github/workflows/blog-publish.yml`** — `workflow_dispatch` with `file` + `status` (dry / draft / published) inputs. Defaults to a dry-run preview so a dispatch never writes by accident.
- **`apps/web/scripts/data/blog-posts/claude-opus-5.md`** — the Claude Opus 5 launch post (humanized).
- Parser unit test.

## Verify
- `bun test apps/web/scripts/__tests__/publish-blog-post.test.ts` → 2 pass
- `bun run apps/web/scripts/publish-blog-post.ts apps/web/scripts/data/blog-posts/claude-opus-5.md` → prints the parsed payload, writes nothing (dry run)

Publish flow after merge: run the workflow with `status=draft` to stage, review on the site, then re-run with `status=published`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)