### PR TITLE
fix(analyze-deps): send repositoryId from the analyzer UI

### DIFF
--- a/apps/web/app/(app)/package-analyzer/page.tsx
+++ b/apps/web/app/(app)/package-analyzer/page.tsx
@@ -29,6 +29,9 @@ export default async function PackageAnalyzerPage({
   const params = await searchParams;
   const defaultUrl = params.repo ?? undefined;
   const autoStart = !!defaultUrl;
+  // Pass the registered repo id through so the analyzer can resolve GitHub
+  // access via the repo's own installation (robust to a stale org binding).
+  const repositoryId = params.repoId ?? undefined;
 
   // Fetch history
   const history = await prisma.packageAnalysis.findMany({
@@ -63,6 +66,7 @@ export default async function PackageAnalyzerPage({
       <PackageAnalyzerClient
         authenticated={true}
         defaultUrl={defaultUrl}
+        repositoryId={repositoryId}
         autoStart={autoStart}
         history={history.map((h) => ({
           ...h,

--- a/apps/web/components/package-analyzer/package-analyzer-client.tsx
+++ b/apps/web/components/package-analyzer/package-analyzer-client.tsx
@@ -9,6 +9,19 @@ import { ResultsSummary } from "./results-summary";
 import { ResultsList } from "./results-list";
 import { AnalysisHistory, type AnalysisHistoryItem } from "./analysis-history";
 
+/**
+ * Normalize a GitHub URL to a comparable owner/repo key so trivial differences
+ * (trailing slash, `.git`, case, whitespace) don't stop us from recognizing the
+ * prefilled repo and sending its repositoryId.
+ */
+function repoKey(url: string): string {
+  return url
+    .trim()
+    .toLowerCase()
+    .replace(/\.git$/, "")
+    .replace(/\/+$/, "");
+}
+
 interface PackageAnalyzerClientProps {
   authenticated?: boolean;
   history?: AnalysisHistoryItem[];
@@ -47,7 +60,7 @@ export function PackageAnalyzerClient({ authenticated, history, defaultUrl, repo
       // Send repositoryId only when analyzing the exact repo it belongs to
       // (the prefilled URL) — if the user edits the URL to another repo, the
       // id no longer matches, so omit it and let the server resolve by org.
-      const sendRepoId = repositoryId && repoUrl.trim() === (defaultUrl ?? "").trim();
+      const sendRepoId = !!repositoryId && repoKey(repoUrl) === repoKey(defaultUrl ?? "");
       const resp = await fetch("/api/analyze-deps", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/apps/web/components/package-analyzer/package-analyzer-client.tsx
+++ b/apps/web/components/package-analyzer/package-analyzer-client.tsx
@@ -13,10 +13,11 @@ interface PackageAnalyzerClientProps {
   authenticated?: boolean;
   history?: AnalysisHistoryItem[];
   defaultUrl?: string;
+  repositoryId?: string;
   autoStart?: boolean;
 }
 
-export function PackageAnalyzerClient({ authenticated, history, defaultUrl, autoStart }: PackageAnalyzerClientProps) {
+export function PackageAnalyzerClient({ authenticated, history, defaultUrl, repositoryId, autoStart }: PackageAnalyzerClientProps) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [progressEntries, setProgressEntries] = useState<ProgressEntry[]>([]);
@@ -43,10 +44,14 @@ export function PackageAnalyzerClient({ authenticated, history, defaultUrl, auto
     redirectingRef.current = false;
 
     try {
+      // Send repositoryId only when analyzing the exact repo it belongs to
+      // (the prefilled URL) — if the user edits the URL to another repo, the
+      // id no longer matches, so omit it and let the server resolve by org.
+      const sendRepoId = repositoryId && repoUrl.trim() === (defaultUrl ?? "").trim();
       const resp = await fetch("/api/analyze-deps", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ repoUrl }),
+        body: JSON.stringify(sendRepoId ? { repoUrl, repositoryId } : { repoUrl }),
       });
 
       if (!resp.ok) {
@@ -131,7 +136,7 @@ export function PackageAnalyzerClient({ authenticated, history, defaultUrl, auto
         setIsLoading(false);
       }
     }
-  }, [addProgress, router]);
+  }, [addProgress, router, repositoryId, defaultUrl]);
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Why
#685 (v1.0.73) made the analyzer resolve GitHub access from the **repo's own** installation when the request includes a `repositoryId` — the fix for private repos whose **org** installation id is stale. But the web client only POSTed `{ repoUrl }`, so that path never fired: it always fell back to the org id.

Confirmed via a read-only prod query: the `aot` org stores a **stale** `githubInstallationId` (`111815536`; the live install is `111609667`), while the repo rows correctly hold `111609667`. So the analyzer 404'd on private repos while reviews (which use the repo id) worked.

## Change
- `page.tsx` passes the URL's `repoId` to the client as `repositoryId`.
- The client includes `repositoryId` in the POST **only when analyzing the exact prefilled repo** (URL unchanged); if the user edits the URL to a different repo, it's omitted so the server resolves by org.

With this, analyzing a registered repo uses its correct per-repo installation → private Art-of-Technology repos analyze.

## Not in this PR
The **root** data issue — the `aot` org's stale `githubInstallationId` — is a one-row DB correction (`→ 111609667`), tracked separately (it also affects any other current-org-installation feature and the raw-URL-paste path). Blocked on VPN/SSH for a direct write; the intended repair is reconnecting the GitHub app from that org, which repopulates it.

## Tests
The resolver this feeds is already covered by `analyzer-install.test.ts`. This PR is UI prop-plumbing; `bun run typecheck` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p