### PR TITLE
ci(release): gate releases on a customer-facing changelog entry + stamp it in bump-version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,31 @@ permissions:
   packages: write
 
 jobs:
+  # ── changelog gate ─────────────────────────────────────────────────────────
+  # Block a release that has no customer-facing CHANGELOG.md entry for its
+  # version, so the public /docs/changelog can never silently fall behind.
+  # Content stays human-curated (scripts/bump-version.sh stamps [Unreleased]
+  # into the version) — we only ENFORCE the entry exists, never auto-write prose.
+  verify-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Require a CHANGELOG.md entry for this version
+        run: |
+          set -euo pipefail
+          SEMVER=${GITHUB_REF#refs/tags/}
+          SEMVER=${SEMVER#v}
+          ESCAPED=${SEMVER//./\\.}
+          if ! grep -qE "^## \[${ESCAPED}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [${SEMVER}]' section. Add a customer-facing entry before tagging — run 'scripts/bump-version.sh ${SEMVER}' to stamp the [Unreleased] notes into a dated version section, then commit and re-tag."
+            exit 1
+          fi
+          echo "CHANGELOG.md has an entry for ${SEMVER} ✓"
+
   # ── self-host distribution image (PUBLIC package) ──────────────────────────
   selfhost:
+    needs: [verify-changelog]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -98,6 +121,7 @@ jobs:
   # they only change on an explicit service update. Skipped when the variables
   # are unset (e.g. on forks).
   prod:
+    needs: [verify-changelog]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
   # into the version) — we only ENFORCE the entry exists, never auto-write prose.
   verify-changelog:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -44,6 +46,10 @@ jobs:
           set -euo pipefail
           SEMVER=${GITHUB_REF#refs/tags/}
           SEMVER=${SEMVER#v}
+          if [ ! -f CHANGELOG.md ]; then
+            echo "::error::CHANGELOG.md not found at the repository root."
+            exit 1
+          fi
           ESCAPED=${SEMVER//./\\.}
           if ! grep -qE "^## \[${ESCAPED}\]" CHANGELOG.md; then
             echo "::error::CHANGELOG.md has no '## [${SEMVER}]' section. Add a customer-facing entry before tagging — run 'scripts/bump-version.sh ${SEMVER}' to stamp the [Unreleased] notes into a dated version section, then commit and re-tag."

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -47,7 +47,10 @@ if (!body) {
   console.warn("[bump-version] WARNING: [Unreleased] had no notes — inserted a placeholder. Edit CHANGELOG.md with customer-facing notes before releasing.");
 }
 const date = new Date().toISOString().slice(0, 10);
-c = c.replace(capture, `## [Unreleased]\n\n## [${v}] - ${date}\n\n${body}\n`);
+const replacement = `## [Unreleased]\n\n## [${v}] - ${date}\n\n${body}\n`;
+// Replacer FUNCTION, not a string: notes can contain `$` (e.g. "$5 / $25 per
+// million tokens"), and String.replace would treat `$&`/`$1`/`$$` specially.
+c = c.replace(capture, () => replacement);
 fs.writeFileSync(p, c);
 console.log(`[bump-version] Stamped CHANGELOG.md [${v}] - ${date}`);
 NODE

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -15,4 +15,41 @@ for f in "$ROOT/package.json" "$ROOT/apps/web/package.json"; do
   echo "Updated $f -> $VERSION"
 done
 
-echo "Now commit, then tag: git tag v$VERSION"
+# Stamp the CUSTOMER-FACING changelog: promote the accumulated `## [Unreleased]`
+# notes into a dated `## [X.Y.Z]` section (Keep a Changelog convention) and open
+# a fresh empty [Unreleased]. We only move human-written notes into place — never
+# generate prose from commits. The release workflow (verify-changelog) refuses to
+# ship a version that has no matching section, so this keeps /docs/changelog from
+# ever falling behind.
+VERSION="$VERSION" ROOT="$ROOT" node <<'NODE'
+const fs = require("fs");
+const v = process.env.VERSION;
+const p = process.env.ROOT + "/CHANGELOG.md";
+if (!fs.existsSync(p)) {
+  console.warn("[bump-version] CHANGELOG.md not found — skipping changelog stamp");
+  process.exit(0);
+}
+let c = fs.readFileSync(p, "utf8");
+const esc = v.replace(/[.]/g, "\\.");
+if (new RegExp("^## \\[" + esc + "\\]", "m").test(c)) {
+  console.log(`[bump-version] CHANGELOG already has [${v}] — leaving as-is`);
+  process.exit(0);
+}
+const capture = /## \[Unreleased\]\s*\n([\s\S]*?)(?=\n## \[|\s*$)/;
+const m = c.match(capture);
+if (!m) {
+  console.warn(`[bump-version] No [Unreleased] section — add a '## [${v}]' entry to CHANGELOG.md manually before releasing.`);
+  process.exit(0);
+}
+let body = m[1].trim();
+if (!body) {
+  body = "- _Maintenance and internal improvements._";
+  console.warn("[bump-version] WARNING: [Unreleased] had no notes — inserted a placeholder. Edit CHANGELOG.md with customer-facing notes before releasing.");
+}
+const date = new Date().toISOString().slice(0, 10);
+c = c.replace(capture, `## [Unreleased]\n\n## [${v}] - ${date}\n\n${body}\n`);
+fs.writeFileSync(p, c);
+console.log(`[bump-version] Stamped CHANGELOG.md [${v}] - ${date}`);
+NODE
+
+echo "Now review CHANGELOG.md, commit, then tag: git tag v$VERSION"


### PR DESCRIPTION
## Why
The public `/docs/changelog` (rendered from `CHANGELOG.md`) had drifted to 1.0.62 while we shipped through 1.0.92. This makes keeping it current part of the release step — **without** auto-generating customer-facing prose from commit messages (those are dev-facing).

## What
- **`release.yml` — `verify-changelog` gate**: a new job that the build jobs (`selfhost`, `prod`) `needs:`, so it gates the whole release. It fails a `v*` tag build if `CHANGELOG.md` has no `## [<version>]` section, with a message pointing at `bump-version.sh`. Enforcement only — never writes prose.
- **`bump-version.sh` — changelog stamp**: after bumping `package.json` versions, it promotes the accumulated `## [Unreleased]` notes into a dated `## [X.Y.Z]` section and opens a fresh `[Unreleased]` (Keep a Changelog convention). Human-written notes are just moved into place; if `[Unreleased]` is empty it warns and inserts a placeholder. Idempotent (skips if the version section already exists).

## Flow going forward
Add customer-facing bullets under `[Unreleased]` as work lands → `scripts/bump-version.sh X.Y.Z` → review `CHANGELOG.md` → commit → tag. A tag without an entry now fails fast instead of shipping a stale changelog.

Verified the stamp transform on a sample changelog (Unreleased → dated section, older entries intact) and `bash -n` on the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p