### PR TITLE
feat(credits): withhold welcome bonus on signup-abuse risk score

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -115,16 +115,18 @@ export async function createOrganization(
       // org (soft-delete-safe). `ownedCount` above is active-only (drives the cap).
       const firstOrg = welcome.eligible && !(await hasEverOwnedOrg(tx, user.id));
 
-      // Atomically claim the one-time bonus: only the tx that flips
-      // welcomeGrantedAt from null wins, so concurrent first-org creates can't
-      // double-grant. Withhold (claim, but no credits) when risk doesn't clear.
+      // Consume the one-time bonus on the first org: stamp welcomeGrantedAt
+      // exactly once (updateMany where null → only one tx wins, so concurrent
+      // creates can't double-grant). A WITHHELD first org still consumes the
+      // bonus, so it can't be retried after an org hard-delete. Credits are
+      // added only when the claim wins AND the risk score clears.
       let grantBonus = false;
-      if (firstOrg && welcome.grant) {
+      if (firstOrg) {
         const claim = await tx.user.updateMany({
           where: { id: user.id, welcomeGrantedAt: null },
           data: { welcomeGrantedAt: new Date() },
         });
-        grantBonus = claim.count === 1;
+        grantBonus = claim.count === 1 && welcome.grant;
       }
 
       return tx.organization.create({

--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -14,6 +14,7 @@ import { createAbortController, abortIndexing } from "@/lib/indexing-abort";
 import { runIndexingInBackground } from "@/lib/indexing-runner";
 import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
 import { canUserCreateOrg, hasEverOwnedOrg } from "@/lib/org-limits";
+import { assessWelcomeCredit } from "@/lib/welcome-credit";
 import { MAX_OWNED_ORGS_PER_USER, WELCOME_FREE_CREDITS } from "@/lib/constants";
 import { encryptString } from "@/lib/crypto";
 import { writeAuditLog } from "@/lib/audit";
@@ -95,6 +96,10 @@ export async function createOrganization(
     slug = `${baseSlug}-${randomSlugSuffix()}`;
   }
 
+  // Assess welcome-bonus risk before the tx (reads only); the tx confirms
+  // first-org atomically.
+  const welcome = await assessWelcomeCredit(user.id);
+
   // Re-check limit and create atomically to prevent TOCTOU race
   let org;
   try {
@@ -106,10 +111,21 @@ export async function createOrganization(
         throw new Error("ORG_LIMIT_REACHED");
       }
 
-      // Welcome bonus is once per user, ever — not once per active org — so it
-      // can't be farmed by delete-and-recreate. `ownedCount` above is active-only
-      // (drives the cap); grant eligibility counts soft-deleted owner rows too.
-      const firstOrg = !(await hasEverOwnedOrg(tx, user.id));
+      // First org = bonus not yet granted (leak-proof stamp) AND never owned an
+      // org (soft-delete-safe). `ownedCount` above is active-only (drives the cap).
+      const firstOrg = welcome.eligible && !(await hasEverOwnedOrg(tx, user.id));
+
+      // Atomically claim the one-time bonus: only the tx that flips
+      // welcomeGrantedAt from null wins, so concurrent first-org creates can't
+      // double-grant. Withhold (claim, but no credits) when risk doesn't clear.
+      let grantBonus = false;
+      if (firstOrg && welcome.grant) {
+        const claim = await tx.user.updateMany({
+          where: { id: user.id, welcomeGrantedAt: null },
+          data: { welcomeGrantedAt: new Date() },
+        });
+        grantBonus = claim.count === 1;
+      }
 
       return tx.organization.create({
         data: {
@@ -122,6 +138,10 @@ export async function createOrganization(
             },
           },
           ...(firstOrg && {
+            welcomeRiskScore: welcome.score,
+            welcomeRiskReason: welcome.reason,
+          }),
+          ...(grantBonus && {
             freeCreditBalance: WELCOME_FREE_CREDITS,
             creditTransactions: {
               create: {

--- a/apps/web/lib/__tests__/org-create.test.ts
+++ b/apps/web/lib/__tests__/org-create.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Integration-ish test of the welcome-bonus gate in createOrgForUser, with
+// @octopus/db mocked (same approach as billing.test.ts). Locks the security
+// property that a WITHHELD first org still consumes the one-time bonus (stamps
+// welcomeGrantedAt), and that delete-recreate / already-granted don't re-grant.
+
+type UserRow = {
+  emailVerified: boolean;
+  signupIp: string | null;
+  welcomeGrantedAt: Date | null;
+};
+
+let userRow: UserRow;
+let ipPeerCount: number;
+let everOwnedCount: number; // hasEverOwnedOrg (no deletedAt filter)
+let activeOwnedCount: number; // cap check (deletedAt: null)
+let claimCount: number; // updateMany result count
+let createdData: Record<string, unknown> | null;
+let claimCalled: boolean;
+
+const orgMemberCount = mock((args: { where?: Record<string, unknown> }) => {
+  const w = args?.where ?? {};
+  // The active-owner counts filter on deletedAt; hasEverOwnedOrg does not.
+  return Promise.resolve("deletedAt" in w ? activeOwnedCount : everOwnedCount);
+});
+const userUpdateMany = mock(() => {
+  claimCalled = true;
+  return Promise.resolve({ count: claimCount });
+});
+const orgCreate = mock((args: { data: Record<string, unknown> }) => {
+  createdData = args.data;
+  return Promise.resolve({ id: "org1", ...args.data });
+});
+
+const client = {
+  organizationMember: { count: orgMemberCount },
+  user: {
+    findUnique: mock(() => Promise.resolve(userRow)),
+    count: mock(() => Promise.resolve(ipPeerCount)),
+    update: mock(() => Promise.resolve({})),
+    updateMany: userUpdateMany,
+  },
+  organization: {
+    findUnique: mock(() => Promise.resolve(null)), // slug is unique on first try
+    create: orgCreate,
+  },
+  $transaction: (fn: (tx: typeof client) => unknown) => fn(client),
+};
+
+mock.module("@octopus/db", () => ({ prisma: client }));
+
+const { createOrgForUser } = await import("@/lib/org-create");
+const { WELCOME_FREE_CREDITS } = await import("@/lib/constants");
+
+beforeEach(() => {
+  userRow = { emailVerified: true, signupIp: null, welcomeGrantedAt: null };
+  ipPeerCount = 0;
+  everOwnedCount = 0;
+  activeOwnedCount = 0;
+  claimCount = 1;
+  createdData = null;
+  claimCalled = false;
+});
+
+describe("createOrgForUser welcome-bonus gate", () => {
+  it("clean first org: grants credits and claims the bonus", async () => {
+    await createOrgForUser("u1", "Test User");
+    expect(claimCalled).toBe(true);
+    expect(createdData?.freeCreditBalance).toBe(WELCOME_FREE_CREDITS);
+    expect(createdData?.creditTransactions).toBeDefined();
+  });
+
+  it("high-velocity first org: withholds credits but STILL stamps (no refarm)", async () => {
+    userRow.signupIp = "203.0.113.7";
+    ipPeerCount = 5; // >= block threshold
+    await createOrgForUser("u1", "Test User");
+    expect(claimCalled).toBe(true); // consumed even though withheld
+    expect(createdData?.freeCreditBalance).toBeUndefined(); // no credits
+    expect(createdData?.welcomeRiskScore).toBeGreaterThan(0);
+    expect(String(createdData?.welcomeRiskReason)).toContain("ip_velocity");
+  });
+
+  it("already granted (welcomeGrantedAt set): no credits, no re-claim", async () => {
+    userRow.welcomeGrantedAt = new Date("2026-01-01T00:00:00Z");
+    await createOrgForUser("u1", "Test User");
+    expect(claimCalled).toBe(false);
+    expect(createdData?.freeCreditBalance).toBeUndefined();
+    expect(createdData?.welcomeRiskScore).toBeUndefined();
+  });
+
+  it("delete-recreate (owns a soft-deleted org): no credits, no claim", async () => {
+    everOwnedCount = 1; // hasEverOwnedOrg → true
+    await createOrgForUser("u1", "Test User");
+    expect(claimCalled).toBe(false);
+    expect(createdData?.freeCreditBalance).toBeUndefined();
+  });
+});

--- a/apps/web/lib/__tests__/welcome-credit.test.ts
+++ b/apps/web/lib/__tests__/welcome-credit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { scoreSignup, WELCOME_RISK } from "@/lib/welcome-credit";
+
+// Guards the signup abuse scorer's bands. Uses default (no-env) thresholds:
+// warn peers 2 (+25), block peers 4 (+50), unverified +15, holdAt 40, blockAt 50.
+describe("scoreSignup", () => {
+  it("clean signup (verified, no IP peers) → allow, score 0", () => {
+    const r = scoreSignup({ emailVerified: true, ipPeerCount: 0 });
+    expect(r.score).toBe(0);
+    expect(r.band).toBe("allow");
+  });
+
+  it("unverified email alone stays under the withhold threshold → allow", () => {
+    const r = scoreSignup({ emailVerified: false, ipPeerCount: 0 });
+    expect(r.score).toBe(15);
+    expect(r.band).toBe("allow");
+    expect(r.reasons).toContain("email_unverified");
+  });
+
+  it("a couple of IP peers alone → allow (conservative: shared office/CGNAT)", () => {
+    const r = scoreSignup({ emailVerified: true, ipPeerCount: 2 });
+    expect(r.score).toBe(25);
+    expect(r.band).toBe("allow");
+  });
+
+  it("warn-level velocity + unverified email → hold (withhold credits)", () => {
+    const r = scoreSignup({ emailVerified: false, ipPeerCount: 3 });
+    expect(r.score).toBe(40);
+    expect(r.band).toBe("hold");
+  });
+
+  it("block-level velocity (4+ peers) → block, reachable on its own", () => {
+    const r = scoreSignup({ emailVerified: true, ipPeerCount: 5 });
+    expect(r.score).toBe(50);
+    expect(r.band).toBe("block");
+    expect(r.reasons.some((x) => x.startsWith("ip_velocity_"))).toBe(true);
+  });
+
+  it("bands are ordered and every band is reachable with default weights", () => {
+    // Sanity: max score exceeds blockAt so 'block' is not dead code.
+    const max =
+      WELCOME_RISK.points.emailUnverified + WELCOME_RISK.points.velocityBlock;
+    expect(max).toBeGreaterThanOrEqual(WELCOME_RISK.blockAt);
+    expect(WELCOME_RISK.blockAt).toBeGreaterThan(WELCOME_RISK.holdAt);
+  });
+});

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -16,10 +16,14 @@ const IS_SELF_HOSTED = process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true";
 
 export const auth = betterAuth({
   trustedOrigins: [process.env.BETTER_AUTH_URL!],
-  // Resolve the client IP from the edge-set, hard-to-spoof header first
-  // (Cloudflare fronts the SaaS), falling back through the proxy chain. This
-  // is the IP used for audit logs and the signup-abuse (Sybil) signal, so the
-  // source must not be the client-controlled first x-forwarded-for hop.
+  // Resolve the client IP from the edge-set, hard-to-spoof header first, then
+  // fall back through the proxy chain. This IP feeds audit logs and the
+  // signup-abuse (Sybil) signal, so the source must not be the client-set first
+  // x-forwarded-for hop. On the SaaS, Cloudflare overwrites cf-connecting-ip so
+  // it's authoritative. Self-host operators MUST ensure their reverse proxy
+  // sets/overwrites these headers (same caveat as lib/request-ip.ts); an
+  // untrusted proxy makes any of them client-spoofable and only weakens the
+  // best-effort signal (it can't grant more than the once-per-user bonus).
   advanced: {
     ipAddress: {
       ipAddressHeaders: ["cf-connecting-ip", "x-real-ip", "x-forwarded-for"],
@@ -98,7 +102,9 @@ export const auth = betterAuth({
                 where: { id: session.userId, signupIp: null },
                 data: { signupIp: session.ipAddress },
               })
-              .catch(() => {});
+              .catch((err) =>
+                console.error("[auth] failed to record signup IP:", err),
+              );
           }
 
           await writeAuditLog({

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -16,6 +16,15 @@ const IS_SELF_HOSTED = process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true";
 
 export const auth = betterAuth({
   trustedOrigins: [process.env.BETTER_AUTH_URL!],
+  // Resolve the client IP from the edge-set, hard-to-spoof header first
+  // (Cloudflare fronts the SaaS), falling back through the proxy chain. This
+  // is the IP used for audit logs and the signup-abuse (Sybil) signal, so the
+  // source must not be the client-controlled first x-forwarded-for hop.
+  advanced: {
+    ipAddress: {
+      ipAddressHeaders: ["cf-connecting-ip", "x-real-ip", "x-forwarded-for"],
+    },
+  },
   database: prismaAdapter(prisma, {
     provider: "postgresql",
   }),
@@ -80,6 +89,17 @@ export const auth = betterAuth({
             where: { id: session.userId },
             select: { email: true },
           });
+
+          // Record the IP of the user's first session as a Sybil signal.
+          // updateMany with `signupIp: null` sets it exactly once, race-free.
+          if (session.ipAddress) {
+            await prisma.user
+              .updateMany({
+                where: { id: session.userId, signupIp: null },
+                data: { signupIp: session.ipAddress },
+              })
+              .catch(() => {});
+          }
 
           await writeAuditLog({
             action: "auth.login",

--- a/apps/web/lib/org-create.ts
+++ b/apps/web/lib/org-create.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@octopus/db";
 import { toBaseSlug, randomSlugSuffix } from "@/lib/slug";
 import { canUserCreateOrg, hasEverOwnedOrg } from "@/lib/org-limits";
+import { assessWelcomeCredit } from "@/lib/welcome-credit";
 import { MAX_OWNED_ORGS_PER_USER, WELCOME_FREE_CREDITS } from "@/lib/constants";
 
 /**
@@ -41,6 +42,10 @@ export async function createOrgForUser(userId: string, userName: string) {
     slug = `${baseSlug}-${randomSlugSuffix()}`;
   }
 
+  // Assess welcome-bonus risk before the tx (reads only); the tx confirms
+  // first-org atomically.
+  const welcome = await assessWelcomeCredit(userId);
+
   // Re-check limit and create atomically to prevent TOCTOU race
   const org = await prisma.$transaction(async (tx) => {
     const ownedCount = await tx.organizationMember.count({
@@ -50,10 +55,21 @@ export async function createOrgForUser(userId: string, userName: string) {
       throw new Error(`Organization limit reached (max ${MAX_OWNED_ORGS_PER_USER}).`);
     }
 
-    // Welcome bonus is once per user, ever — not once per active org — so it
-    // can't be farmed by delete-and-recreate. `ownedCount` above is active-only
-    // (drives the cap); grant eligibility counts soft-deleted owner rows too.
-    const firstOrg = !(await hasEverOwnedOrg(tx, userId));
+    // First org = bonus not yet granted (leak-proof stamp) AND never owned an
+    // org (soft-delete-safe). `ownedCount` above is active-only (drives the cap).
+    const firstOrg = welcome.eligible && !(await hasEverOwnedOrg(tx, userId));
+
+    // Atomically claim the one-time bonus: only the tx that flips
+    // welcomeGrantedAt from null wins, so concurrent first-org creates can't
+    // double-grant. Withhold (claim, but no credits) when risk doesn't clear.
+    let grantBonus = false;
+    if (firstOrg && welcome.grant) {
+      const claim = await tx.user.updateMany({
+        where: { id: userId, welcomeGrantedAt: null },
+        data: { welcomeGrantedAt: new Date() },
+      });
+      grantBonus = claim.count === 1;
+    }
 
     return tx.organization.create({
       data: {
@@ -66,6 +82,10 @@ export async function createOrgForUser(userId: string, userName: string) {
           },
         },
         ...(firstOrg && {
+          welcomeRiskScore: welcome.score,
+          welcomeRiskReason: welcome.reason,
+        }),
+        ...(grantBonus && {
           freeCreditBalance: WELCOME_FREE_CREDITS,
           creditTransactions: {
             create: {

--- a/apps/web/lib/org-create.ts
+++ b/apps/web/lib/org-create.ts
@@ -59,16 +59,18 @@ export async function createOrgForUser(userId: string, userName: string) {
     // org (soft-delete-safe). `ownedCount` above is active-only (drives the cap).
     const firstOrg = welcome.eligible && !(await hasEverOwnedOrg(tx, userId));
 
-    // Atomically claim the one-time bonus: only the tx that flips
-    // welcomeGrantedAt from null wins, so concurrent first-org creates can't
-    // double-grant. Withhold (claim, but no credits) when risk doesn't clear.
+    // Consume the one-time bonus on the first org: stamp welcomeGrantedAt
+    // exactly once (updateMany where null → only one tx wins, so concurrent
+    // creates can't double-grant). A WITHHELD first org still consumes the
+    // bonus, so it can't be retried after an org hard-delete. Credits are added
+    // only when the claim wins AND the risk score clears.
     let grantBonus = false;
-    if (firstOrg && welcome.grant) {
+    if (firstOrg) {
       const claim = await tx.user.updateMany({
         where: { id: userId, welcomeGrantedAt: null },
         data: { welcomeGrantedAt: new Date() },
       });
-      grantBonus = claim.count === 1;
+      grantBonus = claim.count === 1 && welcome.grant;
     }
 
     return tx.organization.create({

--- a/apps/web/lib/welcome-credit.ts
+++ b/apps/web/lib/welcome-credit.ts
@@ -1,0 +1,133 @@
+import { prisma } from "@octopus/db";
+
+/**
+ * Welcome-bonus abuse scoring.
+ *
+ * Disposable / no-MX emails are already blocked at signup (auth.ts
+ * `user.create.before`), so the remaining native signal worth scoring at
+ * grant time is Sybil velocity — many accounts from one signup IP — plus a
+ * small nudge for unverified emails. Heavier IP reputation (datacenter / VPN /
+ * Tor, ASN) is delivered by the maestro-fraud scoring API and plugs in here
+ * later behind the same `scoreSignup` seam.
+ */
+
+/** Env-overridable so prod thresholds can be tuned without a redeploy. */
+function envInt(name: string, fallback: number): number {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) && v >= 0 ? v : fallback;
+}
+
+export const WELCOME_RISK = {
+  velocityWindowDays: envInt("WELCOME_RISK_WINDOW_DAYS", 30),
+  velocityWarnPeers: envInt("WELCOME_RISK_WARN_PEERS", 2),
+  velocityBlockPeers: envInt("WELCOME_RISK_BLOCK_PEERS", 4),
+  points: {
+    emailUnverified: envInt("WELCOME_RISK_PTS_UNVERIFIED", 15),
+    velocityWarn: envInt("WELCOME_RISK_PTS_VELOCITY_WARN", 25),
+    velocityBlock: envInt("WELCOME_RISK_PTS_VELOCITY_BLOCK", 50),
+  },
+  // Score >= holdAt withholds the bonus (signup itself is never blocked);
+  // >= blockAt additionally marks it high-confidence abuse for review. Both
+  // bands withhold in P1 — the split is for logging + future auto-release of
+  // "hold" on step-up. blockAt is reachable by the velocity-block weight alone.
+  holdAt: envInt("WELCOME_RISK_HOLD_AT", 40),
+  blockAt: envInt("WELCOME_RISK_BLOCK_AT", 50),
+} as const;
+
+export type RiskBand = "allow" | "hold" | "block";
+
+export type SignupSignals = {
+  emailVerified: boolean;
+  /** Other users that share this signup IP within the velocity window. */
+  ipPeerCount: number;
+};
+
+export type RiskAssessment = {
+  score: number;
+  band: RiskBand;
+  reasons: string[];
+};
+
+/** Pure additive scorer — no I/O, unit-testable. */
+export function scoreSignup(s: SignupSignals): RiskAssessment {
+  const { points } = WELCOME_RISK;
+  let score = 0;
+  const reasons: string[] = [];
+
+  if (!s.emailVerified) {
+    score += points.emailUnverified;
+    reasons.push("email_unverified");
+  }
+  if (s.ipPeerCount >= WELCOME_RISK.velocityBlockPeers) {
+    score += points.velocityBlock;
+    reasons.push(`ip_velocity_${s.ipPeerCount}`);
+  } else if (s.ipPeerCount >= WELCOME_RISK.velocityWarnPeers) {
+    score += points.velocityWarn;
+    reasons.push(`ip_velocity_${s.ipPeerCount}`);
+  }
+
+  const band: RiskBand =
+    score >= WELCOME_RISK.blockAt
+      ? "block"
+      : score >= WELCOME_RISK.holdAt
+        ? "hold"
+        : "allow";
+  return { score, band, reasons };
+}
+
+export type WelcomeDecision = {
+  /** Bonus not yet granted to this user (leak-proof once-per-user flag). */
+  eligible: boolean;
+  /** eligible AND the risk band is "allow". */
+  grant: boolean;
+  score: number | null;
+  reason: string | null;
+};
+
+/**
+ * Decide whether a user's about-to-be-created first org should receive the
+ * welcome bonus. Reads only — call it BEFORE the create transaction; the caller
+ * still confirms first-org atomically inside the tx via `hasEverOwnedOrg`.
+ *
+ * ponytail: velocity keys on the raw signup IP, so shared egress (office NAT /
+ * CGNAT) can withhold from legit users. That's why the action is WITHHOLD, not
+ * a signup block — an admin can still grant, and device fingerprint (P2) will
+ * disambiguate. Thresholds are env-tunable above.
+ */
+export async function assessWelcomeCredit(userId: string): Promise<WelcomeDecision> {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { emailVerified: true, signupIp: true, welcomeGrantedAt: true },
+    });
+
+    if (!user || user.welcomeGrantedAt) {
+      return { eligible: false, grant: false, score: null, reason: null };
+    }
+
+    let ipPeerCount = 0;
+    if (user.signupIp) {
+      const since = new Date(
+        Date.now() - WELCOME_RISK.velocityWindowDays * 24 * 60 * 60 * 1000,
+      );
+      ipPeerCount = await prisma.user.count({
+        where: { signupIp: user.signupIp, id: { not: userId }, createdAt: { gte: since } },
+      });
+    }
+
+    const risk = scoreSignup({ emailVerified: user.emailVerified, ipPeerCount });
+    return {
+      eligible: true,
+      grant: risk.band === "allow",
+      score: risk.score,
+      reason: risk.reasons.length ? risk.reasons.join(",") : null,
+    };
+  } catch (err) {
+    // Scoring is best-effort. On a read failure, degrade to the pre-risk
+    // behavior (grant to a genuine first org) rather than breaking signup or
+    // punishing a legit user — the once-per-user cap still bounds it to one
+    // bonus. Recorded so failures are visible.
+    console.error("[welcome-credit] risk assessment failed, granting:", err);
+    return { eligible: true, grant: true, score: null, reason: "assess_error" };
+  }
+}

--- a/apps/web/lib/welcome-credit.ts
+++ b/apps/web/lib/welcome-credit.ts
@@ -89,7 +89,7 @@ export type WelcomeDecision = {
  * welcome bonus. Reads only — call it BEFORE the create transaction; the caller
  * still confirms first-org atomically inside the tx via `hasEverOwnedOrg`.
  *
- * ponytail: velocity keys on the raw signup IP, so shared egress (office NAT /
+ * Note: velocity keys on the raw signup IP, so shared egress (office NAT /
  * CGNAT) can withhold from legit users. That's why the action is WITHHOLD, not
  * a signup block — an admin can still grant, and device fingerprint (P2) will
  * disambiguate. Thresholds are env-tunable above.

--- a/packages/db/prisma/migrations/20260727120000_add_signup_risk_fields/migration.sql
+++ b/packages/db/prisma/migrations/20260727120000_add_signup_risk_fields/migration.sql
@@ -4,3 +4,6 @@ ALTER TABLE "users" ADD COLUMN "welcomeGrantedAt" TIMESTAMP(3);
 
 ALTER TABLE "organizations" ADD COLUMN "welcomeRiskScore" INTEGER;
 ALTER TABLE "organizations" ADD COLUMN "welcomeRiskReason" TEXT;
+
+-- Supports the signup-IP velocity count (signupIp = $1 AND createdAt >= $2).
+CREATE INDEX "users_signupIp_idx" ON "users"("signupIp");

--- a/packages/db/prisma/migrations/20260727120000_add_signup_risk_fields/migration.sql
+++ b/packages/db/prisma/migrations/20260727120000_add_signup_risk_fields/migration.sql
@@ -1,0 +1,6 @@
+-- Signup abuse-prevention fields (expand-only, all nullable — safe on live).
+ALTER TABLE "users" ADD COLUMN "signupIp" TEXT;
+ALTER TABLE "users" ADD COLUMN "welcomeGrantedAt" TIMESTAMP(3);
+
+ALTER TABLE "organizations" ADD COLUMN "welcomeRiskScore" INTEGER;
+ALTER TABLE "organizations" ADD COLUMN "welcomeRiskReason" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -29,6 +29,12 @@ model User {
   welcomeEmailSentAt    DateTime?
   marketingEmailsEnabled Boolean @default(true)
 
+  // Signup abuse signals. signupIp is captured at the first session and drives
+  // Sybil velocity scoring; welcomeGrantedAt stamps the one-time welcome bonus
+  // so it can't be re-farmed (leak-proof — survives org soft- OR hard-delete).
+  signupIp         String?
+  welcomeGrantedAt DateTime?
+
   emailSends EmailSend[]
   devices    UserDevice[]
 
@@ -133,6 +139,11 @@ model Organization {
   creditBalance           Decimal  @default(0) @db.Decimal(12, 4)
   freeCreditBalance       Decimal  @default(0) @db.Decimal(12, 4)
   billingEmail            String?
+
+  // Welcome-bonus risk decision recorded when this org was the user's first
+  // (null = never evaluated). Non-null score with 0 free credits = withheld.
+  welcomeRiskScore        Int?
+  welcomeRiskReason       String?
   // Monthly subscription plan (charged off-session against the saved card;
   // grants non-expiring credits each period). "free" | "pro" | "team".
   planTier              String    @default("free")

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -35,6 +35,8 @@ model User {
   signupIp         String?
   welcomeGrantedAt DateTime?
 
+  @@index([signupIp])
+
   emailSends EmailSend[]
   devices    UserDevice[]
 


### PR DESCRIPTION
Follow-up to #679 (P1 of the signup-abuse work). Adds a server-side risk gate on the one-time welcome bonus to slow Sybil farming — **without blocking signup**.

## What it does
On a user's first org, a risk score decides whether the \$150 welcome bonus is granted or **withheld** (org is still created either way; signup is never blocked).

**Signals (native, no external dataset):**
- **signup-IP velocity** — how many other users share this signup IP within a window (the Sybil tell). IP captured once at the first session (`auth.ts` session hook).
- **emailVerified** nudge. Disposable/no-MX email is *already* blocked upstream (`user.create.before`), so it isn't re-scored here.

`scoreSignup()` (`lib/welcome-credit.ts`) is a pure additive scorer; weights + thresholds are env-overridable for tuning without a redeploy. Bands: `< holdAt` allow · `>= holdAt` hold · `>= blockAt` block. **Both hold and block withhold** the credits in P1; the split is for logging + future step-up release. The decision is recorded on the org (`welcomeRiskScore` / `welcomeRiskReason`).

IP reputation (datacenter / VPN / Tor, ASN) is intentionally **not** duplicated here — it's delivered by the maestro-fraud scoring API and plugs into the same `scoreSignup` seam later.

## Leak-proofing
- New `welcomeGrantedAt` stamp makes the bonus once-per-user even against org **hard**-delete (#679's `hasEverOwnedOrg` only covered soft-delete).
- The bonus is **claimed atomically** — `updateMany where welcomeGrantedAt IS NULL`, grant only if it flipped — so concurrent first-org creates can't double-grant.

## Security-pass hardening
- IP resolved from `cf-connecting-ip` first (edge-set, spoof-resistant) instead of the client-controlled first `x-forwarded-for` hop — this feeds both audit logs and the abuse signal.
- `assessWelcomeCredit` **fails open to grant** on a read error: never breaks signup or punishes a legit user, and the once-per-user cap still bounds it to one bonus.

## Known ceilings (documented in code)
- Velocity keys on raw IP, so shared egress (office NAT / CGNAT) can withhold from legit users — which is exactly why the action is *withhold*, not block, and admin-grantable. Device fingerprint (P2) will disambiguate.

## Migration
`add_signup_risk_fields` — expand-only, four **nullable** columns (`users.signupIp`, `users.welcomeGrantedAt`, `organizations.welcomeRiskScore`, `organizations.welcomeRiskReason`). Safe on a live DB; no backfill needed (existing owners are already covered by `hasEverOwnedOrg`).

## Tests
- `welcome-credit.test.ts` — scorer bands, asserting every band is reachable with default weights.
- `bun test` green; `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p