### PR TITLE
fix(anthropic): give Opus 5 the thinking-model treatment (floor + adaptive)

### DIFF
--- a/apps/web/lib/__tests__/thinking.test.ts
+++ b/apps/web/lib/__tests__/thinking.test.ts
@@ -9,23 +9,29 @@ import {
 const FLOOR = ALWAYS_THINKING_MAX_TOKENS_FLOOR;
 
 describe("resolveThinking", () => {
-  it("leaves non-thinking models untouched (no thinking/output config)", () => {
+  it("non-thinking models get the max_tokens floor but NO thinking/output config", () => {
     const r = resolveThinking("claude-sonnet-4-6", 8192, false);
-    expect(r.maxTokens).toBe(8192);
+    expect(r.maxTokens).toBe(FLOOR); // floor applies to all models now
     expect(r.thinking).toBeUndefined();
     expect(r.outputConfig).toBeUndefined();
   });
 
-  it("text path: raises to the floor and sets ADAPTIVE thinking + effort", () => {
+  it("Fable text path: floor + adaptive thinking + effort", () => {
     const r = resolveThinking("claude-fable-5", 8192, false);
     expect(r.maxTokens).toBe(FLOOR);
-    // Must be adaptive — these models reject thinking.type.enabled.
     expect(r.thinking).toEqual({ type: "adaptive" });
     expect(r.outputConfig).toEqual({ effort: DEFAULT_THINKING_EFFORT });
   });
 
-  it("tool path: floor only, no thinking/output config (avoid tool_choice conflict)", () => {
-    const r = resolveThinking("claude-fable-5", 8192, true);
+  it("Opus 5 text path: also gets adaptive thinking (same Claude-5 thinking API)", () => {
+    const r = resolveThinking("claude-opus-5", 8192, false);
+    expect(r.maxTokens).toBe(FLOOR);
+    expect(r.thinking).toEqual({ type: "adaptive" });
+    expect(r.outputConfig).toEqual({ effort: DEFAULT_THINKING_EFFORT });
+  });
+
+  it("always-thinking tool path: floor only, no thinking/output config", () => {
+    const r = resolveThinking("claude-opus-5", 8192, true);
     expect(r.maxTokens).toBe(FLOOR);
     expect(r.thinking).toBeUndefined();
     expect(r.outputConfig).toBeUndefined();
@@ -45,7 +51,7 @@ describe("resolveEffort", () => {
     process.env.FABLE_THINKING_EFFORT = "medium";
     expect(resolveEffort()).toBe("medium");
     process.env.FABLE_THINKING_EFFORT = "bogus";
-    expect(resolveEffort()).toBe(DEFAULT_THINKING_EFFORT); // invalid → default
+    expect(resolveEffort()).toBe(DEFAULT_THINKING_EFFORT);
     delete process.env.FABLE_THINKING_EFFORT;
   });
 });

--- a/apps/web/lib/__tests__/thinking.test.ts
+++ b/apps/web/lib/__tests__/thinking.test.ts
@@ -30,10 +30,18 @@ describe("resolveThinking", () => {
   });
 
   it("Opus 5 text path: also gets adaptive thinking (same Claude-5 thinking API)", () => {
-    const r = resolveThinking("claude-opus-5", 8192, false);
-    expect(r.maxTokens).toBe(FLOOR);
-    expect(r.thinking).toEqual({ type: "adaptive" });
-    expect(r.outputConfig).toEqual({ effort: DEFAULT_THINKING_EFFORT });
+    for (const m of ["claude-opus-5", "claude-opus-5-20260115"]) {
+      const r = resolveThinking(m, 8192, false);
+      expect(r.maxTokens).toBe(FLOOR);
+      expect(r.thinking).toEqual({ type: "adaptive" });
+      expect(r.outputConfig).toEqual({ effort: DEFAULT_THINKING_EFFORT });
+    }
+  });
+
+  it("opus-5 match is bounded — a different id like claude-opus-50 is NOT treated as Opus 5", () => {
+    const r = resolveThinking("claude-opus-50", 8192, false);
+    expect(r.maxTokens).toBe(8192); // no floor, no thinking config
+    expect(r.thinking).toBeUndefined();
   });
 
   it("always-thinking tool path: floor only, no thinking/output config", () => {

--- a/apps/web/lib/__tests__/thinking.test.ts
+++ b/apps/web/lib/__tests__/thinking.test.ts
@@ -9,11 +9,17 @@ import {
 const FLOOR = ALWAYS_THINKING_MAX_TOKENS_FLOOR;
 
 describe("resolveThinking", () => {
-  it("non-thinking models get the max_tokens floor but NO thinking/output config", () => {
+  it("non-thinking models keep their requested budget (no floor → no cap 400)", () => {
     const r = resolveThinking("claude-sonnet-4-6", 8192, false);
-    expect(r.maxTokens).toBe(FLOOR); // floor applies to all models now
+    expect(r.maxTokens).toBe(8192);
     expect(r.thinking).toBeUndefined();
     expect(r.outputConfig).toBeUndefined();
+  });
+
+  it("a lower-cap model is not forced above its budget (no 64k floor)", () => {
+    const r = resolveThinking("claude-3-5-haiku", 4096, false);
+    expect(r.maxTokens).toBe(4096);
+    expect(r.thinking).toBeUndefined();
   });
 
   it("Fable text path: floor + adaptive thinking + effort", () => {

--- a/apps/web/lib/providers/thinking.ts
+++ b/apps/web/lib/providers/thinking.ts
@@ -21,7 +21,7 @@
 // Models that emit always-on thinking and need the adaptive config (confirmed
 // by their "use thinking.type.adaptive" API error). Opus 5 shares the Claude-5
 // thinking API with Fable 5.
-export const ALWAYS_THINKING_MODEL_RX = /^claude-(fable|mythos)-|^claude-opus-5/;
+export const ALWAYS_THINKING_MODEL_RX = /^claude-(?:fable|mythos)-|^claude-opus-5(?:-|$)/;
 export const ALWAYS_THINKING_MAX_TOKENS_FLOOR = 64000;
 
 export type ThinkingEffort = "low" | "medium" | "high" | "xhigh" | "max";

--- a/apps/web/lib/providers/thinking.ts
+++ b/apps/web/lib/providers/thinking.ts
@@ -43,9 +43,10 @@ export type ResolvedThinking = {
 };
 
 /**
- * Raise max_tokens to the floor for every model (so thinking can't starve the
- * answer), and for always-on-thinking models additionally set adaptive thinking
- * + an effort level.
+ * For a thinking-heavy model (ALWAYS_THINKING_MODEL_RX), raise max_tokens to the
+ * floor so thinking can't starve the answer, and additionally set adaptive
+ * thinking + an effort level. All other models are returned with their
+ * requested max_tokens unchanged (no floor — their per-model cap may be lower).
  *
  * Adaptive is applied only on the plain-text path: the forced-`tool_choice`
  * (structured output) path keeps the floor alone and leaves thinking implicit,

--- a/apps/web/lib/providers/thinking.ts
+++ b/apps/web/lib/providers/thinking.ts
@@ -5,9 +5,11 @@
  * blocks that spend from the max_tokens budget BEFORE any text. The small
  * review/title budgets (8192 / 256) get consumed by thinking on hard inputs, so
  * the response ends with stop_reason "max_tokens" and zero text blocks — an
- * empty review. So we raise max_tokens to a floor for EVERY Anthropic model:
- * it's a ceiling not a spend (free on easy inputs, harmless for non-thinking
- * models), and it gives thinking room to finish and still answer.
+ * empty review. So for these models we raise max_tokens to a floor (a ceiling,
+ * not a spend — free on easy inputs) so thinking has room to finish and still
+ * answer. The floor is applied ONLY to this known set: other models have lower
+ * per-model max_tokens caps (e.g. 8192), and blindly raising to 64000 would get
+ * a 400 rejected.
  *
  * The always-on-thinking models additionally REJECT `thinking.type: "enabled"`
  * with an explicit budget ("not supported for this model") — they require
@@ -54,16 +56,15 @@ export function resolveThinking(
   requestedMaxTokens: number,
   useTool: boolean,
 ): ResolvedThinking {
-  // Floor applies to ALL Anthropic models — a high ceiling is free on easy
-  // inputs and stops thinking-heavy models (e.g. Opus 5) from consuming the
-  // whole budget before producing text.
+  // Only the known thinking-heavy Claude-5 models get the floor — they have
+  // high per-model caps (>= 64000) and need the room. Other models keep their
+  // requested budget so we never exceed a lower cap (a 400).
+  if (!ALWAYS_THINKING_MODEL_RX.test(model)) return { maxTokens: requestedMaxTokens };
   const maxTokens = Math.max(requestedMaxTokens, ALWAYS_THINKING_MAX_TOKENS_FLOOR);
-  if (ALWAYS_THINKING_MODEL_RX.test(model) && !useTool) {
-    return {
-      maxTokens,
-      thinking: { type: "adaptive" },
-      outputConfig: { effort: resolveEffort() },
-    };
-  }
-  return { maxTokens };
+  if (useTool) return { maxTokens };
+  return {
+    maxTokens,
+    thinking: { type: "adaptive" },
+    outputConfig: { effort: resolveEffort() },
+  };
 }

--- a/apps/web/lib/providers/thinking.ts
+++ b/apps/web/lib/providers/thinking.ts
@@ -1,21 +1,25 @@
 /**
- * Extended-thinking configuration for Anthropic always-thinking models.
+ * Extended-thinking configuration for Anthropic models.
  *
- * Claude Fable/Mythos models have always-on extended thinking that spends from
- * the max_tokens budget BEFORE any text. With NO thinking config, a hard input's
- * thinking block fills the whole ceiling → stop_reason "max_tokens", zero text,
- * empty review. But these models also REJECT `thinking.type: "enabled"` with an
- * explicit budget ("not supported for this model") — they require
- * `thinking.type: "adaptive"` plus `output_config.effort` to control how much
- * they think. Adaptive lets the model balance thinking vs. answer within
- * max_tokens so the response is never starved.
+ * Claude-5-family models (Fable 5, Opus 5, Mythos, …) emit extended-thinking
+ * blocks that spend from the max_tokens budget BEFORE any text. The small
+ * review/title budgets (8192 / 256) get consumed by thinking on hard inputs, so
+ * the response ends with stop_reason "max_tokens" and zero text blocks — an
+ * empty review. So we raise max_tokens to a floor for EVERY Anthropic model:
+ * it's a ceiling not a spend (free on easy inputs, harmless for non-thinking
+ * models), and it gives thinking room to finish and still answer.
  *
- * We still raise max_tokens to a floor (a ceiling, not a spend — free on easy
- * inputs) to give adaptive thinking room to work.
+ * The always-on-thinking models additionally REJECT `thinking.type: "enabled"`
+ * with an explicit budget ("not supported for this model") — they require
+ * `thinking.type: "adaptive"` plus `output_config.effort`. Adaptive lets the
+ * model balance thinking vs. answer within max_tokens so it isn't starved.
  *
  * Kept out of anthropic.ts (which is `server-only`) so it stays unit-testable.
  */
-export const ALWAYS_THINKING_MODEL_RX = /^claude-(fable|mythos)-/;
+// Models that emit always-on thinking and need the adaptive config (confirmed
+// by their "use thinking.type.adaptive" API error). Opus 5 shares the Claude-5
+// thinking API with Fable 5.
+export const ALWAYS_THINKING_MODEL_RX = /^claude-(fable|mythos)-|^claude-opus-5/;
 export const ALWAYS_THINKING_MAX_TOKENS_FLOOR = 64000;
 
 export type ThinkingEffort = "low" | "medium" | "high" | "xhigh" | "max";
@@ -37,24 +41,29 @@ export type ResolvedThinking = {
 };
 
 /**
- * For always-thinking models, raise max_tokens to the floor and set adaptive
- * thinking + an effort level so the answer is never starved.
+ * Raise max_tokens to the floor for every model (so thinking can't starve the
+ * answer), and for always-on-thinking models additionally set adaptive thinking
+ * + an effort level.
  *
- * Only on the plain-text path: the forced-`tool_choice` (structured output) path
- * keeps the floor alone and leaves thinking implicit, to avoid thinking/
- * tool_choice interactions.
+ * Adaptive is applied only on the plain-text path: the forced-`tool_choice`
+ * (structured output) path keeps the floor alone and leaves thinking implicit,
+ * to avoid thinking/tool_choice interactions.
  */
 export function resolveThinking(
   model: string,
   requestedMaxTokens: number,
   useTool: boolean,
 ): ResolvedThinking {
-  if (!ALWAYS_THINKING_MODEL_RX.test(model)) return { maxTokens: requestedMaxTokens };
+  // Floor applies to ALL Anthropic models — a high ceiling is free on easy
+  // inputs and stops thinking-heavy models (e.g. Opus 5) from consuming the
+  // whole budget before producing text.
   const maxTokens = Math.max(requestedMaxTokens, ALWAYS_THINKING_MAX_TOKENS_FLOOR);
-  if (useTool) return { maxTokens };
-  return {
-    maxTokens,
-    thinking: { type: "adaptive" },
-    outputConfig: { effort: resolveEffort() },
-  };
+  if (ALWAYS_THINKING_MODEL_RX.test(model) && !useTool) {
+    return {
+      maxTokens,
+      thinking: { type: "adaptive" },
+      outputConfig: { effort: resolveEffort() },
+    };
+  }
+  return { maxTokens };
 }


### PR DESCRIPTION
## Symptom
`finance-reconcile` review failed: `Anthropic returned no text (stop_reason: max_tokens, blocks: thinking)` — the empty-response starvation.

## Root cause (from a read-only prod query)
`finance-reconcile` is pinned to **`claude-opus-5`** (not Fable). Opus 5 also emits extended-thinking blocks that spend from `max_tokens`, but the thinking treatment only matched `fable|mythos`, so Opus 5 got no floor (stuck at the 8192 review budget) → thinking consumed it → zero text.

(For reference: platform default = `claude-sonnet-4-6`, `aot` org default = `claude-fable-5`, `finance-reconcile` repo pin = `claude-opus-5`.)

## Fix
Extend the existing always-thinking treatment to **`claude-opus-5`**:
- Add it to `ALWAYS_THINKING_MODEL_RX` with a **bounded** match — `^claude-opus-5(?:-|$)` matches `claude-opus-5` and dated variants (`claude-opus-5-YYYYMMDD`) but **not** `claude-opus-50`.
- Matched models get the 64k `max_tokens` floor + `thinking: {type:"adaptive"}` + `output_config.effort` (the config Claude-5 models require).

**Scope of the floor:** it stays **gated to this known thinking-heavy set**, NOT applied universally. An earlier revision raised it for all models, but that risks a **400 on lower-cap models** (e.g. Claude 3.5 Haiku, cap 8192) — so all other models keep their requested `max_tokens` unchanged.

## Tests
`thinking.test.ts`: Opus 5 (dated + undated) → adaptive; `claude-opus-50` boundary → untreated; lower-cap model (`claude-3-5-haiku` @ 4096) → not raised; tool path → floor only. `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p