### PR TITLE
feat(webhook): skip auto-review on draft PRs (#539, #474)

### DIFF
--- a/apps/web/app/api/github/webhook/route.ts
+++ b/apps/web/app/api/github/webhook/route.ts
@@ -182,10 +182,15 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // ── PR opened / reopened / synchronize → auto-review if repo has autoReview enabled ──
+  // ── PR opened / reopened / synchronize / ready_for_review → auto-review if repo has autoReview enabled ──
+  // `ready_for_review` fires when a draft is marked ready; its payload has
+  // draft:false, so the draft guard below passes it straight through.
   if (
     event === "pull_request" &&
-    (payload.action === "opened" || payload.action === "reopened" || payload.action === "synchronize")
+    (payload.action === "opened" ||
+      payload.action === "reopened" ||
+      payload.action === "synchronize" ||
+      payload.action === "ready_for_review")
   ) {
     const installationId = payload.installation?.id as number | undefined;
     if (!installationId) {
@@ -200,6 +205,7 @@ export async function POST(request: NextRequest) {
     const prUrl: string = payload.pull_request?.html_url ?? "";
     const prAuthor: string = payload.pull_request?.user?.login ?? "unknown";
     const headSha: string = payload.pull_request?.head?.sha ?? "";
+    const isDraft: boolean = payload.pull_request?.draft === true;
 
     console.log(`[webhook] pull_request ${payload.action} — ${repoFullName}#${prNumber}`);
 
@@ -242,6 +248,14 @@ export async function POST(request: NextRequest) {
 
     if (!repo.autoReview) {
       await skipReview(`Auto-review disabled for repo ${repoFullName}`);
+      return NextResponse.json({ ok: true });
+    }
+
+    // Draft PRs are WIP by definition — skip auto-review (posts a neutral check
+    // so the PR isn't left pending). The review fires on `ready_for_review`.
+    // A manual @octopus mention still reviews a draft (explicit opt-in).
+    if (isDraft) {
+      await skipReview(`PR #${prNumber} is a draft`);
       return NextResponse.json({ ok: true });
     }
 


### PR DESCRIPTION
## What

Closes #539 and its duplicate #474. Octopus was auto-reviewing **draft** PRs, which is noisy and wastes review credits on WIP code.

## Change

In `apps/web/app/api/github/webhook/route.ts` (the `pull_request` handler):
- Skip auto-review when `payload.pull_request.draft === true`, posting a neutral check run (via the existing `skipReview` helper) so the PR check isn't left pending forever.
- Add `ready_for_review` to the trigger actions, so the review fires the moment a draft is marked ready (that payload has `draft:false`, so it passes the guard naturally).

## Scope / deliberate omissions

- A **manual `@octopus` mention still reviews a draft** — that's an explicit opt-in and its path is untouched.
- The optional per-repo `reviewDrafts` setting and the defensive `startReviewFlow(isDraft)` param from the issue are intentionally left out — steps 1+2 fully resolve the core complaint with minimal surface area (as the issue itself notes).

## Testing

No route-level test harness exists for this webhook, and the change is a single boolean guard plus one added action string; standing up a full handler mock (prisma + GitHub API + check runs + startReviewFlow) would be disproportionate to a two-line guard. Verified via typecheck and by tracing the GitHub event semantics (draft `synchronize`/`opened` → skip; `ready_for_review` → `draft:false` → review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p