### PR TITLE
feat(review): default model → Opus 4.8; default thinking effort → medium

### DIFF
--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -209,10 +209,10 @@ This is ideal for teams that already have API agreements with AI providers or wa
         heading: "Model Pricing",
         text: `Octopus supports multiple AI models. A 20% platform fee is applied on top of provider costs. Base prices per 1M tokens:
 Claude Fable 5 — $10 input / $50 output. Anthropic's Claude 5 frontier model; the top opt-in tier for the most demanding reviews.
-Claude Opus 5 — $5 input / $25 output. Premium, opt-in review model for a deeper read on tricky pull requests; the platform default is unchanged.
-Claude Opus 4.8 — $5 input / $25 output. Current Opus-tier review model.
+Claude Opus 5 — $5 input / $25 output. Premium, opt-in review model for a deeper read on tricky pull requests.
+Claude Opus 4.8 — $5 input / $25 output. The default review model on Octopus Cloud.
 Claude Opus 4 — $15 input / $75 output. Legacy high-quality review model.
-Claude Sonnet 4.6 and Claude Sonnet 4 — $3 input / $15 output. Primary review models: high quality, fast.
+Claude Sonnet 4.6 and Claude Sonnet 4 — $3 input / $15 output. High quality and fast; Sonnet 4.6 is the default for self-hosted installs.
 Claude Haiku 4.5 — $1 input / $5 output. Lightweight tasks like title generation.
 Gemini 2.5 Pro — $1.25 input / $10 output. Gemini 2.5 Flash — $0.15 input / $0.60 output.
 GPT-5.3 Codex — $1.75 input / $14 output.

--- a/apps/web/lib/providers/thinking.ts
+++ b/apps/web/lib/providers/thinking.ts
@@ -26,7 +26,7 @@ export const ALWAYS_THINKING_MAX_TOKENS_FLOOR = 64000;
 
 export type ThinkingEffort = "low" | "medium" | "high" | "xhigh" | "max";
 const VALID_EFFORTS: readonly ThinkingEffort[] = ["low", "medium", "high", "xhigh", "max"];
-export const DEFAULT_THINKING_EFFORT: ThinkingEffort = "high";
+export const DEFAULT_THINKING_EFFORT: ThinkingEffort = "medium";
 
 /** Effort knob, env-tunable without a redeploy (FABLE_THINKING_EFFORT). */
 export function resolveEffort(): ThinkingEffort {

--- a/packages/db/prisma/migrations/20260728140000_default_model_opus48/migration.sql
+++ b/packages/db/prisma/migrations/20260728140000_default_model_opus48/migration.sql
@@ -1,0 +1,30 @@
+-- Make Claude Opus 4.8 the platform default review model (was Sonnet 4.6).
+-- Resolution order for a repo's reviewer is repo-pin → org-pin → THIS platform
+-- default → hardcoded fallback, so this changes the model an un-pinned org
+-- (e.g. a brand-new signup) gets. Opus 4.8 is a Claude-4.x model (thinking is
+-- opt-in, like Sonnet 4.6), so it does NOT need the always-thinking treatment
+-- and won't starve as the default.
+--
+-- Scoped to the VENDOR production DB via `EXISTS (… slug='aot')` — the same
+-- guard the org-binding repair used — so self-host / dev / CI keep their own
+-- default (this is a hosted-product config choice, not a schema change). Also
+-- guarded on Opus 4.8 being present + active. Idempotent.
+
+-- 1. Clear the current llm default (only in the vendor env, only if Opus 4.8 exists).
+UPDATE "available_models"
+SET "isPlatformDefault" = false, "updatedAt" = now()
+WHERE category = 'llm'
+  AND "isPlatformDefault"
+  AND EXISTS (SELECT 1 FROM "organizations" WHERE "slug" = 'aot')
+  AND EXISTS (
+    SELECT 1 FROM "available_models"
+    WHERE "modelId" = 'claude-opus-4-8' AND category = 'llm' AND "isActive"
+  );
+
+-- 2. Set Opus 4.8 as the default (vendor env only).
+UPDATE "available_models"
+SET "isPlatformDefault" = true, "updatedAt" = now()
+WHERE category = 'llm'
+  AND "modelId" = 'claude-opus-4-8'
+  AND "isActive"
+  AND EXISTS (SELECT 1 FROM "organizations" WHERE "slug" = 'aot');


### PR DESCRIPTION
Stage 1 of the review-model/effort changes (Stage 2 = the platform+per-org effort UI, next).

## 1. Platform default model → Opus 4.8
Guarded data migration flips `isPlatformDefault` from `claude-sonnet-4-6` to `claude-opus-4-8`. Resolution is repo-pin → org-pin → **platform default** → hardcoded, so this is the model an un-pinned org (e.g. a fresh signup) gets.

- **Safe as default:** Opus 4.8 is Claude-4.x — thinking is opt-in (like Sonnet 4.6, the prior default), so it does NOT hit the always-thinking starvation that affects the Claude-5 family (Fable 5 / Opus 5). No thinking treatment needed. Will canary-verify with a live review after deploy.
- **Scoped to the vendor DB** via `EXISTS (SELECT 1 FROM organizations WHERE slug='aot')` (+ Opus-4.8 present/active) → self-host/dev/CI keep their existing default. Idempotent.

## 2. Default thinking effort → medium
`DEFAULT_THINKING_EFFORT` `high` → `medium`. This is the fallback effort for the always-thinking models (Fable/Mythos/Opus-5) when no per-org/platform effort is set — trims the extra latency the adaptive-thinking fix added, at a small depth cost.

## Tests
`thinking.test.ts` green (asserts against the constant); `bun run typecheck` clean.

## Next (Stage 2)
Platform-level effort setting + per-org override in the UI (SystemConfig + an org column + dropdowns), resolving org → platform → this default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p