### PR TITLE
chore: add root editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
## Summary

- add a root `.editorconfig`
- standardize UTF-8 files on LF line endings, two-space indentation, and a final newline
- trim trailing whitespace across editors that support EditorConfig

Closes #493

## Validation

- `git diff --check`
- verified the file uses LF, ends with a newline, and contains every setting from the issue acceptance criteria
