### PR TITLE
fix(db): repair stale GitHub installation binding on the aot org

### DIFF
--- a/packages/db/prisma/migrations/20260728120000_fix_aot_stale_installation/migration.sql
+++ b/packages/db/prisma/migrations/20260728120000_fix_aot_stale_installation/migration.sql
@@ -12,8 +12,16 @@
 -- Guarded on BOTH the slug and the exact stale value, so this matches only the
 -- one affected prod row and is a no-op in every other environment (self-host,
 -- dev, CI) where no such row exists.
+--
+-- githubInstallationId is UNIQUE, so also guard on no other row already holding
+-- the target id: otherwise the UPDATE would raise a unique violation and abort
+-- the entire `migrate deploy`. No org currently holds 111609667, so this
+-- applies now; the guard just turns a future collision into a safe no-op.
 UPDATE "organizations"
 SET "githubInstallationId" = 111609667,
     "updatedAt" = now()
 WHERE "slug" = 'aot'
-  AND "githubInstallationId" = 111815536;
+  AND "githubInstallationId" = 111815536
+  AND NOT EXISTS (
+    SELECT 1 FROM "organizations" WHERE "githubInstallationId" = 111609667
+  );

--- a/packages/db/prisma/migrations/20260728120000_fix_aot_stale_installation/migration.sql
+++ b/packages/db/prisma/migrations/20260728120000_fix_aot_stale_installation/migration.sql
@@ -1,0 +1,19 @@
+-- One-time production data repair (guarded, no-op everywhere else).
+--
+-- The 'aot' (Art-of-Technology) organization row held a STALE GitHub App
+-- installation id (111815536) left over from a previous install. The LIVE
+-- installation is 111609667 — confirmed via the GitHub API (all-repos, not
+-- suspended) and matched by every `repositories.installationId` row for that
+-- org. Because the package analyzer resolves GitHub access from the ORG's
+-- installation id, the stale value made private-repo analyses fail with
+-- "Repository not found or not accessible" (and any other current-org feature
+-- that reads the org installation was affected).
+--
+-- Guarded on BOTH the slug and the exact stale value, so this matches only the
+-- one affected prod row and is a no-op in every other environment (self-host,
+-- dev, CI) where no such row exists.
+UPDATE "organizations"
+SET "githubInstallationId" = 111609667,
+    "updatedAt" = now()
+WHERE "slug" = 'aot'
+  AND "githubInstallationId" = 111815536;


### PR DESCRIPTION
## Why
Read-only prod query (via the new `db-query-wdc` workflow) confirmed the `aot` org row stores a **stale** `githubInstallationId` = `111815536`, while the **live** install is `111609667` (GitHub API: all-repos, not suspended; and every `repositories.installationId` for the org already holds it).

The package analyzer resolves GitHub access from the **org** installation, so the stale value made private-repo analyses 404 — and any other current-org-installation feature is affected. (Reviews were fine — they use the per-repo installation.)

## Fix
Guarded one-row data-repair migration:
```sql
UPDATE "organizations" SET "githubInstallationId" = 111609667, "updatedAt" = now()
WHERE "slug" = 'aot' AND "githubInstallationId" = 111815536;
```
Guarded on slug **and** the exact stale value → matches only the affected prod row, **no-op in every other environment**. Applies via `prisma migrate deploy` on the on-box runner (no SSH/VPN needed).

Fixes the analyzer's manual-URL-paste path and completes the root-cause fix behind #685/#687.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p