### PR TITLE
fix(blog-audio): read ELEVENLABS_API_KEY at call time, not module load

### DIFF
--- a/apps/web/lib/elevenlabs.ts
+++ b/apps/web/lib/elevenlabs.ts
@@ -9,10 +9,15 @@ const MODEL_ID = "eleven_turbo_v2_5";
 // ElevenLabs caps a single TTS request; stay well under and clip long posts.
 export const MAX_TTS_CHARS = 9000;
 
-const apiKey = process.env.ELEVENLABS_API_KEY;
+// Read at call time, not module load: a top-level capture goes stale / can be
+// evaluated before the runtime env is injected, which makes a configured key
+// read as "not set".
+function getApiKey(): string | undefined {
+  return process.env.ELEVENLABS_API_KEY;
+}
 
 export function isElevenLabsConfigured(): boolean {
-  return Boolean(apiKey);
+  return Boolean(getApiKey());
 }
 
 export type ElevenVoice = {
@@ -24,6 +29,7 @@ export type ElevenVoice = {
 
 /** List the account's available voices (for the admin voice picker). */
 export async function listVoices(): Promise<ElevenVoice[]> {
+  const apiKey = getApiKey();
   if (!apiKey) throw new Error("ELEVENLABS_API_KEY is not configured.");
   const res = await fetch(`${API_BASE}/voices`, {
     headers: { "xi-api-key": apiKey, accept: "application/json" },
@@ -48,6 +54,7 @@ export async function listVoices(): Promise<ElevenVoice[]> {
 
 /** Synthesize speech for `text` with `voiceId` → MP3 buffer. */
 export async function synthesizeSpeech(text: string, voiceId: string): Promise<Buffer> {
+  const apiKey = getApiKey();
   if (!apiKey) throw new Error("ELEVENLABS_API_KEY is not configured.");
   const res = await fetch(`${API_BASE}/text-to-speech/${encodeURIComponent(voiceId)}`, {
     method: "POST",


### PR DESCRIPTION
The Blog Read-Aloud admin shows "ELEVENLABS_API_KEY is not set on the platform" even though the key works (38/39 posts already have generated audio).

Cause: `apps/web/lib/elevenlabs.ts` captured the key in a **module-load** top-level `const`, which reads once at import and can be undefined if the module initializes before the runtime env is available — so `isElevenLabsConfigured()` reports not-set despite a configured key.

Fix: read `process.env.ELEVENLABS_API_KEY` via `getApiKey()` at each call (config check, listVoices, synthesizeSpeech).

Note: if the warning persists after deploy, the key genuinely isn't in the **apps/web** service runtime env (verify it's there, not only in review-engine).

tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)