### PR TITLE
fix(claude-code): apply thinking floor + streaming in api-key mode (#683)

### DIFF
--- a/apps/web/lib/providers/claude-code.ts
+++ b/apps/web/lib/providers/claude-code.ts
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 import { prisma } from "@octopus/db";
 import { decryptStringMaybeLegacy } from "@/lib/crypto";
 import { resolveThinking } from "./thinking";
+import { stripLoneSurrogates } from "./sanitize";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
 
 // Mirror the main anthropic provider's per-call ceiling (kept local so the two
@@ -144,16 +145,23 @@ async function runAnthropicApi(params: AiCreateParams, apiKey: string | null): P
       max_tokens: maxTokens,
       ...(thinking ? { thinking } : {}),
       ...(outputConfig ? { output_config: outputConfig } : {}),
+      // Strip lone UTF-16 surrogates: a diff/file body truncated mid-emoji can
+      // leave an unpaired surrogate, which serializes to invalid UTF-8 and makes
+      // Anthropic 400 the whole request ("no low surrogate"). Same guard as the
+      // main anthropic provider.
       system: params.system
         ? [
             {
               type: "text" as const,
-              text: params.system,
+              text: stripLoneSurrogates(params.system),
               ...(params.cacheSystem ? { cache_control: { type: "ephemeral" as const } } : {}),
             },
           ]
         : undefined,
-      messages: params.messages.map((m) => ({ role: m.role, content: m.content })),
+      messages: params.messages.map((m) => ({
+        role: m.role,
+        content: stripLoneSurrogates(m.content),
+      })),
       ...(useTool
         ? {
             tools: [

--- a/apps/web/lib/providers/claude-code.ts
+++ b/apps/web/lib/providers/claude-code.ts
@@ -3,7 +3,12 @@ import Anthropic from "@anthropic-ai/sdk";
 import { spawn } from "node:child_process";
 import { prisma } from "@octopus/db";
 import { decryptStringMaybeLegacy } from "@/lib/crypto";
+import { resolveThinking } from "./thinking";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
+
+// Mirror the main anthropic provider's per-call ceiling (kept local so the two
+// providers stay decoupled).
+const ANTHROPIC_CALL_TIMEOUT_MS = 14 * 60 * 1000;
 
 /**
  * Claude Code — Anthropic's coding-agent CLI. Two auth modes, selectable
@@ -112,41 +117,85 @@ async function runAnthropicApi(params: AiCreateParams, apiKey: string | null): P
 
   const client = getAnthropicClient(apiKey);
 
+  // The Anthropic API model id (strip the "claude-code:" routing prefix). Pass
+  // the bare id to resolveThinking so always-thinking models (Fable/Mythos/
+  // Opus 5) are recognised and get the floor + adaptive thinking treatment.
+  const apiModel = params.model.startsWith("claude-code:")
+    ? params.model.slice(12)
+    : params.model;
+
   const useTool = params.responseSchema !== undefined;
-  const response = await client.messages.create({
-    model: params.model.startsWith("claude-code:") ? params.model.slice(12) : params.model,
-    max_tokens: params.maxTokens,
-    system: params.system
-      ? [
-          {
-            type: "text" as const,
-            text: params.system,
-            ...(params.cacheSystem ? { cache_control: { type: "ephemeral" as const } } : {}),
-          },
-        ]
-      : undefined,
-    messages: params.messages.map((m) => ({ role: m.role, content: m.content })),
-    ...(useTool
-      ? {
-          tools: [
+
+  // Same fix as the main anthropic provider (#682): always-thinking models
+  // spend max_tokens on thinking before any text, so a small budget yields an
+  // empty response. Raise to the floor and, on the text path, use adaptive
+  // thinking + effort. Streaming is REQUIRED once max_tokens hits the floor —
+  // the SDK rejects a non-streaming create with a large max_tokens.
+  const { maxTokens, thinking, outputConfig } = resolveThinking(
+    apiModel,
+    params.maxTokens,
+    useTool,
+    params.effort,
+  );
+
+  const stream = client.messages.stream(
+    {
+      model: apiModel,
+      max_tokens: maxTokens,
+      ...(thinking ? { thinking } : {}),
+      ...(outputConfig ? { output_config: outputConfig } : {}),
+      system: params.system
+        ? [
             {
-              name: params.responseSchema!.name,
-              description: `Return the response as a ${params.responseSchema!.name} object.`,
-              input_schema: params.responseSchema!.schema as Anthropic.Tool.InputSchema,
+              type: "text" as const,
+              text: params.system,
+              ...(params.cacheSystem ? { cache_control: { type: "ephemeral" as const } } : {}),
             },
-          ],
-          tool_choice: { type: "tool" as const, name: params.responseSchema!.name },
-        }
-      : {}),
-  });
+          ]
+        : undefined,
+      messages: params.messages.map((m) => ({ role: m.role, content: m.content })),
+      ...(useTool
+        ? {
+            tools: [
+              {
+                name: params.responseSchema!.name,
+                description: `Return the response as a ${params.responseSchema!.name} object.`,
+                input_schema: params.responseSchema!.schema as Anthropic.Tool.InputSchema,
+              },
+            ],
+            tool_choice: { type: "tool" as const, name: params.responseSchema!.name },
+          }
+        : {}),
+    },
+    { signal: AbortSignal.timeout(ANTHROPIC_CALL_TIMEOUT_MS) },
+  );
+
+  let response: Anthropic.Message;
+  try {
+    response = await stream.finalMessage();
+  } catch (err) {
+    if (
+      err instanceof Anthropic.APIUserAbortError ||
+      (err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError"))
+    ) {
+      throw new Error(
+        `Claude Code (api-key) call timed out after ${ANTHROPIC_CALL_TIMEOUT_MS / 1000}s (model: ${params.model})`,
+      );
+    }
+    throw err;
+  }
 
   let text = "";
   if (useTool) {
     const toolUse = response.content.find((c) => c.type === "tool_use");
     if (toolUse?.type === "tool_use") text = JSON.stringify(toolUse.input);
   } else {
-    const textBlock = response.content[0];
-    text = textBlock?.type === "text" ? textBlock.text : "";
+    // Thinking models prepend a thinking block, so the text is not necessarily
+    // content[0] — collect every text block.
+    text = response.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("");
   }
 
   return {


### PR DESCRIPTION
## What

Closes #683 (follow-up to #682). The main `anthropic` provider fixed the Fable/Mythos "thinking fills `max_tokens` → empty response" failure via `resolveThinking`, but the **claude-code api-key** path (`runAnthropicApi`) had the same latent bug — it called `messages.create` with a raw `max_tokens` and no floor / thinking budget.

## Change (mirrors the main provider)

In `apps/web/lib/providers/claude-code.ts`:
- Pass the **bare model id** (strip the `claude-code:` routing prefix) to `resolveThinking`, so always-thinking models are recognised and get the 64k floor + adaptive thinking + effort on the text path.
- Convert the non-streaming `messages.create` to `messages.stream(...).finalMessage()` — **required** once `max_tokens` hits the floor, since the SDK rejects a large non-streaming create — with the same 14-minute timeout mapping.
- Collect **every** text block (a thinking block can precede the text), instead of reading only `content[0]`.

## Scope / deliberate omissions

- Only affects orgs running a Fable/Mythos/Opus-5 model via **Claude Code api-key** auth mode. The subscription (CLI) path is untouched.
- Empty-text handling left as-is (returns `""`): the floor prevents the empty case, so I kept the change surgical rather than adding the main provider's throw-on-empty (a behavior change beyond this issue's scope).
- `ANTHROPIC_CALL_TIMEOUT_MS` is defined locally (14 min, same value) rather than exported from `anthropic.ts`, to keep the two providers decoupled.

## Testing

`resolveThinking` itself is covered by `thinking.test.ts`. This change is a faithful structural mirror of the reviewed-and-shipped main provider; a dedicated test would require mocking the Anthropic streaming SDK. Verified via typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p