### PR TITLE
chore(deps): bump stripe 20.4 → 22.3 (+ pin apiVersion)

### DIFF
--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -39,6 +39,14 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
+  // NOTE on Stripe API versions: the SDK pin in lib/stripe.ts governs OUTBOUND
+  // calls, but webhook event payload SHAPES are set by the endpoint's version
+  // configured in the Stripe dashboard — the two are independent. This handler
+  // reads only version-stable fields (metadata, object ids, amounts,
+  // payment_intent, payment_status), so an SDK/dashboard version skew (e.g.
+  // after an SDK major bump) does not affect it. If you start reading a
+  // version-sensitive field, first align the dashboard endpoint version.
+
   // Single retry contract for value-bearing work: a duplicate delivery (P2002)
   // is ACKed with 200 (idempotent skip); ANY other failure returns 500 so Stripe
   // retries — otherwise a transient DB/Stripe error would silently drop a paid

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -7,8 +7,8 @@ export function getStripe(): Stripe {
     _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
       // Pin the API version so switching Stripe accounts can't silently change
       // event/object shapes by inheriting a different account default. Matches
-      // the stripe@20.4.1 SDK's generated types.
-      apiVersion: "2026-02-25.clover",
+      // the stripe@22.x SDK's generated types (its pinned LatestApiVersion).
+      apiVersion: "2026-06-24.dahlia",
     });
   }
   return _stripe;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,7 +58,7 @@
     "shadcn": "^4.4.0",
     "sharp": "^0.35.2",
     "sonner": "^2.0.7",
-    "stripe": "^20.4.0",
+    "stripe": "^22.3.0",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.0.0"

--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "shadcn": "^4.4.0",
         "sharp": "^0.35.2",
         "sonner": "^2.0.7",
-        "stripe": "^20.4.0",
+        "stripe": "^22.3.0",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.0.0",
@@ -2645,7 +2645,7 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
-    "stripe": ["stripe@20.4.1", "", { "peerDependencies": { "@types/node": ">=16" }, "optionalPeers": ["@types/node"] }, "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w=="],
+    "stripe": ["stripe@22.3.2", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg=="],
 
     "strnum": ["strnum@2.2.0", "", {}, "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg=="],
 


### PR DESCRIPTION
Supersedes dependabot **#530** (which is stale + Octopus-skipped); done as a tested PR so it gets a real review.

## Change
- `stripe` `^20.4.0` → `^22.3.0` (installed 22.3.2).
- `lib/stripe.ts` pinned `apiVersion`: `"2026-02-25.clover"` → **`"2026-06-24.dahlia"`** — stripe@22's generated `LatestApiVersion`. The SDK types enforce this; without it, typecheck fails (`Type '"2026-02-25.clover"' is not assignable to type '"2026-06-24.dahlia"'`).

## Verification
- `bun run typecheck` — clean.
- `bun test` billing + review-helpers + invoice — **68 pass, 0 fail**.
- Lockfile change is stripe-scoped (20.4.1 → 22.3.2), no unrelated dep churn.

Will close #530 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p