### PR TITLE
fix(review): raise diff cap 30k→300k, stop silently truncating everyday PRs (#1429)

### DIFF
--- a/apps/web/lib/__tests__/truncate-diff.test.ts
+++ b/apps/web/lib/__tests__/truncate-diff.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, mock } from "bun:test";
+
+// github.ts pulls in server-only (via github-app-config) — stub before import.
+mock.module("server-only", () => ({}));
+mock.module("@octopus/db", () => ({ prisma: {} }));
+
+const { truncateDiff } = await import("@/lib/github");
+
+describe("truncateDiff", () => {
+  it("returns small diffs unchanged", () => {
+    const diff = "diff --git a/x b/x\n+hello\n";
+    expect(truncateDiff(diff)).toBe(diff);
+  });
+
+  it("truncates oversized diffs and marks them (never silent)", () => {
+    const big = "x".repeat(400_000);
+    const out = truncateDiff(big);
+    expect(out.length).toBeLessThan(big.length);
+    expect(out).toContain("[... diff truncated");
+    // The default cap (300k) is well above the old 30k, so a 300k diff is NOT
+    // truncated — everyday PRs now review in full.
+    expect(truncateDiff("y".repeat(300_000)).includes("[... diff truncated")).toBe(false);
+  });
+});

--- a/apps/web/lib/__tests__/truncate-diff.test.ts
+++ b/apps/web/lib/__tests__/truncate-diff.test.ts
@@ -1,24 +1,18 @@
-import { describe, it, expect, mock } from "bun:test";
-
-// github.ts pulls in server-only (via github-app-config) — stub before import.
-mock.module("server-only", () => ({}));
-mock.module("@octopus/db", () => ({ prisma: {} }));
-
-const { truncateDiff } = await import("@/lib/github");
+import { describe, it, expect } from "bun:test";
+import { truncateDiff, MAX_DIFF_CHARS, TRUNCATION_MARKER } from "@/lib/diff-truncate";
 
 describe("truncateDiff", () => {
-  it("returns small diffs unchanged", () => {
+  it("returns diffs at or under the cap unchanged", () => {
     const diff = "diff --git a/x b/x\n+hello\n";
     expect(truncateDiff(diff)).toBe(diff);
+    // A diff exactly at the cap is not truncated (everyday PRs review in full).
+    expect(truncateDiff("y".repeat(MAX_DIFF_CHARS))).not.toContain(TRUNCATION_MARKER);
   });
 
   it("truncates oversized diffs and marks them (never silent)", () => {
-    const big = "x".repeat(400_000);
+    const big = "x".repeat(MAX_DIFF_CHARS + 100_000);
     const out = truncateDiff(big);
     expect(out.length).toBeLessThan(big.length);
-    expect(out).toContain("[... diff truncated");
-    // The default cap (300k) is well above the old 30k, so a 300k diff is NOT
-    // truncated — everyday PRs now review in full.
-    expect(truncateDiff("y".repeat(300_000)).includes("[... diff truncated")).toBe(false);
+    expect(out).toContain(TRUNCATION_MARKER);
   });
 });

--- a/apps/web/lib/bitbucket.ts
+++ b/apps/web/lib/bitbucket.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@octopus/db";
+import { truncateDiff } from "@/lib/diff-truncate";
 import { encryptString, decryptStringMaybeLegacy } from "@/lib/crypto";
 
 const BITBUCKET_API = "https://api.bitbucket.org/2.0";
@@ -179,9 +180,7 @@ export async function getPullRequestDiff(
   }
 
   const diff = await res.text();
-  return diff.length > 30_000
-    ? diff.slice(0, 30_000) + "\n\n[... diff truncated at 30,000 chars]"
-    : diff;
+  return truncateDiff(diff);
 }
 
 export async function createPullRequestComment(

--- a/apps/web/lib/diff-truncate.ts
+++ b/apps/web/lib/diff-truncate.ts
@@ -1,0 +1,28 @@
+// Shared diff-size cap for the review engine, used by every provider path
+// (GitHub, GitLab, Bitbucket) so the limit can't drift between them.
+//
+// Sized to fit the model context (~200k-token windows ≈ ~800k chars) alongside
+// the reviewer's RAG context, rulepacks and output, with headroom — 300k chars
+// (~7.5k diff lines) covers the overwhelming majority of PRs so they review IN
+// FULL. Env-tunable (MAX_DIFF_CHARS) to trade coverage vs. token cost without a
+// redeploy. The old 30k default silently truncated everyday PRs, so
+// security-critical files past the cut went unreviewed while a confident score
+// was still posted (#1429).
+
+export const MAX_DIFF_CHARS = (() => {
+  const n = Number(process.env.MAX_DIFF_CHARS);
+  return Number.isFinite(n) && n > 0 ? n : 300_000;
+})();
+
+// Stable substring identifying a truncation notice (also used to build it).
+export const TRUNCATION_MARKER = "[... diff truncated";
+
+/** The factual truncation notice appended to a cut diff (no "split your PR" nag). */
+export function truncationNotice(): string {
+  return `\n\n${TRUNCATION_MARKER} at ${MAX_DIFF_CHARS.toLocaleString("en-US")} chars — remaining files not included]`;
+}
+
+/** Cut a diff to the cap with a truncation notice; leaves ≤cap diffs unchanged. */
+export function truncateDiff(diff: string): string {
+  return diff.length > MAX_DIFF_CHARS ? diff.slice(0, MAX_DIFF_CHARS) + truncationNotice() : diff;
+}

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -359,8 +359,13 @@ export async function getPullRequestDiff(
     console.warn(
       `[github] Diff too large for ${owner}/${repo}#${prNumber} (406), trying /files fallback`,
     );
-    const reconstructed = await getPullRequestDiffViaFiles(token, owner, repo, prNumber);
-    if (reconstructed.includes(TRUNCATION_MARKER) && isInternalCliEnabled()) {
+    const { diff: reconstructed, truncated } = await getPullRequestDiffViaFiles(
+      token,
+      owner,
+      repo,
+      prNumber,
+    );
+    if (truncated && isInternalCliEnabled()) {
       throw new LargePrError(
         `/files fallback also truncated for ${owner}/${repo}#${prNumber}`,
         { owner, repo, prNumber, reason: "too-many-files" },
@@ -410,7 +415,7 @@ async function getPullRequestDiffViaFiles(
   owner: string,
   repo: string,
   prNumber: number,
-): Promise<string> {
+): Promise<{ diff: string; truncated: boolean }> {
   const patches: string[] = [];
   let totalLength = 0;
   let page = 1;
@@ -450,7 +455,11 @@ async function getPullRequestDiffViaFiles(
     page++;
   }
 
-  return truncateDiff(patches.join(""));
+  const joined = patches.join("");
+  // Structured flag instead of sniffing the marker back out of the text (a PR's
+  // own content could contain the marker string and false-positive).
+  const truncated = joined.length > MAX_DIFF_CHARS;
+  return { diff: truncateDiff(joined), truncated };
 }
 
 // GitHub's issue / PR comment API rejects bodies larger than 65536 chars

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -360,7 +360,7 @@ export async function getPullRequestDiff(
       `[github] Diff too large for ${owner}/${repo}#${prNumber} (406), trying /files fallback`,
     );
     const reconstructed = await getPullRequestDiffViaFiles(token, owner, repo, prNumber);
-    if (reconstructed.endsWith(TRUNCATION_MARKER) && isInternalCliEnabled()) {
+    if (reconstructed.includes(TRUNCATION_MARKER) && isInternalCliEnabled()) {
       throw new LargePrError(
         `/files fallback also truncated for ${owner}/${repo}#${prNumber}`,
         { owner, repo, prNumber, reason: "too-many-files" },
@@ -378,13 +378,31 @@ function isInternalCliEnabled(): boolean {
   return process.env.ENABLE_INTERNAL_CLI === "true";
 }
 
-const MAX_DIFF_CHARS = 30_000;
-const TRUNCATION_MARKER = "\n\n[... diff truncated at 30,000 chars]";
+// Max diff size handed to the review engine. Sized to fit the model context
+// (~200k-token windows ≈ ~800k chars) alongside the reviewer's RAG context,
+// rulepacks and output, with headroom — 300k chars (~7.5k diff lines) covers
+// the overwhelming majority of PRs so they review IN FULL. Env-tunable
+// (MAX_DIFF_CHARS) to trade coverage vs. token cost without a redeploy. The old
+// 30k default silently truncated everyday PRs, so security-critical files past
+// the cut went unreviewed while a confident score was still posted (#1429).
+const MAX_DIFF_CHARS = (() => {
+  const n = Number(process.env.MAX_DIFF_CHARS);
+  return Number.isFinite(n) && n > 0 ? n : 300_000;
+})();
 
-function truncateDiff(diff: string): string {
-  return diff.length > MAX_DIFF_CHARS
-    ? diff.slice(0, MAX_DIFF_CHARS) + TRUNCATION_MARKER
-    : diff;
+// Stable substring marking a truncated diff (used to detect truncation in the
+// /files reconstruction path). The full marker appends the actual char count.
+const TRUNCATION_MARKER = "[... diff truncated";
+
+export function truncateDiff(diff: string): string {
+  if (diff.length <= MAX_DIFF_CHARS) return diff;
+  // Only pathological diffs reach here now. Truncate with a factual, dynamic
+  // marker (no "split your PR" nag) so the reviewer at least knows the tail was
+  // cut rather than silently scoring an unreviewed remainder.
+  return (
+    diff.slice(0, MAX_DIFF_CHARS) +
+    `\n\n${TRUNCATION_MARKER} at ${MAX_DIFF_CHARS.toLocaleString("en-US")} chars — remaining files not included]`
+  );
 }
 
 async function getPullRequestDiffViaFiles(

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -419,6 +419,8 @@ async function getPullRequestDiffViaFiles(
   const patches: string[] = [];
   let totalLength = 0;
   let page = 1;
+  let hitCap = false; // set when we stop early due to the size cap (explicit,
+  // so an exact-boundary length can't read as "not truncated")
 
   while (totalLength < MAX_DIFF_CHARS) {
     const res = await fetchWithRetry(
@@ -448,18 +450,19 @@ async function getPullRequestDiffViaFiles(
       patches.push(entry);
       totalLength += entry.length;
 
-      if (totalLength >= MAX_DIFF_CHARS) break;
+      if (totalLength >= MAX_DIFF_CHARS) {
+        hitCap = true;
+        break;
+      }
     }
 
     if (files.length < 100) break;
     page++;
   }
 
-  const joined = patches.join("");
-  // Structured flag instead of sniffing the marker back out of the text (a PR's
-  // own content could contain the marker string and false-positive).
-  const truncated = joined.length > MAX_DIFF_CHARS;
-  return { diff: truncateDiff(joined), truncated };
+  // Explicit cap-hit flag (not inferred from length) so an exact-boundary total
+  // can't misread as complete, and a PR's own content can't false-positive.
+  return { diff: truncateDiff(patches.join("")), truncated: hitCap };
 }
 
 // GitHub's issue / PR comment API rejects bodies larger than 65536 chars

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { getGithubAppConfig } from "@/lib/github-app-config";
+import { MAX_DIFF_CHARS, truncateDiff, truncationNotice } from "@/lib/diff-truncate";
 
 const GITHUB_API = "https://api.github.com";
 const RETRYABLE_STATUSES = new Set([502, 503, 504]);
@@ -383,33 +384,6 @@ function isInternalCliEnabled(): boolean {
   return process.env.ENABLE_INTERNAL_CLI === "true";
 }
 
-// Max diff size handed to the review engine. Sized to fit the model context
-// (~200k-token windows ≈ ~800k chars) alongside the reviewer's RAG context,
-// rulepacks and output, with headroom — 300k chars (~7.5k diff lines) covers
-// the overwhelming majority of PRs so they review IN FULL. Env-tunable
-// (MAX_DIFF_CHARS) to trade coverage vs. token cost without a redeploy. The old
-// 30k default silently truncated everyday PRs, so security-critical files past
-// the cut went unreviewed while a confident score was still posted (#1429).
-const MAX_DIFF_CHARS = (() => {
-  const n = Number(process.env.MAX_DIFF_CHARS);
-  return Number.isFinite(n) && n > 0 ? n : 300_000;
-})();
-
-// Stable substring marking a truncated diff (used to detect truncation in the
-// /files reconstruction path). The full marker appends the actual char count.
-const TRUNCATION_MARKER = "[... diff truncated";
-
-export function truncateDiff(diff: string): string {
-  if (diff.length <= MAX_DIFF_CHARS) return diff;
-  // Only pathological diffs reach here now. Truncate with a factual, dynamic
-  // marker (no "split your PR" nag) so the reviewer at least knows the tail was
-  // cut rather than silently scoring an unreviewed remainder.
-  return (
-    diff.slice(0, MAX_DIFF_CHARS) +
-    `\n\n${TRUNCATION_MARKER} at ${MAX_DIFF_CHARS.toLocaleString("en-US")} chars — remaining files not included]`
-  );
-}
-
 async function getPullRequestDiffViaFiles(
   token: string,
   owner: string,
@@ -462,7 +436,11 @@ async function getPullRequestDiffViaFiles(
 
   // Explicit cap-hit flag (not inferred from length) so an exact-boundary total
   // can't misread as complete, and a PR's own content can't false-positive.
-  return { diff: truncateDiff(patches.join("")), truncated: hitCap };
+  // Append the notice whenever we hit the cap (covers the exact-boundary case
+  // truncateDiff's length check would miss).
+  const joined = patches.join("");
+  const diff = hitCap ? joined.slice(0, MAX_DIFF_CHARS) + truncationNotice() : joined;
+  return { diff, truncated: hitCap };
 }
 
 // GitHub's issue / PR comment API rejects bodies larger than 65536 chars

--- a/apps/web/lib/gitlab.ts
+++ b/apps/web/lib/gitlab.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@octopus/db";
+import { truncateDiff } from "@/lib/diff-truncate";
 import { decryptString, encryptString, decryptStringMaybeLegacy } from "@/lib/crypto";
 
 // ── Token Management ──
@@ -269,9 +270,7 @@ export async function getPullRequestDiff(
   }
 
   const diff = parts.join("\n");
-  return diff.length > 30_000
-    ? diff.slice(0, 30_000) + "\n\n[... diff truncated at 30,000 chars]"
-    : diff;
+  return truncateDiff(diff);
 }
 
 export async function createPullRequestComment(


### PR DESCRIPTION
## Problem (found by an external reviewer on a real PR)

`getPullRequestDiff` (`apps/web/lib/github.ts`) capped the diff at **`MAX_DIFF_CHARS = 30_000`**. When a diff exceeded that and `ENABLE_INTERNAL_CLI` was off, it **silently truncated** to the first 30k chars via `truncateDiff` and reviewed only that slice — the remaining files were never sent to the model, yet a normal **score was still posted**. 30k chars ≈ 7.5k tokens, absurdly low for 200k-token models, so this fired on everyday PRs. In the reported case the security-critical files (`sql-guard.ts`, `read-only-db.ts`, `registry.ts`) came after the cut and were **never reviewed**, while a 2/5 was posted as if they had been.

## Fix

- **Raise the default cap to `300_000` chars** (~7.5k diff lines) — fits ~200k-token model windows alongside the reviewer's RAG context + rulepacks + output, so the overwhelming majority of PRs now review **in full**.
- **`MAX_DIFF_CHARS` is now env-tunable** — dial coverage vs. token cost without a redeploy.
- Only genuinely pathological diffs still truncate, now with a **factual dynamic marker** (no "split your PR" nag). Fixed the `/files`-reconstruction truncation detection to match the dynamic marker (`includes`, not `endsWith`).

## Notes
- The full large-PR pipeline (clone + `git diff` → `large-review-result.ts`) still exists behind `ENABLE_INTERNAL_CLI`; this fix makes the **non-CLI** path (the common one) review whole PRs instead of a 30k slice.
- No cost change for normal PRs (they were already under 300k); only previously-truncated large PRs now send more of their diff — which is the point.

## Test
`truncateDiff` leaves ≤cap diffs unchanged and marks oversized ones; a 300k diff is no longer truncated. `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p