### PR TITLE
fix(middleware): allow token-less /api/oss-review trigger through (#536 follow-up)

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -30,6 +30,9 @@ const publicPrefixes = [
   "/api/analyze-deps",
   "/api/blog",
   "/api/ask-octopus",
+  // Token-less OSS bot-review trigger — called by a zero-permission action with
+  // no session; gated by allowlist + consent file + rate limit in the handler.
+  "/api/oss-review",
   "/api/status",
   "/api/health",
   "/api/ready",


### PR DESCRIPTION
Follow-up to #536. That PR added `POST /api/oss-review` but not the middleware allowlist entry, so an **unauthenticated** request — which is the entire design (a zero-permission trigger action with no session) — was **307-redirected to `/login`** and never reached the handler. Verified in prod: `POST /api/oss-review` → 307 → `/login`.

Adds `/api/oss-review` to `publicPrefixes`. It remains gated **in the handler** by `isBotAccountConfigured()` (503 until a bot token is set) + repo allowlist + `.github/octopus.yml` consent + rate limit — same unauthenticated-but-guarded model as `/api/github-action/review`.

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p