### PR TITLE
feat(review): exclude generated files from review before the size cap (#1429)

### DIFF
--- a/apps/web/lib/__tests__/generated-files.test.ts
+++ b/apps/web/lib/__tests__/generated-files.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "bun:test";
+import {
+  buildGeneratedMatcher,
+  splitDiffByIgnore,
+  parseGitattributesGenerated,
+} from "@/lib/generated-files";
+
+function section(path: string): string {
+  return `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n@@ -1 +1 @@\n-x\n+y\n`;
+}
+
+describe("splitDiffByIgnore (default generated patterns)", () => {
+  it("excludes generated files but keeps hand-written ones", () => {
+    const diff =
+      section("packages/db/drizzle/meta/0007_snapshot.json") +
+      section("bun.lock") +
+      section("src/__snapshots__/foo.test.ts.snap") +
+      section("packages/shared/src/constants.ts");
+    const { kept, skipped } = splitDiffByIgnore(diff, buildGeneratedMatcher());
+
+    expect(skipped).toContain("packages/db/drizzle/meta/0007_snapshot.json");
+    expect(skipped).toContain("bun.lock");
+    expect(skipped).toContain("src/__snapshots__/foo.test.ts.snap");
+    expect(kept).toContain("packages/shared/src/constants.ts");
+    expect(kept).not.toContain("drizzle/meta");
+  });
+});
+
+describe("parseGitattributesGenerated", () => {
+  it("picks up linguist-generated / -diff markers and ignores =false", () => {
+    const content = [
+      "src/gen/*.ts linguist-generated=true",
+      "docs/api.md -diff",
+      "# a comment",
+      "src/real.ts text",
+      "vendored/keep.ts linguist-generated=false",
+    ].join("\n");
+    const pats = parseGitattributesGenerated(content);
+    expect(pats).toEqual(["src/gen/*.ts", "docs/api.md"]);
+  });
+
+  it("a .gitattributes-marked file is excluded on top of defaults", () => {
+    const diff = section("src/gen/client.ts") + section("src/app.ts");
+    const ig = buildGeneratedMatcher("src/gen/*.ts linguist-generated");
+    const { kept, skipped } = splitDiffByIgnore(diff, ig);
+    expect(skipped).toContain("src/gen/client.ts");
+    expect(kept).toContain("src/app.ts");
+  });
+});

--- a/apps/web/lib/__tests__/generated-files.test.ts
+++ b/apps/web/lib/__tests__/generated-files.test.ts
@@ -27,7 +27,7 @@ describe("splitDiffByIgnore (default generated patterns)", () => {
 });
 
 describe("parseGitattributesGenerated", () => {
-  it("picks up linguist-generated / -diff markers and ignores =false", () => {
+  it("picks up linguist-generated / -diff markers and emits negations for =false", () => {
     const content = [
       "src/gen/*.ts linguist-generated=true",
       "docs/api.md -diff",
@@ -36,7 +36,16 @@ describe("parseGitattributesGenerated", () => {
       "vendored/keep.ts linguist-generated=false",
     ].join("\n");
     const pats = parseGitattributesGenerated(content);
-    expect(pats).toEqual(["src/gen/*.ts", "docs/api.md"]);
+    expect(pats).toEqual(["src/gen/*.ts", "docs/api.md", "!vendored/keep.ts"]);
+  });
+
+  it("=false re-includes a file that a default pattern would exclude", () => {
+    const diff = section("keep.snap") + section("other.snap");
+    // Defaults exclude *.snap; the repo un-marks keep.snap → it stays in review.
+    const ig = buildGeneratedMatcher("keep.snap linguist-generated=false");
+    const { kept, skipped } = splitDiffByIgnore(diff, ig);
+    expect(kept).toContain("keep.snap");
+    expect(skipped).toContain("other.snap");
   });
 
   it("a .gitattributes-marked file is excluded on top of defaults", () => {

--- a/apps/web/lib/bitbucket.ts
+++ b/apps/web/lib/bitbucket.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@octopus/db";
-import { truncateDiff } from "@/lib/diff-truncate";
+import { truncateDiff, MAX_FETCH_DIFF_CHARS } from "@/lib/diff-truncate";
 import { encryptString, decryptStringMaybeLegacy } from "@/lib/crypto";
 
 const BITBUCKET_API = "https://api.bitbucket.org/2.0";
@@ -180,7 +180,8 @@ export async function getPullRequestDiff(
   }
 
   const diff = await res.text();
-  return truncateDiff(diff);
+  // Raw-fetch ceiling; generated/ignored filtering + the review cap happen downstream.
+  return truncateDiff(diff, MAX_FETCH_DIFF_CHARS);
 }
 
 export async function createPullRequestComment(

--- a/apps/web/lib/community-review.ts
+++ b/apps/web/lib/community-review.ts
@@ -4,6 +4,8 @@ import { indexRepository } from "@/lib/indexer";
 import { summarizeRepository } from "@/lib/summarizer";
 import { analyzeRepository } from "@/lib/analyzer";
 import { getRepositoryTree, getPullRequestDiff } from "@/lib/github";
+import { buildGeneratedMatcher, splitDiffByIgnore } from "@/lib/generated-files";
+import { truncateDiff } from "@/lib/diff-truncate";
 import { eventBus } from "@/lib/events/bus";
 import { persistCommunityReviewToPR } from "@/lib/community-pr-persist";
 import { decryptString } from "@/lib/crypto";
@@ -212,6 +214,17 @@ export async function processCommunityReview(jobId: string): Promise<void> {
     if (isBotAccount && (!diff || diff.trim().length === 0) && job.prNumber != null) {
       const [ownerPart, repoPart] = fullName.split("/");
       diff = await getPullRequestDiff(0, ownerPart, repoPart, job.prNumber, githubToken);
+    }
+
+    // Exclude generated files (defaults) before the review cap so a large
+    // generated file can't crowd real files out of the review (#1429). Then cap
+    // to the review size (the fetch ceiling above is larger).
+    {
+      const { kept, skipped } = splitDiffByIgnore(diff ?? "", buildGeneratedMatcher());
+      diff = truncateDiff(kept);
+      if (skipped.length > 0) {
+        LOG(jobId, `excluded ${skipped.length} generated file(s): ${skipped.slice(0, 10).join(", ")}`);
+      }
     }
 
     LOG(jobId, "generating review...");

--- a/apps/web/lib/diff-truncate.ts
+++ b/apps/web/lib/diff-truncate.ts
@@ -14,15 +14,25 @@ export const MAX_DIFF_CHARS = (() => {
   return Number.isFinite(n) && n > 0 ? n : 300_000;
 })();
 
+// Raw-fetch ceiling — how much diff a provider fetch returns BEFORE generated/
+// ignored files are filtered out. Must be well above MAX_DIFF_CHARS so a large
+// generated file (e.g. a 12k-line ORM snapshot) doesn't crowd real files out of
+// the fetch: it's fetched, then filtered, then the remainder is capped to
+// MAX_DIFF_CHARS for review. Only genuinely enormous raw diffs hit this.
+export const MAX_FETCH_DIFF_CHARS = (() => {
+  const n = Number(process.env.MAX_FETCH_DIFF_CHARS);
+  return Number.isFinite(n) && n > 0 ? n : 1_500_000;
+})();
+
 // Stable substring identifying a truncation notice (also used to build it).
 export const TRUNCATION_MARKER = "[... diff truncated";
 
 /** The factual truncation notice appended to a cut diff (no "split your PR" nag). */
-export function truncationNotice(): string {
-  return `\n\n${TRUNCATION_MARKER} at ${MAX_DIFF_CHARS.toLocaleString("en-US")} chars — remaining files not included]`;
+export function truncationNotice(cap: number = MAX_DIFF_CHARS): string {
+  return `\n\n${TRUNCATION_MARKER} at ${cap.toLocaleString("en-US")} chars — remaining files not included]`;
 }
 
-/** Cut a diff to the cap with a truncation notice; leaves ≤cap diffs unchanged. */
-export function truncateDiff(diff: string): string {
-  return diff.length > MAX_DIFF_CHARS ? diff.slice(0, MAX_DIFF_CHARS) + truncationNotice() : diff;
+/** Cut a diff to `cap` with a truncation notice; leaves ≤cap diffs unchanged. */
+export function truncateDiff(diff: string, cap: number = MAX_DIFF_CHARS): string {
+  return diff.length > cap ? diff.slice(0, cap) + truncationNotice(cap) : diff;
 }

--- a/apps/web/lib/generated-files.ts
+++ b/apps/web/lib/generated-files.ts
@@ -56,11 +56,15 @@ export function parseGitattributesGenerated(content: string): string[] {
     if (!line || line.startsWith("#")) continue;
     const [pattern, ...attrs] = line.split(/\s+/);
     if (!pattern) continue;
+    const unsets = attrs.some((a) => a === "linguist-generated=false" || a === "linguist-generated=");
     const marksGenerated = attrs.some(
       (a) => a === "linguist-generated" || a === "linguist-generated=true" || a === "-diff",
     );
-    const unsets = attrs.some((a) => a === "linguist-generated=false" || a === "linguist-generated=");
-    if (marksGenerated && !unsets) patterns.push(pattern);
+    // `=false` un-marks a file (e.g. re-include one file matched by a broader
+    // rule or a default). Emit an `ignore` negation so it's kept in review.
+    // Order is preserved so a later negation overrides an earlier match.
+    if (unsets) patterns.push(`!${pattern}`);
+    else if (marksGenerated) patterns.push(pattern);
   }
   return patterns;
 }

--- a/apps/web/lib/generated-files.ts
+++ b/apps/web/lib/generated-files.ts
@@ -1,0 +1,99 @@
+import ignore, { type Ignore } from "ignore";
+
+/**
+ * Generated files nobody hand-writes. Reviewing them wastes the diff budget and,
+ * because they often sort early (e.g. ORM snapshots, lockfiles), crowds real
+ * hand-written files out of the review entirely (#1429). We exclude them from
+ * the reviewed diff — detected via a curated default list PLUS the repo's own
+ * `.gitattributes` `linguist-generated` / `-diff` markers.
+ *
+ * Kept conservative to avoid hiding real code: only clear-cut generated paths.
+ * Repos extend this with `.gitattributes` for anything project-specific.
+ */
+export const DEFAULT_GENERATED_PATTERNS: string[] = [
+  // Dependency lockfiles
+  "package-lock.json",
+  "npm-shrinkwrap.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "bun.lock",
+  "bun.lockb",
+  "Cargo.lock",
+  "poetry.lock",
+  "Pipfile.lock",
+  "composer.lock",
+  "Gemfile.lock",
+  "go.sum",
+  "flake.lock",
+  // ORM migration snapshots (the #1429 case — Drizzle emits a large JSON snapshot)
+  "**/drizzle/meta/**",
+  "**/atlas.sum",
+  // Test snapshots
+  "**/*.snap",
+  "**/__snapshots__/**",
+  // Minified / source maps / bundled output
+  "**/*.min.js",
+  "**/*.min.css",
+  "**/*.map",
+  // Common codegen outputs
+  "**/*.pb.go",
+  "**/*_pb2.py",
+  "**/*_pb2.pyi",
+  "**/*.pb.cc",
+  "**/*.pb.h",
+];
+
+/**
+ * Extract path patterns marked as generated in a `.gitattributes` file:
+ * `linguist-generated` (bare or `=true`) or `-diff`. `=false` un-marks and is
+ * skipped. Returns gitignore-compatible globs (gitattributes globs are close
+ * enough for the `ignore` matcher; a leading `/`-less pattern matches anywhere).
+ */
+export function parseGitattributesGenerated(content: string): string[] {
+  const patterns: string[] = [];
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const [pattern, ...attrs] = line.split(/\s+/);
+    if (!pattern) continue;
+    const marksGenerated = attrs.some(
+      (a) => a === "linguist-generated" || a === "linguist-generated=true" || a === "-diff",
+    );
+    const unsets = attrs.some((a) => a === "linguist-generated=false" || a === "linguist-generated=");
+    if (marksGenerated && !unsets) patterns.push(pattern);
+  }
+  return patterns;
+}
+
+/**
+ * Build an `ignore` matcher for generated files: the built-in defaults plus any
+ * `.gitattributes` generated markers. Pass the repo's `.gitattributes` content
+ * (or omit for defaults-only).
+ */
+export function buildGeneratedMatcher(gitattributesContent?: string | null): Ignore {
+  const ig = ignore();
+  ig.add(DEFAULT_GENERATED_PATTERNS);
+  if (gitattributesContent) ig.add(parseGitattributesGenerated(gitattributesContent));
+  return ig;
+}
+
+/**
+ * Split a unified diff into the files to review vs. the files an `ignore` matcher
+ * excludes (generated and/or `.octopusignore`). Returns the kept diff and the
+ * list of excluded file paths (for a review-summary note).
+ */
+export function splitDiffByIgnore(diff: string, ig: Ignore): { kept: string; skipped: string[] } {
+  const sections = diff.split(/(?=^diff --git )/m);
+  const skipped: string[] = [];
+  const keptSections = sections.filter((section) => {
+    const match = section.match(/^diff --git a\/(.+?) b\/(.+)/);
+    if (!match) return true; // preamble / unparseable — keep
+    const path = match[2];
+    if (ig.ignores(path)) {
+      skipped.push(path);
+      return false;
+    }
+    return true;
+  });
+  return { kept: keptSections.join(""), skipped };
+}

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -337,6 +337,12 @@ export async function getPullRequestDiff(
 
   if (res.ok) {
     const diff = await res.text();
+    // Intentional: the internal-cli (clone + git diff) handoff now triggers at
+    // the raw-fetch ceiling (MAX_FETCH_DIFF_CHARS), not the review cap. Below the
+    // ceiling the standard path fetches the whole diff, excludes generated /
+    // ignored files, THEN caps to MAX_DIFF_CHARS — which reviews most large PRs
+    // fully (better than the summary-only large-PR path). internal-cli is
+    // reserved for genuinely enormous raw diffs.
     if (diff.length > MAX_FETCH_DIFF_CHARS) {
       if (isInternalCliEnabled()) {
         throw new LargePrError(

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { getGithubAppConfig } from "@/lib/github-app-config";
-import { MAX_DIFF_CHARS, truncateDiff, truncationNotice } from "@/lib/diff-truncate";
+import { MAX_FETCH_DIFF_CHARS, truncateDiff, truncationNotice } from "@/lib/diff-truncate";
 
 const GITHUB_API = "https://api.github.com";
 const RETRYABLE_STATUSES = new Set([502, 503, 504]);
@@ -337,17 +337,17 @@ export async function getPullRequestDiff(
 
   if (res.ok) {
     const diff = await res.text();
-    if (diff.length > MAX_DIFF_CHARS) {
+    if (diff.length > MAX_FETCH_DIFF_CHARS) {
       if (isInternalCliEnabled()) {
         throw new LargePrError(
-          `Diff exceeds ${MAX_DIFF_CHARS} chars for ${owner}/${repo}#${prNumber}`,
+          `Diff exceeds ${MAX_FETCH_DIFF_CHARS} chars for ${owner}/${repo}#${prNumber}`,
           { owner, repo, prNumber, reason: "diff-too-large" },
         );
       }
       console.warn(
-        `[github] Diff over ${MAX_DIFF_CHARS} chars for ${owner}/${repo}#${prNumber} but ENABLE_INTERNAL_CLI is off — truncating for review engine`,
+        `[github] Diff over ${MAX_FETCH_DIFF_CHARS} chars for ${owner}/${repo}#${prNumber} but ENABLE_INTERNAL_CLI is off — truncating for review engine`,
       );
-      return truncateDiff(diff);
+      return truncateDiff(diff, MAX_FETCH_DIFF_CHARS);
     }
     return diff;
   }
@@ -396,7 +396,7 @@ async function getPullRequestDiffViaFiles(
   let hitCap = false; // set when we stop early due to the size cap (explicit,
   // so an exact-boundary length can't read as "not truncated")
 
-  while (totalLength < MAX_DIFF_CHARS) {
+  while (totalLength < MAX_FETCH_DIFF_CHARS) {
     const res = await fetchWithRetry(
       `${GITHUB_API}/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`,
       {
@@ -424,7 +424,7 @@ async function getPullRequestDiffViaFiles(
       patches.push(entry);
       totalLength += entry.length;
 
-      if (totalLength >= MAX_DIFF_CHARS) {
+      if (totalLength >= MAX_FETCH_DIFF_CHARS) {
         hitCap = true;
         break;
       }
@@ -439,7 +439,9 @@ async function getPullRequestDiffViaFiles(
   // Append the notice whenever we hit the cap (covers the exact-boundary case
   // truncateDiff's length check would miss).
   const joined = patches.join("");
-  const diff = hitCap ? joined.slice(0, MAX_DIFF_CHARS) + truncationNotice() : joined;
+  const diff = hitCap
+    ? joined.slice(0, MAX_FETCH_DIFF_CHARS) + truncationNotice(MAX_FETCH_DIFF_CHARS)
+    : joined;
   return { diff, truncated: hitCap };
 }
 

--- a/apps/web/lib/gitlab.ts
+++ b/apps/web/lib/gitlab.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@octopus/db";
-import { truncateDiff } from "@/lib/diff-truncate";
+import { truncateDiff, MAX_FETCH_DIFF_CHARS } from "@/lib/diff-truncate";
 import { decryptString, encryptString, decryptStringMaybeLegacy } from "@/lib/crypto";
 
 // ── Token Management ──
@@ -270,7 +270,8 @@ export async function getPullRequestDiff(
   }
 
   const diff = parts.join("\n");
-  return truncateDiff(diff);
+  // Raw-fetch ceiling; generated/ignored filtering + the review cap happen downstream.
+  return truncateDiff(diff, MAX_FETCH_DIFF_CHARS);
 }
 
 export async function createPullRequestComment(

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -52,7 +52,13 @@ import * as gitlab from "@/lib/gitlab";
 import { getGithubAppConfig } from "@/lib/github-app-config";
 import { parseOctopusIgnore, filterDiff, detectBadCommits } from "@/lib/octopus-ignore";
 import { buildGeneratedMatcher, splitDiffByIgnore } from "@/lib/generated-files";
-import { MAX_DIFF_CHARS, truncateDiff } from "@/lib/diff-truncate";
+import {
+  MAX_DIFF_CHARS,
+  MAX_FETCH_DIFF_CHARS,
+  TRUNCATION_MARKER,
+  truncateDiff,
+  truncationNotice,
+} from "@/lib/diff-truncate";
 import type { ReviewComment } from "@/lib/github";
 import { eventBus } from "@/lib/events";
 import {
@@ -1313,6 +1319,13 @@ export async function processReview(pullRequestId: string): Promise<void> {
       const before = diff.length;
       diff = truncateDiff(diff);
       console.log(`[reviewer] Capped filtered diff ${before} → ${diff.length} chars`);
+    }
+
+    // If the raw diff hit the fetch ceiling (truncated), keep that signal even
+    // when section-filtering dropped the fetch marker (rare: the last raw file
+    // was excluded). Length check — not marker sniffing.
+    if (rawDiff.length >= MAX_FETCH_DIFF_CHARS && !diff.includes(TRUNCATION_MARKER)) {
+      diff += truncationNotice(MAX_FETCH_DIFF_CHARS);
     }
 
     const diffFiles = extractDiffFiles(diff);

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -51,6 +51,8 @@ import * as bitbucket from "@/lib/bitbucket";
 import * as gitlab from "@/lib/gitlab";
 import { getGithubAppConfig } from "@/lib/github-app-config";
 import { parseOctopusIgnore, filterDiff, detectBadCommits } from "@/lib/octopus-ignore";
+import { buildGeneratedMatcher, splitDiffByIgnore } from "@/lib/generated-files";
+import { MAX_DIFF_CHARS, truncateDiff } from "@/lib/diff-truncate";
 import type { ReviewComment } from "@/lib/github";
 import { eventBus } from "@/lib/events";
 import {
@@ -1251,8 +1253,39 @@ export async function processReview(pullRequestId: string): Promise<void> {
       console.log(`[reviewer] Detected ${badFiles.length} build artifact / dependency files in diff`);
     }
 
-    // Fetch .octopusignore if it exists in the repo
     let diff = rawDiff;
+
+    // Exclude generated files (built-in defaults + the repo's .gitattributes
+    // linguist-generated markers) BEFORE the review cap, so a large generated
+    // file (e.g. an ORM snapshot) can't consume the budget and crowd real,
+    // hand-written files out of the review (#1429).
+    let skippedGenerated: string[] = [];
+    {
+      let gitattributes: string | null = null;
+      if (repoTree.includes(".gitattributes")) {
+        try {
+          gitattributes = isGitHub && installationId
+            ? await ghGetFileContent(installationId, owner, repoName, repo.defaultBranch, ".gitattributes")
+            : isBitbucket
+              ? await bitbucket.getFileContent(org.id, owner, repoName, repo.defaultBranch, ".gitattributes")
+              : isGitlab
+                ? await gitlab.getFileContent(org.id, projectPath, repo.defaultBranch, ".gitattributes")
+                : null;
+        } catch (err) {
+          console.warn("[reviewer] Failed to fetch .gitattributes, using default generated patterns only:", err);
+        }
+      }
+      const { kept, skipped } = splitDiffByIgnore(diff, buildGeneratedMatcher(gitattributes));
+      diff = kept;
+      skippedGenerated = skipped;
+      if (skippedGenerated.length > 0) {
+        console.log(
+          `[reviewer] Excluded ${skippedGenerated.length} generated file(s) from review: ${skippedGenerated.slice(0, 10).join(", ")}`,
+        );
+      }
+    }
+
+    // Fetch .octopusignore (user-authored) if it exists in the repo
     let octopusIg: ReturnType<typeof parseOctopusIgnore> | undefined;
     if (repoTree.includes(".octopusignore")) {
       try {
@@ -1272,6 +1305,14 @@ export async function processReview(pullRequestId: string): Promise<void> {
       } catch (err) {
         console.warn("[reviewer] Failed to fetch .octopusignore, continuing without it:", err);
       }
+    }
+
+    // Final review cap AFTER filtering — generated/ignored files never consumed
+    // the budget, so the remaining hand-written files are what gets reviewed.
+    if (diff.length > MAX_DIFF_CHARS) {
+      const before = diff.length;
+      diff = truncateDiff(diff);
+      console.log(`[reviewer] Capped filtered diff ${before} → ${diff.length} chars`);
     }
 
     const diffFiles = extractDiffFiles(diff);
@@ -1828,6 +1869,16 @@ export async function processReview(pullRequestId: string): Promise<void> {
         "",
       ].filter(Boolean).join("\n");
       reviewBody = badFilesSection + "\n\n" + reviewBody;
+    }
+
+    // Note generated files excluded from review, so a reader knows they were
+    // intentionally skipped (not overlooked). Non-blocking footnote.
+    if (skippedGenerated.length > 0) {
+      const shown = skippedGenerated.slice(0, 10).map((f) => `\`${f}\``).join(", ");
+      const more = skippedGenerated.length > 10 ? ` and ${skippedGenerated.length - 10} more` : "";
+      reviewBody +=
+        `\n\n<sub>ℹ️ Skipped ${skippedGenerated.length} generated file(s) (not reviewed): ${shown}${more}. ` +
+        `Mark files with \`linguist-generated\` in \`.gitattributes\` to control this.</sub>`;
     }
 
     await logAiUsage({


### PR DESCRIPTION
## Problem (follow-on to the truncation fix, found by another reviewer)

Even after raising the review cap to 300k, a single large **generated** file defeats it. In the reported PR, Drizzle's snapshot JSON is **12,970 lines (~500k+ chars)** — it alone exceeds the cap, sorts **early** alphabetically (`packages/db/drizzle/meta/`), gets truncated in first, and the real hand-written file after it (`packages/shared/src/constants.ts` — which held the "is this account a bank" function everything depends on) was **never reviewed**. It recurs on **every migration PR**. And filtering ran *after* the fetch-time truncation, so it couldn't help.

## Fix — filter generated/ignored files BEFORE the cap

- **`lib/generated-files.ts`**: curated `DEFAULT_GENERATED_PATTERNS` (lockfiles, `**/drizzle/meta/**`, `*.snap`, `*.min.*`, `*.map`, protobuf output…) **plus** parsing the repo's **`.gitattributes` `linguist-generated`/`-diff`** markers. `splitDiffByIgnore` returns the kept diff + the skipped file list.
- **Separate the raw-fetch ceiling from the review cap**: `MAX_FETCH_DIFF_CHARS` (default 1.5M, env-tunable) for the provider fetch, `MAX_DIFF_CHARS` (300k) for review. Fetches (GitHub/GitLab/Bitbucket) now return whole files up to the ceiling; the reviewer **excludes generated + `.octopusignore` files, then caps** — so generated files never consume the budget.
- **`reviewer.ts`** fetches `.gitattributes`, excludes generated + `.octopusignore` before the cap, and adds a footnote listing skipped generated files. **Community path** applies the defaults + cap too.
- Conservative defaults (no `**/generated/**` catch-all) to avoid hiding real code; repos extend via `.gitattributes`.

## Result
Hand-written files in migration/lockfile PRs now get reviewed instead of being dropped for generator output — closes the structural blind spot. The reporter's `.gitattributes linguist-generated` experiment now "just works."

## Tests
`splitDiffByIgnore` excludes generated (drizzle/meta, lockfiles, snapshots) while keeping real files; `.gitattributes` parsing honors `linguist-generated`/`-diff` and `=false`. `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p