### PR TITLE
fix(anthropic): cap Fable/Mythos thinking budget so reviews aren't empty

### DIFF
--- a/apps/web/lib/__tests__/thinking.test.ts
+++ b/apps/web/lib/__tests__/thinking.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import {
+  resolveThinking,
+  ALWAYS_THINKING_MAX_TOKENS_FLOOR,
+  ALWAYS_THINKING_OUTPUT_HEADROOM,
+} from "@/lib/providers/thinking";
+
+const FLOOR = ALWAYS_THINKING_MAX_TOKENS_FLOOR;
+const HEADROOM = ALWAYS_THINKING_OUTPUT_HEADROOM;
+
+describe("resolveThinking", () => {
+  it("leaves non-thinking models untouched (no thinking, max_tokens as requested)", () => {
+    const r = resolveThinking("claude-sonnet-4-6", 8192, false);
+    expect(r.maxTokens).toBe(8192);
+    expect(r.thinking).toBeUndefined();
+  });
+
+  it("text path: raises to the floor and caps thinking to reserve output headroom", () => {
+    const r = resolveThinking("claude-fable-5", 8192, false);
+    expect(r.maxTokens).toBe(FLOOR);
+    expect(r.thinking).toEqual({ type: "enabled", budget_tokens: FLOOR - HEADROOM });
+    // The whole point: output room is always reserved, budget is a valid cap.
+    expect(r.maxTokens - r.thinking!.budget_tokens).toBe(HEADROOM);
+    expect(r.thinking!.budget_tokens).toBeGreaterThanOrEqual(1024);
+    expect(r.thinking!.budget_tokens).toBeLessThan(r.maxTokens);
+  });
+
+  it("tool path: raises to the floor but sets NO thinking (forced tool_choice conflict)", () => {
+    const r = resolveThinking("claude-fable-5", 8192, true);
+    expect(r.maxTokens).toBe(FLOOR);
+    expect(r.thinking).toBeUndefined();
+  });
+
+  it("honors a caller max_tokens above the floor and scales the budget with it", () => {
+    const r = resolveThinking("claude-mythos-1", 100000, false);
+    expect(r.maxTokens).toBe(100000);
+    expect(r.thinking!.budget_tokens).toBe(100000 - HEADROOM);
+    expect(r.maxTokens - r.thinking!.budget_tokens).toBe(HEADROOM);
+  });
+});

--- a/apps/web/lib/providers/anthropic.ts
+++ b/apps/web/lib/providers/anthropic.ts
@@ -2,6 +2,7 @@ import "server-only";
 import Anthropic from "@anthropic-ai/sdk";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
 import { splitSystemForCache, type CacheTtl } from "./system-cache";
+import { resolveThinking } from "./thinking";
 
 let platformClient: Anthropic | null = null;
 
@@ -12,19 +13,6 @@ function getClient(apiKey?: string | null): Anthropic {
   }
   return platformClient;
 }
