### PR TITLE
feat(admin): session revocation (super-admin console + per-org member sign-out)

### DIFF
--- a/apps/web/app/(app)/settings/invitations/invitations-panel.tsx
+++ b/apps/web/app/(app)/settings/invitations/invitations-panel.tsx
@@ -189,7 +189,7 @@ export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
   }
 
   async function handleRevokeSessions() {
-    if (!revokeSessionsTarget) return;
+    if (!revokeSessionsTarget || actionLoading === revokeSessionsTarget.id) return;
     const target = revokeSessionsTarget;
     setActionLoading(target.id);
     try {

--- a/apps/web/app/(app)/settings/invitations/invitations-panel.tsx
+++ b/apps/web/app/(app)/settings/invitations/invitations-panel.tsx
@@ -28,7 +28,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { IconX } from "@tabler/icons-react";
+import { IconX, IconLogout } from "@tabler/icons-react";
 import { toast } from "sonner";
 import { InviteModal } from "./invite-modal";
 
@@ -89,6 +89,7 @@ export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [roleChanging, setRoleChanging] = useState<string | null>(null);
   const [removeTarget, setRemoveTarget] = useState<Member | null>(null);
+  const [revokeSessionsTarget, setRevokeSessionsTarget] = useState<Member | null>(null);
 
   const fetchMembers = useCallback(async () => {
     setMembersLoading(true);
@@ -187,7 +188,37 @@ export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
     }
   }
 
+  async function handleRevokeSessions() {
+    if (!revokeSessionsTarget) return;
+    setActionLoading(revokeSessionsTarget.id);
+    try {
+      const res = await fetch(
+        `/api/orgs/${orgId}/members/${revokeSessionsTarget.id}/revoke-sessions`,
+        { method: "POST" },
+      );
+      const data = await res.json();
+      if (!res.ok) {
+        toast.error(data.error || "Failed to revoke sessions");
+        return;
+      }
+      toast.success(
+        `Signed out ${revokeSessionsTarget.user.name || revokeSessionsTarget.user.email} (${data.count} session${data.count === 1 ? "" : "s"}).`,
+      );
+    } finally {
+      setActionLoading(null);
+      setRevokeSessionsTarget(null);
+    }
+  }
+
   function canRemoveMember(target: Member): boolean {
+    if (!isAdmin) return false;
+    if (target.user.id === callerUserId) return false;
+    if (target.role === "owner") return false;
+    return true;
+  }
+
+  // Same gate as removal: admins can sign out anyone but the owner and themselves.
+  function canRevokeSessions(target: Member): boolean {
     if (!isAdmin) return false;
     if (target.user.id === callerUserId) return false;
     if (target.role === "owner") return false;
@@ -274,6 +305,18 @@ export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
               </SelectContent>
             </Select>
           )}
+          {canRevokeSessions(m) && (
+            <Button
+              size="icon"
+              variant="ghost"
+              className="size-7 text-muted-foreground hover:text-foreground"
+              onClick={() => setRevokeSessionsTarget(m)}
+              disabled={isBusy}
+              title="Sign this member out (revoke all sessions)"
+            >
+              <IconLogout className="size-4" />
+            </Button>
+          )}
           {canRemoveMember(m) && (
             <Button
               size="icon"
@@ -281,6 +324,7 @@ export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
               className="size-7 text-muted-foreground hover:text-destructive"
               onClick={() => setRemoveTarget(m)}
               disabled={isBusy}
+              title="Remove member"
             >
               <IconX className="size-4" />
             </Button>
@@ -409,6 +453,24 @@ export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
             <AlertDialogAction onClick={handleRevoke}>
               {revokeTarget?.status === "accepted" ? "Remove" : "Revoke"}
             </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={!!revokeSessionsTarget}
+        onOpenChange={(o) => !o && setRevokeSessionsTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Sign Out Member</AlertDialogTitle>
+            <AlertDialogDescription>
+              Revoke all sessions for <strong>{revokeSessionsTarget?.user.name || revokeSessionsTarget?.user.email}</strong>? They&apos;ll have to sign in again. This signs them out of Octopus entirely — across every organization and device, not just this one. They remain a member.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleRevokeSessions}>Sign out</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/web/app/(app)/settings/invitations/invitations-panel.tsx
+++ b/apps/web/app/(app)/settings/invitations/invitations-panel.tsx
@@ -190,20 +190,24 @@ export function InvitationsPanel({ orgId, isAdmin }: InvitationsPanelProps) {
 
   async function handleRevokeSessions() {
     if (!revokeSessionsTarget) return;
-    setActionLoading(revokeSessionsTarget.id);
+    const target = revokeSessionsTarget;
+    setActionLoading(target.id);
     try {
       const res = await fetch(
-        `/api/orgs/${orgId}/members/${revokeSessionsTarget.id}/revoke-sessions`,
+        `/api/orgs/${orgId}/members/${target.id}/revoke-sessions`,
         { method: "POST" },
       );
-      const data = await res.json();
+      // Parse defensively: an error response may not be JSON (e.g. a 500/edge page).
+      const data = await res.json().catch(() => ({}) as { error?: string; count?: number });
       if (!res.ok) {
         toast.error(data.error || "Failed to revoke sessions");
         return;
       }
       toast.success(
-        `Signed out ${revokeSessionsTarget.user.name || revokeSessionsTarget.user.email} (${data.count} session${data.count === 1 ? "" : "s"}).`,
+        `Signed out ${target.user.name || target.user.email} (${data.count ?? 0} session${data.count === 1 ? "" : "s"}).`,
       );
+    } catch {
+      toast.error("Failed to revoke sessions");
     } finally {
       setActionLoading(null);
       setRevokeSessionsTarget(null);

--- a/apps/web/app/admin/sessions/actions.ts
+++ b/apps/web/app/admin/sessions/actions.ts
@@ -1,0 +1,74 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { prisma } from "@octopus/db";
+import { getSuperAdmin } from "@/lib/superadmin";
+import { writeAuditLog } from "@/lib/audit";
+
+/**
+ * Revoke ALL sessions of a single user (by email) — forces them to re-login
+ * everywhere. Super-admin only. Deleting the `sessions` rows invalidates every
+ * session token immediately (better-auth validates tokens against the row).
+ */
+export async function revokeUserSessionsByEmail(
+  _prev: { error?: string; success?: boolean; count?: number; email?: string },
+  formData: FormData,
+): Promise<{ error?: string; success?: boolean; count?: number; email?: string }> {
+  const sa = await getSuperAdmin();
+  if (!sa) return { error: "Not authorized." };
+
+  const email = ((formData.get("email") as string) ?? "").trim().toLowerCase();
+  if (!email) return { error: "Email is required." };
+
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true, email: true },
+  });
+  if (!user) return { error: `No user found for ${email}.` };
+
+  const { count } = await prisma.session.deleteMany({ where: { userId: user.id } });
+
+  await writeAuditLog({
+    action: "admin.user_sessions_revoked",
+    category: "admin",
+    actorId: sa.id,
+    actorEmail: sa.email,
+    targetType: "user",
+    targetId: user.id,
+    metadata: { email: user.email, count },
+  });
+
+  revalidatePath("/admin/sessions");
+  return { success: true, count, email: user.email };
+}
+
+/**
+ * Nuclear option: revoke EVERY session platform-wide (incident response). This
+ * signs out every user, including the acting super-admin. Requires a typed
+ * confirmation server-side as well as in the UI.
+ */
+export async function revokeAllSessions(
+  _prev: { error?: string; success?: boolean; count?: number },
+  formData: FormData,
+): Promise<{ error?: string; success?: boolean; count?: number }> {
+  const sa = await getSuperAdmin();
+  if (!sa) return { error: "Not authorized." };
+
+  if (((formData.get("confirm") as string) ?? "").trim() !== "REVOKE ALL") {
+    return { error: 'Type "REVOKE ALL" to confirm.' };
+  }
+
+  const { count } = await prisma.session.deleteMany({});
+
+  await writeAuditLog({
+    action: "admin.all_sessions_revoked",
+    category: "admin",
+    actorId: sa.id,
+    actorEmail: sa.email,
+    targetType: "platform",
+    metadata: { count },
+  });
+
+  revalidatePath("/admin/sessions");
+  return { success: true, count };
+}

--- a/apps/web/app/admin/sessions/actions.ts
+++ b/apps/web/app/admin/sessions/actions.ts
@@ -4,6 +4,13 @@ import { revalidatePath } from "next/cache";
 import { prisma } from "@octopus/db";
 import { getSuperAdmin } from "@/lib/superadmin";
 import { writeAuditLog } from "@/lib/audit";
+import { normalizeEmail } from "@/lib/email-normalize";
+
+// The vendor console is inert on self-host (single-tenant); mirror the page's
+// self-host 404 in the actions so they can't be invoked directly there either.
+function selfHostBlocked(): boolean {
+  return process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true";
+}
 
 /**
  * Revoke ALL sessions of a single user (by email) — forces them to re-login
@@ -14,17 +21,28 @@ export async function revokeUserSessionsByEmail(
   _prev: { error?: string; success?: boolean; count?: number; email?: string },
   formData: FormData,
 ): Promise<{ error?: string; success?: boolean; count?: number; email?: string }> {
+  if (selfHostBlocked()) return { error: "Not authorized." };
   const sa = await getSuperAdmin();
   if (!sa) return { error: "Not authorized." };
 
-  const email = ((formData.get("email") as string) ?? "").trim().toLowerCase();
-  if (!email) return { error: "Email is required." };
+  const raw = ((formData.get("email") as string) ?? "").trim().toLowerCase();
+  if (!raw) return { error: "Email is required." };
 
-  const user = await prisma.user.findUnique({
-    where: { email },
+  // User.email is stored in canonical (normalized) form, so look up the
+  // normalized address first, then fall back to the raw form for legacy
+  // accounts created before normalization landed (mirrors lib/auth.ts).
+  const normalized = normalizeEmail(raw);
+  let user = await prisma.user.findUnique({
+    where: { email: normalized },
     select: { id: true, email: true },
   });
-  if (!user) return { error: `No user found for ${email}.` };
+  if (!user && raw !== normalized) {
+    user = await prisma.user.findUnique({
+      where: { email: raw },
+      select: { id: true, email: true },
+    });
+  }
+  if (!user) return { error: `No user found for ${raw}.` };
 
   const { count } = await prisma.session.deleteMany({ where: { userId: user.id } });
 
@@ -51,6 +69,7 @@ export async function revokeAllSessions(
   _prev: { error?: string; success?: boolean; count?: number },
   formData: FormData,
 ): Promise<{ error?: string; success?: boolean; count?: number }> {
+  if (selfHostBlocked()) return { error: "Not authorized." };
   const sa = await getSuperAdmin();
   if (!sa) return { error: "Not authorized." };
 

--- a/apps/web/app/admin/sessions/page.tsx
+++ b/apps/web/app/admin/sessions/page.tsx
@@ -1,0 +1,21 @@
+import { notFound } from "next/navigation";
+import { getSuperAdmin } from "@/lib/superadmin";
+import { SessionsClient } from "./sessions-client";
+
+// Per-request: the super-admin guard reads the session, and the env allowlist is
+// empty at build time (a static prerender would bake in a 404).
+export const dynamic = "force-dynamic";
+
+/**
+ * /admin/sessions — vendor (Octopus staff) session-revocation console.
+ * Super-admin only (env allowlist); 404 for everyone else so the route isn't
+ * disclosed. Hidden on self-host.
+ */
+export default async function AdminSessionsPage() {
+  if (process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true") notFound();
+
+  const sa = await getSuperAdmin();
+  if (!sa) notFound();
+
+  return <SessionsClient />;
+}

--- a/apps/web/app/admin/sessions/sessions-client.tsx
+++ b/apps/web/app/admin/sessions/sessions-client.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { revokeUserSessionsByEmail, revokeAllSessions } from "./actions";
+
+export function SessionsClient() {
+  const [email, setEmail] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [busy, startTransition] = useTransition();
+  const [userResult, setUserResult] = useState<{ error?: string; success?: boolean; count?: number; email?: string }>({});
+  const [allResult, setAllResult] = useState<{ error?: string; success?: boolean; count?: number }>({});
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 p-6 md:p-10">
+      <div>
+        <h1 className="text-xl font-semibold">Session Revocation</h1>
+        <p className="text-sm text-muted-foreground">
+          Force users to re-authenticate. Revoking a user&apos;s sessions signs them
+          out of Octopus entirely, across every organization and device.
+        </p>
+      </div>
+
+      {/* Revoke a single user's sessions */}
+      <form
+        action={(formData) => {
+          startTransition(async () => {
+            setUserResult({});
+            setUserResult(await revokeUserSessionsByEmail({}, formData));
+          });
+        }}
+        className="space-y-3 rounded-lg border p-5"
+      >
+        <div className="space-y-2">
+          <Label htmlFor="email">Revoke a user&apos;s sessions</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="user@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <p className="text-xs text-muted-foreground">
+            Use for a compromised or leaked session. The user stays active and can
+            sign back in — this only invalidates their current sessions.
+          </p>
+        </div>
+        {userResult.error && <p className="text-sm text-destructive">{userResult.error}</p>}
+        {userResult.success && (
+          <p className="text-sm text-green-600">
+            Revoked {userResult.count} session{userResult.count === 1 ? "" : "s"} for {userResult.email}.
+          </p>
+        )}
+        <Button type="submit" size="sm" disabled={busy || !email.trim()}>
+          {busy ? "Working..." : "Revoke sessions"}
+        </Button>
+      </form>
+
+      {/* Nuclear: revoke everything */}
+      <form
+        action={(formData) => {
+          startTransition(async () => {
+            setAllResult({});
+            setAllResult(await revokeAllSessions({}, formData));
+          });
+        }}
+        className="space-y-3 rounded-lg border border-destructive/40 p-5"
+      >
+        <div className="space-y-2">
+          <Label htmlFor="confirm" className="text-destructive">
+            Revoke ALL platform sessions
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Incident response only. Signs out every user on the platform —
+            <strong> including you</strong>. Type <code>REVOKE ALL</code> to confirm.
+          </p>
+          <Input
+            id="confirm"
+            name="confirm"
+            placeholder="REVOKE ALL"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            autoComplete="off"
+          />
+        </div>
+        {allResult.error && <p className="text-sm text-destructive">{allResult.error}</p>}
+        {allResult.success && (
+          <p className="text-sm text-green-600">Revoked {allResult.count} sessions platform-wide.</p>
+        )}
+        <Button
+          type="submit"
+          size="sm"
+          variant="destructive"
+          disabled={busy || confirm !== "REVOKE ALL"}
+        >
+          {busy ? "Working..." : "Revoke all sessions"}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/app/api/orgs/[orgId]/members/[memberId]/revoke-sessions/route.ts
+++ b/apps/web/app/api/orgs/[orgId]/members/[memberId]/revoke-sessions/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { writeAuditLog } from "@/lib/audit";
+
+// POST /api/orgs/:orgId/members/:memberId/revoke-sessions
+// Sign a member out of Octopus by revoking all their sessions. Owner/admin only.
+// NOTE: sessions are per-user, not per-org, so this signs the member out of
+// EVERY organization and device they're using — not just this one.
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ orgId: string; memberId: string }> },
+) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { orgId, memberId } = await params;
+
+  // Caller must be owner or admin of this org.
+  const caller = await prisma.organizationMember.findFirst({
+    where: {
+      organizationId: orgId,
+      userId: session.user.id,
+      role: { in: ["owner", "admin"] },
+      deletedAt: null,
+    },
+  });
+  if (!caller) {
+    return NextResponse.json({ error: "Forbidden: admin role required" }, { status: 403 });
+  }
+
+  // Target must be a current member of THIS org (prevents revoking arbitrary users).
+  const target = await prisma.organizationMember.findFirst({
+    where: { id: memberId, organizationId: orgId, deletedAt: null },
+    select: { userId: true, role: true, user: { select: { email: true } } },
+  });
+  if (!target) {
+    return NextResponse.json({ error: "Member not found" }, { status: 404 });
+  }
+
+  // Use the self-service sign-out for your own sessions.
+  if (target.userId === session.user.id) {
+    return NextResponse.json(
+      { error: "Cannot revoke your own sessions here. Use Settings → Sessions." },
+      { status: 400 },
+    );
+  }
+
+  // Protect the owner (mirrors remove/role-change guards).
+  if (target.role === "owner") {
+    return NextResponse.json({ error: "Cannot revoke the owner's sessions" }, { status: 400 });
+  }
+
+  const { count } = await prisma.session.deleteMany({ where: { userId: target.userId } });
+
+  await writeAuditLog({
+    action: "auth.member_sessions_revoked",
+    category: "auth",
+    actorId: session.user.id,
+    actorEmail: session.user.email,
+    organizationId: orgId,
+    targetType: "user",
+    targetId: target.userId,
+    metadata: { memberId, email: target.user.email, count },
+  });
+
+  return NextResponse.json({ success: true, count });
+}


### PR DESCRIPTION
## What

Adds the ability for admins to **force users to re-authenticate** by revoking their sessions — requested as an admin capability after a session token was leaked in a bug report. Revoking deletes the user's `sessions` rows, which invalidates every token immediately (better-auth validates tokens against the row).

Two surfaces, per the agreed scope (**both**):

### 1. Super-admin console — `/admin/sessions`
Env-allowlist gated (same `getSuperAdmin()` guard as `/admin/telemetry` and `/admin/settings`), 404 for everyone else, hidden on self-host.
- **Revoke a user's sessions by email** — targeted response to a leaked/compromised session; the user stays active and can sign back in.
- **Revoke ALL platform sessions** — incident-response nuke, gated by a typed `REVOKE ALL` confirmation **server-side and in the UI**. Signs out everyone, including the acting admin (stated in the copy).
- Both actions re-check `getSuperAdmin()` and write an `admin`-category audit log.

### 2. Per-org owner/admin — Settings → Team
- `POST /api/orgs/:orgId/members/:memberId/revoke-sessions` signs a member out.
- Authz mirrors the existing member endpoints exactly: caller must be **owner/admin of the org**, target must be a **current member of that org** (no arbitrary-user reach), and **owner + self are protected**.
- A sign-out button per member with a confirm dialog. Audit-logged (`auth` category).

## Important nuance (surfaced in the UI)

Sessions are **per-user, not per-org**, so revoking signs the member out of **every** organization and device — not just the current one. The confirm dialogs state this explicitly so an org admin isn't surprised.

## Testing

Typecheck clean. Mechanism (`prisma.session.deleteMany({ where: { userId } })`) and authz mirror existing, reviewed patterns (`members/[memberId]` PATCH/DELETE guards; `/admin/*` super-admin gate). No new migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p