### PR TITLE
feat(self-host): one-click GitHub App creation (App Manifest flow)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,11 @@ AUDIT_LOG_RETENTION_DAYS=
 # building from source. Leave both unset for the hosted build.
 NEXT_PUBLIC_APP_VERSION=
 NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=
+# Optional RUNTIME self-host flag. NEXT_PUBLIC_OCTOPUS_SELF_HOSTED is inlined at
+# build time, so if you build a custom image without the build arg, set
+# OCTOPUS_SELF_HOSTED=true at runtime to enable server-side self-host features
+# (e.g. one-click GitHub App creation). Not needed for the official self-host image.
+OCTOPUS_SELF_HOSTED=
 # First-boot admin seed (self-host only). The password is RANDOM per install and
 # printed once to the boot log; set OCTOPUS_ADMIN_PASSWORD (10+ chars) to pin a
 # known one, or OCTOPUS_ADMIN_EMAIL to change the address. DISABLE_ADMIN_SEED=true

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
+import { getGithubAppConfig } from "@/lib/github-app-config";
 import { prisma } from "@octopus/db";
 import { decryptStringMaybeLegacy } from "@/lib/crypto";
 import { Card } from "@/components/ui/card";
@@ -175,7 +176,7 @@ export default async function DashboardPage({
   const indexedRepos = repos.filter((r) => r.indexStatus === "indexed").length;
   const notIndexedRepos = totalRepos - indexedRepos;
   const githubConnected = org.githubInstallationId !== null;
-  const githubAppSlug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG;
+  const githubAppSlug = (await getGithubAppConfig())?.slug ?? undefined;
 
   const bitbucketIntegration = await prisma.bitbucketIntegration.findUnique({
     where: { organizationId: org.id },

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
+import { getGithubAppConfig } from "@/lib/github-app-config";
 import { prisma } from "@octopus/db";
 import { AppSidebar, MobileHeader } from "@/components/app-sidebar";
 import { ChatWrapper } from "@/components/chat-wrapper";
@@ -177,7 +178,7 @@ export default async function AppLayout({
     canCreateOrg,
   };
 
-  const githubAppSlug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG;
+  const githubAppSlug = (await getGithubAppConfig())?.slug ?? undefined;
 
   // Check GitHub for orgs that need permission — auto-clear if already granted
   const flaggedOrgs = orgs.filter((o) => o.needsPermissionGrant && o.githubInstallationId);

--- a/apps/web/app/(app)/repositories/page.tsx
+++ b/apps/web/app/(app)/repositories/page.tsx
@@ -1,6 +1,7 @@
 import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
+import { getGithubAppConfig } from "@/lib/github-app-config";
 import { prisma } from "@octopus/db";
 import { HARDCODED_REVIEW_MODEL, HARDCODED_EMBED_MODEL } from "@/lib/ai-client";
 import { RepositoriesContent } from "./repositories-content";
@@ -227,7 +228,7 @@ export default async function RepositoriesPage({
       repos={mappedRepos}
       orgId={orgId}
       selectedRepoId={selectedRepoId ?? null}
-      githubAppSlug={process.env.NEXT_PUBLIC_GITHUB_APP_SLUG ?? null}
+      githubAppSlug={(await getGithubAppConfig())?.slug ?? null}
       favoriteRepoIds={favoriteRepoIds}
       availableModels={availableModels}
       orgDefaultLlmName={orgDefaultLlmName}

--- a/apps/web/app/(app)/settings/integrations/github-integration-card.tsx
+++ b/apps/web/app/(app)/settings/integrations/github-integration-card.tsx
@@ -191,26 +191,28 @@ export function GitHubIntegrationCard({
                   account, or enter a GitHub organization to create it there (needed
                   if your repos live in an org).
                 </p>
-                <Input
-                  value={manifestOrg}
-                  onChange={(e) => setManifestOrg(e.target.value)}
-                  placeholder="GitHub organization (optional)"
-                  aria-label="GitHub organization (optional)"
-                />
-                <Button asChild>
-                  <a
-                    href={createAppHref}
-                    onClick={() =>
-                      trackEvent("cta_click", {
-                        location: "settings_integrations",
-                        label: "create_github_app_manifest",
-                      })
-                    }
-                  >
+                <form
+                  className="space-y-3"
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    trackEvent("cta_click", {
+                      location: "settings_integrations",
+                      label: "create_github_app_manifest",
+                    });
+                    window.location.href = createAppHref;
+                  }}
+                >
+                  <Input
+                    value={manifestOrg}
+                    onChange={(e) => setManifestOrg(e.target.value)}
+                    placeholder="GitHub organization (optional)"
+                    aria-label="GitHub organization (optional)"
+                  />
+                  <Button type="submit">
                     <IconBrandGithub className="mr-2 size-4" />
                     Create GitHub App
-                  </a>
-                </Button>
+                  </Button>
+                </form>
                 <p className="text-xs">
                   <a
                     href="/docs/github-app"

--- a/apps/web/app/(app)/settings/integrations/github-integration-card.tsx
+++ b/apps/web/app/(app)/settings/integrations/github-integration-card.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -38,6 +39,11 @@ type GitHubError =
   | "invalid_state_malformed"
   | "replay_detected"
   | "not_a_member"
+  | "manifest_forbidden"
+  | "manifest_already_configured"
+  | "manifest_bad_org"
+  | "manifest_expired"
+  | "manifest_failed"
   | null;
 
 const ERROR_TITLES: Record<Exclude<GitHubError, null>, string> = {
@@ -49,6 +55,11 @@ const ERROR_TITLES: Record<Exclude<GitHubError, null>, string> = {
   invalid_state_malformed: "Install flow could not be verified",
   replay_detected: "Install link already used",
   not_a_member: "Organization access lost",
+  manifest_forbidden: "Not allowed",
+  manifest_already_configured: "GitHub App already set up",
+  manifest_bad_org: "Invalid organization",
+  manifest_expired: "Setup expired",
+  manifest_failed: "Couldn't create the GitHub App",
 };
 
 const ERROR_MESSAGES: Record<Exclude<GitHubError, null>, string> = {
@@ -67,6 +78,16 @@ const ERROR_MESSAGES: Record<Exclude<GitHubError, null>, string> = {
     "This install link has already been used. Please start a new install flow.",
   not_a_member:
     "You are no longer a member of the organization you started the install for. Switch organizations and try again.",
+  manifest_forbidden:
+    "Only an organization owner or admin can create the GitHub App. Ask an admin, or switch to an org you own.",
+  manifest_already_configured:
+    "A GitHub App is already configured for this instance. Reload the page — you should see an “Install GitHub App” button.",
+  manifest_bad_org:
+    "That doesn't look like a valid GitHub organization name. Leave it blank to create the App under your personal account.",
+  manifest_expired:
+    "The setup flow expired. Please start again and finish within 15 minutes.",
+  manifest_failed:
+    "Something went wrong creating the GitHub App. Please try again; if it persists, use the manual setup guide.",
 };
 
 const INSTALL_URL = "/api/github/install?returnTo=/settings/integrations";
@@ -74,10 +95,12 @@ const INSTALL_URL = "/api/github/install?returnTo=/settings/integrations";
 export function GitHubIntegrationCard({
   data,
   appSlug,
+  isSelfHosted = false,
   error,
 }: {
   data: GitHubData;
   appSlug: string | null;
+  isSelfHosted?: boolean;
   error?: GitHubError;
 }) {
   const [isPending, startTransition] = useTransition();
@@ -85,6 +108,10 @@ export function GitHubIntegrationCard({
   const [errorOpen, setErrorOpen] = useState<boolean>(Boolean(error));
   const [confirmDisconnectOpen, setConfirmDisconnectOpen] = useState(false);
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
+  const [manifestOrg, setManifestOrg] = useState("");
+  const createAppHref = `/api/github/app-manifest/new${
+    manifestOrg.trim() ? `?org=${encodeURIComponent(manifestOrg.trim())}` : ""
+  }`;
 
   useEffect(() => {
     setErrorOpen(Boolean(error));
@@ -155,6 +182,44 @@ export function GitHubIntegrationCard({
                   Install GitHub App
                 </a>
               </Button>
+            ) : isSelfHosted ? (
+              <div className="space-y-3">
+                <p className="text-sm text-[#888]">
+                  Octopus needs a GitHub App (separate from OAuth login) to receive
+                  PR webhooks and post reviews. Create one automatically — no manual
+                  config. Leave the field blank to create it under your personal
+                  account, or enter a GitHub organization to create it there (needed
+                  if your repos live in an org).
+                </p>
+                <Input
+                  value={manifestOrg}
+                  onChange={(e) => setManifestOrg(e.target.value)}
+                  placeholder="GitHub organization (optional)"
+                  aria-label="GitHub organization (optional)"
+                />
+                <Button asChild>
+                  <a
+                    href={createAppHref}
+                    onClick={() =>
+                      trackEvent("cta_click", {
+                        location: "settings_integrations",
+                        label: "create_github_app_manifest",
+                      })
+                    }
+                  >
+                    <IconBrandGithub className="mr-2 size-4" />
+                    Create GitHub App
+                  </a>
+                </Button>
+                <p className="text-xs">
+                  <a
+                    href="/docs/github-app"
+                    className="text-cyan-400 underline decoration-cyan-400/30 underline-offset-2 hover:decoration-cyan-400"
+                  >
+                    Prefer to set it up manually? →
+                  </a>
+                </p>
+              </div>
             ) : (
               <div className="rounded-lg border border-amber-900/30 bg-amber-950/10 p-3 text-sm">
                 <p className="font-medium text-amber-200">

--- a/apps/web/app/(app)/settings/integrations/page.tsx
+++ b/apps/web/app/(app)/settings/integrations/page.tsx
@@ -10,6 +10,7 @@ import { GitlabIntegrationCard } from "./gitlab-integration-card";
 import { LinearIntegrationCard } from "./linear-integration-card";
 import { JiraIntegrationCard } from "./jira-integration-card";
 import { getGithubAppConfig } from "@/lib/github-app-config";
+import { isSelfHosted } from "@/lib/self-hosted";
 
 const ALLOWED_GITHUB_ERRORS = [
   "installation_already_bound",
@@ -129,7 +130,7 @@ export default async function IntegrationsPage({
   // DB-first so the card flips to "Install" after a manifest-created app whose
   // NEXT_PUBLIC_* slug isn't baked into this build.
   const appSlug = (await getGithubAppConfig())?.slug ?? null;
-  const isSelfHosted = process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true";
+  const selfHosted = isSelfHosted();
 
   return (
     <div className="space-y-6">
@@ -138,7 +139,7 @@ export default async function IntegrationsPage({
       <GitHubIntegrationCard
         data={githubData}
         appSlug={appSlug}
-        isSelfHosted={isSelfHosted}
+        isSelfHosted={selfHosted}
         error={githubError}
       />
       <BitbucketIntegrationCard data={bitbucketIntegration} />

--- a/apps/web/app/(app)/settings/integrations/page.tsx
+++ b/apps/web/app/(app)/settings/integrations/page.tsx
@@ -9,6 +9,7 @@ import { BitbucketDebugBanner } from "./bitbucket-debug-banner";
 import { GitlabIntegrationCard } from "./gitlab-integration-card";
 import { LinearIntegrationCard } from "./linear-integration-card";
 import { JiraIntegrationCard } from "./jira-integration-card";
+import { getGithubAppConfig } from "@/lib/github-app-config";
 
 const ALLOWED_GITHUB_ERRORS = [
   "installation_already_bound",
@@ -19,6 +20,11 @@ const ALLOWED_GITHUB_ERRORS = [
   "invalid_state_malformed",
   "replay_detected",
   "not_a_member",
+  "manifest_forbidden",
+  "manifest_already_configured",
+  "manifest_bad_org",
+  "manifest_expired",
+  "manifest_failed",
 ] as const;
 
 type GitHubErrorCode = (typeof ALLOWED_GITHUB_ERRORS)[number];
@@ -120,7 +126,10 @@ export default async function IntegrationsPage({
       .catch(() => null),
   ]);
 
-  const appSlug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG ?? null;
+  // DB-first so the card flips to "Install" after a manifest-created app whose
+  // NEXT_PUBLIC_* slug isn't baked into this build.
+  const appSlug = (await getGithubAppConfig())?.slug ?? null;
+  const isSelfHosted = process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true";
 
   return (
     <div className="space-y-6">
@@ -129,6 +138,7 @@ export default async function IntegrationsPage({
       <GitHubIntegrationCard
         data={githubData}
         appSlug={appSlug}
+        isSelfHosted={isSelfHosted}
         error={githubError}
       />
       <BitbucketIntegrationCard data={bitbucketIntegration} />

--- a/apps/web/app/api/github/app-manifest/callback/route.ts
+++ b/apps/web/app/api/github/app-manifest/callback/route.ts
@@ -37,7 +37,15 @@ export async function GET(request: NextRequest) {
   if (!code || !state) return errorRedirect("failed");
 
   const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) return NextResponse.redirect(new URL("/login", baseUrl));
+  if (!session) {
+    // Session expired between "Create" on GitHub and this callback: preserve the
+    // one-time code + state through login so re-authenticating resumes the flow
+    // instead of orphaning the just-created app. (The state cookie survives login.)
+    const resume = `/api/github/app-manifest/callback?code=${encodeURIComponent(code)}&state=${encodeURIComponent(state)}`;
+    return NextResponse.redirect(
+      new URL(`/login?callbackUrl=${encodeURIComponent(resume)}`, baseUrl),
+    );
+  }
 
   // Validate state: decrypt, expiry, cookie-nonce (CSRF), then re-check the
   // caller is still an owner/admin of the org from the signed state.

--- a/apps/web/app/api/github/app-manifest/callback/route.ts
+++ b/apps/web/app/api/github/app-manifest/callback/route.ts
@@ -3,7 +3,7 @@ import { cookies, headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { decryptJson } from "@/lib/crypto";
-import { saveGithubAppConfig } from "@/lib/github-app-config";
+import { saveGithubAppConfig, hasDbGithubApp } from "@/lib/github-app-config";
 import { signInstallState } from "@/lib/github-install-state";
 import {
   GITHUB_MANIFEST_STATE_COOKIE,
@@ -67,6 +67,12 @@ export async function GET(request: NextRequest) {
     select: { organizationId: true },
   });
   if (!membership) return errorRedirect("forbidden");
+
+  // Re-check (fresh, non-memoized DB read) that no App has been provisioned
+  // since this flow started — never clobber existing credentials (TOCTOU guard).
+  // If one now exists, the app just created on GitHub is a harmless orphan the
+  // admin can delete there.
+  if (await hasDbGithubApp()) return errorRedirect("already_configured");
 
   // Exchange the one-time code for the new App's credentials. The code itself
   // authorizes this call, so no JWT/token is needed.

--- a/apps/web/app/api/github/app-manifest/callback/route.ts
+++ b/apps/web/app/api/github/app-manifest/callback/route.ts
@@ -112,8 +112,9 @@ export async function GET(request: NextRequest) {
     return errorRedirect("failed");
   }
 
+  let saved: boolean;
   try {
-    await saveGithubAppConfig({
+    saved = await saveGithubAppConfig({
       appId: conv.id,
       slug: conv.slug,
       htmlUrl: conv.html_url ?? null,
@@ -126,6 +127,8 @@ export async function GET(request: NextRequest) {
     console.error("[app-manifest] failed to persist app config:", err);
     return errorRedirect("failed");
   }
+  // Conditional write lost to a concurrent flow — an App is already configured.
+  if (!saved) return errorRedirect("already_configured");
 
   // Auto-continue: send the user to install the freshly-created App on their
   // repos. The install callback binds the installation to the org as usual.

--- a/apps/web/app/api/github/app-manifest/callback/route.ts
+++ b/apps/web/app/api/github/app-manifest/callback/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { decryptJson } from "@/lib/crypto";
 import { saveGithubAppConfig, hasDbGithubApp } from "@/lib/github-app-config";
+import { isSelfHosted } from "@/lib/self-hosted";
 import { signInstallState } from "@/lib/github-install-state";
 import {
   GITHUB_MANIFEST_STATE_COOKIE,
@@ -28,7 +29,7 @@ function errorRedirect(reason: string): NextResponse {
  * persist them (encrypted), then send the user straight into installing the App.
  */
 export async function GET(request: NextRequest) {
-  if (process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED !== "true") {
+  if (!isSelfHosted()) {
     return NextResponse.json({ error: "not_self_hosted" }, { status: 404 });
   }
 
@@ -97,6 +98,7 @@ export async function GET(request: NextRequest) {
     const res = await fetch(`${GITHUB_API}/app-manifests/${code}/conversions`, {
       method: "POST",
       headers: { Accept: "application/vnd.github+json" },
+      signal: AbortSignal.timeout(15_000),
     });
     if (!res.ok) {
       console.error(`[app-manifest] conversions failed: ${res.status}`);

--- a/apps/web/app/api/github/app-manifest/callback/route.ts
+++ b/apps/web/app/api/github/app-manifest/callback/route.ts
@@ -1,0 +1,129 @@
+import { NextRequest, NextResponse } from "next/server";
+import { cookies, headers } from "next/headers";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { decryptJson } from "@/lib/crypto";
+import { saveGithubAppConfig } from "@/lib/github-app-config";
+import { signInstallState } from "@/lib/github-install-state";
+import {
+  GITHUB_MANIFEST_STATE_COOKIE,
+  type GithubManifestState,
+} from "@/lib/github-manifest-state";
+
+const baseUrl = process.env.BETTER_AUTH_URL || "http://localhost:3000";
+const GITHUB_API = "https://api.github.com";
+
+function errorRedirect(reason: string): NextResponse {
+  const res = NextResponse.redirect(
+    new URL(`/settings/integrations?error=manifest_${reason}`, baseUrl),
+  );
+  res.cookies.delete(GITHUB_MANIFEST_STATE_COOKIE);
+  return res;
+}
+
+/**
+ * GET /api/github/app-manifest/callback — finish the App Manifest flow.
+ * GitHub redirects here with a one-time `code` after the user creates the App.
+ * We validate the CSRF state, exchange the code for the App's credentials,
+ * persist them (encrypted), then send the user straight into installing the App.
+ */
+export async function GET(request: NextRequest) {
+  if (process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED !== "true") {
+    return NextResponse.json({ error: "not_self_hosted" }, { status: 404 });
+  }
+
+  const code = request.nextUrl.searchParams.get("code");
+  const state = request.nextUrl.searchParams.get("state");
+  if (!code || !state) return errorRedirect("failed");
+
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return NextResponse.redirect(new URL("/login", baseUrl));
+
+  // Validate state: decrypt, expiry, cookie-nonce (CSRF), then re-check the
+  // caller is still an owner/admin of the org from the signed state.
+  let payload: GithubManifestState;
+  try {
+    payload = decryptJson<GithubManifestState>(state);
+  } catch {
+    return errorRedirect("failed");
+  }
+  if (typeof payload.exp !== "number" || payload.exp < Date.now()) {
+    return errorRedirect("expired");
+  }
+  const cookieStore = await cookies();
+  const cookieNonce = cookieStore.get(GITHUB_MANIFEST_STATE_COOKIE)?.value;
+  if (!cookieNonce || cookieNonce !== payload.nonce) {
+    return errorRedirect("failed");
+  }
+  if (payload.userId !== session.user.id) return errorRedirect("forbidden");
+
+  const membership = await prisma.organizationMember.findFirst({
+    where: {
+      userId: session.user.id,
+      organizationId: payload.orgId,
+      role: { in: ["owner", "admin"] },
+      deletedAt: null,
+    },
+    select: { organizationId: true },
+  });
+  if (!membership) return errorRedirect("forbidden");
+
+  // Exchange the one-time code for the new App's credentials. The code itself
+  // authorizes this call, so no JWT/token is needed.
+  let conv: {
+    id: number;
+    slug: string;
+    html_url?: string;
+    pem: string;
+    webhook_secret?: string;
+    client_id?: string;
+    client_secret?: string;
+  };
+  try {
+    const res = await fetch(`${GITHUB_API}/app-manifests/${code}/conversions`, {
+      method: "POST",
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!res.ok) {
+      console.error(`[app-manifest] conversions failed: ${res.status}`);
+      return errorRedirect("failed");
+    }
+    conv = await res.json();
+  } catch (err) {
+    console.error("[app-manifest] conversions error:", err);
+    return errorRedirect("failed");
+  }
+
+  if (!conv?.id || !conv.slug || !conv.pem) {
+    return errorRedirect("failed");
+  }
+
+  try {
+    await saveGithubAppConfig({
+      appId: conv.id,
+      slug: conv.slug,
+      htmlUrl: conv.html_url ?? null,
+      clientId: conv.client_id ?? null,
+      privateKey: conv.pem,
+      webhookSecret: conv.webhook_secret ?? null,
+      clientSecret: conv.client_secret ?? null,
+    });
+  } catch (err) {
+    console.error("[app-manifest] failed to persist app config:", err);
+    return errorRedirect("failed");
+  }
+
+  // Auto-continue: send the user to install the freshly-created App on their
+  // repos. The install callback binds the installation to the org as usual.
+  const installState = signInstallState({
+    uid: session.user.id,
+    oid: membership.organizationId,
+    rt: "/settings/integrations",
+  });
+  const installUrl = new URL(`https://github.com/apps/${conv.slug}/installations/new`);
+  installUrl.searchParams.set("state", installState);
+
+  const res = NextResponse.redirect(installUrl.toString());
+  res.cookies.delete(GITHUB_MANIFEST_STATE_COOKIE);
+  return res;
+}

--- a/apps/web/app/api/github/app-manifest/new/route.ts
+++ b/apps/web/app/api/github/app-manifest/new/route.ts
@@ -5,6 +5,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { encryptJson } from "@/lib/crypto";
 import { isGithubAppConfigured } from "@/lib/github-app-config";
+import { isSelfHosted } from "@/lib/self-hosted";
 import {
   GITHUB_MANIFEST_STATE_COOKIE,
   GITHUB_MANIFEST_STATE_TTL_MS,
@@ -34,7 +35,7 @@ function htmlAttr(s: string): string {
  * is already configured (so we never clobber existing credentials).
  */
 export async function GET(request: NextRequest) {
-  if (process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED !== "true") {
+  if (!isSelfHosted()) {
     return NextResponse.json({ error: "not_self_hosted" }, { status: 404 });
   }
 

--- a/apps/web/app/api/github/app-manifest/new/route.ts
+++ b/apps/web/app/api/github/app-manifest/new/route.ts
@@ -1,0 +1,118 @@
+import crypto from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { cookies, headers } from "next/headers";
+import { auth } from "@/lib/auth";
+import { prisma } from "@octopus/db";
+import { encryptJson } from "@/lib/crypto";
+import { isGithubAppConfigured } from "@/lib/github-app-config";
+import {
+  GITHUB_MANIFEST_STATE_COOKIE,
+  GITHUB_MANIFEST_STATE_TTL_MS,
+  buildAppManifest,
+  type GithubManifestState,
+} from "@/lib/github-manifest-state";
+
+const baseUrl = process.env.BETTER_AUTH_URL || "http://localhost:3000";
+
+// GitHub org/user logins: alphanumeric or single hyphens, max 39 chars.
+const GH_LOGIN_RX = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+
+function htmlAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * GET /api/github/app-manifest/new — start the GitHub App Manifest flow
+ * (self-hosted only). Returns an auto-submitting form that POSTs a prefilled
+ * app manifest to github.com; GitHub redirects to /app-manifest/callback with a
+ * one-time code. Gated to self-host + an org owner/admin, and refused if an App
+ * is already configured (so we never clobber existing credentials).
+ */
+export async function GET(request: NextRequest) {
+  if (process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED !== "true") {
+    return NextResponse.json({ error: "not_self_hosted" }, { status: 404 });
+  }
+
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return NextResponse.redirect(new URL("/login", baseUrl));
+
+  const cookieStore = await cookies();
+  const orgId =
+    request.nextUrl.searchParams.get("orgId") || cookieStore.get("current_org_id")?.value;
+  if (!orgId) return NextResponse.redirect(new URL("/dashboard", baseUrl));
+
+  // Only an owner/admin of the org may provision the platform's GitHub App.
+  const membership = await prisma.organizationMember.findFirst({
+    where: {
+      userId: session.user.id,
+      organizationId: orgId,
+      role: { in: ["owner", "admin"] },
+      deletedAt: null,
+    },
+    select: { organizationId: true },
+  });
+  if (!membership) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=manifest_forbidden", baseUrl),
+    );
+  }
+
+  if (await isGithubAppConfigured()) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=manifest_already_configured", baseUrl),
+    );
+  }
+
+  // Optional GitHub org to own the app; blank = personal account.
+  const org = (request.nextUrl.searchParams.get("org") ?? "").trim();
+  if (org && !GH_LOGIN_RX.test(org)) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=manifest_bad_org", baseUrl),
+    );
+  }
+
+  const nonce = crypto.randomBytes(16).toString("base64url");
+  const state = encryptJson({
+    userId: session.user.id,
+    orgId: membership.organizationId,
+    org,
+    nonce,
+    exp: Date.now() + GITHUB_MANIFEST_STATE_TTL_MS,
+  } satisfies GithubManifestState);
+
+  // Globally-unique app name per GitHub's requirement.
+  const name = `octopus-${crypto.randomBytes(5).toString("hex")}`;
+  const manifest = buildAppManifest(baseUrl, name);
+
+  const action = org
+    ? `https://github.com/organizations/${encodeURIComponent(org)}/settings/apps/new`
+    : "https://github.com/settings/apps/new";
+  const actionUrl = `${action}?state=${encodeURIComponent(state)}`;
+
+  const html = `<!doctype html><html><head><meta charset="utf-8"><title>Creating GitHub App…</title></head>
+<body style="font-family:system-ui;padding:2rem;color:#444">
+<p>Redirecting to GitHub to create your Octopus GitHub App…</p>
+<form id="f" method="post" action="${htmlAttr(actionUrl)}">
+<input type="hidden" name="manifest" value="${htmlAttr(JSON.stringify(manifest))}">
+<noscript><button type="submit">Continue to GitHub</button></noscript>
+</form>
+<script>document.getElementById("f").submit();</script>
+</body></html>`;
+
+  const res = new NextResponse(html, {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+  res.cookies.set(GITHUB_MANIFEST_STATE_COOKIE, nonce, {
+    httpOnly: true,
+    secure: baseUrl.startsWith("https://"),
+    sameSite: "lax",
+    path: "/",
+    maxAge: Math.floor(GITHUB_MANIFEST_STATE_TTL_MS / 1000),
+  });
+  return res;
+}

--- a/apps/web/app/api/github/install/route.ts
+++ b/apps/web/app/api/github/install/route.ts
@@ -3,6 +3,7 @@ import { cookies, headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { signInstallState } from "@/lib/github-install-state";
+import { getGithubAppConfig } from "@/lib/github-app-config";
 
 const baseUrl = process.env.BETTER_AUTH_URL || "http://localhost:3000";
 
@@ -13,7 +14,7 @@ function safeRelativePath(value: string | null | undefined): string {
 }
 
 export async function GET(request: NextRequest) {
-  const appSlug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG;
+  const appSlug = (await getGithubAppConfig())?.slug;
   if (!appSlug) {
     return NextResponse.json({ error: "github_app_not_configured" }, { status: 500 });
   }

--- a/apps/web/app/api/github/webhook/route.ts
+++ b/apps/web/app/api/github/webhook/route.ts
@@ -11,10 +11,11 @@ import {
   updateCheckRun,
 } from "@/lib/github";
 import { startReviewFlow } from "@/lib/webhook-shared";
+import { getGithubAppConfig } from "@/lib/github-app-config";
 
-function verifySignature(payload: string, signature: string | null): boolean {
+async function verifySignature(payload: string, signature: string | null): Promise<boolean> {
   if (!signature) return false;
-  const secret = process.env.GITHUB_WEBHOOK_SECRET;
+  const secret = (await getGithubAppConfig())?.webhookSecret;
   if (!secret) return false;
 
   const expected =
@@ -32,7 +33,7 @@ export async function POST(request: NextRequest) {
   const body = await request.text();
   const signature = request.headers.get("x-hub-signature-256");
 
-  if (!verifySignature(body, signature)) {
+  if (!(await verifySignature(body, signature))) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
   }
 
@@ -394,11 +395,12 @@ export async function POST(request: NextRequest) {
     // comment author is a Bot whose login matches our app slug (covers old
     // payloads or edge cases where performed_via_github_app is absent).
     const commentId: number = payload.comment?.id;
-    const ownAppId = process.env.GITHUB_APP_ID;
+    const appConfig = await getGithubAppConfig();
+    const ownAppId = appConfig?.appId;
     const viaAppId = payload.comment?.performed_via_github_app?.id;
     const authorType: string | undefined = payload.comment?.user?.type;
     const authorLogin: string = payload.comment?.user?.login ?? "";
-    const appSlug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG ?? "";
+    const appSlug = appConfig?.slug ?? "";
     const isOwnApp = !!ownAppId && viaAppId != null && String(viaAppId) === String(ownAppId);
     const isOwnBotLogin =
       authorType === "Bot" && !!appSlug && authorLogin.toLowerCase() === `${appSlug}[bot]`.toLowerCase();

--- a/apps/web/lib/__tests__/github-app-config.test.ts
+++ b/apps/web/lib/__tests__/github-app-config.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+// Mutable SystemConfig row the mocked prisma returns.
+let sysRow: Record<string, unknown> | null = null;
+mock.module("@octopus/db", () => ({
+  prisma: {
+    systemConfig: { findUnique: () => Promise.resolve(sysRow) },
+  },
+}));
+
+const { getGithubAppConfig, clearGithubAppConfigCache } = await import(
+  "@/lib/github-app-config"
+);
+
+// decryptStringMaybeLegacy returns its input unchanged when the value isn't
+// valid ciphertext, so plaintext test values round-trip without a data key.
+const ENV = [
+  "GITHUB_APP_ID",
+  "GITHUB_APP_PRIVATE_KEY",
+  "GITHUB_WEBHOOK_SECRET",
+  "NEXT_PUBLIC_GITHUB_APP_SLUG",
+  "GITHUB_CLIENT_ID",
+];
+
+beforeEach(() => {
+  sysRow = null;
+  clearGithubAppConfigCache();
+  for (const k of ENV) delete process.env[k];
+});
+
+describe("getGithubAppConfig", () => {
+  it("prefers a DB-configured app over env", async () => {
+    sysRow = {
+      githubAppId: "999",
+      githubAppSlug: "octopus-db",
+      githubAppClientId: "cid-db",
+      githubAppHtmlUrl: "https://github.com/apps/octopus-db",
+      githubAppPrivateKeyEnc: "PEM-DB",
+      githubAppWebhookSecretEnc: "WH-DB",
+    };
+    process.env.GITHUB_APP_ID = "111";
+    process.env.GITHUB_APP_PRIVATE_KEY = "PEM-ENV";
+    process.env.NEXT_PUBLIC_GITHUB_APP_SLUG = "octopus-env";
+
+    const c = await getGithubAppConfig();
+    expect(c?.appId).toBe("999");
+    expect(c?.slug).toBe("octopus-db");
+    expect(c?.privateKey).toBe("PEM-DB");
+    expect(c?.webhookSecret).toBe("WH-DB");
+    expect(c?.htmlUrl).toBe("https://github.com/apps/octopus-db");
+  });
+
+  it("falls back to env when there is no DB app", async () => {
+    sysRow = null;
+    process.env.GITHUB_APP_ID = "111";
+    process.env.GITHUB_APP_PRIVATE_KEY = "PEM-ENV";
+    process.env.GITHUB_WEBHOOK_SECRET = "WH-ENV";
+    process.env.NEXT_PUBLIC_GITHUB_APP_SLUG = "octopus-env";
+
+    const c = await getGithubAppConfig();
+    expect(c?.appId).toBe("111");
+    expect(c?.slug).toBe("octopus-env");
+    expect(c?.privateKey).toBe("PEM-ENV");
+    expect(c?.webhookSecret).toBe("WH-ENV");
+    expect(c?.htmlUrl).toBeNull();
+  });
+
+  it("ignores a partial DB row (id without key) and uses env", async () => {
+    sysRow = { githubAppId: "999", githubAppPrivateKeyEnc: null };
+    process.env.GITHUB_APP_ID = "111";
+    process.env.GITHUB_APP_PRIVATE_KEY = "PEM-ENV";
+    const c = await getGithubAppConfig();
+    expect(c?.appId).toBe("111");
+  });
+
+  it("returns null when neither DB nor env is configured", async () => {
+    sysRow = null;
+    expect(await getGithubAppConfig()).toBeNull();
+  });
+});

--- a/apps/web/lib/__tests__/github-manifest.test.ts
+++ b/apps/web/lib/__tests__/github-manifest.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "bun:test";
+import { buildAppManifest } from "@/lib/github-manifest-state";
+
+describe("buildAppManifest", () => {
+  const base = "https://octo.example.com";
+  const m = buildAppManifest(base, "octopus-abc12345");
+
+  it("uses the given octopus- name and the deployment URLs", () => {
+    expect(m.name).toBe("octopus-abc12345");
+    expect(m.name.startsWith("octopus-")).toBe(true);
+    expect(m.url).toBe(base);
+    expect(m.hook_attributes.url).toBe(`${base}/api/github/webhook`);
+    expect(m.hook_attributes.active).toBe(true);
+    expect(m.redirect_url).toBe(`${base}/api/github/app-manifest/callback`);
+    expect(m.setup_url).toBe(`${base}/api/github/callback`);
+    expect(m.setup_on_update).toBe(true);
+    expect(m.public).toBe(false);
+  });
+
+  it("requests exactly the permissions and events Octopus needs", () => {
+    expect(m.default_permissions).toEqual({
+      contents: "read",
+      pull_requests: "write",
+      checks: "write",
+      metadata: "read",
+    });
+    expect(m.default_events).toEqual(["pull_request", "pull_request_review"]);
+  });
+});

--- a/apps/web/lib/github-app-config.ts
+++ b/apps/web/lib/github-app-config.ts
@@ -1,0 +1,129 @@
+import "server-only";
+import { prisma } from "@octopus/db";
+import { encryptString, decryptStringMaybeLegacy } from "@/lib/crypto";
+
+/**
+ * Resolved GitHub App credentials. Source is the SystemConfig singleton when a
+ * self-hoster provisioned an App via the manifest flow (lib/github-app-config
+ * saveGithubAppConfig), otherwise the GITHUB_APP_* / NEXT_PUBLIC_GITHUB_APP_SLUG
+ * env vars (cloud + manually-configured self-host). DB wins over env.
+ */
+export type GithubAppConfig = {
+  appId: string;
+  privateKey: string;
+  webhookSecret: string | null;
+  slug: string | null;
+  clientId: string | null;
+  htmlUrl: string | null;
+};
+
+// Small in-process memo so we don't hit the DB on every GitHub API call /
+// webhook. Invalidated explicitly after a manifest write (clearCache).
+const TTL_MS = 30_000;
+let cache: { value: GithubAppConfig | null; at: number } | null = null;
+
+export function clearGithubAppConfigCache(): void {
+  cache = null;
+}
+
+function fromEnv(): GithubAppConfig | null {
+  const appId = process.env.GITHUB_APP_ID;
+  const privateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+  if (!appId || !privateKey) return null;
+  return {
+    appId,
+    privateKey,
+    webhookSecret: process.env.GITHUB_WEBHOOK_SECRET ?? null,
+    slug: process.env.NEXT_PUBLIC_GITHUB_APP_SLUG ?? null,
+    clientId: process.env.GITHUB_CLIENT_ID ?? null,
+    htmlUrl: null,
+  };
+}
+
+async function resolve(): Promise<GithubAppConfig | null> {
+  // DB-first: a manifest-provisioned App overrides env. On any DB error, fall
+  // back to env rather than breaking every GitHub call (mirrors review-effort).
+  try {
+    const row = await prisma.systemConfig.findUnique({
+      where: { id: "singleton" },
+      select: {
+        githubAppId: true,
+        githubAppSlug: true,
+        githubAppClientId: true,
+        githubAppHtmlUrl: true,
+        githubAppPrivateKeyEnc: true,
+        githubAppWebhookSecretEnc: true,
+      },
+    });
+    if (row?.githubAppId && row.githubAppPrivateKeyEnc) {
+      return {
+        appId: row.githubAppId,
+        privateKey: decryptStringMaybeLegacy(row.githubAppPrivateKeyEnc),
+        webhookSecret: row.githubAppWebhookSecretEnc
+          ? decryptStringMaybeLegacy(row.githubAppWebhookSecretEnc)
+          : null,
+        slug: row.githubAppSlug,
+        clientId: row.githubAppClientId,
+        htmlUrl: row.githubAppHtmlUrl,
+      };
+    }
+  } catch (err) {
+    console.error("[github-app-config] DB read failed, falling back to env:", err);
+  }
+  return fromEnv();
+}
+
+/** Resolved GitHub App config (DB-first, env fallback), memoized ~30s. */
+export async function getGithubAppConfig(): Promise<GithubAppConfig | null> {
+  if (cache && Date.now() - cache.at < TTL_MS) return cache.value;
+  const value = await resolve();
+  cache = { value, at: Date.now() };
+  return value;
+}
+
+/** Whether a GitHub App is configured at all (DB or env). */
+export async function isGithubAppConfigured(): Promise<boolean> {
+  return (await getGithubAppConfig()) !== null;
+}
+
+/** Whether an App is configured specifically in the DB (manifest-provisioned). */
+export async function hasDbGithubApp(): Promise<boolean> {
+  try {
+    const row = await prisma.systemConfig.findUnique({
+      where: { id: "singleton" },
+      select: { githubAppId: true },
+    });
+    return Boolean(row?.githubAppId);
+  } catch {
+    return false;
+  }
+}
+
+export type SaveGithubAppInput = {
+  appId: string | number;
+  slug: string;
+  htmlUrl?: string | null;
+  clientId?: string | null;
+  privateKey: string; // PEM
+  webhookSecret?: string | null;
+  clientSecret?: string | null;
+};
+
+/** Persist manifest-provisioned App credentials (secrets encrypted) + clear the memo. */
+export async function saveGithubAppConfig(input: SaveGithubAppInput): Promise<void> {
+  const data = {
+    githubAppId: String(input.appId),
+    githubAppSlug: input.slug,
+    githubAppHtmlUrl: input.htmlUrl ?? null,
+    githubAppClientId: input.clientId ?? null,
+    githubAppPrivateKeyEnc: encryptString(input.privateKey),
+    githubAppWebhookSecretEnc: input.webhookSecret ? encryptString(input.webhookSecret) : null,
+    githubAppClientSecretEnc: input.clientSecret ? encryptString(input.clientSecret) : null,
+  };
+  await prisma.systemConfig.upsert({
+    where: { id: "singleton" },
+    update: data,
+    create: { id: "singleton", ...data },
+  });
+  clearGithubAppConfigCache();
+}

--- a/apps/web/lib/github-app-config.ts
+++ b/apps/web/lib/github-app-config.ts
@@ -109,8 +109,13 @@ export type SaveGithubAppInput = {
   clientSecret?: string | null;
 };
 
-/** Persist manifest-provisioned App credentials (secrets encrypted) + clear the memo. */
-export async function saveGithubAppConfig(input: SaveGithubAppInput): Promise<void> {
+/**
+ * Persist manifest-provisioned App credentials (secrets encrypted). Writes
+ * CONDITIONALLY — only when no App is configured yet — so a concurrent second
+ * manifest flow can never clobber the first (a plain upsert would overwrite).
+ * Returns true if it wrote, false if an App already existed. Clears the memo on write.
+ */
+export async function saveGithubAppConfig(input: SaveGithubAppInput): Promise<boolean> {
   const data = {
     githubAppId: String(input.appId),
     githubAppSlug: input.slug,
@@ -120,10 +125,32 @@ export async function saveGithubAppConfig(input: SaveGithubAppInput): Promise<vo
     githubAppWebhookSecretEnc: input.webhookSecret ? encryptString(input.webhookSecret) : null,
     githubAppClientSecretEnc: input.clientSecret ? encryptString(input.clientSecret) : null,
   };
-  await prisma.systemConfig.upsert({
-    where: { id: "singleton" },
-    update: data,
-    create: { id: "singleton", ...data },
+
+  // Atomic guard: update the singleton only while githubAppId is still null.
+  const updated = await prisma.systemConfig.updateMany({
+    where: { id: "singleton", githubAppId: null },
+    data,
   });
-  clearGithubAppConfigCache();
+  if (updated.count > 0) {
+    clearGithubAppConfigCache();
+    return true;
+  }
+
+  // count 0 → the singleton row is missing, or an App is already set.
+  const existing = await prisma.systemConfig.findUnique({
+    where: { id: "singleton" },
+    select: { githubAppId: true },
+  });
+  if (existing?.githubAppId) return false; // already configured — never clobber
+  if (!existing) {
+    try {
+      await prisma.systemConfig.create({ data: { id: "singleton", ...data } });
+      clearGithubAppConfigCache();
+      return true;
+    } catch {
+      // lost the create race on the singleton PK → someone else configured it.
+      return false;
+    }
+  }
+  return false;
 }

--- a/apps/web/lib/github-manifest-state.ts
+++ b/apps/web/lib/github-manifest-state.ts
@@ -1,0 +1,47 @@
+// Shared between the GitHub App Manifest start + callback routes. Kept out of the
+// route.ts files because Next.js only allows HTTP-method / route-config exports
+// from a route segment. Mirrors lib/slack-oauth.ts.
+
+// HttpOnly cookie holding the per-transaction nonce. The callback requires it to
+// match the nonce embedded in the encrypted `state`, binding the flow to the
+// browser that started it (CSRF protection).
+export const GITHUB_MANIFEST_STATE_COOKIE = "gh_manifest_state";
+
+// State lifetime: long enough to fill in the GitHub "Create App" screen, short
+// enough to bound the replay window of a leaked code+state pair.
+export const GITHUB_MANIFEST_STATE_TTL_MS = 15 * 60 * 1000;
+
+// Contract for the encrypted `state` blob. `org` is the optional GitHub org the
+// app is being created under (empty = personal account).
+export type GithubManifestState = {
+  userId: string;
+  orgId: string;
+  org: string;
+  nonce: string;
+  exp: number;
+};
+
+/**
+ * The GitHub App manifest submitted to github.com/settings/apps/new. Pure so it
+ * can be unit-tested. Permissions/events mirror the manual docs (contents:read,
+ * pull_requests:write, checks:write, metadata:read; pull_request +
+ * pull_request_review). `name` must be globally unique on GitHub.
+ */
+export function buildAppManifest(baseUrl: string, name: string) {
+  return {
+    name,
+    url: baseUrl,
+    hook_attributes: { url: `${baseUrl}/api/github/webhook`, active: true },
+    redirect_url: `${baseUrl}/api/github/app-manifest/callback`,
+    setup_url: `${baseUrl}/api/github/callback`,
+    setup_on_update: true,
+    public: false,
+    default_permissions: {
+      contents: "read",
+      pull_requests: "write",
+      checks: "write",
+      metadata: "read",
+    },
+    default_events: ["pull_request", "pull_request_review"],
+  };
+}

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { getGithubAppConfig } from "@/lib/github-app-config";
 
 const GITHUB_API = "https://api.github.com";
 const RETRYABLE_STATUSES = new Set([502, 503, 504]);
@@ -24,17 +25,23 @@ async function fetchWithRetry(
   throw new Error("Exceeded max retries");
 }
 
-function getPrivateKey(): string {
-  const raw = process.env.GITHUB_APP_PRIVATE_KEY!;
-  // Support base64-encoded key (recommended for env vars)
+// Support base64-encoded keys (recommended for env vars) as well as raw PEM.
+function normalizePrivateKey(raw: string): string {
   if (!raw.includes("-----BEGIN")) {
     return Buffer.from(raw, "base64").toString("utf-8");
   }
   return raw;
 }
 
-export function createAppJwt(): string {
-  const appId = process.env.GITHUB_APP_ID!;
+export async function createAppJwt(): Promise<string> {
+  // App id + private key come from the resolver (DB-first for manifest-created
+  // self-host apps, env fallback for cloud / manual self-host).
+  const config = await getGithubAppConfig();
+  if (!config) {
+    throw new Error(
+      "GitHub App is not configured (no manifest-created app and no GITHUB_APP_* env vars).",
+    );
+  }
   const now = Math.floor(Date.now() / 1000);
 
   const header = Buffer.from(
@@ -42,13 +49,13 @@ export function createAppJwt(): string {
   ).toString("base64url");
 
   const payload = Buffer.from(
-    JSON.stringify({ iat: now - 60, exp: now + 600, iss: appId }),
+    JSON.stringify({ iat: now - 60, exp: now + 600, iss: config.appId }),
   ).toString("base64url");
 
   const signature = crypto
     .createSign("RSA-SHA256")
     .update(`${header}.${payload}`)
-    .sign(getPrivateKey(), "base64url");
+    .sign(normalizePrivateKey(config.privateKey), "base64url");
 
   return `${header}.${payload}.${signature}`;
 }
@@ -56,7 +63,7 @@ export function createAppJwt(): string {
 export async function getInstallationPermissions(
   installationId: number,
 ): Promise<Record<string, string>> {
-  const jwt = createAppJwt();
+  const jwt = await createAppJwt();
   const res = await fetchWithRetry(
     `${GITHUB_API}/app/installations/${installationId}`,
     {
@@ -78,7 +85,7 @@ export async function getInstallationPermissions(
 export async function getInstallationToken(
   installationId: number,
 ): Promise<string> {
-  const jwt = createAppJwt();
+  const jwt = await createAppJwt();
   const res = await fetchWithRetry(
     `${GITHUB_API}/app/installations/${installationId}/access_tokens`,
     {

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -49,6 +49,7 @@ import {
 } from "@/lib/github";
 import * as bitbucket from "@/lib/bitbucket";
 import * as gitlab from "@/lib/gitlab";
+import { getGithubAppConfig } from "@/lib/github-app-config";
 import { parseOctopusIgnore, filterDiff, detectBadCommits } from "@/lib/octopus-ignore";
 import type { ReviewComment } from "@/lib/github";
 import { eventBus } from "@/lib/events";
@@ -1531,7 +1532,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
     }
 
     // Fetch prior review comments once — shared by prompt context injection and inline dedup.
-    const appSlug = process.env.NEXT_PUBLIC_GITHUB_APP_SLUG ?? "octopus-review";
+    const appSlug = (await getGithubAppConfig())?.slug ?? "octopus-review";
     const botLogin = `${appSlug}[bot]`;
     let allPriorReviewComments: import("@/lib/github").PRReviewComment[] = [];
     const priorSummaryTableFindings: PriorFinding[] = [];

--- a/apps/web/lib/self-hosted.ts
+++ b/apps/web/lib/self-hosted.ts
@@ -1,0 +1,16 @@
+/**
+ * Server-side self-hosted detection.
+ *
+ * `NEXT_PUBLIC_OCTOPUS_SELF_HOSTED` is inlined at BUILD time (even in server
+ * code), so the official self-host image — built with
+ * `--build-arg NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true` — reports self-host
+ * correctly. For custom/prebuilt images where that flag wasn't baked in, also
+ * honor a plain **runtime** `OCTOPUS_SELF_HOSTED=true` so server-side gates
+ * (e.g. the GitHub App manifest routes) still work without a rebuild.
+ */
+export function isSelfHosted(): boolean {
+  return (
+    process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true" ||
+    process.env.OCTOPUS_SELF_HOSTED === "true"
+  );
+}

--- a/packages/db/prisma/migrations/20260730120000_github_app_config/migration.sql
+++ b/packages/db/prisma/migrations/20260730120000_github_app_config/migration.sql
@@ -1,0 +1,12 @@
+-- Self-hosted GitHub App config (App Manifest flow, #self-host). Additive and
+-- nullable — safe on live and a no-op on cloud (columns stay null; the resolver
+-- falls back to the GITHUB_APP_* env vars). Secret columns hold ciphertext.
+
+-- AlterTable
+ALTER TABLE "system_config" ADD COLUMN     "githubAppClientId" TEXT,
+ADD COLUMN     "githubAppClientSecretEnc" TEXT,
+ADD COLUMN     "githubAppHtmlUrl" TEXT,
+ADD COLUMN     "githubAppId" TEXT,
+ADD COLUMN     "githubAppPrivateKeyEnc" TEXT,
+ADD COLUMN     "githubAppSlug" TEXT,
+ADD COLUMN     "githubAppWebhookSecretEnc" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -866,6 +866,15 @@ model SystemConfig {
   announcements       Json @default("[]") // landing-page announcement bar entries (see lib/announcements types)
   latestRelease       Json?    // cached latest GitHub release for the self-hosted Updates page (see lib/releases.ts)
   blogAudioVoiceId    String?  // selected ElevenLabs voice id for blog read-aloud (see lib/elevenlabs.ts)
+  // Self-hosted GitHub App created via the App Manifest flow (see lib/github-app-config.ts).
+  // Takes precedence over the GITHUB_APP_* env vars; secrets are encrypted at rest (crypto.ts).
+  githubAppId              String? // GitHub App id (plaintext)
+  githubAppSlug            String? // App slug, used to build the install URL (plaintext)
+  githubAppClientId        String? // OAuth client id (plaintext)
+  githubAppHtmlUrl         String? // App's github.com settings URL (plaintext)
+  githubAppPrivateKeyEnc   String? // encrypted PEM private key
+  githubAppWebhookSecretEnc String? // encrypted webhook secret
+  githubAppClientSecretEnc String? // encrypted OAuth client secret
   updatedAt DateTime @updatedAt
 
   @@map("system_config")


### PR DESCRIPTION
## What

Self-hosters currently must **manually** create a GitHub App (a 15-step walkthrough) and paste four env vars + restart. This adds a **"Create GitHub App" button** (self-host only) that runs GitHub's **App Manifest flow** end-to-end — like Dokploy — names the app `octopus-<random>`, stores the credentials, and continues straight into installing it on the user's repos. No manual config.

## How it works
1. Button → `/api/github/app-manifest/new` (gated: self-host + org owner/admin): builds a prefilled manifest, sets an encrypted state + HttpOnly cookie nonce (CSRF), and returns an auto-submitting form to `github.com/settings/apps/new` (or `…/organizations/<org>/…` when the optional org field is filled).
2. User clicks "Create GitHub App" on GitHub → redirected to `/api/github/app-manifest/callback` with a one-time `code`.
3. Callback validates state, exchanges the code at `POST /app-manifests/{code}/conversions`, persists the app (secrets encrypted), and **auto-continues** to the install screen → the existing `/api/github/callback` binds the installation to the org.

## Key pieces
- **`SystemConfig` + migration**: encrypted `githubApp*` columns (additive, nullable — no-op on cloud).
- **`lib/github-app-config.ts`**: DB-first resolver with env fallback, ~30s memo, `saveGithubAppConfig` (encrypts PEM / webhook secret / client secret via `crypto.ts`). Wired into `github.ts` (`createAppJwt` now async), the webhook signature check, the install route, and the server-side slug reads (settings/dashboard/layout/repos + reviewer bot-match).
- **Two new routes** under `app/api/github/app-manifest/`.
- **UI**: `github-integration-card` shows the button + optional org input on self-host; keeps the manual guide as a secondary link. Cloud branch unchanged.

## Safety / scope
- **Self-host only**; cloud keeps its env-configured shared app (resolver returns env when no DB app exists — regression-safe).
- Manifest requests exactly the perms/events the manual docs specify: `contents:read`, `pull_requests:write`, `checks:write`, `metadata:read`; `pull_request` + `pull_request_review`. App is created **private** (personal) or **org-owned**.
- Secrets encrypted at rest; state is CSRF-protected (encrypted + cookie nonce); owner/admin gated and re-checked in the callback.

## Tests
Resolver precedence/fallback + manifest-builder shape. `bunx tsc --noEmit` clean; full lib suite green except a pre-existing nodemailer/SMTP network test unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p