### PR TITLE
perf(cost): 1h prompt-cache TTL for the review system prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,13 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 # Billing: multiplier over provider list price when charging credits (default 1.2)
 PLATFORM_MARKUP=1.2
 
+# Prompt-cache TTL for the Anthropic review system prefix: "1h" (default) or
+# "5m". "1h" keeps the cached rulepack/instruction prefix alive across a repo's
+# review burst for a higher cache-hit rate; "5m" is cheaper per write but
+# expires between sporadic reviews. Also sets the cache-write premium used in
+# cost accounting (2x for 1h, 1.25x for 5m). Invalid values fall back to "1h".
+PROMPT_CACHE_TTL=1h
+
 # Cohere (Reranking)
 COHERE_API_KEY=
 

--- a/apps/web/lib/__tests__/cost.test.ts
+++ b/apps/web/lib/__tests__/cost.test.ts
@@ -8,6 +8,11 @@ mock.module("@octopus/db", () => ({
 
 import { calcCost, formatUsd, formatNumber } from "@/lib/cost";
 
+// The cache-write premium tracks PROMPT_CACHE_TTL (1.25x for 5m, 2x for 1h).
+// Pin 5m so the formula assertions below stay deterministic; a dedicated test
+// covers the 1h (2x) default.
+process.env.PROMPT_CACHE_TTL = "5m";
+
 describe("calcCost", () => {
   const pricing = new Map<string, { input: number; output: number }>([
     ["claude-sonnet-4-20250514", { input: 3, output: 15 }],
@@ -67,6 +72,19 @@ describe("calcCost", () => {
     //          = (0 + 187.5 + 24 + 750) / 1M = 0.0009615
     // cost = 0.0009615 * 1.2 = 0.001_153_8
     expect(cost).toBeCloseTo(0.0011538, 5);
+  });
+
+  it("uses the 2x cache-write premium under the 1h TTL default", () => {
+    const prev = process.env.PROMPT_CACHE_TTL;
+    process.env.PROMPT_CACHE_TTL = "1h";
+    try {
+      // plainInput = 700; (700*3 + 300*3*2 + 500*15)/1M = (2100 + 1800 + 7500)/1M
+      //            = 0.0114; * 1.2 markup = 0.01368
+      const cost = calcCost(pricing, "claude-sonnet-4-20250514", 1000, 500, 0, 300);
+      expect(cost).toBeCloseTo(0.01368, 5);
+    } finally {
+      process.env.PROMPT_CACHE_TTL = prev;
+    }
   });
 
   it("works with embedding model (output price = 0)", () => {

--- a/apps/web/lib/__tests__/system-cache.test.ts
+++ b/apps/web/lib/__tests__/system-cache.test.ts
@@ -8,7 +8,7 @@ describe("splitSystemForCache (#650)", () => {
     const blocks = splitSystemForCache(sys, true);
     expect(blocks).toHaveLength(2);
     expect(blocks[0].text).toBe("INSTRUCTIONS + RULEPACKS");
-    expect(blocks[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(blocks[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
     expect(blocks[1].text).toBe("VOLATILE CONTEXT");
     expect(blocks[1].cache_control).toBeUndefined();
   });
@@ -30,12 +30,23 @@ describe("splitSystemForCache (#650)", () => {
   it("no marker + caching → single cached block", () => {
     const blocks = splitSystemForCache("plain system", true);
     expect(blocks).toHaveLength(1);
-    expect(blocks[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(blocks[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 
   it("drops an empty suffix", () => {
     const blocks = splitSystemForCache(`prefix${CACHE_BREAKPOINT}   `, true);
     expect(blocks).toHaveLength(1);
+  });
+
+  it("honors an explicit ttl (5m) and defaults to 1h", () => {
+    expect(splitSystemForCache(sys, true, "5m")[0].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "5m",
+    });
+    expect(splitSystemForCache(sys, true)[0].cache_control).toEqual({
+      type: "ephemeral",
+      ttl: "1h",
+    });
   });
 });
 
@@ -49,6 +60,6 @@ describe("splitSystemForCache empty-side guards (#650)", () => {
   it("never emits an empty suffix block (marker at end → single cached block)", () => {
     const blocks = splitSystemForCache(`only static${CACHE_BREAKPOINT}`, true);
     expect(blocks).toHaveLength(1);
-    expect(blocks[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(blocks[0].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
   });
 });

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -89,10 +89,15 @@ export function calcCost(
 ): number {
   const p = pricing.get(model);
   if (!p) return 0;
+  // Cache-write premium tracks PROMPT_CACHE_TTL (the same env that sets the
+  // actual TTL on Anthropic review calls): a 1h cache write costs 2x base input,
+  // a 5m write 1.25x. Reviews are the dominant Anthropic path, so this keeps the
+  // billed write cost aligned with what Anthropic charges under the active TTL.
+  const cacheWriteMultiplier = process.env.PROMPT_CACHE_TTL === "5m" ? 1.25 : 2;
   const plainInput = Math.max(inputTokens - cacheReadTokens - cacheWriteTokens, 0);
   const baseCost =
     (plainInput * p.input +
-      cacheWriteTokens * p.input * 1.25 +
+      cacheWriteTokens * p.input * cacheWriteMultiplier +
       cacheReadTokens * p.input * 0.1 +
       outputTokens * p.output) /
     1_000_000;

--- a/apps/web/lib/providers/anthropic.ts
+++ b/apps/web/lib/providers/anthropic.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import Anthropic from "@anthropic-ai/sdk";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
-import { splitSystemForCache } from "./system-cache";
+import { splitSystemForCache, type CacheTtl } from "./system-cache";
 
 let platformClient: Anthropic | null = null;
 
@@ -43,6 +43,12 @@ export const anthropicProvider: Provider = {
   async create(params: AiCreateParams, apiKey?: string | null): Promise<AiResponse> {
     const client = getClient(apiKey);
 
+    // Prompt-cache TTL for the stable system prefix. Default 1h so the cached
+    // rulepack/instruction prefix survives across a repo's review burst (5m
+    // expires between sporadic reviews → low hit rate). Set PROMPT_CACHE_TTL=5m
+    // to opt back down. Read at call time so it's tunable without a redeploy.
+    const cacheTtl: CacheTtl = process.env.PROMPT_CACHE_TTL === "5m" ? "5m" : "1h";
+
     const maxTokens = ALWAYS_THINKING_MODEL_RX.test(params.model)
       ? Math.max(params.maxTokens, ALWAYS_THINKING_MAX_TOKENS_FLOOR)
       : params.maxTokens;
@@ -61,7 +67,7 @@ export const anthropicProvider: Provider = {
       {
         model: params.model,
         max_tokens: maxTokens,
-        system: params.system ? splitSystemForCache(params.system, params.cacheSystem) : undefined,
+        system: params.system ? splitSystemForCache(params.system, params.cacheSystem, cacheTtl) : undefined,
         messages: params.messages.map((m) => ({
           role: m.role,
           content: m.content,

--- a/apps/web/lib/providers/system-cache.ts
+++ b/apps/web/lib/providers/system-cache.ts
@@ -8,7 +8,17 @@
  */
 export const CACHE_BREAKPOINT = "<!--CACHE_BREAKPOINT-->";
 
-export type SystemBlock = { type: "text"; text: string; cache_control?: { type: "ephemeral" } };
+/** Cache TTL: "5m" (default Anthropic ephemeral) or "1h" (extended). Reviews are
+ *  sporadic, so "1h" keeps the cached prefix alive across a work session for a
+ *  much higher hit rate; a 1h write costs 2x base input vs 1.25x for 5m, so it
+ *  pays off once the prefix is read again within the hour (active repos). */
+export type CacheTtl = "5m" | "1h";
+
+export type SystemBlock = {
+  type: "text";
+  text: string;
+  cache_control?: { type: "ephemeral"; ttl: CacheTtl };
+};
 
 /**
  * Split a system prompt into Anthropic system blocks. With caching on and a
@@ -18,7 +28,12 @@ export type SystemBlock = { type: "text"; text: string; cache_control?: { type: 
  * Without a marker → a single (optionally cached) block. Any stray marker text
  * is always removed.
  */
-export function splitSystemForCache(system: string, cacheSystem?: boolean): SystemBlock[] {
+export function splitSystemForCache(
+  system: string,
+  cacheSystem?: boolean,
+  ttl: CacheTtl = "1h",
+): SystemBlock[] {
+  const cc = { type: "ephemeral" as const, ttl };
   if (cacheSystem && system.includes(CACHE_BREAKPOINT)) {
     const idx = system.indexOf(CACHE_BREAKPOINT);
     const prefix = system.slice(0, idx);
@@ -27,11 +42,11 @@ export function splitSystemForCache(system: string, cacheSystem?: boolean): Syst
     // Guard both sides: Anthropic rejects an empty text block, so only emit a
     // block when it has content. A marker at the very start (empty prefix) thus
     // degrades cleanly to a single uncached suffix block instead of a 400.
-    if (prefix.trim()) blocks.push({ type: "text", text: prefix, cache_control: { type: "ephemeral" } });
+    if (prefix.trim()) blocks.push({ type: "text", text: prefix, cache_control: cc });
     if (suffix.trim()) blocks.push({ type: "text", text: suffix });
     if (blocks.length > 0) return blocks;
     // Extreme fallback (marker-only input): fall through to the single-block path.
   }
   const text = system.split(CACHE_BREAKPOINT).join("");
-  return [{ type: "text", text, ...(cacheSystem ? { cache_control: { type: "ephemeral" } } : {}) }];
+  return [{ type: "text", text, ...(cacheSystem ? { cache_control: cc } : {}) }];
 }


### PR DESCRIPTION
Answers the low prompt-cache-hit-rate flagged in the Anthropic console.

Caching is already wired (`system-cache.ts` sets `cache_control` on the stable rulepack/instruction prefix), but it used the **5-minute** ephemeral TTL. Reviews on a repo are sporadic, so the cached prefix expires between them → each review re-writes the cache but rarely reads it → low hit rate.

**Change:** default the stable prefix to Anthropic's **1-hour** extended TTL (`ttl: "1h"`, GA in SDK 0.91.1 — no beta header). It survives a repo's review burst / steady cross-org volume, so subsequent reviews hit the cache.

- Env-tunable: `PROMPT_CACHE_TTL=5m` opts back down; read at call time (no redeploy to change).
- Trade-off (documented): a 1h cache *write* costs 2× base input vs 1.25× for 5m, so it's a net win once the prefix is read again within the hour — true for active repos, marginal for one-off reviews.
- Only the Anthropic API path (platform + BYOK Anthropic). tsc clean, 8/8 cache tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)