-
-/**
- * Claude Fable/Mythos models have always-on extended thinking that spends
- * from the max_tokens budget BEFORE any text is produced, and a tokenizer
- * that uses ~30% more tokens than Opus-tier models. Budgets tuned for other
- * models (8192 for reviews, 256 for titles) get fully consumed by the
- * thinking block on hard inputs, the response ends with
- * stop_reason "max_tokens" and zero text blocks, and the whole review fails.
- * Raise the cap to a floor that leaves room for thinking + text; max_tokens
- * is a ceiling, not a spend, so the floor costs nothing on easy inputs.
- */
-const ALWAYS_THINKING_MODEL_RX = /^claude-(fable|mythos)-/;
-const ALWAYS_THINKING_MAX_TOKENS_FLOOR = 64000;
 
 /**
  * Hard deadline for one Anthropic call, thinking time included. The SDK's
@@ -49,14 +37,14 @@ export const anthropicProvider: Provider = {
     // to opt back down. Read at call time so it's tunable without a redeploy.
     const cacheTtl: CacheTtl = process.env.PROMPT_CACHE_TTL === "5m" ? "5m" : "1h";
 
-    const maxTokens = ALWAYS_THINKING_MODEL_RX.test(params.model)
-      ? Math.max(params.maxTokens, ALWAYS_THINKING_MAX_TOKENS_FLOOR)
-      : params.maxTokens;
-
     // When a responseSchema is provided, use Anthropic tool-use for enforced
     // structured output: define a single tool whose input_schema matches the
     // requested shape, force it via tool_choice, then return the tool input.
     const useTool = params.responseSchema !== undefined;
+
+    // Always-thinking models (Fable/Mythos): raise max_tokens to the floor and,
+    // on the text path, cap the thinking budget so the answer always has room.
+    const { maxTokens, thinking } = resolveThinking(params.model, params.maxTokens, useTool);
 
     // Streaming here is purely between this process and the Anthropic API —
     // finalMessage() buffers the SSE chunks and returns the same complete
@@ -67,6 +55,7 @@ export const anthropicProvider: Provider = {
       {
         model: params.model,
         max_tokens: maxTokens,
+        ...(thinking ? { thinking } : {}),
         system: params.system ? splitSystemForCache(params.system, params.cacheSystem, cacheTtl) : undefined,
         messages: params.messages.map((m) => ({
           role: m.role,

--- a/apps/web/lib/providers/thinking.ts
+++ b/apps/web/lib/providers/thinking.ts
@@ -1,0 +1,48 @@
+/**
+ * Extended-thinking budget resolution for Anthropic always-thinking models.
+ *
+ * Claude Fable/Mythos models have always-on extended thinking that spends from
+ * the max_tokens budget BEFORE any text is produced, and a tokenizer that uses
+ * ~30% more tokens than Opus-tier models. Budgets tuned for other models (8192
+ * for reviews, 256 for titles) get fully consumed by the thinking block on hard
+ * inputs: the response ends with stop_reason "max_tokens" and zero text blocks,
+ * and the whole review fails.
+ *
+ * Raising max_tokens to a floor is necessary but NOT sufficient — with no
+ * explicit budget the thinking block can still spend the entire ceiling. So we
+ * also cap the thinking budget at (max_tokens - headroom), which guarantees the
+ * answer always has room. max_tokens is a ceiling, not a spend, so the floor
+ * costs nothing on easy inputs.
+ *
+ * Kept out of anthropic.ts (which is `server-only`) so it stays unit-testable.
+ */
+export const ALWAYS_THINKING_MODEL_RX = /^claude-(fable|mythos)-/;
+export const ALWAYS_THINKING_MAX_TOKENS_FLOOR = 64000;
+export const ALWAYS_THINKING_OUTPUT_HEADROOM = 16000;
+
+export type ResolvedThinking = {
+  maxTokens: number;
+  thinking?: { type: "enabled"; budget_tokens: number };
+};
+
+/**
+ * For always-thinking models, raise max_tokens to the floor and cap the
+ * thinking budget so text output is always reserved.
+ *
+ * Only on the plain-text path: forced `tool_choice` (structured output) is
+ * incompatible with an explicit thinking budget, so there we keep the floor
+ * alone and leave thinking implicit.
+ */
+export function resolveThinking(
+  model: string,
+  requestedMaxTokens: number,
+  useTool: boolean,
+): ResolvedThinking {
+  if (!ALWAYS_THINKING_MODEL_RX.test(model)) return { maxTokens: requestedMaxTokens };
+  const maxTokens = Math.max(requestedMaxTokens, ALWAYS_THINKING_MAX_TOKENS_FLOOR);
+  if (useTool) return { maxTokens };
+  return {
+    maxTokens,
+    thinking: { type: "enabled", budget_tokens: maxTokens - ALWAYS_THINKING_OUTPUT_HEADROOM },
+  };
+}


### PR DESCRIPTION
## Problem
Reviews on always-thinking models (`claude-fable-*`, `claude-mythos-*`) intermittently fail with `Anthropic returned no text (stop_reason: max_tokens, blocks: thinking)`. These models spend from `max_tokens` on the thinking block **before** any text. Raising `max_tokens` to a 64k floor (existing mitigation) isn't sufficient: with no explicit thinking budget, a hard input's thinking block can consume the entire ceiling, leaving zero text blocks — the review comes back empty and the whole run fails.

Reported from the field: Octopus review failing twice with the same error on a PR whose own tests pass — the AI provider returns an empty response (thinking fills `max_tokens`), not a transient blip.

## Fix
Cap the thinking budget at `max_tokens - 16k` on the plain-text path, guaranteeing ~16k tokens are always reserved for the answer (`budget_tokens` must be ≥1024 and `< max_tokens` — both hold). `max_tokens` stays a ceiling, so easy inputs are unaffected.

- **Text path** (reviews, titles, summaries): sets `thinking: { type: "enabled", budget_tokens: max_tokens - 16000 }`.
- **Structured-output path** (forced `tool_choice`): left as-is — an explicit thinking budget is **incompatible** with forced `tool_choice`, so only the `max_tokens` floor applies there.
- Non-thinking models (Sonnet/Opus/Haiku): completely untouched.

Extracted the regex + floor + new `resolveThinking()` into `providers/thinking.ts` (no `server-only`) so the budget math is unit-testable.

## Tests
`thinking.test.ts`: non-thinking passthrough, text-path floor+budget with reserved headroom, tool-path no-thinking, and caller-max_tokens-above-floor scaling. `bun run typecheck` clean.

## Verification limit
Verified by types + unit tests. The live Fable path can't be exercised from CI, and this PR's own review runs on the default Sonnet reviewer (unaffected). **Re-trigger a Fable review after deploy to confirm end-to-end.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p