### PR TITLE
fix(web): bind Linear, Jira, and Bitbucket OAuth state to the initiating browser and user

### DIFF
--- a/apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx
+++ b/apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx
@@ -11,6 +11,11 @@ const OAUTH_ERROR_MESSAGES = {
     description:
       "Start the integration connection again from this page in the same browser.",
   },
+  forbidden: {
+    title: "Connection flow changed accounts",
+    description:
+      "Sign in with the account that started the integration connection, then try again.",
+  },
 } as const;
 
 type OAuthErrorCode = keyof typeof OAUTH_ERROR_MESSAGES;

--- a/apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx
+++ b/apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx
@@ -16,6 +16,11 @@ const OAUTH_ERROR_MESSAGES = {
     description:
       "Sign in with the account that started the integration connection, then try again.",
   },
+  insufficient_role: {
+    title: "Permission required",
+    description:
+      "Only organization owners and admins can connect integrations. Ask an admin to connect it, or try again once your role is updated.",
+  },
 } as const;
 
 type OAuthErrorCode = keyof typeof OAUTH_ERROR_MESSAGES;

--- a/apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx
+++ b/apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx
@@ -20,7 +20,7 @@ export function IntegrationOAuthErrorBanner({
 }: {
   error: string | null;
 }) {
-  if (!error || !(error in OAUTH_ERROR_MESSAGES)) return null;
+  if (!error || !Object.hasOwn(OAUTH_ERROR_MESSAGES, error)) return null;
 
   const content = OAUTH_ERROR_MESSAGES[error as OAuthErrorCode];
   return (

--- a/apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx
+++ b/apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx
@@ -12,9 +12,9 @@ const OAUTH_ERROR_MESSAGES = {
       "Start the integration connection again from this page in the same browser.",
   },
   forbidden: {
-    title: "Connection flow changed accounts",
+    title: "Connection not permitted",
     description:
-      "Sign in with the account that started the integration connection, then try again.",
+      "Sign in with the account that started the integration connection and make sure it has an owner or admin role in the organization, then try again.",
   },
   insufficient_role: {
     title: "Permission required",

--- a/apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx
+++ b/apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx
@@ -1,0 +1,38 @@
+import { IconAlertTriangle } from "@tabler/icons-react";
+
+const OAUTH_ERROR_MESSAGES = {
+  state_expired: {
+    title: "Connection flow expired",
+    description:
+      "Start the integration connection again and complete it within 10 minutes.",
+  },
+  invalid_state: {
+    title: "Connection flow could not be verified",
+    description:
+      "Start the integration connection again from this page in the same browser.",
+  },
+} as const;
+
+type OAuthErrorCode = keyof typeof OAUTH_ERROR_MESSAGES;
+
+export function IntegrationOAuthErrorBanner({
+  error,
+}: {
+  error: string | null;
+}) {
+  if (!error || !(error in OAUTH_ERROR_MESSAGES)) return null;
+
+  const content = OAUTH_ERROR_MESSAGES[error as OAuthErrorCode];
+  return (
+    <div
+      role="alert"
+      className="flex gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm"
+    >
+      <IconAlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-400" />
+      <div>
+        <p className="font-medium text-foreground">{content.title}</p>
+        <p className="mt-0.5 text-muted-foreground">{content.description}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/(app)/settings/integrations/page.tsx
+++ b/apps/web/app/(app)/settings/integrations/page.tsx
@@ -9,6 +9,7 @@ import { BitbucketDebugBanner } from "./bitbucket-debug-banner";
 import { GitlabIntegrationCard } from "./gitlab-integration-card";
 import { LinearIntegrationCard } from "./linear-integration-card";
 import { JiraIntegrationCard } from "./jira-integration-card";
+import { IntegrationOAuthErrorBanner } from "./integration-oauth-error-banner";
 import { getGithubAppConfig } from "@/lib/github-app-config";
 import { isSelfHosted } from "@/lib/self-hosted";
 
@@ -142,6 +143,7 @@ export default async function IntegrationsPage({
 
   return (
     <div className="space-y-6">
+      <IntegrationOAuthErrorBanner error={rawError} />
       {bbDebug && <BitbucketDebugBanner debugJson={bbDebug} />}
       {glDebug && <BitbucketDebugBanner debugJson={glDebug} title="GitLab Connect Debug" />}
       <GitHubIntegrationCard

--- a/apps/web/app/api/bitbucket/callback/route.ts
+++ b/apps/web/app/api/bitbucket/callback/route.ts
@@ -72,7 +72,7 @@ export async function GET(request: NextRequest) {
 
   if (!member || (member.role !== "owner" && member.role !== "admin")) {
     return NextResponse.redirect(
-      new URL("/settings/integrations?error=forbidden", baseUrl),
+      new URL("/settings/integrations?error=insufficient_role", baseUrl),
     );
   }
 

--- a/apps/web/app/api/bitbucket/callback/route.ts
+++ b/apps/web/app/api/bitbucket/callback/route.ts
@@ -1,16 +1,24 @@
 import crypto from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { prisma } from "@octopus/db";
 import { auth } from "@/lib/auth";
 import { listWorkspaceRepos, createWebhook } from "@/lib/bitbucket";
 import { encryptString } from "@/lib/crypto";
+import {
+  integrationOAuthStateCookie,
+  verifyIntegrationOAuthState,
+} from "@/lib/integration-oauth-state";
 
 export async function GET(request: NextRequest) {
   const baseUrl = process.env.BETTER_AUTH_URL || request.url;
   const code = request.nextUrl.searchParams.get("code");
   const stateParam = request.nextUrl.searchParams.get("state");
   const error = request.nextUrl.searchParams.get("error");
+  const cookieStore = await cookies();
+  const stateCookie = integrationOAuthStateCookie("bitbucket");
+  const cookieNonce = cookieStore.get(stateCookie)?.value;
+  cookieStore.delete(stateCookie);
 
   if (error) {
     console.error("[bitbucket-callback] OAuth error:", error);
@@ -25,6 +33,24 @@ export async function GET(request: NextRequest) {
     );
   }
 
+  const verified = verifyIntegrationOAuthState({
+    state: stateParam,
+    cookieNonce,
+    provider: "bitbucket",
+  });
+  if (!verified.ok) {
+    return NextResponse.redirect(
+      new URL(`/settings/integrations?error=${verified.error}`, baseUrl),
+    );
+  }
+  const { orgId, userId } = verified.state;
+  const workspaceSlug = verified.state.context?.workspaceSlug;
+  if (!workspaceSlug) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=invalid_state", baseUrl),
+    );
+  }
+
   // Verify the user is authenticated
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) {
@@ -32,21 +58,9 @@ export async function GET(request: NextRequest) {
       new URL("/settings/integrations?error=unauthorized", baseUrl),
     );
   }
-
-  let orgId: string;
-  let stateNonce: string;
-  let workspaceSlug: string;
-  try {
-    const parsed = JSON.parse(
-      Buffer.from(stateParam, "base64url").toString("utf-8"),
-    );
-    orgId = parsed.orgId;
-    stateNonce = parsed.nonce;
-    workspaceSlug = parsed.workspaceSlug;
-    if (!orgId || !stateNonce || !workspaceSlug) throw new Error("Missing state fields");
-  } catch {
+  if (session.user.id !== userId) {
     return NextResponse.redirect(
-      new URL("/settings/integrations?error=invalid_state", baseUrl),
+      new URL("/settings/integrations?error=forbidden", baseUrl),
     );
   }
 

--- a/apps/web/app/api/bitbucket/oauth/route.ts
+++ b/apps/web/app/api/bitbucket/oauth/route.ts
@@ -1,8 +1,12 @@
-import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import { headers, cookies } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
+import {
+  createIntegrationOAuthState,
+  integrationOAuthStateCookie,
+  integrationOAuthStateCookieOptions,
+} from "@/lib/integration-oauth-state";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -48,9 +52,12 @@ export async function GET(request: Request) {
     );
   }
 
-  // Include a CSRF nonce in the state to prevent state forgery
-  const nonce = crypto.randomBytes(16).toString("hex");
-  const state = Buffer.from(JSON.stringify({ orgId, nonce, workspaceSlug })).toString("base64url");
+  const { state, nonce } = createIntegrationOAuthState({
+    provider: "bitbucket",
+    orgId,
+    userId: session.user.id,
+    context: { workspaceSlug },
+  });
 
   const params = new URLSearchParams({
     client_id: clientId,
@@ -60,7 +67,13 @@ export async function GET(request: Request) {
     scope: "account repository pullrequest webhook",
   });
 
-  return NextResponse.redirect(
+  const response = NextResponse.redirect(
     `https://bitbucket.org/site/oauth2/authorize?${params.toString()}`,
   );
+  response.cookies.set(
+    integrationOAuthStateCookie("bitbucket"),
+    nonce,
+    integrationOAuthStateCookieOptions(),
+  );
+  return response;
 }

--- a/apps/web/app/api/jira/callback/route.ts
+++ b/apps/web/app/api/jira/callback/route.ts
@@ -69,7 +69,7 @@ export async function GET(request: NextRequest) {
   });
   if (!member || (member.role !== "owner" && member.role !== "admin")) {
     return NextResponse.redirect(
-      new URL("/settings/integrations?error=forbidden", baseUrl),
+      new URL("/settings/integrations?error=insufficient_role", baseUrl),
     );
   }
 

--- a/apps/web/app/api/jira/callback/route.ts
+++ b/apps/web/app/api/jira/callback/route.ts
@@ -9,6 +9,10 @@ import {
 } from "@/lib/jira";
 import { encryptJson } from "@/lib/crypto";
 import { writeAuditLog } from "@/lib/audit";
+import {
+  integrationOAuthStateCookie,
+  verifyIntegrationOAuthState,
+} from "@/lib/integration-oauth-state";
 
 const PENDING_MAX_AGE_SECONDS = 5 * 60;
 
@@ -17,6 +21,10 @@ export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get("code");
   const stateParam = request.nextUrl.searchParams.get("state");
   const error = request.nextUrl.searchParams.get("error");
+  const cookieStore = await cookies();
+  const stateCookie = integrationOAuthStateCookie("jira");
+  const cookieNonce = cookieStore.get(stateCookie)?.value;
+  cookieStore.delete(stateCookie);
 
   if (error) {
     console.error("[jira-callback] OAuth error:", error);
@@ -31,17 +39,17 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  let orgId: string;
-  try {
-    const parsed = JSON.parse(
-      Buffer.from(stateParam, "base64url").toString("utf-8"),
-    );
-    orgId = parsed.orgId;
-  } catch {
+  const verified = verifyIntegrationOAuthState({
+    state: stateParam,
+    cookieNonce,
+    provider: "jira",
+  });
+  if (!verified.ok) {
     return NextResponse.redirect(
-      new URL("/settings/integrations?error=invalid_state", baseUrl),
+      new URL(`/settings/integrations?error=${verified.error}`, baseUrl),
     );
   }
+  const { orgId, userId } = verified.state;
 
   // Verify the authenticated user is an admin of the org referenced in state.
   // Without this, a crafted callback URL could bind an attacker's Jira tokens
@@ -49,6 +57,11 @@ export async function GET(request: NextRequest) {
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) {
     return NextResponse.redirect(new URL("/login", baseUrl));
+  }
+  if (session.user.id !== userId) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=forbidden", baseUrl),
+    );
   }
   const member = await prisma.organizationMember.findFirst({
     where: { userId: session.user.id, organizationId: orgId, deletedAt: null },
@@ -172,7 +185,6 @@ export async function GET(request: NextRequest) {
     sites,
   });
 
-  const cookieStore = await cookies();
   cookieStore.set(JIRA_OAUTH_PENDING_COOKIE, payload, {
     httpOnly: true,
     sameSite: "lax",

--- a/apps/web/app/api/jira/oauth/route.ts
+++ b/apps/web/app/api/jira/oauth/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server";
 import { headers, cookies } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
+import {
+  createIntegrationOAuthState,
+  integrationOAuthStateCookie,
+  integrationOAuthStateCookieOptions,
+} from "@/lib/integration-oauth-state";
 
 export async function GET() {
   const session = await auth.api.getSession({
@@ -36,7 +41,11 @@ export async function GET() {
     );
   }
 
-  const state = Buffer.from(JSON.stringify({ orgId })).toString("base64url");
+  const { state, nonce } = createIntegrationOAuthState({
+    provider: "jira",
+    orgId,
+    userId: session.user.id,
+  });
 
   const params = new URLSearchParams({
     audience: "api.atlassian.com",
@@ -48,7 +57,13 @@ export async function GET() {
     prompt: "consent",
   });
 
-  return NextResponse.redirect(
+  const response = NextResponse.redirect(
     `https://auth.atlassian.com/authorize?${params.toString()}`,
   );
+  response.cookies.set(
+    integrationOAuthStateCookie("jira"),
+    nonce,
+    integrationOAuthStateCookieOptions(),
+  );
+  return response;
 }

--- a/apps/web/app/api/linear/callback/route.ts
+++ b/apps/web/app/api/linear/callback/route.ts
@@ -1,16 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { getLinearViewer } from "@/lib/linear";
 import { writeAuditLog } from "@/lib/audit";
 import { encryptString } from "@/lib/crypto";
+import {
+  integrationOAuthStateCookie,
+  verifyIntegrationOAuthState,
+} from "@/lib/integration-oauth-state";
 
 export async function GET(request: NextRequest) {
   const baseUrl = process.env.BETTER_AUTH_URL || request.url;
   const code = request.nextUrl.searchParams.get("code");
   const stateParam = request.nextUrl.searchParams.get("state");
   const error = request.nextUrl.searchParams.get("error");
+  const cookieStore = await cookies();
+  const stateCookie = integrationOAuthStateCookie("linear");
+  const cookieNonce = cookieStore.get(stateCookie)?.value;
+  cookieStore.delete(stateCookie);
 
   if (error) {
     console.error("[linear-callback] OAuth error:", error);
@@ -25,23 +33,28 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  let orgId: string;
-  try {
-    const parsed = JSON.parse(
-      Buffer.from(stateParam, "base64url").toString("utf-8"),
-    );
-    orgId = parsed.orgId;
-  } catch {
+  const verified = verifyIntegrationOAuthState({
+    state: stateParam,
+    cookieNonce,
+    provider: "linear",
+  });
+  if (!verified.ok) {
     return NextResponse.redirect(
-      new URL("/settings/integrations?error=invalid_state", baseUrl),
+      new URL(`/settings/integrations?error=${verified.error}`, baseUrl),
     );
   }
+  const { orgId, userId } = verified.state;
 
   // Verify the authenticated user is an admin of the org referenced in state
   // to prevent a crafted callback from binding attacker tokens to a victim org.
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) {
     return NextResponse.redirect(new URL("/login", baseUrl));
+  }
+  if (session.user.id !== userId) {
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=forbidden", baseUrl),
+    );
   }
   const member = await prisma.organizationMember.findFirst({
     where: { userId: session.user.id, organizationId: orgId, deletedAt: null },

--- a/apps/web/app/api/linear/callback/route.ts
+++ b/apps/web/app/api/linear/callback/route.ts
@@ -62,7 +62,7 @@ export async function GET(request: NextRequest) {
   });
   if (!member || (member.role !== "owner" && member.role !== "admin")) {
     return NextResponse.redirect(
-      new URL("/settings/integrations?error=forbidden", baseUrl),
+      new URL("/settings/integrations?error=insufficient_role", baseUrl),
     );
   }
 

--- a/apps/web/app/api/linear/oauth/route.ts
+++ b/apps/web/app/api/linear/oauth/route.ts
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server";
 import { headers, cookies } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
+import {
+  createIntegrationOAuthState,
+  integrationOAuthStateCookie,
+  integrationOAuthStateCookieOptions,
+} from "@/lib/integration-oauth-state";
 
 export async function GET() {
   const session = await auth.api.getSession({
@@ -36,7 +41,11 @@ export async function GET() {
     );
   }
 
-  const state = Buffer.from(JSON.stringify({ orgId })).toString("base64url");
+  const { state, nonce } = createIntegrationOAuthState({
+    provider: "linear",
+    orgId,
+    userId: session.user.id,
+  });
 
   const params = new URLSearchParams({
     client_id: clientId,
@@ -46,7 +55,13 @@ export async function GET() {
     state,
   });
 
-  return NextResponse.redirect(
+  const response = NextResponse.redirect(
     `https://linear.app/oauth/authorize?${params.toString()}`,
   );
+  response.cookies.set(
+    integrationOAuthStateCookie("linear"),
+    nonce,
+    integrationOAuthStateCookieOptions(),
+  );
+  return response;
 }

--- a/apps/web/lib/__tests__/email-send.test.ts
+++ b/apps/web/lib/__tests__/email-send.test.ts
@@ -25,7 +25,8 @@ process.env.EMAIL_FROM_NAME = "Octopus";
 // Cache-bust: other test files (e.g. via lib/incidents) may have already
 // imported @/lib/email with real nodemailer, so force a fresh evaluation
 // that picks up the createTransport mock above.
-const { sendEmail } = await import("@/lib/email?email-send-test");
+const emailModuleSpecifier = `@/lib/email?email-send-test=${Date.now()}`;
+const { sendEmail } = (await import(emailModuleSpecifier)) as typeof import("@/lib/email");
 
 describe("email transporter (nodemailer v9 surface)", () => {
   beforeEach(() => sendMailMock.mockClear());

--- a/apps/web/lib/__tests__/email-send.test.ts
+++ b/apps/web/lib/__tests__/email-send.test.ts
@@ -22,7 +22,10 @@ process.env.EMAIL_PASSWORD = "p";
 process.env.EMAIL_FROM = "noreply@test";
 process.env.EMAIL_FROM_NAME = "Octopus";
 
-const { sendEmail } = await import("@/lib/email");
+// Cache-bust: other test files (e.g. via lib/incidents) may have already
+// imported @/lib/email with real nodemailer, so force a fresh evaluation
+// that picks up the createTransport mock above.
+const { sendEmail } = await import("@/lib/email?email-send-test");
 
 describe("email transporter (nodemailer v9 surface)", () => {
   beforeEach(() => sendMailMock.mockClear());

--- a/apps/web/lib/__tests__/integration-oauth-state.test.ts
+++ b/apps/web/lib/__tests__/integration-oauth-state.test.ts
@@ -26,7 +26,12 @@ const mockFetch = mock(() =>
   ),
 );
 
+const actualHeaders = await import("next/headers");
+const actualAuth = await import("@/lib/auth");
+const actualDb = await import("@octopus/db");
+
 mock.module("next/headers", () => ({
+  ...actualHeaders,
   headers: () => Promise.resolve(new Headers()),
   cookies: () =>
     Promise.resolve({
@@ -40,6 +45,7 @@ mock.module("next/headers", () => ({
 }));
 
 mock.module("@/lib/auth", () => ({
+  ...actualAuth,
   auth: {
     api: {
       getSession: () => Promise.resolve({ user: { id: currentUserId } }),
@@ -48,6 +54,7 @@ mock.module("@/lib/auth", () => ({
 }));
 
 mock.module("@octopus/db", () => ({
+  ...actualDb,
   prisma: {
     organizationMember: {
       findFirst: () => Promise.resolve({ role: "owner" }),

--- a/apps/web/lib/__tests__/integration-oauth-state.test.ts
+++ b/apps/web/lib/__tests__/integration-oauth-state.test.ts
@@ -55,16 +55,28 @@ mock.module("@octopus/db", () => ({
   },
 }));
 
+// mock.module leaks into other test files in the same `bun test` run, so
+// preserve each module's real exports and override only what this file stubs.
+const actualLinear = await import("@/lib/linear");
+const actualAudit = await import("@/lib/audit");
+const actualJira = await import("@/lib/jira");
+const actualBitbucket = await import("@/lib/bitbucket");
+
 mock.module("@/lib/linear", () => ({
+  ...actualLinear,
   getLinearViewer: () => Promise.reject(new Error("not reached")),
 }));
-mock.module("@/lib/audit", () => ({ writeAuditLog: () => Promise.resolve() }));
+mock.module("@/lib/audit", () => ({
+  ...actualAudit,
+  writeAuditLog: () => Promise.resolve(),
+}));
 mock.module("@/lib/jira", () => ({
+  ...actualJira,
   encryptJiraToken: (value: string) => value,
   getAccessibleResources: () => Promise.resolve([]),
-  JIRA_OAUTH_PENDING_COOKIE: "jira_oauth_pending",
 }));
 mock.module("@/lib/bitbucket", () => ({
+  ...actualBitbucket,
   createWebhook: () => Promise.resolve(null),
   listWorkspaceRepos: () => Promise.resolve([]),
 }));

--- a/apps/web/lib/__tests__/integration-oauth-state.test.ts
+++ b/apps/web/lib/__tests__/integration-oauth-state.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+process.env.BETTER_AUTH_SECRET ??= "test-secret-for-integration-oauth-state";
+process.env.BETTER_AUTH_URL ??= "https://app.test";
+process.env.LINEAR_CLIENT_ID ??= "linear-client";
+process.env.LINEAR_CLIENT_SECRET ??= "linear-secret";
+process.env.LINEAR_REDIRECT_URI ??= "https://app.test/api/linear/callback";
+process.env.JIRA_CLIENT_ID ??= "jira-client";
+process.env.JIRA_CLIENT_SECRET ??= "jira-secret";
+process.env.JIRA_REDIRECT_URI ??= "https://app.test/api/jira/callback";
+process.env.BITBUCKET_CLIENT_ID ??= "bitbucket-client";
+process.env.BITBUCKET_CLIENT_SECRET ??= "bitbucket-secret";
+process.env.BITBUCKET_REDIRECT_URI ??= "https://app.test/api/bitbucket/callback";
+
+const ORG_ID = "org_admin_controls";
+const USER_ID = "user_admin";
+
+let requestCookies: Map<string, string>;
+let currentUserId: string;
+const mockFetch = mock(() =>
+  Promise.resolve(
+    new Response(JSON.stringify({ error: "invalid_grant" }), {
+      status: 400,
+      headers: { "content-type": "application/json" },
+    }),
+  ),
+);
+
+mock.module("next/headers", () => ({
+  headers: () => Promise.resolve(new Headers()),
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) =>
+        requestCookies.has(name)
+          ? { name, value: requestCookies.get(name)! }
+          : undefined,
+      set: (name: string, value: string) => requestCookies.set(name, value),
+      delete: (name: string) => requestCookies.delete(name),
+    }),
+}));
+
+mock.module("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: () => Promise.resolve({ user: { id: currentUserId } }),
+    },
+  },
+}));
+
+mock.module("@octopus/db", () => ({
+  prisma: {
+    organizationMember: {
+      findFirst: () => Promise.resolve({ role: "owner" }),
+    },
+  },
+}));
+
+mock.module("@/lib/linear", () => ({
+  getLinearViewer: () => Promise.reject(new Error("not reached")),
+}));
+mock.module("@/lib/audit", () => ({ writeAuditLog: () => Promise.resolve() }));
+mock.module("@/lib/jira", () => ({
+  encryptJiraToken: (value: string) => value,
+  getAccessibleResources: () => Promise.resolve([]),
+  JIRA_OAUTH_PENDING_COOKIE: "jira_oauth_pending",
+}));
+mock.module("@/lib/bitbucket", () => ({
+  createWebhook: () => Promise.resolve(null),
+  listWorkspaceRepos: () => Promise.resolve([]),
+}));
+
+const originalFetch = globalThis.fetch;
+const { GET: linearStart } = await import("@/app/api/linear/oauth/route");
+const { GET: linearCallback } = await import("@/app/api/linear/callback/route");
+const { GET: jiraStart } = await import("@/app/api/jira/oauth/route");
+const { GET: jiraCallback } = await import("@/app/api/jira/callback/route");
+const { GET: bitbucketStart } = await import("@/app/api/bitbucket/oauth/route");
+const { GET: bitbucketCallback } = await import(
+  "@/app/api/bitbucket/callback/route"
+);
+const {
+  createIntegrationOAuthState,
+  INTEGRATION_OAUTH_STATE_TTL_MS,
+  verifyIntegrationOAuthState,
+} = await import("@/lib/integration-oauth-state");
+
+function callbackRequest(provider: string, state: string) {
+  const url = new URL(`https://app.test/api/${provider}/callback`);
+  url.searchParams.set("code", "attacker-code");
+  url.searchParams.set("state", state);
+  return Object.assign(new Request(url), { nextUrl: url }) as never;
+}
+
+function errorOf(response: Response): string | null {
+  return new URL(response.headers.get("location")!).searchParams.get("error");
+}
+
+type Provider = "linear" | "jira" | "bitbucket";
+
+async function startFlow(provider: Provider): Promise<Response> {
+  if (provider === "linear") return linearStart();
+  if (provider === "jira") return jiraStart();
+  return bitbucketStart(
+    new Request("https://app.test/api/bitbucket/oauth?workspace=workspace"),
+  );
+}
+
+const callbacks = {
+  linear: linearCallback,
+  jira: jiraCallback,
+  bitbucket: bitbucketCallback,
+};
+
+beforeEach(() => {
+  requestCookies = new Map([["current_org_id", ORG_ID]]);
+  currentUserId = USER_ID;
+  mockFetch.mockClear();
+  globalThis.fetch = mockFetch as typeof fetch;
+});
+
+describe("integration OAuth state boundary", () => {
+  it.each([
+    ["linear", linearCallback, { orgId: ORG_ID }],
+    ["jira", jiraCallback, { orgId: ORG_ID }],
+    [
+      "bitbucket",
+      bitbucketCallback,
+      { orgId: ORG_ID, nonce: "attacker-chosen", workspaceSlug: "workspace" },
+    ],
+  ] as const)(
+    "%s rejects attacker-authored state before exchanging the code",
+    async (provider, callback, payload) => {
+      const forgedState = Buffer.from(JSON.stringify(payload)).toString("base64url");
+
+      const response = await callback(callbackRequest(provider, forgedState));
+
+      expect(errorOf(response)).toBe("invalid_state");
+      expect(mockFetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects expired server-issued state", () => {
+    const issuedAt = 1_000;
+    const issued = createIntegrationOAuthState({
+      provider: "linear",
+      orgId: ORG_ID,
+      userId: USER_ID,
+      now: issuedAt,
+    });
+
+    expect(
+      verifyIntegrationOAuthState({
+        state: issued.state,
+        cookieNonce: issued.nonce,
+        provider: "linear",
+        now: issuedAt + INTEGRATION_OAUTH_STATE_TTL_MS + 1,
+      }),
+    ).toEqual({ ok: false, error: "state_expired" });
+  });
+
+  it.each(["linear", "jira", "bitbucket"] as const)(
+    "%s rejects genuine state replayed through a browser without its nonce cookie",
+    async (provider) => {
+      const startResponse = await startFlow(provider);
+      const state = new URL(startResponse.headers.get("location")!).searchParams.get(
+        "state",
+      )!;
+
+      requestCookies = new Map();
+      const response = await callbacks[provider](
+        callbackRequest(provider, state),
+      );
+
+      expect(errorOf(response)).toBe("invalid_state");
+      expect(mockFetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["linear", "jira", "bitbucket"] as const)(
+    "%s accepts state from the same browser and reaches the provider exchange",
+    async (provider) => {
+      const startResponse = await startFlow(provider);
+      const location = new URL(startResponse.headers.get("location")!);
+      const state = location.searchParams.get("state")!;
+      const cookieName = `${provider}_oauth_state`;
+      const nonce = startResponse.cookies.get(cookieName)!.value;
+
+      requestCookies = new Map([[cookieName, nonce]]);
+      const response = await callbacks[provider](
+        callbackRequest(provider, state),
+      );
+
+      expect(errorOf(response)).toBe("token_exchange");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(requestCookies.has(cookieName)).toBeFalse();
+    },
+  );
+
+  it("rejects a callback completed by a different signed-in user", async () => {
+    const startResponse = await startFlow("linear");
+    const location = new URL(startResponse.headers.get("location")!);
+    const state = location.searchParams.get("state")!;
+    const cookieName = "linear_oauth_state";
+    const nonce = startResponse.cookies.get(cookieName)!.value;
+
+    currentUserId = "user_other";
+    requestCookies = new Map([[cookieName, nonce]]);
+    const response = await linearCallback(callbackRequest("linear", state));
+
+    expect(errorOf(response)).toBe("forbidden");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});

--- a/apps/web/lib/integration-oauth-state.ts
+++ b/apps/web/lib/integration-oauth-state.ts
@@ -1,0 +1,104 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { decryptJson, encryptJson } from "@/lib/crypto";
+
+export type IntegrationOAuthProvider = "linear" | "jira" | "bitbucket";
+
+export const INTEGRATION_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+export type IntegrationOAuthState = {
+  v: 1;
+  provider: IntegrationOAuthProvider;
+  orgId: string;
+  userId: string;
+  nonce: string;
+  exp: number;
+  context?: Record<string, string>;
+};
+
+type VerifiedState =
+  | { ok: true; state: IntegrationOAuthState }
+  | { ok: false; error: "invalid_state" | "state_expired" };
+
+export function integrationOAuthStateCookie(
+  provider: IntegrationOAuthProvider,
+): string {
+  return `${provider}_oauth_state`;
+}
+
+export function createIntegrationOAuthState(input: {
+  provider: IntegrationOAuthProvider;
+  orgId: string;
+  userId: string;
+  context?: Record<string, string>;
+  now?: number;
+}): { state: string; nonce: string } {
+  const nonce = randomBytes(32).toString("base64url");
+  const value: IntegrationOAuthState = {
+    v: 1,
+    provider: input.provider,
+    orgId: input.orgId,
+    userId: input.userId,
+    nonce,
+    exp: (input.now ?? Date.now()) + INTEGRATION_OAUTH_STATE_TTL_MS,
+    ...(input.context ? { context: input.context } : {}),
+  };
+
+  return { state: encryptJson(value), nonce };
+}
+
+export function integrationOAuthStateCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax" as const,
+    path: "/",
+    maxAge: Math.floor(INTEGRATION_OAUTH_STATE_TTL_MS / 1000),
+  };
+}
+
+export function verifyIntegrationOAuthState(input: {
+  state: string;
+  cookieNonce: string | undefined;
+  provider: IntegrationOAuthProvider;
+  now?: number;
+}): VerifiedState {
+  let value: IntegrationOAuthState;
+  try {
+    value = decryptJson<IntegrationOAuthState>(input.state);
+  } catch {
+    return { ok: false, error: "invalid_state" };
+  }
+
+  if (
+    value?.v !== 1 ||
+    value.provider !== input.provider ||
+    typeof value.orgId !== "string" ||
+    !value.orgId ||
+    typeof value.userId !== "string" ||
+    !value.userId ||
+    typeof value.nonce !== "string" ||
+    !value.nonce ||
+    typeof value.exp !== "number"
+  ) {
+    return { ok: false, error: "invalid_state" };
+  }
+
+  if ((input.now ?? Date.now()) > value.exp) {
+    return { ok: false, error: "state_expired" };
+  }
+
+  if (!input.cookieNonce || !noncesMatch(input.cookieNonce, value.nonce)) {
+    return { ok: false, error: "invalid_state" };
+  }
+
+  return { ok: true, state: value };
+}
+
+function noncesMatch(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left);
+  const rightBytes = Buffer.from(right);
+  return (
+    leftBytes.length === rightBytes.length &&
+    timingSafeEqual(leftBytes, rightBytes)
+  );
+}


### PR DESCRIPTION
## Intent

Continue the remaining security hardening work from the revised Octopus report, starting with SEC-05. Fix Linear, Jira, and Bitbucket OAuth state so enabled integrations are bound to the initiating browser, signed-in user, organization, provider, and an expiry while preserving legitimate callback URLs and provider behavior. Use a shared in-process boundary rather than adding a database migration or new service, retain the live owner/admin role check, add malicious replay/forgery and legitimate-flow regression coverage, and keep the report honest that this phase is not merged or deployed yet.

## What Changed

- Added a shared `integration-oauth-state` helper that issues encrypted OAuth state bound to the signed-in user, organization, provider, a browser cookie nonce, and a 10-minute expiry; the Linear, Jira, and Bitbucket start and callback routes now use it, rejecting forged, expired, replayed, or cross-user callbacks while keeping the live owner/admin role check.
- Callback failures now redirect to the integrations settings page with typed error codes (including a distinct `insufficient_role` code split out from `forbidden`), rendered by a new `IntegrationOAuthErrorBanner` component with copy broad enough to cover legacy role-failure redirects from other flows.
- Added a 236-line test suite covering forged state, expired state, cookie-less replay, cross-user hijack, and the legitimate same-browser flow across all three providers, and fixed a cross-file module cache leak that was breaking the email-send tests.

## Risk Assessment

✅ Low: The final commit is a two-line banner copy change that exactly follows the user's scoping instructions, making the legacy forbidden message accurate for all its emitters while leaving the verified SEC-05 hardening and its test coverage unchanged.

## Testing

Ran the new 11-case OAuth-state suite and the full 718-test web suite (all green), then drove the real Linear/Jira/Bitbucket route handlers end-to-end to capture an HTTP transcript proving forged, replayed, expired, and cross-user callbacks are rejected before any token exchange while the legitimate same-browser flow keeps unchanged provider URLs and reaches the exchange; also screenshotted the new settings-page error banners and confirmed the Octopus report honestly marks the phase as not merged or deployed.

<details>
<summary>Evidence: OAuth flow HTTP transcript (legit, forged, replay, cross-user for all 3 providers)</summary>

```text
bun test v1.3.13 (bf2e2cec)

lib/__tests__/oauth-evidence-transcript.test.ts:
2026-08-01T18:20:26.113Z WARN [Better Auth]: Social provider google is missing clientId or clientSecret
2026-08-01T18:20:26.113Z WARN [Better Auth]: Social provider github is missing clientId or clientSecret

=== LINEAR ===
[1] Admin user_alice_admin of org_acme clicks "Connect linear"
  start: HTTP 307 -> https://linear.app/oauth/authorize?client_id=linear-client&redirect_uri=https://app.test/api/linear/callback&response_type=code&scope=read,write&state=DznkK4HUaIGq6mNxF9OS5Y5ayrW4xZHueDr3uu5U…(235 chars)
  Set-Cookie: linear_oauth_state=pI6xF6sKQ3iJspMB5Nwr…(43 chars); HttpOnly=true; SameSite=lax; Path=/; Max-Age=600
  state param is an encrypted envelope (not decodable base64 JSON)
[linear-callback] Token exchange failed: {"error":"invalid_grant"}
  callback (same browser): HTTP 307 -> https://app.test/settings/integrations?error=token_exchange
  provider token-exchange reached: 1 call(s); nonce cookie consumed: true
[2] Attacker forges state {"orgId":"org_acme",…} (old format)
  callback (forged state): HTTP 307 -> https://app.test/settings/integrations?error=invalid_state
  provider token-exchange reached: 0 call(s)
  [3] Victim's genuine start (state stolen by attacker): HTTP 307 -> https://linear.app/oauth/authorize?client_id=linear-client&redirect_uri=https://app.test/api/linear/callback&response_type=code&scope=read,write&state=uiJBIjL3xWPt4yyCdotoXjKDDsuKAD_gq4wQkrJM…(235 chars)
  callback (attacker's browser, no cookie): HTTP 307 -> https://app.test/settings/integrations?error=invalid_state
  provider token-exchange reached: 0 call(s)

=== JIRA ===
[1] Admin user_alice_admin of org_acme clicks "Connect jira"
  start: HTTP 307 -> https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=jira-client&scope=read:jira-work write:jira-work read:me offline_access&redirect_uri=https://app.test/api/jira/callback&state=XYC6Yr_k19i4_oIHllkM105zZzVks7vHLsQAi3Jq…(232 chars)&response_type=code&prompt=consent
  Set-Cookie: jira_oauth_state=o9YAvRY71x8GU0q55knw…(43 chars); HttpOnly=true; SameSite=lax; Path=/; Max-Age=600
  state param is an encrypted envelope (not decodable base64 JSON)
[jira-callback] Token exchange failed: {"error":"invalid_grant"}
  callback (same browser): HTTP 307 -> https://app.test/settings/integrations?error=token_exchange
  provider token-exchange reached: 1 call(s); nonce cookie consumed: true
[2] Attacker forges state {"orgId":"org_acme",…} (old format)
  callback (forged state): HTTP 307 -> https://app.test/settings/integrations?error=invalid_state
  provider token-exchange reached: 0 call(s)
  [3] Victim's genuine start (state stolen by attacker): HTTP 307 -> https://auth.atlassian.com/authorize?audience=api.atlassian.com&client_id=jira-client&scope=read:jira-work write:jira-work read:me offline_access&redirect_uri=https://app.test/api/jira/callback&state=5lACCyapEOfmqNp9gJWtTxRwIGW4K4yh1lgduGLe…(232 chars)&response_type=code&prompt=consent
  callback (attacker's browser, no cookie): HTTP 307 -> https://app.test/settings/integrations?error=invalid_state
  provider token-exchange reached: 0 call(s)

=== BITBUCKET ===
[1] Admin user_alice_admin of org_acme clicks "Connect bitbucket"
  start: HTTP 307 -> https://bitbucket.org/site/oauth2/authorize?client_id=bitbucket-client&response_type=code&redirect_uri=https://app.test/api/bitbucket/callback&state=U8Vw9lcFwEQGQ5fC1Ch1Uy2JlKnyfm9npf3BnnUs…(290 chars)&scope=account repository pullrequest webhook
  Set-Cookie: bitbucket_oauth_state=PnYYMRPc-NaxxnZuJQd8…(43 chars); HttpOnly=true; SameSite=lax; Path=/; Max-Age=600
  state param is an encrypted envelope (not decodable base64 JSON)
[bitbucket-callback] Token exchange failed: {
  error: "invalid_grant",
}
  callback (same browser): HTTP 307 -> https://app.test/settings/integrations?error=token_exchange
  provider token-exchange reached: 1 call(s); nonce cookie consumed: true
[2] Attacker forges state {"orgId":"org_acme",…} (old format)
  callback (forged state): HTTP 307 -> https://app.test/settings/integrations?error=invalid_state
  provider token-exchange reached: 0 call(s)
  [3] Victim's genuine start (state stolen by attacker): HTTP 307 -> https://bitbucket.org/site/oauth2/authorize?client_id=bitbucket-client&response_type=code&redirect_uri=https://app.test/api/bitbucket/callback&state=w2me9jjKr1nPGYGdfQiRec7szxsb-f_j3p5KD07j…(290 chars)&scope=account repository pullrequest webhook
  callback (attacker's browser, no cookie): HTTP 307 -> https://app.test/settings/integrations?error=invalid_state
  provider token-exchange reached: 0 call(s)

=== CROSS-USER ===
[4] user_alice_admin starts the Linear flow, but a different signed-in user completes it
  start: HTTP 307 -> https://linear.app/oauth/authorize?client_id=linear-client&redirect_uri=https://app.test/api/linear/callback&response_type=code&scope=read,write&state=syzX4f2jhXaOBPF1dNYQw3wvVSeLtz6dndumIdfE…(235 chars)
  callback (session user_mallory): HTTP 307 -> https://app.test/settings/integrations?error=forbidden
  provider token-exchange reached: 0 call(s)

 4 pass
 0 fail
Ran 4 tests across 1 file. [366.00ms]
```
</details>
- Evidence: Integration OAuth error banners screenshot (all 4 error codes + unknown-code case) (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KYZ82T5JA1NRBMRYTJF4AGMD/oauth-error-banners.png</code>)
<details>
<summary>Evidence: Rendered banner HTML (source of screenshot)</summary>

```text
<!doctype html>
<html class="dark">
<head>
<meta charset="utf-8">
<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
<style type="text/tailwindcss">
@theme {
  --color-background: oklch(0.147 0.004 49.25);
  --color-foreground: oklch(0.985 0.001 106.423);
  --color-muted-foreground: oklch(0.709 0.01 56.259);
}
</style>
<style>
body { background: oklch(0.147 0.004 49.25); font-family: ui-sans-serif, system-ui, sans-serif; padding: 32px; max-width: 720px; }
h1 { color: oklch(0.985 0.001 106.423); font-size: 18px; margin-bottom: 24px; }
.case { margin-bottom: 24px; }
.label { color: oklch(0.709 0.01 56.259); font-size: 12px; font-family: ui-monospace, monospace; margin-bottom: 8px; }
.none { color: oklch(0.709 0.01 56.259); font-size: 13px; font-style: italic; }
</style>
</head>
<body>
<h1>Integration OAuth error banner — /settings/integrations</h1>
<div class="case"><p class="label">/settings/integrations?error=state_expired</p><div class="flex gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm" role="alert"><svg class="tabler-icon tabler-icon-alert-triangle mt-0.5 size-4 shrink-0 text-amber-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4"></path><path d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.87l-8.106 -13.536a1.914 1.914 0 0 0 -3.274 0"></path><path d="M12 16h.01"></path></svg><div><p class="font-medium text-foreground">Connection flow expired</p><p class="mt-0.5 text-muted-foreground">Start the integration connection again and complete it within 10 minutes.</p></div></div></div>
<div class="case"><p class="label">/settings/integrations?error=invalid_state</p><div class="flex gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm" role="alert"><svg class="tabler-icon tabler-icon-alert-triangle mt-0.5 size-4 shrink-0 text-amber-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4"></path><path d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.87l-8.106 -13.536a1.914 1.914 0 0 0 -3.274 0"></path><path d="M12 16h.01"></path></svg><div><p class="font-medium text-foreground">Connection flow could not be verified</p><p class="mt-0.5 text-muted-foreground">Start the integration connection again from this page in the same browser.</p></div></div></div>
<div class="case"><p class="label">/settings/integrations?error=forbidden</p><div class="flex gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm" role="alert"><svg class="tabler-icon tabler-icon-alert-triangle mt-0.5 size-4 shrink-0 text-amber-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4"></path><path d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.87l-8.106 -13.536a1.914 1.914 0 0 0 -3.274 0"></path><path d="M12 16h.01"></path></svg><div><p class="font-medium text-foreground">Connection not permitted</p><p class="mt-0.5 text-muted-foreground">Sign in with the account that started the integration connection and make sure it has an owner or admin role in the organization, then try again.</p></div></div></div>
<div class="case"><p class="label">/settings/integrations?error=insufficient_role</p><div class="flex gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm" role="alert"><svg class="tabler-icon tabler-icon-alert-triangle mt-0.5 size-4 shrink-0 text-amber-400" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4"></path><path d="M10.363 3.591l-8.106 13.534a1.914 1.914 0 0 0 1.636 2.871h16.214a1.914 1.914 0 0 0 1.636 -2.87l-8.106 -13.536a1.914 1.914 0 0 0 -3.274 0"></path><path d="M12 16h.01"></path></svg><div><p class="font-medium text-foreground">Permission required</p><p class="mt-0.5 text-muted-foreground">Only organization owners and admins can connect integrations. Ask an admin to connect it, or try again once your role is updated.</p></div></div></div>
<div class="case"><p class="label">/settings/integrations?error=some_unknown_code</p><p class="none">(banner renders nothing — unknown code ignored)</p></div>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ℹ️ `apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx:15` - The `forbidden` error code is emitted for two distinct failures: the callback completed by a different signed-in user (user-mismatch) and the same user lacking owner/admin role at callback time. The banner in integration-oauth-error-banner.tsx renders &#34;Connection flow changed accounts&#34; for both, which is misleading advice when the real cause is insufficient role. Consider a distinct code (e.g. insufficient_role) or broader copy.
- ℹ️ `apps/web/lib/integration-oauth-state.ts:48` - The per-provider state cookies are set with path &#34;/&#34; and no `__Host-` prefix (secure only in production). A `__Host-` prefixed name (or scoping path to the provider callback) would eliminate subdomain cookie-tossing fixation as a theoretical vector. Defense-in-depth only: exploiting it would still require a server-issued encrypted state whose embedded nonce matches the planted cookie, and the user-id check still applies.

🔧 Fix: split insufficient-role OAuth error from forbidden with distinct copy
1 info still open:
- ℹ️ `apps/web/app/(app)/settings/integrations/integration-oauth-error-banner.tsx:14` - The insufficient_role/forbidden split was applied to the three SEC-05 callbacks, but other integrations-page flows still emit error=forbidden for role failures: gitlab/callback/route.ts:92, slack/callback/route.ts:87 and :97, jira/select-site/page.tsx:50, and jira-task-action.ts:78/:92. Because the banner added by this branch now renders &#34;Connection flow changed accounts&#34; for any forbidden code, those pre-existing role-failure redirects display misleading account-mismatch copy. Decide whether to extend the insufficient_role code to those emitters (they are outside SEC-05 scope, hence ask-user).

🔧 Fix: broaden legacy forbidden banner copy to cover role failures
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun test lib/__tests__/integration-oauth-state.test.ts` — the new 11-test suite covering forged state, expired state, cookie-less replay, legitimate same-browser flow, and cross-user hijack for all three providers (11 pass)</code>
- <code>`bun test` in apps/web — full suite regression including the touched email-send test (718 pass, 0 fail across 69 files)</code>
- `Manual end-to-end transcript harness driving the real route handlers: start redirect (encrypted state + Set-Cookie inspection), same-browser callback reaching token exchange with cookie consumption, forged old-format state, stolen-state replay without cookie, and different-signed-in-user callback, for Linear/Jira/Bitbucket`
- <code>Rendered the real `IntegrationOAuthErrorBanner` component for all four error codes plus an unknown code and screenshotted it via headless Chrome</code>
- `Verified diff adds no Prisma migration and retains the live organizationMember owner/admin role check`
- `Read the revised Octopus report artifact and confirmed it states SEC-05 is implemented on the phase-2 branch but not merged, released, or deployed`

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CHANGELOG.md:8` - No [Unreleased] CHANGELOG entry was added for the OAuth state hardening (10-minute expiry, same-browser/user binding, new error banners). This follows repo precedent — customer-facing changelog entries are written in dedicated release-time commits, and phase-1 security hardening added none — and the change intent requires honest reporting that this phase is not merged or deployed yet. A user-facing entry should be written when this ships in a release.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
