### PR TITLE
fix(chat): back off agent-status polling on failure (#440)

### DIFF
--- a/apps/web/components/chat-provider.tsx
+++ b/apps/web/components/chat-provider.tsx
@@ -384,7 +384,7 @@ export function ChatProvider({
       if (!stopped) timer = setTimeout(fetchAgents, delay);
     };
 
-    fetchAgents();
+    void fetchAgents();
     return () => {
       stopped = true;
       if (timer) clearTimeout(timer);

--- a/apps/web/components/chat-provider.tsx
+++ b/apps/web/components/chat-provider.tsx
@@ -348,9 +348,20 @@ export function ChatProvider({
     };
   }, [orgId, loadConversations]);
 
-  // Fetch connected agents on mount and periodically
+  // Fetch connected agents on mount and periodically.
+  // Self-scheduling with exponential backoff: a healthy session polls every 30s,
+  // but on failure (e.g. a 401 from a stale tab whose session expired) the delay
+  // doubles up to a 10-min cap instead of hammering the endpoint every 30s
+  // forever. Recovers to 30s automatically once a request succeeds again.
   useEffect(() => {
+    const BASE_MS = 30_000;
+    const MAX_MS = 10 * 60_000;
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let delay = BASE_MS;
+
     const fetchAgents = async () => {
+      if (stopped) return;
       try {
         const res = await fetch(`/api/agent/status?orgId=${orgId}`);
         if (res.ok) {
@@ -363,12 +374,21 @@ export function ChatProvider({
               capabilities: a.capabilities,
             })),
           );
+          delay = BASE_MS;
+        } else {
+          delay = Math.min(delay * 2, MAX_MS);
         }
-      } catch {}
+      } catch {
+        delay = Math.min(delay * 2, MAX_MS);
+      }
+      if (!stopped) timer = setTimeout(fetchAgents, delay);
     };
+
     fetchAgents();
-    const interval = setInterval(fetchAgents, 30_000);
-    return () => clearInterval(interval);
+    return () => {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+    };
   }, [orgId]);
 
   const createNewChat = useCallback(() => {


### PR DESCRIPTION
## What

Closes #440. nginx logs showed **~55k `401`s** (~21% of ingress over 10 days) on `GET /api/agent/status`, almost all from two IPs.

Root cause: `chat-provider.tsx` polled the endpoint every **30s via a fixed `setInterval`** and silently ignored non-ok responses (`if (res.ok)` with no `else`). A browser tab left open after its session expired kept polling every 30s forever — 30s × a couple of stale tabs × 10 days ≈ the observed ~55k. (The issue calls them "agent clients"; it's actually the web app's agent-presence poll — the only interval poller of that endpoint in the codebase.)

## Fix

Replace the fixed interval with a **self-scheduling timeout + capped exponential backoff**:
- healthy session → unchanged, polls every 30s;
- on failure (401 or network) → delay doubles up to a **10-min cap**, so a dead session drops from ~2,880 requests/day to a handful;
- resets to 30s on the next success, so it **recovers automatically** if the session comes back.

## Testing

Typecheck clean. Behavior traced: success resets `delay=BASE`, failure sets `delay=min(delay*2, MAX)`, cleanup sets `stopped` + clears the timer (no leak/re-entrancy on `orgId` change or unmount). Verification per the issue is the nginx 401 rate dropping post-deploy as stale tabs cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p