### PR TITLE
fix(avatar): rate-limit + pixel-cap the org avatar upload

### DIFF
--- a/apps/web/app/api/organizations/avatar/route.ts
+++ b/apps/web/app/api/organizations/avatar/route.ts
@@ -7,10 +7,20 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { uploadToR2, deleteFromR2, extractR2Key, isR2Configured } from "@/lib/r2";
 import { writeAuditLog } from "@/lib/audit";
+import { fixedWindowLimit, tooManyRequests } from "@/lib/rate-limit";
 
 const MAX_UPLOAD_BYTES = 5 * 1024 * 1024; // 5 MB
 const ALLOWED_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "image/gif"]);
 const OUTPUT_SIZE = 512;
+// Reject a compressed "pixel bomb" before libvips allocates the raster: a few MB
+// can decode to hundreds of MP. 100 MP covers any real avatar source; sharp's
+// ~268 MP default would otherwise let a 5 MB input drive a ~1–2 GB allocation.
+const MAX_INPUT_PIXELS = 100_000_000;
+// Avatar changes are rare; this is generous for real use and caps the CPU/R2/
+// audit cost of an unthrottled loop. The endpoint is also exempt from Cloudflare
+// edge rate limiting, so the app is the only place this can be enforced.
+const UPLOAD_LIMIT = 10;
+const UPLOAD_WINDOW_S = 10 * 60; // 10 minutes
 
 async function getOwnerContext() {
   const session = await auth.api.getSession({ headers: await headers() });
@@ -38,6 +48,11 @@ export async function POST(req: Request) {
   const ctx = await getOwnerContext();
   if ("error" in ctx) return NextResponse.json({ error: ctx.error }, { status: ctx.status });
 
+  // Throttle before the expensive work (formData read + sharp decode/resize +
+  // R2 write + audit row). Keyed per user; fails open on a Redis outage.
+  const rl = await fixedWindowLimit(`avatar-upload:${ctx.userId}`, UPLOAD_LIMIT, UPLOAD_WINDOW_S);
+  if (!rl.ok) return tooManyRequests("Too many avatar uploads. Try again later.", rl.retryAfterSeconds);
+
   const formData = await req.formData();
   const file = formData.get("file");
   if (!(file instanceof File)) {
@@ -60,7 +75,7 @@ export async function POST(req: Request) {
 
   let outputBuffer: Buffer;
   try {
-    outputBuffer = await sharp(inputBuffer, { failOn: "truncated" })
+    outputBuffer = await sharp(inputBuffer, { failOn: "truncated", limitInputPixels: MAX_INPUT_PIXELS })
       .rotate()
       .resize(OUTPUT_SIZE, OUTPUT_SIZE, { fit: "cover", position: "center" })
       .webp({ quality: 88 })


### PR DESCRIPTION
## Context

Verification of an external security report — *"Missing Rate Limiting on Avatar Upload → storage abuse"* (`POST /api/organizations/avatar`, claimed Medium). I verified it end-to-end (route + R2 + middleware + edge) and adversarially cross-checked from 5 angles.

**The storage-abuse framing is refuted:** every upload is re-encoded by `sharp` to a fixed 512×512 webp and the **prior avatar is deleted on each write** (`route.ts:86-93`), so a sequential loop leaves **~1 tiny object per org, not 2000**. It's also owner/admin-gated (no IDOR/cross-tenant). R2 cost for the PoC's 2000 loops is ~$0.01.

**But two real, lower-severity gaps are confirmed:**
1. **No rate limiting** at any layer — and the endpoint is explicitly exempt from Cloudflare edge rate limiting (the `Avatar Upload` skip rule), so the app is the only place it can live. An owner/admin loop drives unthrottled `sharp` CPU + R2 writes + one `audit_log` row per call.
2. **`sharp` ran with no `limitInputPixels`** — a ~5 MB *compressed* "pixel bomb" can decode to a near-268 MP raster (~1–2 GB allocation) *before* the downscale → OOM/DoS risk.

## Fix (reuses the existing invite-route limiter)

- `fixedWindowLimit(\`avatar-upload:${userId}\`, 10, 10min)` before the expensive work; returns 429 via `tooManyRequests`. **Fails open** on a Redis outage (same semantics as invites).
- `limitInputPixels: 100_000_000` on the `sharp` decode — covers any real avatar source, rejects bombs before allocation.

## Severity

**Low** — defense-in-depth on a privileged, non-accumulating endpoint. The report's Medium/storage-abuse framing does not hold; the real value is DoS/cost hygiene on an edge-unprotected path.

## Testing

Typecheck clean. No dedicated route test: exercising this handler needs auth + prisma + R2 + sharp + Redis mocks for what is two guard lines wiring an already-shared, already-used limiter (`lib/rate-limit.ts`) plus one `sharp` option. Verified by reading the resolved flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p