### PR TITLE
fix(credits): grant welcome bonus once per user, not per active org

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -13,7 +13,7 @@ import type { LogLevel } from "@/lib/indexer";
 import { createAbortController, abortIndexing } from "@/lib/indexing-abort";
 import { runIndexingInBackground } from "@/lib/indexing-runner";
 import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
-import { canUserCreateOrg } from "@/lib/org-limits";
+import { canUserCreateOrg, hasEverOwnedOrg } from "@/lib/org-limits";
 import { MAX_OWNED_ORGS_PER_USER, WELCOME_FREE_CREDITS } from "@/lib/constants";
 import { encryptString } from "@/lib/crypto";
 import { writeAuditLog } from "@/lib/audit";
@@ -106,7 +106,10 @@ export async function createOrganization(
         throw new Error("ORG_LIMIT_REACHED");
       }
 
-      const firstOrg = ownedCount === 0;
+      // Welcome bonus is once per user, ever — not once per active org — so it
+      // can't be farmed by delete-and-recreate. `ownedCount` above is active-only
+      // (drives the cap); grant eligibility counts soft-deleted owner rows too.
+      const firstOrg = !(await hasEverOwnedOrg(tx, user.id));
 
       return tx.organization.create({
         data: {

--- a/apps/web/lib/__tests__/org-limits.test.ts
+++ b/apps/web/lib/__tests__/org-limits.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { hasEverOwnedOrg } from "@/lib/org-limits";
+
+// Regression guard for the welcome-credit farming leak: the bonus is once per
+// user ever, so eligibility must count owner memberships INCLUDING soft-deleted
+// ones. If the count ever regains a `deletedAt` filter, delete-and-recreate
+// re-grants the bonus and this test fails.
+describe("hasEverOwnedOrg", () => {
+  function counterReturning(count: number) {
+    let seenWhere: Record<string, unknown> | undefined;
+    const client = {
+      organizationMember: {
+        count: (args: { where: { userId: string; role: string } }) => {
+          seenWhere = args.where;
+          return Promise.resolve(count);
+        },
+      },
+    };
+    return { client, where: () => seenWhere };
+  }
+
+  it("is false for a user who has never owned an org", async () => {
+    const { client } = counterReturning(0);
+    expect(await hasEverOwnedOrg(client, "u1")).toBe(false);
+  });
+
+  it("is true when a soft-deleted owner membership exists (delete-recreate can't refarm)", async () => {
+    const { client } = counterReturning(1);
+    expect(await hasEverOwnedOrg(client, "u1")).toBe(true);
+  });
+
+  it("counts owner memberships without a deletedAt filter", async () => {
+    const { client, where } = counterReturning(0);
+    await hasEverOwnedOrg(client, "u1");
+    expect(where()).toEqual({ userId: "u1", role: "owner" });
+    expect(where()).not.toHaveProperty("deletedAt");
+  });
+});

--- a/apps/web/lib/org-create.ts
+++ b/apps/web/lib/org-create.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@octopus/db";
 import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
-import { canUserCreateOrg } from "@/lib/org-limits";
+import { canUserCreateOrg, hasEverOwnedOrg } from "@/lib/org-limits";
 import { MAX_OWNED_ORGS_PER_USER, WELCOME_FREE_CREDITS } from "@/lib/constants";
 
 /**
@@ -50,7 +50,10 @@ export async function createOrgForUser(userId: string, userName: string) {
       throw new Error(`Organization limit reached (max ${MAX_OWNED_ORGS_PER_USER}).`);
     }
 
-    const firstOrg = ownedCount === 0;
+    // Welcome bonus is once per user, ever — not once per active org — so it
+    // can't be farmed by delete-and-recreate. `ownedCount` above is active-only
+    // (drives the cap); grant eligibility counts soft-deleted owner rows too.
+    const firstOrg = !(await hasEverOwnedOrg(tx, userId));
 
     return tx.organization.create({
       data: {

--- a/apps/web/lib/org-limits.ts
+++ b/apps/web/lib/org-limits.ts
@@ -13,13 +13,29 @@ export async function canUserCreateOrg(userId: string): Promise<boolean> {
   return count < MAX_OWNED_ORGS_PER_USER;
 }
 
-export async function isFirstOrgForUser(userId: string): Promise<boolean> {
-  const count = await prisma.organizationMember.count({
-    where: {
-      userId,
-      role: "owner",
-      organization: { deletedAt: null },
-    },
+/** Minimal client shape for counting owner memberships — satisfied by both the
+ *  Prisma client and a `$transaction` client, so the check can run inside a tx. */
+type OrgMemberCounter = {
+  organizationMember: {
+    count(args: { where: { userId: string; role: string } }): Promise<number>;
+  };
+};
+
+/**
+ * Whether the user has EVER owned an organization, counting soft-deleted ones.
+ *
+ * The welcome bonus is granted only when this is false, so it can't be farmed
+ * by delete-and-recreate: deleting an org only *soft*-deletes the owner
+ * membership, and this count omits the `deletedAt` filter, so a returning user
+ * no longer looks like a first-time owner. Pass the `$transaction` client at
+ * call sites so the eligibility check stays atomic with the org create.
+ */
+export async function hasEverOwnedOrg(
+  client: OrgMemberCounter,
+  userId: string,
+): Promise<boolean> {
+  const count = await client.organizationMember.count({
+    where: { userId, role: "owner" },
   });
-  return count === 0;
+  return count > 0;
 }


### PR DESCRIPTION
## Problem

The \$150 welcome bonus (`WELCOME_FREE_CREDITS`) was granted whenever a user had **zero active owned orgs** (`firstOrg = ownedCount === 0`, where `ownedCount` filters `deletedAt: null`). Deleting an org only *soft*-deletes the org and its owner membership, so after a delete the active count returns to 0 and the next org create re-grants the bonus. That makes the grant repeatable via delete → recreate, indefinitely. The eligibility check was duplicated across both create paths, so both leaked.

## Fix

Gate the grant on whether the user has **ever** owned an org — soft-deleted rows included — via one small, tx-safe helper:

```ts
export async function hasEverOwnedOrg(client, userId) {
  const count = await client.organizationMember.count({ where: { userId, role: "owner" } });
  return count > 0;
}
```

- Used by both grant sites: `createOrgForUser` (`org-create.ts`, the login/OAuth/CLI path) and the interactive `createOrganization` action (`actions.ts`).
- Takes the `$transaction` client, so the eligibility check stays atomic with the org create (does not fall back to a separate global-`prisma` read).
- The active-only `ownedCount` still drives `MAX_OWNED_ORGS_PER_USER`, so a user who deletes an org can still recreate one within the cap — they just don't collect a second bonus.
- Retires the previously **unused**, soft-delete-blind `isFirstOrgForUser` helper (it had the same latent bug and zero callers).

## Tests

New `org-limits.test.ts` locks the fix: eligibility is false for a never-owner, true when a soft-deleted owner membership exists, and the count is asserted to carry **no** `deletedAt` filter (the exact regression that reopens the leak).

- `bun test lib/__tests__/org-limits.test.ts` → 3 pass
- `bun run typecheck` → clean

## Follow-up (not in this PR)

The fix relies on owner memberships only ever being *soft*-deleted. A fully leak-proof version records a `welcomeGrantedAt` timestamp on the user (needs a migration) and is planned as part of the broader signup-risk work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p