### PR TITLE
feat(models): reasoning-effort control (platform default + per-org override)

### DIFF
--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -18,6 +18,7 @@ import { assessWelcomeCredit } from "@/lib/welcome-credit";
 import { MAX_OWNED_ORGS_PER_USER, WELCOME_FREE_CREDITS } from "@/lib/constants";
 import { encryptString } from "@/lib/crypto";
 import { validateProviderUrl } from "@/lib/providers/url-validation";
+import { asThinkingEffort } from "@/lib/providers/thinking";
 import { writeAuditLog } from "@/lib/audit";
 import { canUseLiveTelemetry } from "@/lib/entitlements";
 import { getClientIp } from "@/lib/request-ip";
@@ -412,10 +413,12 @@ export async function updateDefaultModels(
 
   const defaultModelId = (formData.get("defaultModelId") as string)?.trim() || null;
   const defaultEmbedModelId = (formData.get("defaultEmbedModelId") as string)?.trim() || null;
+  // Empty string = "Inherit platform default"; otherwise must be a valid effort.
+  const reviewEffort = asThinkingEffort((formData.get("reviewEffort") as string)?.trim()) ?? null;
 
   await prisma.organization.update({
     where: { id: orgId },
-    data: { defaultModelId, defaultEmbedModelId },
+    data: { defaultModelId, defaultEmbedModelId, reviewEffort },
   });
 
   revalidatePath("/settings/models");

--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -413,8 +413,13 @@ export async function updateDefaultModels(
 
   const defaultModelId = (formData.get("defaultModelId") as string)?.trim() || null;
   const defaultEmbedModelId = (formData.get("defaultEmbedModelId") as string)?.trim() || null;
-  // Empty string = "Inherit platform default"; otherwise must be a valid effort.
-  const reviewEffort = asThinkingEffort((formData.get("reviewEffort") as string)?.trim()) ?? null;
+  // Empty = "Inherit platform default"; a non-empty value must be a valid effort
+  // (reject rather than silently clear the override).
+  const rawEffort = (formData.get("reviewEffort") as string)?.trim() || "";
+  const reviewEffort = rawEffort ? asThinkingEffort(rawEffort) : null;
+  if (rawEffort && reviewEffort === undefined) {
+    return { error: "Invalid reasoning effort." };
+  }
 
   await prisma.organization.update({
     where: { id: orgId },

--- a/apps/web/app/(app)/settings/models/models-settings.tsx
+++ b/apps/web/app/(app)/settings/models/models-settings.tsx
@@ -330,11 +330,15 @@ function RepositoryModelsSection({
   );
 }
 
+const EFFORT_OPTIONS = ["low", "medium", "high", "xhigh", "max"] as const;
+
 export function ModelsSettings({
   isOwner,
   availableModels,
   currentModelId,
   currentEmbedModelId,
+  currentReviewEffort,
+  platformDefaultEffort,
   platformDefaultLlmName,
   platformDefaultEmbedName,
   initialRepos,
@@ -345,6 +349,8 @@ export function ModelsSettings({
   availableModels: AvailableModel[];
   currentModelId: string | null;
   currentEmbedModelId: string | null;
+  currentReviewEffort: string | null;
+  platformDefaultEffort: string;
   platformDefaultLlmName: string | null;
   platformDefaultEmbedName: string | null;
   initialRepos: RepoModelItem[];
@@ -353,6 +359,7 @@ export function ModelsSettings({
 }) {
   const [selectedModelId, setSelectedModelId] = useState(currentModelId ?? "");
   const [selectedEmbedModelId, setSelectedEmbedModelId] = useState(currentEmbedModelId ?? "");
+  const [selectedEffort, setSelectedEffort] = useState(currentReviewEffort ?? "");
   const [saving, startTransition] = useTransition();
   const [saveResult, setSaveResult] = useState<{ error?: string; success?: boolean }>({});
 
@@ -440,6 +447,32 @@ export function ModelsSettings({
               </select>
               <p className="text-xs text-muted-foreground">
                 Used for code search and context retrieval.
+              </p>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-2">
+              <Label htmlFor="reviewEffort">Reasoning Effort</Label>
+              <select
+                id="reviewEffort"
+                name="reviewEffort"
+                value={selectedEffort}
+                onChange={(e) => setSelectedEffort(e.target.value)}
+                disabled={!isOwner}
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="">{`(Platform Default — ${platformDefaultEffort})`}</option>
+                {EFFORT_OPTIONS.map((e) => (
+                  <option key={e} value={e}>
+                    {e}
+                  </option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground">
+                How hard extended-thinking models (e.g. Fable, Opus 5) reason before
+                answering. Higher effort is more thorough but slower. Ignored by models
+                without extended thinking.
               </p>
             </div>
 

--- a/apps/web/app/(app)/settings/models/models-settings.tsx
+++ b/apps/web/app/(app)/settings/models/models-settings.tsx
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { LATEST_MODEL_ID } from "@/lib/model-latest";
+import { VALID_EFFORTS } from "@/lib/providers/thinking";
 import { IconPencil, IconCheck, IconX, IconSearch, IconLoader2 } from "@tabler/icons-react";
 import { updateDefaultModels } from "../../actions";
 import { updateRepoModels } from "../../repositories/actions";
@@ -330,8 +331,6 @@ function RepositoryModelsSection({
   );
 }
 
-const EFFORT_OPTIONS = ["low", "medium", "high", "xhigh", "max"] as const;
-
 export function ModelsSettings({
   isOwner,
   availableModels,
@@ -463,7 +462,7 @@ export function ModelsSettings({
                 className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <option value="">{`(Platform Default — ${platformDefaultEffort})`}</option>
-                {EFFORT_OPTIONS.map((e) => (
+                {VALID_EFFORTS.map((e) => (
                   <option key={e} value={e}>
                     {e}
                   </option>

--- a/apps/web/app/(app)/settings/models/page.tsx
+++ b/apps/web/app/(app)/settings/models/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { HARDCODED_REVIEW_MODEL, HARDCODED_EMBED_MODEL } from "@/lib/ai-client";
+import { DEFAULT_THINKING_EFFORT } from "@/lib/providers/thinking";
 import { ModelsSettings } from "./models-settings";
 
 const INITIAL_REPO_COUNT = 10;
@@ -30,6 +31,7 @@ export default async function ModelsPage() {
             id: true,
             defaultModelId: true,
             defaultEmbedModelId: true,
+            reviewEffort: true,
           },
         },
       },
@@ -77,10 +79,17 @@ export default async function ModelsPage() {
   // hosted SaaS OLLAMA_SERVER_URL is unset, so the panel stays hidden.
   const ollamaEnabled = !!process.env.OLLAMA_SERVER_URL?.trim();
 
-  const platformDefaults = await prisma.availableModel.findMany({
-    where: { isPlatformDefault: true, isActive: true },
-    select: { modelId: true, displayName: true, category: true },
-  });
+  const [platformDefaults, sysConfig] = await Promise.all([
+    prisma.availableModel.findMany({
+      where: { isPlatformDefault: true, isActive: true },
+      select: { modelId: true, displayName: true, category: true },
+    }),
+    prisma.systemConfig.findUnique({
+      where: { id: "singleton" },
+      select: { defaultReviewEffort: true },
+    }),
+  ]);
+  const platformDefaultEffort = sysConfig?.defaultReviewEffort || DEFAULT_THINKING_EFFORT;
   const platformDefaultLlm =
     platformDefaults.find((m) => m.category === "llm") ??
     availableModels.find((m) => m.modelId === HARDCODED_REVIEW_MODEL) ??
@@ -97,6 +106,8 @@ export default async function ModelsPage() {
       availableModels={availableModels}
       currentModelId={member.organization.defaultModelId}
       currentEmbedModelId={member.organization.defaultEmbedModelId}
+      currentReviewEffort={member.organization.reviewEffort}
+      platformDefaultEffort={platformDefaultEffort}
       platformDefaultLlmName={platformDefaultLlm?.displayName ?? null}
       platformDefaultEmbedName={platformDefaultEmbed?.displayName ?? null}
       initialRepos={repos}

--- a/apps/web/app/(app)/settings/models/page.tsx
+++ b/apps/web/app/(app)/settings/models/page.tsx
@@ -84,10 +84,10 @@ export default async function ModelsPage() {
       where: { isPlatformDefault: true, isActive: true },
       select: { modelId: true, displayName: true, category: true },
     }),
-    prisma.systemConfig.findUnique({
-      where: { id: "singleton" },
-      select: { defaultReviewEffort: true },
-    }),
+    // Label-only; a read failure must not break the whole page.
+    prisma.systemConfig
+      .findUnique({ where: { id: "singleton" }, select: { defaultReviewEffort: true } })
+      .catch(() => null),
   ]);
   const platformDefaultEffort = sysConfig?.defaultReviewEffort || DEFAULT_THINKING_EFFORT;
   const platformDefaultLlm =

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@octopus/db";
 import { getSuperAdmin } from "@/lib/superadmin";
 import { asThinkingEffort } from "@/lib/providers/thinking";
+import { writeAuditLog } from "@/lib/audit";
 
 /**
  * Set the platform-default thinking-model reasoning effort
@@ -25,6 +26,16 @@ export async function setPlatformReviewEffort(
     where: { id: "singleton" },
     update: { defaultReviewEffort },
     create: { id: "singleton", defaultReviewEffort },
+  });
+
+  await writeAuditLog({
+    action: "platform.review_effort.update",
+    category: "admin",
+    actorId: sa.id,
+    actorEmail: sa.email,
+    targetType: "SystemConfig",
+    targetId: "singleton",
+    metadata: { defaultReviewEffort },
   });
 
   revalidatePath("/admin/settings");

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -19,8 +19,13 @@ export async function setPlatformReviewEffort(
   const sa = await getSuperAdmin();
   if (!sa) return { error: "Not authorized." };
 
-  const raw = (formData.get("defaultReviewEffort") as string)?.trim();
-  const defaultReviewEffort = asThinkingEffort(raw) ?? null;
+  // Empty = clear the override (built-in default applies); a non-empty value
+  // must be valid (reject rather than silently clear).
+  const raw = (formData.get("defaultReviewEffort") as string)?.trim() || "";
+  const defaultReviewEffort = raw ? asThinkingEffort(raw) : null;
+  if (raw && defaultReviewEffort === undefined) {
+    return { error: "Invalid reasoning effort." };
+  }
 
   await prisma.systemConfig.upsert({
     where: { id: "singleton" },

--- a/apps/web/app/admin/settings/actions.ts
+++ b/apps/web/app/admin/settings/actions.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@octopus/db";
+import { getSuperAdmin } from "@/lib/superadmin";
+import { asThinkingEffort } from "@/lib/providers/thinking";
+
+/**
+ * Set the platform-default thinking-model reasoning effort
+ * (SystemConfig.defaultReviewEffort). Super-admin only; an empty value clears
+ * the override so the built-in code default (medium) applies. Orgs can still
+ * override this per-org.
+ */
+export async function setPlatformReviewEffort(
+  _prevState: { error?: string; success?: boolean },
+  formData: FormData,
+): Promise<{ error?: string; success?: boolean }> {
+  const sa = await getSuperAdmin();
+  if (!sa) return { error: "Not authorized." };
+
+  const raw = (formData.get("defaultReviewEffort") as string)?.trim();
+  const defaultReviewEffort = asThinkingEffort(raw) ?? null;
+
+  await prisma.systemConfig.upsert({
+    where: { id: "singleton" },
+    update: { defaultReviewEffort },
+    create: { id: "singleton", defaultReviewEffort },
+  });
+
+  revalidatePath("/admin/settings");
+  return { success: true };
+}

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -1,0 +1,33 @@
+import { notFound } from "next/navigation";
+import { prisma } from "@octopus/db";
+import { getSuperAdmin } from "@/lib/superadmin";
+import { DEFAULT_THINKING_EFFORT } from "@/lib/providers/thinking";
+import { SettingsClient } from "./settings-client";
+
+// Per-request only: the super-admin guard reads the session, and the env
+// allowlist is empty at build time (so a static prerender would bake in a 404).
+export const dynamic = "force-dynamic";
+
+/**
+ * /admin/settings — vendor (Octopus staff) platform settings. Super-admin only
+ * (env allowlist); 404 for everyone else so the route isn't disclosed. Hidden
+ * on self-host.
+ */
+export default async function AdminSettingsPage() {
+  if (process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true") notFound();
+
+  const sa = await getSuperAdmin();
+  if (!sa) notFound();
+
+  const sysConfig = await prisma.systemConfig.findUnique({
+    where: { id: "singleton" },
+    select: { defaultReviewEffort: true },
+  });
+
+  return (
+    <SettingsClient
+      currentEffort={sysConfig?.defaultReviewEffort ?? null}
+      builtInDefault={DEFAULT_THINKING_EFFORT}
+    />
+  );
+}

--- a/apps/web/app/admin/settings/page.tsx
+++ b/apps/web/app/admin/settings/page.tsx
@@ -19,10 +19,9 @@ export default async function AdminSettingsPage() {
   const sa = await getSuperAdmin();
   if (!sa) notFound();
 
-  const sysConfig = await prisma.systemConfig.findUnique({
-    where: { id: "singleton" },
-    select: { defaultReviewEffort: true },
-  });
+  const sysConfig = await prisma.systemConfig
+    .findUnique({ where: { id: "singleton" }, select: { defaultReviewEffort: true } })
+    .catch(() => null);
 
   return (
     <SettingsClient

--- a/apps/web/app/admin/settings/settings-client.tsx
+++ b/apps/web/app/admin/settings/settings-client.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { setPlatformReviewEffort } from "./actions";
+
+const EFFORT_OPTIONS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+export function SettingsClient({
+  currentEffort,
+  builtInDefault,
+}: {
+  currentEffort: string | null;
+  builtInDefault: string;
+}) {
+  const [selected, setSelected] = useState(currentEffort ?? "");
+  const [saving, startTransition] = useTransition();
+  const [result, setResult] = useState<{ error?: string; success?: boolean }>({});
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6 md:p-10">
+      <div>
+        <h1 className="text-xl font-semibold">Platform Settings</h1>
+        <p className="text-sm text-muted-foreground">
+          Defaults applied across all organizations. Orgs can override these on their
+          own settings pages.
+        </p>
+      </div>
+
+      <form
+        action={(formData) => {
+          startTransition(async () => {
+            setResult({});
+            setResult(await setPlatformReviewEffort({}, formData));
+          });
+        }}
+        className="space-y-4 rounded-lg border p-5"
+      >
+        <div className="space-y-2">
+          <Label htmlFor="defaultReviewEffort">Default Reasoning Effort</Label>
+          <select
+            id="defaultReviewEffort"
+            name="defaultReviewEffort"
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+            className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors"
+          >
+            <option value="">{`(Built-in default — ${builtInDefault})`}</option>
+            {EFFORT_OPTIONS.map((e) => (
+              <option key={e} value={e}>
+                {e}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-muted-foreground">
+            How hard extended-thinking models (Fable, Opus 5) reason before answering.
+            Higher effort is more thorough but slower. Ignored by models without
+            extended thinking. An org override takes precedence over this.
+          </p>
+        </div>
+
+        {result.error && <p className="text-sm text-destructive">{result.error}</p>}
+        {result.success && <p className="text-sm text-green-600">Saved.</p>}
+
+        <Button type="submit" disabled={saving} size="sm">
+          {saving ? "Saving..." : "Save"}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/admin/settings/settings-client.tsx
+++ b/apps/web/app/admin/settings/settings-client.tsx
@@ -3,9 +3,8 @@
 import { useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { VALID_EFFORTS } from "@/lib/providers/thinking";
 import { setPlatformReviewEffort } from "./actions";
-
-const EFFORT_OPTIONS = ["low", "medium", "high", "xhigh", "max"] as const;
 
 export function SettingsClient({
   currentEffort,
@@ -47,7 +46,7 @@ export function SettingsClient({
             className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors"
           >
             <option value="">{`(Built-in default — ${builtInDefault})`}</option>
-            {EFFORT_OPTIONS.map((e) => (
+            {VALID_EFFORTS.map((e) => (
               <option key={e} value={e}>
                 {e}
               </option>

--- a/apps/web/lib/__tests__/review-effort.test.ts
+++ b/apps/web/lib/__tests__/review-effort.test.ts
@@ -5,10 +5,14 @@ mock.module("server-only", () => ({}));
 // Mutable fixtures the mocked prisma reads from — each test sets these.
 let orgRow: { reviewEffort: string | null } | null = null;
 let sysRow: { defaultReviewEffort: string | null } | null = null;
+let dbThrows = false;
 
 mock.module("@octopus/db", () => ({
   prisma: {
-    organization: { findUnique: () => Promise.resolve(orgRow) },
+    organization: {
+      findUnique: () =>
+        dbThrows ? Promise.reject(new Error("db down")) : Promise.resolve(orgRow),
+    },
     systemConfig: { findUnique: () => Promise.resolve(sysRow) },
   },
 }));
@@ -18,6 +22,7 @@ const { getReviewEffort } = await import("@/lib/review-effort");
 beforeEach(() => {
   orgRow = null;
   sysRow = null;
+  dbThrows = false;
 });
 
 describe("getReviewEffort", () => {
@@ -43,5 +48,10 @@ describe("getReviewEffort", () => {
     orgRow = { reviewEffort: "bogus" };
     sysRow = { defaultReviewEffort: "medium" };
     expect(await getReviewEffort("org1")).toBe("medium");
+  });
+
+  it("returns undefined on a DB error instead of throwing (provider falls back)", async () => {
+    dbThrows = true;
+    expect(await getReviewEffort("org1")).toBeUndefined();
   });
 });

--- a/apps/web/lib/__tests__/review-effort.test.ts
+++ b/apps/web/lib/__tests__/review-effort.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+// Mutable fixtures the mocked prisma reads from — each test sets these.
+let orgRow: { reviewEffort: string | null } | null = null;
+let sysRow: { defaultReviewEffort: string | null } | null = null;
+
+mock.module("@octopus/db", () => ({
+  prisma: {
+    organization: { findUnique: () => Promise.resolve(orgRow) },
+    systemConfig: { findUnique: () => Promise.resolve(sysRow) },
+  },
+}));
+
+const { getReviewEffort } = await import("@/lib/review-effort");
+
+beforeEach(() => {
+  orgRow = null;
+  sysRow = null;
+});
+
+describe("getReviewEffort", () => {
+  it("org override wins over the platform default", async () => {
+    orgRow = { reviewEffort: "high" };
+    sysRow = { defaultReviewEffort: "low" };
+    expect(await getReviewEffort("org1")).toBe("high");
+  });
+
+  it("falls back to the platform default when the org has no override", async () => {
+    orgRow = { reviewEffort: null };
+    sysRow = { defaultReviewEffort: "xhigh" };
+    expect(await getReviewEffort("org1")).toBe("xhigh");
+  });
+
+  it("returns undefined when neither is set (provider uses env/built-in default)", async () => {
+    orgRow = { reviewEffort: null };
+    sysRow = null;
+    expect(await getReviewEffort("org1")).toBeUndefined();
+  });
+
+  it("ignores an invalid stored value and falls through", async () => {
+    orgRow = { reviewEffort: "bogus" };
+    sysRow = { defaultReviewEffort: "medium" };
+    expect(await getReviewEffort("org1")).toBe("medium");
+  });
+});

--- a/apps/web/lib/__tests__/thinking.test.ts
+++ b/apps/web/lib/__tests__/thinking.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   resolveThinking,
   resolveEffort,
+  asThinkingEffort,
   ALWAYS_THINKING_MAX_TOKENS_FLOOR,
   DEFAULT_THINKING_EFFORT,
 } from "@/lib/providers/thinking";
@@ -55,6 +56,26 @@ describe("resolveThinking", () => {
     const r = resolveThinking("claude-mythos-1", 100000, false);
     expect(r.maxTokens).toBe(100000);
     expect(r.thinking).toEqual({ type: "adaptive" });
+  });
+
+  it("an explicit effort overrides the default", () => {
+    const r = resolveThinking("claude-fable-5", 8192, false, "high");
+    expect(r.outputConfig).toEqual({ effort: "high" });
+  });
+
+  it("explicit effort is ignored on the tool path and by non-thinking models", () => {
+    expect(resolveThinking("claude-fable-5", 8192, true, "high").outputConfig).toBeUndefined();
+    expect(resolveThinking("claude-sonnet-4-6", 8192, false, "high").outputConfig).toBeUndefined();
+  });
+});
+
+describe("asThinkingEffort", () => {
+  it("passes valid efforts through and rejects everything else", () => {
+    expect(asThinkingEffort("xhigh")).toBe("xhigh");
+    expect(asThinkingEffort("bogus")).toBeUndefined();
+    expect(asThinkingEffort("")).toBeUndefined();
+    expect(asThinkingEffort(null)).toBeUndefined();
+    expect(asThinkingEffort(undefined)).toBeUndefined();
   });
 });
 

--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -3,6 +3,8 @@ import { prisma } from "@octopus/db";
 import { decryptStringMaybeLegacy } from "@/lib/crypto";
 import { getProvider } from "./providers";
 import type { AiCreateParams, AiProvider, AiResponse } from "./providers";
+import { ALWAYS_THINKING_MODEL_RX } from "./providers/thinking";
+import { getReviewEffort } from "./review-effort";
 
 export type { AiCreateParams, AiMessage, AiProvider, AiResponse } from "./providers";
 
@@ -143,6 +145,12 @@ export async function createAiMessage(
   const provider = await resolveProvider(params.model);
   const keys = await getOrgKeys(orgId);
   const orgKey = getOrgKeyForProvider(keys, provider);
+
+  // Only always-thinking models consume effort; resolve it lazily so we don't
+  // add a DB read to every non-thinking call. An explicit params.effort wins.
+  if (params.effort === undefined && ALWAYS_THINKING_MODEL_RX.test(params.model)) {
+    params = { ...params, effort: await getReviewEffort(orgId) };
+  }
 
   try {
     return await getProvider(provider).create(params, orgKey, orgId);

--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -146,9 +146,14 @@ export async function createAiMessage(
   const keys = await getOrgKeys(orgId);
   const orgKey = getOrgKeyForProvider(keys, provider);
 
-  // Only always-thinking models consume effort; resolve it lazily so we don't
-  // add a DB read to every non-thinking call. An explicit params.effort wins.
-  if (params.effort === undefined && ALWAYS_THINKING_MODEL_RX.test(params.model)) {
+  // Only always-thinking models on the text path consume effort; resolve it
+  // lazily so we don't add a DB read to non-thinking calls or to the forced-tool
+  // path (where resolveThinking ignores effort). An explicit params.effort wins.
+  if (
+    params.effort === undefined &&
+    params.responseSchema === undefined &&
+    ALWAYS_THINKING_MODEL_RX.test(params.model)
+  ) {
     params = { ...params, effort: await getReviewEffort(orgId) };
   }
 

--- a/apps/web/lib/providers/anthropic.ts
+++ b/apps/web/lib/providers/anthropic.ts
@@ -50,6 +50,7 @@ export const anthropicProvider: Provider = {
       params.model,
       params.maxTokens,
       useTool,
+      params.effort,
     );
 
     // Streaming here is purely between this process and the Anthropic API —

--- a/apps/web/lib/providers/index.ts
+++ b/apps/web/lib/providers/index.ts
@@ -11,6 +11,7 @@ import { opencodeProvider } from "./opencode";
 import { claudeCodeProvider } from "./claude-code";
 import { mockProvider } from "./mock";
 import { mockFailProvider } from "./mock-fail";
+import type { ThinkingEffort } from "./thinking";
 
 export type AiProvider =
   | "anthropic"
@@ -50,6 +51,12 @@ export type AiCreateParams = {
   messages: AiMessage[];
   cacheSystem?: boolean;
   responseSchema?: ResponseJsonSchema;
+  /**
+   * Thinking-model reasoning effort, resolved per-org (org override → platform
+   * default) by the router. Only affects always-thinking models; others ignore
+   * it. Falls back to the env/built-in default when unset.
+   */
+  effort?: ThinkingEffort;
 };
 
 export type AiResponse = {

--- a/apps/web/lib/providers/thinking.ts
+++ b/apps/web/lib/providers/thinking.ts
@@ -25,15 +25,17 @@ export const ALWAYS_THINKING_MODEL_RX = /^claude-(?:fable|mythos)-|^claude-opus-
 export const ALWAYS_THINKING_MAX_TOKENS_FLOOR = 64000;
 
 export type ThinkingEffort = "low" | "medium" | "high" | "xhigh" | "max";
-const VALID_EFFORTS: readonly ThinkingEffort[] = ["low", "medium", "high", "xhigh", "max"];
+export const VALID_EFFORTS: readonly ThinkingEffort[] = ["low", "medium", "high", "xhigh", "max"];
 export const DEFAULT_THINKING_EFFORT: ThinkingEffort = "medium";
 
-/** Effort knob, env-tunable without a redeploy (FABLE_THINKING_EFFORT). */
+/** Narrow an arbitrary string to a valid ThinkingEffort (else undefined). */
+export function asThinkingEffort(v: string | null | undefined): ThinkingEffort | undefined {
+  return v && (VALID_EFFORTS as readonly string[]).includes(v) ? (v as ThinkingEffort) : undefined;
+}
+
+/** Env fallback effort (FABLE_THINKING_EFFORT), else the built-in default. */
 export function resolveEffort(): ThinkingEffort {
-  const v = process.env.FABLE_THINKING_EFFORT;
-  return v && (VALID_EFFORTS as readonly string[]).includes(v)
-    ? (v as ThinkingEffort)
-    : DEFAULT_THINKING_EFFORT;
+  return asThinkingEffort(process.env.FABLE_THINKING_EFFORT) ?? DEFAULT_THINKING_EFFORT;
 }
 
 export type ResolvedThinking = {
@@ -56,6 +58,7 @@ export function resolveThinking(
   model: string,
   requestedMaxTokens: number,
   useTool: boolean,
+  effort?: ThinkingEffort,
 ): ResolvedThinking {
   // Only the known thinking-heavy Claude-5 models get the floor — they have
   // high per-model caps (>= 64000) and need the room. Other models keep their
@@ -66,6 +69,8 @@ export function resolveThinking(
   return {
     maxTokens,
     thinking: { type: "adaptive" },
-    outputConfig: { effort: resolveEffort() },
+    // Caller-resolved effort (org override → platform default) wins; else the
+    // env/built-in default.
+    outputConfig: { effort: effort ?? resolveEffort() },
   };
 }

--- a/apps/web/lib/review-effort.ts
+++ b/apps/web/lib/review-effort.ts
@@ -1,0 +1,24 @@
+import "server-only";
+import { prisma } from "@octopus/db";
+import { asThinkingEffort, type ThinkingEffort } from "./providers/thinking";
+
+/**
+ * Resolve the thinking-model reasoning effort for an org:
+ *   org override (Organization.reviewEffort)
+ *   → platform default (SystemConfig.defaultReviewEffort)
+ *   → undefined (provider falls back to env / built-in default).
+ * Only matters for always-thinking models; other models ignore effort.
+ */
+export async function getReviewEffort(orgId: string): Promise<ThinkingEffort | undefined> {
+  const [org, sysRow] = await Promise.all([
+    prisma.organization.findUnique({
+      where: { id: orgId },
+      select: { reviewEffort: true },
+    }),
+    prisma.systemConfig.findUnique({
+      where: { id: "singleton" },
+      select: { defaultReviewEffort: true },
+    }),
+  ]);
+  return asThinkingEffort(org?.reviewEffort) ?? asThinkingEffort(sysRow?.defaultReviewEffort);
+}

--- a/apps/web/lib/review-effort.ts
+++ b/apps/web/lib/review-effort.ts
@@ -10,15 +10,23 @@ import { asThinkingEffort, type ThinkingEffort } from "./providers/thinking";
  * Only matters for always-thinking models; other models ignore effort.
  */
 export async function getReviewEffort(orgId: string): Promise<ThinkingEffort | undefined> {
-  const [org, sysRow] = await Promise.all([
-    prisma.organization.findUnique({
-      where: { id: orgId },
-      select: { reviewEffort: true },
-    }),
-    prisma.systemConfig.findUnique({
-      where: { id: "singleton" },
-      select: { defaultReviewEffort: true },
-    }),
-  ]);
-  return asThinkingEffort(org?.reviewEffort) ?? asThinkingEffort(sysRow?.defaultReviewEffort);
+  // Effort is a non-critical enhancement: on any DB error, fall through to
+  // undefined so the provider uses the env/built-in default rather than failing
+  // the whole AI call. Mirrors the defensive systemConfig reads in review-core.
+  try {
+    const [org, sysRow] = await Promise.all([
+      prisma.organization.findUnique({
+        where: { id: orgId },
+        select: { reviewEffort: true },
+      }),
+      prisma.systemConfig.findUnique({
+        where: { id: "singleton" },
+        select: { defaultReviewEffort: true },
+      }),
+    ]);
+    return asThinkingEffort(org?.reviewEffort) ?? asThinkingEffort(sysRow?.defaultReviewEffort);
+  } catch (err) {
+    console.error("[review-effort] failed to resolve effort, using provider default:", err);
+    return undefined;
+  }
 }

--- a/packages/db/prisma/migrations/20260729120000_review_effort/migration.sql
+++ b/packages/db/prisma/migrations/20260729120000_review_effort/migration.sql
@@ -1,0 +1,5 @@
+-- Thinking-model effort settings (expand-only, both nullable — safe on live).
+-- Per-org override; null = inherit the platform default.
+ALTER TABLE "organizations" ADD COLUMN "reviewEffort" TEXT;
+-- Platform default; null = the built-in code default (medium).
+ALTER TABLE "system_config" ADD COLUMN "defaultReviewEffort" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -136,6 +136,9 @@ model Organization {
   claudeCodeApiKey     String?
   defaultModelId       String?
   defaultEmbedModelId  String?
+  // Per-org thinking-model effort override (low|medium|high|xhigh|max);
+  // null = inherit the platform default (SystemConfig.defaultReviewEffort).
+  reviewEffort         String?
   monthlySpendLimitUsd    Float?
   checkFailureThreshold   String   @default("critical") // "critical" | "high" | "medium" | "none"
   reviewsPaused           Boolean  @default(false)
@@ -855,6 +858,9 @@ model OllamaModelPull {
 model SystemConfig {
   id        String   @id @default("singleton")
   defaultReviewConfig Json @default("{}")
+  // Platform default thinking-model effort (low|medium|high|xhigh|max);
+  // null = the built-in code default (DEFAULT_THINKING_EFFORT = medium).
+  defaultReviewEffort String?
   blockedAuthors      Json @default("[]") // string[] of globally blocked PR author usernames
   queueConfig         Json @default("{}") // { reviewTimeoutSeconds, reviewConcurrency }
   announcements       Json @default("[]") // landing-page announcement bar entries (see lib/announcements types)


### PR DESCRIPTION
## What

Adds a UI and resolution path to set the **reasoning effort** used by extended-thinking review models (Fable, Mythos, Opus 5), both platform-wide and per-org. Completes the effort half of the "default Opus 4.8 + effort control" work (Opus 4.8 default + `medium` default already shipped in v1.0.78).

## Where it's set

- **Platform default** — `/admin/settings` (super-admin only, env allowlist). Stored in `SystemConfig.defaultReviewEffort`. Empty = built-in `DEFAULT_THINKING_EFFORT` (`medium`).
- **Per-org override** — Settings → Models (owner/admin only). Stored in `Organization.reviewEffort`. Empty = inherit the platform default.

## Resolution order

`org override → platform default → env (FABLE_THINKING_EFFORT) / built-in default`, via `getReviewEffort()` in `lib/review-effort.ts`.

## Plumbing

`AiCreateParams.effort` → anthropic provider → `resolveThinking(model, maxTokens, useTool, effort?)`. The router injects the resolved effort **only for always-thinking models**, so non-thinking calls add no extra DB read. Effort still only lands on the plain-text path (not the forced-tool path), unchanged.

## Migration

Expand-only, both columns nullable (`ADD COLUMN … TEXT`). Safe on live; applies to self-host too (it's a schema change, not a vendor-only config flip).

## Tests

- `thinking.test.ts`: explicit effort overrides the default; ignored on tool path / non-thinking models; `asThinkingEffort` whitelist.
- `review-effort.test.ts`: org-over-platform precedence, platform fallback, undefined when unset, invalid stored value falls through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p