### PR TITLE
fix(build): externalize sharp so next build collects the avatar route

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -9,7 +9,11 @@ const nextConfig: NextConfig = {
   transpilePackages: ["@octopus/db", "@octopus/package-analyzer"],
   // pdfkit reads its built-in AFM font data from disk at runtime; bundling it
   // breaks those reads, so keep it external (traced into standalone output).
-  serverExternalPackages: ["pdfkit"],
+  // sharp is a native module — Next auto-externalized 0.34, but 0.35's packaging
+  // trips the bundler during `next build` page-data collection (routes importing
+  // it, e.g. /api/organizations/avatar, fail with an externalImport error), so
+  // pin it external explicitly.
+  serverExternalPackages: ["pdfkit", "sharp"],
   experimental: {
     serverActions: {
       allowedOrigins: ["octopus-review.ai", "*.octopus-review.ai"],


### PR DESCRIPTION
## Problem
The **v1.0.76 release build failed** (master is currently un-releasable):
> `Failed to collect page data for /api/organizations/avatar` — `externalImport` error, preceded by many "the whole project was traced unintentionally" warnings.

`/api/organizations/avatar` imports **`sharp`**. Next auto-externalized sharp **0.34**, but the **0.35 bump (#528)** changed its packaging, so Next tried to bundle/trace it and page-data collection threw. The per-PR `ci` check runs typecheck/test but **not a full `next build`**, so this only surfaced at release time.

## Fix
Add `sharp` to `serverExternalPackages` (alongside `pdfkit`).

## Verification
Full local `bun run build` → **exit 0**; `/api/organizations/avatar` builds as a dynamic route (no collection error).

## Follow-up (not here)
Add a `next build` (or `docker build`) step to the `ci` workflow so build-only failures are caught on the PR, not at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p