### PR TITLE
ci(release): parallelize the two image builds; drop unused QEMU

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,18 @@ name: Release Docker image to GHCR
 # `latestRelease` from SystemConfig, refreshed on demand (cached 1h) by
 # apps/web/lib/releases.ts when an admin opens the page.
 #
+# Two image variants are built (they differ only in build-time NEXT_PUBLIC_*
+# values baked into the client bundle, so each needs its own `next build`):
+#   - selfhost: PUBLIC octopus-selfhost package (self-hosters `compose pull`)
+#   - hosted:   PRIVATE octopus package (the hosted deploy stack pulls this)
+# They run as PARALLEL jobs (wall-clock ≈ the slower build, not the sum) since
+# their `next build` outputs can't be shared.
+#
 # Maintainers cut a release by:
 #   1. Bump apps/web/package.json version
 #   2. git tag v0.X.Y && git push origin v0.X.Y
-#   3. This workflow builds, pushes, and creates a GitHub Release with
-#      auto-generated notes.
+#   3. This workflow builds + pushes both variants, then creates a GitHub
+#      Release with auto-generated notes.
 
 on:
   push:
@@ -22,15 +29,15 @@ permissions:
   packages: write
 
 jobs:
-  build-and-publish:
+  # ── self-host distribution image (PUBLIC package) ──────────────────────────
+  selfhost:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
+      # No QEMU: builds are linux/amd64 only on an amd64 runner, so emulation
+      # setup is pure overhead. Add setup-qemu-action back if arm64 is added.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -47,7 +54,6 @@ jobs:
       - name: Derive image tags
         id: tags
         run: |
-          # Strip the leading "v" from the tag — e.g. v0.2.0 → 0.2.0
           REF_NAME=${GITHUB_REF#refs/tags/}
           SEMVER=${REF_NAME#v}
           echo "semver=$SEMVER" >> $GITHUB_OUTPUT
@@ -58,8 +64,6 @@ jobs:
         with:
           context: .
           file: apps/web/Dockerfile
-          # ARM64 build is slow and the primary deployment target is x86_64;
-          # add linux/arm64 to platforms when there's demand.
           platforms: linux/amd64
           push: true
           # The self-host distribution lives on a SEPARATE package
@@ -84,15 +88,39 @@ jobs:
           cache-from: type=gha,scope=selfhost
           cache-to: type=gha,mode=max,scope=selfhost
 
-      # Hosted-deployment variant of the same commit. NEXT_PUBLIC_* values are
-      # inlined into the client bundle at build time, so the hosted instance
-      # needs its own build: selfHosted OFF, plus the instance's GitHub App
-      # slug + Pubby key (both are client-exposed identifiers, not secrets —
-      # they ship in every page's JS — hence repo *variables*, not secrets).
-      # Pushes an immutable `X.Y.Z-prod` plus the `latest-web`/`latest-engine`
-      # aliases the deployment stack pulls. Moving the aliases does NOT touch
-      # running services — they only change on an explicit service update.
-      # Skipped when the variables are unset (e.g. on forks).
+  # ── hosted-deploy image (PRIVATE package) ──────────────────────────────────
+  # NEXT_PUBLIC_* values are inlined into the client bundle at build time, so
+  # the hosted instance needs its own build: selfHosted OFF, plus the instance's
+  # GitHub App slug + Pubby key (both are client-exposed identifiers, not
+  # secrets — they ship in every page's JS — hence repo *variables*). Pushes an
+  # immutable `X.Y.Z-prod` plus the `latest-web`/`latest-engine` aliases the
+  # deployment stack pulls. Moving the aliases does NOT touch running services —
+  # they only change on an explicit service update. Skipped when the variables
+  # are unset (e.g. on forks).
+  prod:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Derive image tags
+        id: tags
+        run: |
+          REF_NAME=${GITHUB_REF#refs/tags/}
+          SEMVER=${REF_NAME#v}
+          echo "semver=$SEMVER" >> $GITHUB_OUTPUT
+          echo "image_name=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+
       - name: Build + push image (hosted deploy variant)
         if: ${{ vars.NEXT_PUBLIC_PUBBY_KEY != '' && vars.NEXT_PUBLIC_GITHUB_APP_SLUG != '' }}
         uses: docker/build-push-action@v6
@@ -115,6 +143,17 @@ jobs:
             NEXT_PUBLIC_PUBBY_KEY=${{ vars.NEXT_PUBLIC_PUBBY_KEY }}
           cache-from: type=gha,scope=prod
           cache-to: type=gha,mode=max,scope=prod
+
+  # ── GitHub Release (once, after both images are pushed) ────────────────────
+  release:
+    needs: [selfhost, prod]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Derive semver
+        id: tags
+        run: |
+          REF_NAME=${GITHUB_REF#refs/tags/}
+          echo "semver=${REF_NAME#v}" >> $GITHUB_OUTPUT
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Problem
The release build takes **~8–9.5 min** (measured: #689 8m36s, #687 9m32s, #684 9m07s). The `release.yml` job builds the **self-host** and **hosted** image variants **sequentially in one job**, so total = build1 + build2. The two differ only in build-time `NEXT_PUBLIC_*` values inlined into the client bundle, so each genuinely needs its own `next build` (outputs can't be shared) — but they don't need to be serial.

## Change
- **Parallelize**: split into two independent jobs (`selfhost`, `prod`) that run concurrently → wall-clock ≈ the slower single build instead of the sum. Expected **~halving** of the build phase (~9 min → ~4–5 min).
- **Gated release job**: `release` (needs `[selfhost, prod]`) publishes the GitHub Release once, after both images push.
- **Drop `setup-qemu-action`**: builds are `linux/amd64` on an amd64 runner; QEMU emulation setup was pure overhead.

## Safety
Every image tag (`-selfhost:{semver,latest}`, `:{semver}-prod`, `latest-web`, `latest-engine`), build-arg, label, and per-variant cache scope (`selfhost`/`prod`) is **byte-identical** to the previous steps — only the job structure changed and QEMU was removed. The deploy contract (stack pulls `latest-web`/`latest-engine`/`X.Y.Z-prod`) is unchanged.

## Verification
YAML validated; jobs = `selfhost`, `prod`, `release` (release needs both). A workflow change can only be fully timed on a real `v*` tag — the next release will confirm the wall-clock drop.

## Follow-ups (not in this PR)
If more speed is wanted: registry-type build cache (often faster/more reliable than the GHA cache for large Node builds), and a shared `deps` cache scope across both variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p