### PR TITLE
fix(db): idempotent Opus 4.6→4.8 swap migration (unblock v1.0.61 deploy)

### DIFF
--- a/packages/db/prisma/migrations/20260724221000_swap_opus46_to_opus48/migration.sql
+++ b/packages/db/prisma/migrations/20260724221000_swap_opus46_to_opus48/migration.sql
@@ -1,14 +1,18 @@
 -- Replace Claude Opus 4.6 with Claude Opus 4.8 in the offered catalogue.
--- Anthropic's current Opus tier is $5/$25 (down from the old $15/$75), so the
--- stale Opus 4.6 row is renamed in place to Opus 4.8 at the new price. Updating
--- the existing row preserves its sortOrder and any admin isPlatformDefault choice.
--- Idempotent: if no 4.6 row exists (fresh env already seeded with 4.8 via seed.ts)
--- this is a no-op.
-UPDATE "available_models"
-SET
-  "modelId"     = 'claude-opus-4-8',
-  "displayName" = 'Claude Opus 4.8',
-  "inputPrice"  = 5,
-  "outputPrice" = 25,
-  "updatedAt"   = now()
-WHERE "modelId" = 'claude-opus-4-6-20250619';
+-- Anthropic's current Opus tier is $5/$25 (down from the old $15/$75). Some
+-- environments already have a claude-opus-4-8 row, so we do NOT rename 4.6 in
+-- place (that collides on the unique modelId). Instead: ensure 4.8 exists at
+-- the right price (insert or refresh), then drop the stale 4.6 row.
+-- Fully idempotent regardless of which rows already exist.
+INSERT INTO "available_models"
+  ("id","modelId","displayName","provider","category","inputPrice","outputPrice","isActive","isPlatformDefault","sortOrder","createdAt","updatedAt")
+VALUES
+  ('seed_claude_opus_4_8','claude-opus-4-8','Claude Opus 4.8','anthropic','llm',5,25,true,false,1,now(),now())
+ON CONFLICT ("modelId") DO UPDATE SET
+  "displayName" = EXCLUDED."displayName",
+  "inputPrice"  = EXCLUDED."inputPrice",
+  "outputPrice" = EXCLUDED."outputPrice",
+  "isActive"    = EXCLUDED."isActive",
+  "updatedAt"   = now();
+
+DELETE FROM "available_models" WHERE "modelId" = 'claude-opus-4-6-20250619';

--- a/packages/db/prisma/migrations/20260724221000_swap_opus46_to_opus48/migration.sql
+++ b/packages/db/prisma/migrations/20260724221000_swap_opus46_to_opus48/migration.sql
@@ -15,4 +15,13 @@ ON CONFLICT ("modelId") DO UPDATE SET
   "isActive"    = EXCLUDED."isActive",
   "updatedAt"   = now();
 
+-- If an admin had pinned 4.6 as the platform default, carry that onto 4.8 so the
+-- DELETE below doesn't silently unset the org's default reviewer.
+UPDATE "available_models" SET "isPlatformDefault" = true, "updatedAt" = now()
+WHERE "modelId" = 'claude-opus-4-8'
+  AND EXISTS (
+    SELECT 1 FROM "available_models"
+    WHERE "modelId" = 'claude-opus-4-6-20250619' AND "isPlatformDefault" = true
+  );
+
 DELETE FROM "available_models" WHERE "modelId" = 'claude-opus-4-6-20250619';


### PR DESCRIPTION
## Incident
The **v1.0.61 deploy failed** at `prisma migrate deploy`. Migration `20260724220000_add_opus5` applied, but `20260724221000_swap_opus46_to_opus48` errored:

```
duplicate key value violates unique constraint "available_models_modelId_key"
DETAIL: Key ("modelId")=(claude-opus-4-8) already exists.
```

Prod's `available_models` already contained a `claude-opus-4-8` row (DB catalogue was ahead of code), so the original in-place `UPDATE modelId 4.6 → 4.8` collided. Prod stayed on 1.0.60 (healthy); the failed record blocks further deploys until cleared.

## Fix
Rewrite the migration to never rename:
- `INSERT ... claude-opus-4-8 ... ON CONFLICT (modelId) DO UPDATE` → ensures 4.8 exists at $5/$25 whether or not it was already there (self-heals stale price).
- `DELETE ... WHERE modelId = 'claude-opus-4-6-20250619'` → drops the stale 4.6 row.

Idempotent in every environment. No rename, so no unique-constraint collision.

## Recovery sequence
1. Clear prod's failed record: `migrate resolve --rolled-back 20260724221000_swap_opus46_to_opus48` (bookkeeping only; the failed txn already rolled back, no data changed).
2. Merge this → tag v1.0.62 → redeploy. Corrected swap + the Fable 5 migration then apply cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)