### PR TITLE
fix(analyze-deps): resolve installation from the repo, not just current org

### DIFF
--- a/apps/web/app/api/analyze-deps/route.ts
+++ b/apps/web/app/api/analyze-deps/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@octopus/db";
 import { analyzeRepositoryDependencies } from "@octopus/package-analyzer";
 import type { AnalysisProgressEvent } from "@octopus/package-analyzer";
 import { getInstallationToken } from "@/lib/github";
+import { resolveAnalyzerInstallation } from "@/lib/analyzer-install";
 
 const GITHUB_API = "https://api.github.com/repos";
 
@@ -72,7 +73,16 @@ export async function POST(req: NextRequest) {
       try {
         const token = await getInstallationToken(installationId);
         h.Authorization = `token ${token}`;
-      } catch { /* fall back to unauthenticated */ }
+      } catch (err) {
+        // Don't silently fall back to unauthenticated — that turns a token
+        // failure into a misleading "repository not found" for private repos
+        // (this hid a broken analyzer for months). Log it; the caller still
+        // gets the not-found error, but the real cause is now visible.
+        console.error(
+          `[analyze-deps] installation token failed for installation=${installationId}:`,
+          err,
+        );
+      }
     }
     return h;
   }
@@ -89,6 +99,16 @@ export async function POST(req: NextRequest) {
   if (!repoUrl || typeof repoUrl !== "string") {
     return Response.json({ error: "repoUrl is required" }, { status: 400 });
   }
+
+  // Prefer the repository's own installation (live, webhook-populated — the
+  // same source reviews use) over the current org's stored id, which can be
+  // stale/null. Authorized to the repo's org inside the resolver.
+  installationId = await resolveAnalyzerInstallation(prisma, {
+    repositoryId,
+    callerOrgId: orgId,
+    callerUserId: userId,
+    fallbackInstallationId: installationId,
+  });
 
   const parsed = parseGitHubUrl(repoUrl);
   if (!parsed) {

--- a/apps/web/lib/__tests__/analyzer-install.test.ts
+++ b/apps/web/lib/__tests__/analyzer-install.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { resolveAnalyzerInstallation } from "@/lib/analyzer-install";
+
+function client(
+  repo: { installationId: number | null; organizationId: string } | null,
+  isMember: boolean,
+) {
+  return {
+    repository: {
+      findUnique: () => Promise.resolve(repo),
+    },
+    organizationMember: {
+      findFirst: () => Promise.resolve(isMember ? { id: "m1" } : null),
+    },
+  };
+}
+
+describe("resolveAnalyzerInstallation", () => {
+  it("no repositoryId → returns the fallback (current-org) installation", async () => {
+    const got = await resolveAnalyzerInstallation(client(null, false), {
+      repositoryId: null,
+      callerOrgId: "org1",
+      callerUserId: "u1",
+      fallbackInstallationId: 42,
+    });
+    expect(got).toBe(42);
+  });
+
+  it("repo in caller's current org → uses the repo's own installation", async () => {
+    const got = await resolveAnalyzerInstallation(
+      client({ installationId: 111609667, organizationId: "org1" }, false),
+      { repositoryId: "r1", callerOrgId: "org1", callerUserId: "u1", fallbackInstallationId: null },
+    );
+    expect(got).toBe(111609667); // fixes null/stale org column
+  });
+
+  it("repo in another org the caller is a MEMBER of → still uses repo installation", async () => {
+    const got = await resolveAnalyzerInstallation(
+      client({ installationId: 999, organizationId: "org2" }, true),
+      { repositoryId: "r1", callerOrgId: "org1", callerUserId: "u1", fallbackInstallationId: 7 },
+    );
+    expect(got).toBe(999);
+  });
+
+  it("repo in an org the caller does NOT belong to → refuses, keeps fallback (tenancy)", async () => {
+    const got = await resolveAnalyzerInstallation(
+      client({ installationId: 999, organizationId: "org2" }, false),
+      { repositoryId: "r1", callerOrgId: "org1", callerUserId: "u1", fallbackInstallationId: 7 },
+    );
+    expect(got).toBe(7); // does NOT leak org2's installation
+  });
+
+  it("unknown repositoryId → fallback", async () => {
+    const got = await resolveAnalyzerInstallation(client(null, true), {
+      repositoryId: "missing",
+      callerOrgId: "org1",
+      callerUserId: "u1",
+      fallbackInstallationId: 5,
+    });
+    expect(got).toBe(5);
+  });
+
+  it("repo authorized but its own installationId is null → fallback", async () => {
+    const got = await resolveAnalyzerInstallation(
+      client({ installationId: null, organizationId: "org1" }, false),
+      { repositoryId: "r1", callerOrgId: "org1", callerUserId: "u1", fallbackInstallationId: 8 },
+    );
+    expect(got).toBe(8);
+  });
+});

--- a/apps/web/lib/analyzer-install.ts
+++ b/apps/web/lib/analyzer-install.ts
@@ -1,0 +1,58 @@
+/**
+ * Resolve the GitHub App installation the package analyzer should use.
+ *
+ * The analyzer historically used only the *current org's* stored
+ * `githubInstallationId`, which can be stale/null (a webhook nulls it and
+ * nothing always re-populates it) — so private-repo analyses silently fell back
+ * to unauthenticated and 404'd. Reviews never hit this because they resolve the
+ * token from the *repository's own* `installationId` (see reviewer.ts). This
+ * mirrors that: when a known repository is being analyzed, prefer its live
+ * per-repo installation, but only after confirming the caller is authorized for
+ * that repo's org (so a repositoryId can't reach another tenant's install).
+ */
+
+type InstallResolverClient = {
+  repository: {
+    findUnique(args: {
+      where: { id: string };
+      select: { installationId: true; organizationId: true };
+    }): Promise<{ installationId: number | null; organizationId: string } | null>;
+  };
+  organizationMember: {
+    findFirst(args: {
+      where: { userId: string; organizationId: string; deletedAt: null };
+      select: { id: true };
+    }): Promise<{ id: string } | null>;
+  };
+};
+
+export async function resolveAnalyzerInstallation(
+  client: InstallResolverClient,
+  opts: {
+    repositoryId?: string | null;
+    callerOrgId: string;
+    callerUserId: string;
+    fallbackInstallationId: number | null;
+  },
+): Promise<number | null> {
+  const { repositoryId, callerOrgId, callerUserId, fallbackInstallationId } = opts;
+  if (!repositoryId) return fallbackInstallationId;
+
+  const repo = await client.repository.findUnique({
+    where: { id: repositoryId },
+    select: { installationId: true, organizationId: true },
+  });
+  if (!repo) return fallbackInstallationId;
+
+  // Tenancy: only use the repo's own installation if the caller belongs to the
+  // repo's org (the caller's current org, or any org they're a member of).
+  const authorized =
+    repo.organizationId === callerOrgId ||
+    (await client.organizationMember.findFirst({
+      where: { userId: callerUserId, organizationId: repo.organizationId, deletedAt: null },
+      select: { id: true },
+    })) !== null;
+  if (!authorized) return fallbackInstallationId;
+
+  return repo.installationId ?? fallbackInstallationId;
+}


### PR DESCRIPTION
## Symptom
Package Analyzer returns **"Repository not found or not accessible"** for private repos (e.g. Art-of-Technology/verivo-ai, pulse-rebuild, stech.com) even though the org is on the correct Octopus org and the GitHub App has **All repositories** access (installation `111609667`, healthy). No successful analysis in ~4 months, while PR **reviews** on the same repos work fine.

## Root cause
The analyzer authorizes GitHub using only the **current org's** stored `githubInstallationId` (`route.ts`). That column gets nulled by a webhook (`github/webhook/route.ts:179-180`) and isn't reliably re-populated, so on a stale/null value `githubHeaders()` **silently** falls back to unauthenticated → every private repo 404s. Reviews are immune because they resolve the token from the **repository's own** `installationId` (`reviewer.ts:687`) / the webhook `installation.id`, not the org column.

## Fix
- When a known `repositoryId` is analyzed, resolve the installation from **that repo** (`repo.installationId`), preferring it over the current-org id — mirroring reviews. Tenancy-checked: only used if the caller belongs to the repo's org, so a `repositoryId` can't reach another tenant's installation. Falls back to the current-org id otherwise → **no regression**.
- Stop silently swallowing installation-token failures in `githubHeaders()` — log them, so a broken token can't masquerade as "repo not found" again (this hid the breakage for months).
- New `resolveAnalyzerInstallation` helper + unit tests (current-org repo, cross-org member, non-member refusal, unknown repo, null-install fallbacks).

## Tests
`analyzer-install.test.ts` 6/6; `bun run typecheck` clean.

## Note
This is safe/no-regression regardless of DB state, and resolves the symptom **iff** `repository.installationId` is populated for the affected repos (a DB check is being run to confirm; if both org- and repo-level ids are null, the complementary fix is repopulating the installation binding, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p