### PR TITLE
feat(community): include upgrade URL in daily-limit 429 (#621)

### DIFF
--- a/apps/web/app/api/github-action/review/route.ts
+++ b/apps/web/app/api/github-action/review/route.ts
@@ -194,7 +194,11 @@ export async function POST(request: NextRequest) {
     const todayCount = await getCommunityReviewCountToday(orgId);
     if (todayCount >= communityDailyLimit) {
       return Response.json(
-        { error: "Daily review limit reached (community tier). Add octopus-api-key for unlimited reviews." },
+        {
+          error:
+            "Daily review limit reached (community tier). Add an octopus-api-key for unlimited reviews, or see pricing to upgrade: https://octopus-review.ai/docs/pricing",
+          upgradeUrl: "https://octopus-review.ai/docs/pricing",
+        },
         { status: 429 },
       );
     }


### PR DESCRIPTION
## What

Closes #621. When a community repo hits the free daily review limit, the GitHub Action received a bare 429 telling the user to "add octopus-api-key" — a dead end with no link.

Now the 429 body includes the pricing URL directly in the `error` message (so the current action, which prints `error`, surfaces it) plus a structured `upgradeUrl` field for the action to render a proper link in a later update.

## Change

Single response in `apps/web/app/api/github-action/review/route.ts` (the community rate-limit branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p