### PR TITLE
fix(models): dynamic 'Latest' label on the latest model

### DIFF
--- a/apps/web/app/(app)/settings/models/models-settings.tsx
+++ b/apps/web/app/(app)/settings/models/models-settings.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import { LATEST_MODEL_ID } from "@/lib/model-latest";
 import { IconPencil, IconCheck, IconX, IconSearch, IconLoader2 } from "@tabler/icons-react";
 import { updateDefaultModels } from "../../actions";
 import { updateRepoModels } from "../../repositories/actions";
@@ -117,7 +118,8 @@ function RepoModelRow({
               </option>
               {llmModels.map((m) => (
                 <option key={m.modelId} value={m.modelId}>
-                  {m.displayName} ({m.provider})
+                  {m.displayName}
+                  {m.modelId === LATEST_MODEL_ID ? " (Latest)" : ""} ({m.provider})
                 </option>
               ))}
             </select>

--- a/apps/web/lib/model-latest.ts
+++ b/apps/web/lib/model-latest.ts
@@ -1,0 +1,4 @@
+// Single source of truth for which model shows the "Latest" label in the model
+// picker. Client-safe (no server imports). Update this one line when a newer
+// model launches — the label is never baked into model display names.
+export const LATEST_MODEL_ID = "claude-opus-5";

--- a/packages/db/prisma/migrations/20260725120000_relabel_latest_models/migration.sql
+++ b/packages/db/prisma/migrations/20260725120000_relabel_latest_models/migration.sql
@@ -1,0 +1,9 @@
+-- The "Latest" label now lives in the model picker UI (LATEST_MODEL_ID in
+-- apps/web/lib/model-latest.ts), shown dynamically on the current latest model.
+-- It should NOT be baked into model display names, where it goes stale. Strip a
+-- trailing " Latest" from any available_models display name. Idempotent: a
+-- second run matches nothing.
+UPDATE "available_models"
+SET "displayName" = regexp_replace("displayName", '\s*Latest$', ''),
+    "updatedAt" = now()
+WHERE "displayName" LIKE '% Latest';


### PR DESCRIPTION
Per feedback ("latest is opus 5, don't hardcode that — put the Latest label on the latest model").

**Before:** 'Latest' was baked into stale display names ('Claude Sonnet 4.6 Latest', 'Claude Opus 4.6 Latest'), so the picker showed old models as 'Latest'.

**After:**
- `LATEST_MODEL_ID` (`apps/web/lib/model-latest.ts`, = `claude-opus-5`) is the single source of truth; the model picker appends '(Latest)' to that model dynamically. One line to update on the next launch.
- Data migration strips a trailing ' Latest' from all `available_models` display names (idempotent).

Default reviewer (Sonnet) unchanged. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)