### PR TITLE
fix(anthropic): use adaptive thinking for Fable/Mythos (enabled is rejected)

### DIFF
--- a/apps/web/lib/__tests__/thinking.test.ts
+++ b/apps/web/lib/__tests__/thinking.test.ts
@@ -1,40 +1,51 @@
 import { describe, expect, it } from "bun:test";
 import {
   resolveThinking,
+  resolveEffort,
   ALWAYS_THINKING_MAX_TOKENS_FLOOR,
-  ALWAYS_THINKING_OUTPUT_HEADROOM,
+  DEFAULT_THINKING_EFFORT,
 } from "@/lib/providers/thinking";
 
 const FLOOR = ALWAYS_THINKING_MAX_TOKENS_FLOOR;
-const HEADROOM = ALWAYS_THINKING_OUTPUT_HEADROOM;
 
 describe("resolveThinking", () => {
-  it("leaves non-thinking models untouched (no thinking, max_tokens as requested)", () => {
+  it("leaves non-thinking models untouched (no thinking/output config)", () => {
     const r = resolveThinking("claude-sonnet-4-6", 8192, false);
     expect(r.maxTokens).toBe(8192);
     expect(r.thinking).toBeUndefined();
+    expect(r.outputConfig).toBeUndefined();
   });
 
-  it("text path: raises to the floor and caps thinking to reserve output headroom", () => {
+  it("text path: raises to the floor and sets ADAPTIVE thinking + effort", () => {
     const r = resolveThinking("claude-fable-5", 8192, false);
     expect(r.maxTokens).toBe(FLOOR);
-    expect(r.thinking).toEqual({ type: "enabled", budget_tokens: FLOOR - HEADROOM });
-    // The whole point: output room is always reserved, budget is a valid cap.
-    expect(r.maxTokens - r.thinking!.budget_tokens).toBe(HEADROOM);
-    expect(r.thinking!.budget_tokens).toBeGreaterThanOrEqual(1024);
-    expect(r.thinking!.budget_tokens).toBeLessThan(r.maxTokens);
+    // Must be adaptive — these models reject thinking.type.enabled.
+    expect(r.thinking).toEqual({ type: "adaptive" });
+    expect(r.outputConfig).toEqual({ effort: DEFAULT_THINKING_EFFORT });
   });
 
-  it("tool path: raises to the floor but sets NO thinking (forced tool_choice conflict)", () => {
+  it("tool path: floor only, no thinking/output config (avoid tool_choice conflict)", () => {
     const r = resolveThinking("claude-fable-5", 8192, true);
     expect(r.maxTokens).toBe(FLOOR);
     expect(r.thinking).toBeUndefined();
+    expect(r.outputConfig).toBeUndefined();
   });
 
-  it("honors a caller max_tokens above the floor and scales the budget with it", () => {
+  it("honors a caller max_tokens above the floor", () => {
     const r = resolveThinking("claude-mythos-1", 100000, false);
     expect(r.maxTokens).toBe(100000);
-    expect(r.thinking!.budget_tokens).toBe(100000 - HEADROOM);
-    expect(r.maxTokens - r.thinking!.budget_tokens).toBe(HEADROOM);
+    expect(r.thinking).toEqual({ type: "adaptive" });
+  });
+});
+
+describe("resolveEffort", () => {
+  it("defaults to a valid effort and accepts env overrides", () => {
+    delete process.env.FABLE_THINKING_EFFORT;
+    expect(resolveEffort()).toBe(DEFAULT_THINKING_EFFORT);
+    process.env.FABLE_THINKING_EFFORT = "medium";
+    expect(resolveEffort()).toBe("medium");
+    process.env.FABLE_THINKING_EFFORT = "bogus";
+    expect(resolveEffort()).toBe(DEFAULT_THINKING_EFFORT); // invalid → default
+    delete process.env.FABLE_THINKING_EFFORT;
   });
 });

--- a/apps/web/lib/providers/anthropic.ts
+++ b/apps/web/lib/providers/anthropic.ts
@@ -43,8 +43,13 @@ export const anthropicProvider: Provider = {
     const useTool = params.responseSchema !== undefined;
 
     // Always-thinking models (Fable/Mythos): raise max_tokens to the floor and,
-    // on the text path, cap the thinking budget so the answer always has room.
-    const { maxTokens, thinking } = resolveThinking(params.model, params.maxTokens, useTool);
+    // on the text path, use adaptive thinking + effort so the answer isn't
+    // starved. (These models reject an explicit thinking budget.)
+    const { maxTokens, thinking, outputConfig } = resolveThinking(
+      params.model,
+      params.maxTokens,
+      useTool,
+    );
 
     // Streaming here is purely between this process and the Anthropic API —
     // finalMessage() buffers the SSE chunks and returns the same complete
@@ -56,6 +61,7 @@ export const anthropicProvider: Provider = {
         model: params.model,
         max_tokens: maxTokens,
         ...(thinking ? { thinking } : {}),
+        ...(outputConfig ? { output_config: outputConfig } : {}),
         system: params.system ? splitSystemForCache(params.system, params.cacheSystem, cacheTtl) : undefined,
         messages: params.messages.map((m) => ({
           role: m.role,

--- a/apps/web/lib/providers/thinking.ts
+++ b/apps/web/lib/providers/thinking.ts
@@ -1,37 +1,48 @@
 /**
- * Extended-thinking budget resolution for Anthropic always-thinking models.
+ * Extended-thinking configuration for Anthropic always-thinking models.
  *
  * Claude Fable/Mythos models have always-on extended thinking that spends from
- * the max_tokens budget BEFORE any text is produced, and a tokenizer that uses
- * ~30% more tokens than Opus-tier models. Budgets tuned for other models (8192
- * for reviews, 256 for titles) get fully consumed by the thinking block on hard
- * inputs: the response ends with stop_reason "max_tokens" and zero text blocks,
- * and the whole review fails.
+ * the max_tokens budget BEFORE any text. With NO thinking config, a hard input's
+ * thinking block fills the whole ceiling → stop_reason "max_tokens", zero text,
+ * empty review. But these models also REJECT `thinking.type: "enabled"` with an
+ * explicit budget ("not supported for this model") — they require
+ * `thinking.type: "adaptive"` plus `output_config.effort` to control how much
+ * they think. Adaptive lets the model balance thinking vs. answer within
+ * max_tokens so the response is never starved.
  *
- * Raising max_tokens to a floor is necessary but NOT sufficient — with no
- * explicit budget the thinking block can still spend the entire ceiling. So we
- * also cap the thinking budget at (max_tokens - headroom), which guarantees the
- * answer always has room. max_tokens is a ceiling, not a spend, so the floor
- * costs nothing on easy inputs.
+ * We still raise max_tokens to a floor (a ceiling, not a spend — free on easy
+ * inputs) to give adaptive thinking room to work.
  *
  * Kept out of anthropic.ts (which is `server-only`) so it stays unit-testable.
  */
 export const ALWAYS_THINKING_MODEL_RX = /^claude-(fable|mythos)-/;
 export const ALWAYS_THINKING_MAX_TOKENS_FLOOR = 64000;
-export const ALWAYS_THINKING_OUTPUT_HEADROOM = 16000;
+
+export type ThinkingEffort = "low" | "medium" | "high" | "xhigh" | "max";
+const VALID_EFFORTS: readonly ThinkingEffort[] = ["low", "medium", "high", "xhigh", "max"];
+export const DEFAULT_THINKING_EFFORT: ThinkingEffort = "high";
+
+/** Effort knob, env-tunable without a redeploy (FABLE_THINKING_EFFORT). */
+export function resolveEffort(): ThinkingEffort {
+  const v = process.env.FABLE_THINKING_EFFORT;
+  return v && (VALID_EFFORTS as readonly string[]).includes(v)
+    ? (v as ThinkingEffort)
+    : DEFAULT_THINKING_EFFORT;
+}
 
 export type ResolvedThinking = {
   maxTokens: number;
-  thinking?: { type: "enabled"; budget_tokens: number };
+  thinking?: { type: "adaptive" };
+  outputConfig?: { effort: ThinkingEffort };
 };
 
 /**
- * For always-thinking models, raise max_tokens to the floor and cap the
- * thinking budget so text output is always reserved.
+ * For always-thinking models, raise max_tokens to the floor and set adaptive
+ * thinking + an effort level so the answer is never starved.
  *
- * Only on the plain-text path: forced `tool_choice` (structured output) is
- * incompatible with an explicit thinking budget, so there we keep the floor
- * alone and leave thinking implicit.
+ * Only on the plain-text path: the forced-`tool_choice` (structured output) path
+ * keeps the floor alone and leaves thinking implicit, to avoid thinking/
+ * tool_choice interactions.
  */
 export function resolveThinking(
   model: string,
@@ -43,6 +54,7 @@ export function resolveThinking(
   if (useTool) return { maxTokens };
   return {
     maxTokens,
-    thinking: { type: "enabled", budget_tokens: maxTokens - ALWAYS_THINKING_OUTPUT_HEADROOM },
+    thinking: { type: "adaptive" },
+    outputConfig: { effort: resolveEffort() },
   };
 }


### PR DESCRIPTION
**Hotfix for a live failure introduced by #682 / v1.0.70.**

#682 set `thinking: { type: "enabled", budget_tokens }` for always-thinking models. Fable/Mythos **reject** that:

> `400 invalid_request_error: "thinking.type.enabled" is not supported for this model. Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.`

So Fable reviews now hard-fail (observed across multiple PRs). This switches to the config the API actually accepts:

- **`thinking: { type: "adaptive" }` + `output_config: { effort }`** on the plain-text path. Adaptive balances thinking vs. answer within `max_tokens`, so the response is never starved (the original empty-review symptom) — and it's the supported shape.
- `effort` is env-tunable without a redeploy: `FABLE_THINKING_EFFORT` (default `high`).
- `max_tokens` floor (64k) and the forced-`tool_choice` path (floor-only, no thinking) are unchanged.
- Non-thinking models (Sonnet/Opus/Haiku) untouched.

## Tests
`thinking.test.ts` updated for the adaptive shape + effort env override. `bun run typecheck` clean (confirms `output_config`/adaptive types on the stream params).

## Verification limit (again, honestly)
This follows the API's own error instruction, but the live Fable path can't be exercised from CI. **Re-trigger a Fable review after deploy to confirm end-to-end.** If it still fails, next lever is dropping `FABLE_THINKING_EFFORT` or temporarily pointing the reviewer at Sonnet.

Supersedes the `enabled` approach from #682. #683 (claude-code path) still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p