### PR TITLE
fix(middleware): stop 307→/login for public content paths (#443)

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -13,15 +13,6 @@ const publicPrefixes = [
   "/not-a-rabbit",
   "/compare",
   "/vs-",
-  // Public content/marketing + feed paths. These must never bounce anonymous
-  // visitors or crawlers to /login; ones that aren't built yet then fall
-  // through to a normal 404 instead of a 307→/login (#443). (Extensioned feeds
-  // like /feed.xml already bypass the middleware via the matcher's dot rule.)
-  "/careers",
-  "/open-positions",
-  "/jobs",
-  "/feed",
-  "/rss",
   "/api/auth",
   "/api/github",
   "/api/bitbucket/webhook",
@@ -45,6 +36,14 @@ const publicPrefixes = [
 ];
 const publicExact = ["/"];
 
+// Public content/marketing + feed paths. Anonymous visitors and crawlers must
+// never be bounced to /login here; paths that aren't built yet then fall
+// through to a normal 404 instead of a 307→/login (#443). Matched on an exact
+// or path-segment boundary (not a bare prefix) so "/feed" can't also whitelist
+// a future "/feedback". Extensioned feeds like /feed.xml already bypass the
+// middleware via the matcher's dot rule.
+const publicContentPrefixes = ["/careers", "/open-positions", "/jobs", "/feed", "/rss"];
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -66,7 +65,8 @@ export function middleware(request: NextRequest) {
 
   if (
     publicExact.includes(pathname) ||
-    publicPrefixes.some((path) => pathname.startsWith(path))
+    publicPrefixes.some((path) => pathname.startsWith(path)) ||
+    publicContentPrefixes.some((path) => pathname === path || pathname.startsWith(path + "/"))
   ) {
     return NextResponse.next();
   }

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -13,6 +13,15 @@ const publicPrefixes = [
   "/not-a-rabbit",
   "/compare",
   "/vs-",
+  // Public content/marketing + feed paths. These must never bounce anonymous
+  // visitors or crawlers to /login; ones that aren't built yet then fall
+  // through to a normal 404 instead of a 307→/login (#443). (Extensioned feeds
+  // like /feed.xml already bypass the middleware via the matcher's dot rule.)
+  "/careers",
+  "/open-positions",
+  "/jobs",
+  "/feed",
+  "/rss",
   "/api/auth",
   "/api/github",
   "/api/bitbucket/webhook",


### PR DESCRIPTION
## What

Closes #443. `/careers`, `/open-positions`, `/jobs`, `/feed`, `/rss` returned a **307 → /login** for anonymous visitors (the middleware's catch-all treats every unauthenticated non-public path as "redirect to login"). That's an auth bounce on public/marketing/feed URLs — bad UX and bad for crawlers.

## Fix

Add those paths to the middleware `publicPrefixes` allowlist. None are built yet, so they now fall through to a **normal 404** instead of the login redirect — exactly the issue's acceptance criterion ("if they don't exist, return a proper 404 instead of an auth redirect"). If/when the pages or the RSS feed (#444) land, they serve publicly with no further middleware change. Extensioned feeds like `/feed.xml` already bypass middleware via the matcher's dot rule.

## Deliberately scoped

I did **not** invert the auth model (allowlisting protected routes instead of public ones) — that's a larger, riskier change and a separate design decision. This is the minimal, safe fix for the named paths.

## Testing

Typecheck clean. Verified against the matcher: these dot-less paths hit the middleware; being in `publicPrefixes` now returns `NextResponse.next()` → Next serves the route or 404s, instead of the 307 redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p