### PR TITLE
fix(anthropic): strip lone UTF-16 surrogates from review requests

### DIFF
--- a/apps/web/lib/__tests__/sanitize.test.ts
+++ b/apps/web/lib/__tests__/sanitize.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "bun:test";
+import { stripLoneSurrogates } from "@/lib/providers/sanitize";
+
+const FFFD = "�";
+
+describe("stripLoneSurrogates", () => {
+  it("leaves plain text and valid emoji (surrogate pairs) untouched", () => {
+    expect(stripLoneSurrogates("hello world")).toBe("hello world");
+    expect(stripLoneSurrogates("done 😀!")).toBe("done 😀!"); // 😀
+    expect(stripLoneSurrogates("astral 𐀀 ok")).toBe("astral 𐀀 ok");
+  });
+
+  it("replaces a lone HIGH surrogate (the 'no low surrogate' case)", () => {
+    expect(stripLoneSurrogates("bad\uD800end")).toBe(`bad${FFFD}end`);
+    expect(stripLoneSurrogates("trailing\uD83D")).toBe(`trailing${FFFD}`); // pair split at end
+  });
+
+  it("replaces a lone LOW surrogate", () => {
+    expect(stripLoneSurrogates("\uDE00leading")).toBe(`${FFFD}leading`); // pair split at start
+  });
+
+  it("handles multiple lone surrogates while keeping valid pairs", () => {
+    const input = `\uD800a😀b\uDC00`; // lone-high, valid 😀, lone-low
+    expect(stripLoneSurrogates(input)).toBe(`${FFFD}a😀b${FFFD}`);
+  });
+
+  it("produces a string with no remaining lone surrogates", () => {
+    const cleaned = stripLoneSurrogates("x\uD800y\uDC00z😀");
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(cleaned)).toBe(false);
+  });
+});

--- a/apps/web/lib/providers/anthropic.ts
+++ b/apps/web/lib/providers/anthropic.ts
@@ -3,6 +3,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
 import { splitSystemForCache, type CacheTtl } from "./system-cache";
 import { resolveThinking } from "./thinking";
+import { stripLoneSurrogates } from "./sanitize";
 
 let platformClient: Anthropic | null = null;
 
@@ -62,10 +63,15 @@ export const anthropicProvider: Provider = {
         max_tokens: maxTokens,
         ...(thinking ? { thinking } : {}),
         ...(outputConfig ? { output_config: outputConfig } : {}),
-        system: params.system ? splitSystemForCache(params.system, params.cacheSystem, cacheTtl) : undefined,
+        // Strip lone UTF-16 surrogates from all text: a diff/file body truncated
+        // mid-emoji can leave an unpaired surrogate, which serializes to invalid
+        // UTF-8 and makes Anthropic 400 the whole request ("no low surrogate").
+        system: params.system
+          ? splitSystemForCache(stripLoneSurrogates(params.system), params.cacheSystem, cacheTtl)
+          : undefined,
         messages: params.messages.map((m) => ({
           role: m.role,
-          content: m.content,
+          content: stripLoneSurrogates(m.content),
         })),
         ...(useTool
           ? {

--- a/apps/web/lib/providers/sanitize.ts
+++ b/apps/web/lib/providers/sanitize.ts
@@ -1,0 +1,19 @@
+/**
+ * Replace unpaired UTF-16 surrogates with the replacement char (U+FFFD).
+ *
+ * JS strings are UTF-16 and can hold lone surrogates — e.g. when review content
+ * (a diff or file body) is truncated mid-emoji, splitting a surrogate pair.
+ * Serializing such a string into a JSON request body produces invalid UTF-8,
+ * and Anthropic rejects the whole request with
+ * `400 invalid_request_error: ... no low surrogate in string`, failing the
+ * review. This strips only the UNPAIRED halves; valid surrogate pairs (real
+ * emoji, astral-plane chars) are left intact.
+ */
+const LONE_SURROGATE =
+  // high surrogate not followed by a low surrogate, OR
+  // low surrogate not preceded by a high surrogate
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+export function stripLoneSurrogates(s: string): string {
+  return s.replace(LONE_SURROGATE, "�");
+}


### PR DESCRIPTION
## Symptom
Reviews intermittently fail with:
> `400 invalid_request_error: The request body is not valid JSON: no low surrogate in string: line 1 column NNNNN`

Seen on PR #685's review; other PRs (pulse-rebuild #1286) review fine — so it's content-specific.

## Cause
A diff or file body truncated mid-emoji leaves an **unpaired UTF-16 surrogate** in the content string. Serialized into the JSON request body it's invalid UTF-8, and Anthropic rejects the whole request → the review fails. `github.ts:465` already guards GitHub-comment truncation against a trailing high surrogate, but nothing sanitized the content **sent to the model**.

## Fix
`stripLoneSurrogates()` replaces only the **unpaired** surrogate halves with U+FFFD (valid emoji / astral pairs untouched), applied to the system prompt and every message content in the Anthropic provider — the single choke point for all Anthropic requests, including reviews.

## Tests
`sanitize.test.ts`: plain text, valid pairs, lone-high (the exact failure), lone-low, split-at-edges, and a "no remaining lone surrogate" invariant. `bun run typecheck` clean.

Note: this also unblocks PR #685's own review path going forward (that PR was break-glass merged since its review couldn't complete due to this bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p