### PR TITLE
fix(webhooks): add signature-verified tenant-resolution shadow ledger with bounded retention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,7 +146,7 @@ ADMIN_EMAILS=
 AUDIT_LOG_RETENTION_DAYS=
 # Signature-verified webhook delivery metadata retention (days). Default 30;
 # tune this to the shadow-observation window and available database capacity.
-# Must be a positive integer; invalid values fail the cleanup job visibly.
+# Must be an integer from 1 to 365; invalid values fail the cleanup job visibly.
 WEBHOOK_DELIVERY_RETENTION_DAYS=
 # Self-hosted build metadata (baked into the GHCR image by release.yml).
 # NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true surfaces the in-app Updates page +

--- a/.env.example
+++ b/.env.example
@@ -144,6 +144,9 @@ ADMIN_EMAILS=
 # Default 365. Bump for compliance regimes (SOC2 ≥365, HIPAA ~6yr); the daily
 # pg-boss job deletes AuditLog rows older than this.
 AUDIT_LOG_RETENTION_DAYS=
+# Signature-verified webhook delivery metadata retention (days). Default 30;
+# tune this to the shadow-observation window and available database capacity.
+WEBHOOK_DELIVERY_RETENTION_DAYS=
 # Self-hosted build metadata (baked into the GHCR image by release.yml).
 # NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true surfaces the in-app Updates page +
 # settings nav entry, AND enables email/password sign-in + sign-up (off on the

--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,7 @@ ADMIN_EMAILS=
 AUDIT_LOG_RETENTION_DAYS=
 # Signature-verified webhook delivery metadata retention (days). Default 30;
 # tune this to the shadow-observation window and available database capacity.
+# Must be a positive integer; invalid values fail the cleanup job visibly.
 WEBHOOK_DELIVERY_RETENTION_DAYS=
 # Self-hosted build metadata (baked into the GHCR image by release.yml).
 # NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true surfaces the in-app Updates page +

--- a/.env.example
+++ b/.env.example
@@ -146,7 +146,7 @@ ADMIN_EMAILS=
 AUDIT_LOG_RETENTION_DAYS=
 # Signature-verified webhook delivery metadata retention (days). Default 30;
 # tune this to the shadow-observation window and available database capacity.
-# Must be an integer from 1 to 365; invalid values fail the cleanup job visibly.
+# Must be an integer from 1 to 365; invalid values fail server startup.
 WEBHOOK_DELIVERY_RETENTION_DAYS=
 # Self-hosted build metadata (baked into the GHCR image by release.yml).
 # NEXT_PUBLIC_OCTOPUS_SELF_HOSTED=true surfaces the in-app Updates page +

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- GitHub webhook deliveries are now recorded in a signature-verified delivery ledger that cross-checks tenant routing in shadow mode — observation only, with no change to how reviews are dispatched. Only bounded metadata is stored (never payload content), retained 30 days by default; self-hosted deployments can tune this via `WEBHOOK_DELIVERY_RETENTION_DAYS`.
+
 ## [1.0.91] - 2026-08-01
 
 ### Security

--- a/apps/web/app/(landing)/docs/data-retention/page.tsx
+++ b/apps/web/app/(landing)/docs/data-retention/page.tsx
@@ -78,7 +78,7 @@ const RETENTION: RetentionRow[] = [
     category: "Webhook deliveries",
     what: "Signature-verified webhook delivery metadata (IDs, event type, payload hash — never payload content)",
     retention: "30 days (hosted default)",
-    notes: "Tunable via WEBHOOK_DELIVERY_RETENTION_DAYS; pruned daily.",
+    notes: "Pruned daily; WEBHOOK_DELIVERY_RETENTION_DAYS accepts positive integers and fails the cleanup job on invalid configuration.",
   },
   {
     category: "Activity events",

--- a/apps/web/app/(landing)/docs/data-retention/page.tsx
+++ b/apps/web/app/(landing)/docs/data-retention/page.tsx
@@ -78,7 +78,7 @@ const RETENTION: RetentionRow[] = [
     category: "Webhook deliveries",
     what: "Signature-verified webhook delivery metadata (IDs, event type, payload hash — never payload content)",
     retention: "30 days (hosted default)",
-    notes: "Pruned daily; WEBHOOK_DELIVERY_RETENTION_DAYS accepts 1–365 days and fails the cleanup job on invalid configuration.",
+    notes: "Pruned daily; WEBHOOK_DELIVERY_RETENTION_DAYS accepts 1–365 days and fails server startup on invalid configuration.",
   },
   {
     category: "Activity events",

--- a/apps/web/app/(landing)/docs/data-retention/page.tsx
+++ b/apps/web/app/(landing)/docs/data-retention/page.tsx
@@ -75,6 +75,12 @@ const RETENTION: RetentionRow[] = [
     retention: "30 days for hosted; self-hosters control their own",
   },
   {
+    category: "Webhook deliveries",
+    what: "Signature-verified webhook delivery metadata (IDs, event type, payload hash — never payload content)",
+    retention: "30 days (hosted default)",
+    notes: "Tunable via WEBHOOK_DELIVERY_RETENTION_DAYS; pruned daily.",
+  },
+  {
     category: "Activity events",
     what: "Live team-telemetry feed rows (coarse actions only — no content)",
     retention: "30 days (hosted default)",
@@ -97,7 +103,7 @@ export default function DataRetentionPage() {
           Compliance
         </div>
         <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Data Retention</h1>
-        <p className="mt-3 text-sm text-[#555]">Last updated: May 2026</p>
+        <p className="mt-3 text-sm text-[#555]">Last updated: August 2026</p>
       </div>
 
       <P>
@@ -182,9 +188,11 @@ export default function DataRetentionPage() {
       <Section title="Self-hosters">
         <P>
           Self-hosted Octopus stores everything in your PostgreSQL + Qdrant +
-          object-storage. There is no automatic retention beyond the
-          90-day-post-close window for review findings. Configure retention for
-          your stored data per your own compliance requirements.
+          object-storage. There is no automatic retention beyond the built-in
+          pruning jobs above (review findings, audit logs, activity events, and
+          webhook delivery metadata — the latter three have configurable
+          windows). Configure retention for your other stored data per your own
+          compliance requirements.
         </P>
       </Section>
     </article>

--- a/apps/web/app/(landing)/docs/data-retention/page.tsx
+++ b/apps/web/app/(landing)/docs/data-retention/page.tsx
@@ -78,7 +78,7 @@ const RETENTION: RetentionRow[] = [
     category: "Webhook deliveries",
     what: "Signature-verified webhook delivery metadata (IDs, event type, payload hash — never payload content)",
     retention: "30 days (hosted default)",
-    notes: "Pruned daily; WEBHOOK_DELIVERY_RETENTION_DAYS accepts positive integers and fails the cleanup job on invalid configuration.",
+    notes: "Pruned daily; WEBHOOK_DELIVERY_RETENTION_DAYS accepts 1–365 days and fails the cleanup job on invalid configuration.",
   },
   {
     category: "Activity events",

--- a/apps/web/app/api/github/webhook/route.ts
+++ b/apps/web/app/api/github/webhook/route.ts
@@ -1,5 +1,7 @@
+import "server-only";
+
 import crypto from "node:crypto";
-import { NextRequest, NextResponse } from "next/server";
+import { after, NextRequest, NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
 import { prisma } from "@octopus/db";
 import {
@@ -12,6 +14,11 @@ import {
 } from "@/lib/github";
 import { startReviewFlow } from "@/lib/webhook-shared";
 import { getGithubAppConfig } from "@/lib/github-app-config";
+import {
+  observeGithubWebhookDeliveryInShadowMode,
+  type LegacyWebhookRepository,
+  type GithubWebhookTenantResolution,
+} from "@/lib/webhook-tenant";
 
 async function verifySignature(payload: string, signature: string | null): Promise<boolean> {
   if (!signature) return false;
@@ -38,7 +45,28 @@ export async function POST(request: NextRequest) {
   }
 
   const event = request.headers.get("x-github-event");
+  const deliveryId = request.headers.get("x-github-delivery");
+  const payloadSha256 = crypto.createHash("sha256").update(body).digest("hex");
   const payload = JSON.parse(body);
+  let legacyRepository: LegacyWebhookRepository | null | undefined;
+  let tenantResolution: GithubWebhookTenantResolution | undefined;
+
+  // SEC-06 shadow mode: observe only signature-verified delivery metadata and
+  // compare the installation-scoped result with the route's existing lookup.
+  // The callback runs after the response and never changes routing or rejects a
+  // duplicate; enforcement follows only after production mismatches are understood.
+  after(async () => {
+    await observeGithubWebhookDeliveryInShadowMode({
+      deliveryId,
+      eventType: event,
+      action: payload.action,
+      payloadSha256,
+      installationId: payload.installation?.id,
+      repositoryExternalId: payload.repository?.id,
+      legacyRepository,
+      tenantResolution,
+    });
+  });
 
   if (event === "installation" || event === "installation_repositories") {
     const installationId = payload.installation?.id as number | undefined;
@@ -47,7 +75,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Find the org linked to this installation
-    const org = await prisma.organization.findFirst({
+    const org = await prisma.organization.findUnique({
       where: { githubInstallationId: installationId },
       select: { id: true },
     });
@@ -55,6 +83,14 @@ export async function POST(request: NextRequest) {
     if (!org) {
       return NextResponse.json({ ok: true });
     }
+
+    // Snapshot before an `installation.deleted` event clears the binding below.
+    tenantResolution = {
+      provider: "github",
+      status: "installation_only",
+      organizationId: org.id,
+      repositoryId: null,
+    };
 
     // Sync repos from GitHub
     try {
@@ -215,6 +251,9 @@ export async function POST(request: NextRequest) {
       where: { provider: "github", externalId: repoExternalId },
       select: { id: true, organizationId: true, autoReview: true, installationId: true },
     });
+    legacyRepository = repo
+      ? { id: repo.id, organizationId: repo.organizationId }
+      : null;
 
     if (!repo) {
       console.warn(`[webhook] Repo not found in DB — externalId: ${repoExternalId}`);
@@ -318,6 +357,9 @@ export async function POST(request: NextRequest) {
       where: { provider: "github", externalId: repoExternalId },
       select: { id: true, fullName: true, defaultBranch: true, indexStatus: true, organizationId: true },
     });
+    legacyRepository = repo
+      ? { id: repo.id, organizationId: repo.organizationId }
+      : null;
 
     if (repo) {
       await prisma.pullRequest.updateMany({
@@ -432,6 +474,9 @@ export async function POST(request: NextRequest) {
         where: { provider: "github", externalId: repoExternalId },
         select: { id: true, organizationId: true, installationId: true },
       });
+      legacyRepository = repo
+        ? { id: repo.id, organizationId: repo.organizationId }
+        : null;
 
       if (!repo) {
         console.warn(`[webhook] Repo not found in DB — externalId: ${repoExternalId}, fullName: ${repoFullName}`);

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -42,6 +42,10 @@ export async function register() {
       // ACTIVITY_RETENTION_DAYS (default 30).
       await boss.schedule("enforce-activity-retention", "0 4 * * *");
 
+      // Verified webhook-delivery telemetry retention (04:30 UTC). The default
+      // 30-day window is configurable via WEBHOOK_DELIVERY_RETENTION_DAYS.
+      await boss.schedule("enforce-webhook-delivery-retention", "30 4 * * *");
+
       // Daily release-cache refresh (05:00 UTC — offset from the retention jobs).
       // Gated to self-hosted: the release-check/update panel only surfaces there
       // (same server-side flag the admin bootstrap above uses). pg-boss dedups

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,6 +1,13 @@
 export async function register() {
   // Only start queue workers on the server (not during build or edge runtime)
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Fail before queue startup if retention is misconfigured; otherwise the
+    // daily cleanup could remain broken while delivery telemetry keeps growing.
+    const { resolveWebhookDeliveryRetentionDays } = await import(
+      "./lib/webhook-tenant"
+    );
+    resolveWebhookDeliveryRetentionDays();
+
     const { reconcileStaleRepoStates } = await import("./lib/boot-reconciler");
     await reconcileStaleRepoStates();
 

--- a/apps/web/lib/__tests__/fixtures/github-webhook-shadow-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/github-webhook-shadow-harness.ts
@@ -1,0 +1,248 @@
+import crypto from "node:crypto";
+import { mock } from "bun:test";
+
+const WEBHOOK_SECRET = "github-webhook-shadow-test-secret";
+
+type AfterCallback = () => void | Promise<void>;
+type DeliveryUpsertArgs = {
+  where: {
+    provider_deliveryId: { provider: string; deliveryId: string };
+  };
+  create: Record<string, unknown>;
+  update: Record<string, unknown>;
+};
+
+const afterCallbacks: AfterCallback[] = [];
+const deliveryAttempts = new Map<string, number>();
+const deliveryPayloadHashes = new Map<string, string>();
+const deliveryWrites: DeliveryUpsertArgs[] = [];
+const reviewCalls: Array<Record<string, unknown>> = [];
+let failNextLedgerWrite = false;
+
+const webhookDeliveryStore = {
+  upsert: (args: DeliveryUpsertArgs) => {
+    if (failNextLedgerWrite) {
+      failNextLedgerWrite = false;
+      return Promise.reject(new Error("ledger unavailable"));
+    }
+    deliveryWrites.push(args);
+    const key = `${args.where.provider_deliveryId.provider}:${args.where.provider_deliveryId.deliveryId}`;
+    const attemptCount = (deliveryAttempts.get(key) ?? 0) + 1;
+    deliveryAttempts.set(key, attemptCount);
+    const payloadSha256 = deliveryPayloadHashes.get(key) ??
+      String(args.create.payloadSha256);
+    deliveryPayloadHashes.set(key, payloadSha256);
+    return Promise.resolve({ attemptCount, payloadSha256 });
+  },
+  update: () => Promise.resolve({ payloadHashCollisionCount: 1 }),
+};
+
+mock.module("server-only", () => ({}));
+mock.module("next/server", () => ({
+  after: (callback: AfterCallback) => afterCallbacks.push(callback),
+  NextRequest: Request,
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => Response.json(body, init),
+  },
+}));
+mock.module("next/cache", () => ({ revalidatePath: () => undefined }));
+mock.module("@/lib/github-app-config", () => ({
+  getGithubAppConfig: () =>
+    Promise.resolve({ webhookSecret: WEBHOOK_SECRET, appId: "123", slug: "octopus" }),
+}));
+mock.module("@/lib/github", () => ({
+  listInstallationRepos: () => Promise.resolve([]),
+  getRepositoryDetails: () => Promise.resolve(null),
+  addCommentReaction: () => Promise.resolve(),
+  getPullRequestDetails: () => Promise.resolve(null),
+  createCheckRun: () => Promise.resolve(1),
+  updateCheckRun: () => Promise.resolve(),
+}));
+mock.module("@/lib/webhook-shared", () => ({
+  startReviewFlow: (input: Record<string, unknown>) => {
+    reviewCalls.push(input);
+    return Promise.resolve();
+  },
+}));
+mock.module("@octopus/db", () => ({
+  prisma: {
+    organization: {
+      findUnique: (args: {
+        where: { githubInstallationId?: number; id?: string };
+      }) => {
+        if (args.where.githubInstallationId === 222) {
+          return Promise.resolve({ id: "org_b" });
+        }
+        if (args.where.id === "org_a") {
+          return Promise.resolve({ blockedAuthors: [] });
+        }
+        return Promise.resolve(null);
+      },
+      updateMany: () => Promise.resolve({ count: 1 }),
+    },
+    repository: {
+      findFirst: () =>
+        Promise.resolve({
+          id: "repo_a",
+          organizationId: "org_a",
+          autoReview: true,
+          installationId: 222,
+        }),
+      findUnique: () =>
+        Promise.resolve({ id: "repo_b", organizationId: "org_b" }),
+      findMany: () => Promise.resolve([]),
+      count: () => Promise.resolve(2),
+      update: () => Promise.resolve({}),
+      upsert: () => Promise.resolve({}),
+    },
+    systemConfig: {
+      findUnique: () => Promise.resolve({ blockedAuthors: [] }),
+    },
+    webhookDelivery: webhookDeliveryStore,
+    $transaction: <T>(
+      callback: (transaction: {
+        webhookDelivery: typeof webhookDeliveryStore;
+      }) => Promise<T>,
+    ) => callback({ webhookDelivery: webhookDeliveryStore }),
+  },
+}));
+
+const { POST } = await import("@/app/api/github/webhook/route");
+
+function pullRequestBody() {
+  return JSON.stringify({
+    action: "opened",
+    installation: { id: 222 },
+    repository: { id: 9001, full_name: "shared/repository" },
+    pull_request: {
+      number: 17,
+      title: "Tenant collision regression",
+      html_url: "https://github.test/shared/repository/pull/17",
+      user: { login: "contributor" },
+      head: { sha: "abc123" },
+      draft: false,
+    },
+  });
+}
+
+function webhookRequest(
+  body: string,
+  options: {
+    deliveryId?: string;
+    eventType?: string;
+    validSignature?: boolean;
+  } = {},
+) {
+  const signature = crypto
+    .createHmac("sha256", WEBHOOK_SECRET)
+    .update(body)
+    .digest("hex");
+  return new Request("https://app.test/api/github/webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-github-event": options.eventType ?? "pull_request",
+      "x-github-delivery": options.deliveryId ?? "delivery-123",
+      "x-hub-signature-256": options.validSignature === false
+        ? "sha256=invalid"
+        : `sha256=${signature}`,
+    },
+    body,
+  }) as never;
+}
+
+async function runAfterCallbacks() {
+  const callbacks = afterCallbacks.splice(0);
+  await Promise.all(callbacks.map((callback) => callback()));
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const originalConsole = {
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+};
+console.log = () => undefined;
+console.info = () => undefined;
+console.warn = () => undefined;
+
+try {
+  const invalidResponse = await POST(
+    webhookRequest(pullRequestBody(), { validSignature: false }),
+  );
+  assert(invalidResponse.status === 401, "invalid signature was not rejected");
+  assert(afterCallbacks.length === 0, "invalid signature scheduled observation");
+  assert(deliveryWrites.length === 0, "invalid signature wrote to the ledger");
+  assert(reviewCalls.length === 0, "invalid signature started a review");
+
+  const collisionResponse = await POST(webhookRequest(pullRequestBody()));
+  assert(collisionResponse.status === 200, "valid collision response failed");
+  assert(reviewCalls[0]?.orgId === "org_a", "shadow mode changed legacy routing");
+  await runAfterCallbacks();
+  const collision = deliveryWrites.at(-1)?.create;
+  assert(collision?.resolvedOrganizationId === "org_b", "trusted tenant was not recorded");
+  assert(collision?.legacyOrganizationId === "org_a", "legacy tenant was not recorded");
+  assert(collision?.comparisonStatus === "ambiguous", "collision was not marked ambiguous");
+
+  const reviewsBeforeReplay = reviewCalls.length;
+  await POST(
+    webhookRequest(pullRequestBody(), { deliveryId: "delivery-replayed" }),
+  );
+  await runAfterCallbacks();
+  await POST(
+    webhookRequest(pullRequestBody(), { deliveryId: "delivery-replayed" }),
+  );
+  await runAfterCallbacks();
+  assert(
+    reviewCalls.length === reviewsBeforeReplay + 2,
+    "duplicate delivery was incorrectly suppressed in shadow mode",
+  );
+  assert(
+    deliveryAttempts.get("github:delivery-replayed") === 2,
+    "duplicate attempt count was not incremented",
+  );
+
+  failNextLedgerWrite = true;
+  const failureResponse = await POST(
+    webhookRequest(pullRequestBody(), { deliveryId: "delivery-db-failure" }),
+  );
+  await runAfterCallbacks();
+  assert(failureResponse.status === 200, "ledger failure changed webhook response");
+
+  const uninstallBody = JSON.stringify({
+    action: "deleted",
+    installation: { id: 222 },
+  });
+  const uninstallResponse = await POST(
+    webhookRequest(uninstallBody, {
+      deliveryId: "delivery-uninstall",
+      eventType: "installation",
+    }),
+  );
+  await runAfterCallbacks();
+  const uninstall = deliveryWrites.at(-1)?.create;
+  assert(uninstallResponse.status === 200, "uninstall response failed");
+  assert(
+    uninstall?.resolvedOrganizationId === "org_b" &&
+      uninstall?.resolutionStatus === "installation_only",
+    "uninstall lost its pre-mutation tenant snapshot",
+  );
+
+  originalConsole.log(JSON.stringify({
+    invalidSignatureRejected: true,
+    legacyRoutingPreserved: true,
+    duplicateAttemptCount: 2,
+    ledgerFailureNonFatal: true,
+    uninstallTenantCaptured: true,
+  }));
+} catch (error) {
+  originalConsole.warn(error);
+  process.exitCode = 1;
+} finally {
+  console.log = originalConsole.log;
+  console.info = originalConsole.info;
+  console.warn = originalConsole.warn;
+}

--- a/apps/web/lib/__tests__/github-webhook-tenant-shadow.test.ts
+++ b/apps/web/lib/__tests__/github-webhook-tenant-shadow.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+describe("GitHub webhook tenant shadow mode", () => {
+  it("preserves routing while observing verified collisions, retries, and uninstall", async () => {
+    const harnessPath = fileURLToPath(
+      new URL("./fixtures/github-webhook-shadow-harness.ts", import.meta.url),
+    );
+    const process = Bun.spawn([globalThis.process.execPath, harnessPath], {
+      cwd: globalThis.process.cwd(),
+      env: globalThis.process.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode, stderr).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      invalidSignatureRejected: true,
+      legacyRoutingPreserved: true,
+      duplicateAttemptCount: 2,
+      ledgerFailureNonFatal: true,
+      uninstallTenantCaptured: true,
+    });
+  });
+});

--- a/apps/web/lib/__tests__/github-webhook-tenant-shadow.test.ts
+++ b/apps/web/lib/__tests__/github-webhook-tenant-shadow.test.ts
@@ -19,7 +19,12 @@ describe("GitHub webhook tenant shadow mode", () => {
     ]);
 
     expect(exitCode, stderr).toBe(0);
-    expect(JSON.parse(stdout)).toEqual({
+    const resultLine = stdout
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0)
+      .at(-1);
+    expect(resultLine).toBeDefined();
+    expect(JSON.parse(resultLine!)).toEqual({
       invalidSignatureRejected: true,
       legacyRoutingPreserved: true,
       duplicateAttemptCount: 2,

--- a/apps/web/lib/__tests__/webhook-tenant.test.ts
+++ b/apps/web/lib/__tests__/webhook-tenant.test.ts
@@ -1,0 +1,411 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("server-only", () => ({}));
+mock.module("@octopus/db", () => ({ prisma: {} }));
+
+const {
+  compareWebhookTenantResolution,
+  enforceWebhookDeliveryRetention,
+  observeGithubWebhookDelivery,
+  observeGithubWebhookDeliveryInShadowMode,
+  resolveWebhookTenant,
+} = await import("@/lib/webhook-tenant");
+
+const PAYLOAD_SHA = "a".repeat(64);
+
+function createStore() {
+  const webhookDelivery = {
+    upsert: mock(() =>
+      Promise.resolve({ attemptCount: 1, payloadSha256: PAYLOAD_SHA }),
+    ),
+    update: mock(() =>
+      Promise.resolve({ payloadHashCollisionCount: 1 }),
+    ),
+    deleteMany: mock(() => Promise.resolve({ count: 0 })),
+  };
+  return {
+    organization: {
+      findUnique: mock(() => Promise.resolve({ id: "org_b" } as { id: string } | null)),
+    },
+    repository: {
+      findUnique: mock(() =>
+        Promise.resolve({ id: "repo_b", organizationId: "org_b" } as {
+          id: string;
+          organizationId: string;
+        } | null),
+      ),
+      count: mock(() => Promise.resolve(1)),
+    },
+    webhookDelivery,
+    $transaction: async <T>(
+      callback: (transaction: { webhookDelivery: typeof webhookDelivery }) =>
+        Promise<T>,
+    ) => callback({ webhookDelivery }),
+  };
+}
+
+describe("resolveWebhookTenant", () => {
+  it("resolves a GitHub repository only inside the installation-owned organization", async () => {
+    const store = createStore();
+
+    const result = await resolveWebhookTenant(
+      {
+        provider: "github",
+        installationId: 222,
+        repositoryExternalId: "9001",
+      },
+      store,
+    );
+
+    expect(result).toEqual({
+      provider: "github",
+      status: "resolved",
+      organizationId: "org_b",
+      repositoryId: "repo_b",
+    });
+    expect(store.organization.findUnique).toHaveBeenCalledWith({
+      where: { githubInstallationId: 222 },
+      select: { id: true },
+    });
+    expect(store.repository.findUnique).toHaveBeenCalledWith({
+      where: {
+        provider_externalId_organizationId: {
+          provider: "github",
+          externalId: "9001",
+          organizationId: "org_b",
+        },
+      },
+      select: { id: true, organizationId: true },
+    });
+  });
+
+  it("never falls back to a repository-only lookup for an unmapped installation", async () => {
+    const store = createStore();
+    store.organization.findUnique.mockResolvedValue(null);
+
+    const result = await resolveWebhookTenant(
+      {
+        provider: "github",
+        installationId: 999,
+        repositoryExternalId: "9001",
+      },
+      store,
+    );
+
+    expect(result).toEqual({
+      provider: "github",
+      status: "unmapped_installation",
+      organizationId: null,
+      repositoryId: null,
+    });
+    expect(store.repository.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("supports installation events that do not carry a repository", async () => {
+    const store = createStore();
+
+    const result = await resolveWebhookTenant(
+      { provider: "github", installationId: 222, repositoryExternalId: null },
+      store,
+    );
+
+    expect(result).toEqual({
+      provider: "github",
+      status: "installation_only",
+      organizationId: "org_b",
+      repositoryId: null,
+    });
+    expect(store.repository.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe("compareWebhookTenantResolution", () => {
+  it("reports a cross-tenant legacy selection without changing either result", () => {
+    expect(
+      compareWebhookTenantResolution(
+        {
+          provider: "github",
+          status: "resolved",
+          organizationId: "org_b",
+          repositoryId: "repo_b",
+        },
+        { id: "repo_a", organizationId: "org_a" },
+        1,
+      ),
+    ).toBe("mismatch");
+  });
+
+  it("reports duplicate tenant rows as ambiguous even if the legacy row happens to match", () => {
+    expect(
+      compareWebhookTenantResolution(
+        {
+          provider: "github",
+          status: "resolved",
+          organizationId: "org_b",
+          repositoryId: "repo_b",
+        },
+        { id: "repo_b", organizationId: "org_b" },
+        2,
+      ),
+    ).toBe("ambiguous");
+  });
+});
+
+describe("observeGithubWebhookDelivery", () => {
+  let store = createStore();
+
+  beforeEach(() => {
+    store = createStore();
+  });
+
+  it("records only bounded metadata and the trusted tenant resolution", async () => {
+    store.repository.count.mockResolvedValue(2);
+
+    const result = await observeGithubWebhookDelivery(
+      {
+        deliveryId: "delivery-123",
+        eventType: "pull_request",
+        action: "opened",
+        payloadSha256: PAYLOAD_SHA,
+        installationId: 222,
+        repositoryExternalId: "9001",
+        legacyRepository: { id: "repo_a", organizationId: "org_a" },
+      },
+      store,
+    );
+
+    expect(result).toEqual({
+      recorded: true,
+      attemptCount: 1,
+      payloadHashCollision: false,
+      resolutionStatus: "resolved",
+      comparisonStatus: "ambiguous",
+    });
+    expect(store.webhookDelivery.upsert).toHaveBeenCalledTimes(1);
+    const [{ create, update, where }] = store.webhookDelivery.upsert.mock.calls[0];
+    expect(where).toEqual({
+      provider_deliveryId: { provider: "github", deliveryId: "delivery-123" },
+    });
+    expect(create).toMatchObject({
+      provider: "github",
+      deliveryId: "delivery-123",
+      deliveryIdSource: "provider",
+      eventType: "pull_request",
+      action: "opened",
+      payloadSha256: PAYLOAD_SHA,
+      providerInstallationId: "222",
+      providerRepositoryId: "9001",
+      resolvedOrganizationId: "org_b",
+      resolvedRepositoryId: "repo_b",
+      legacyOrganizationId: "org_a",
+      legacyRepositoryId: "repo_a",
+      resolutionStatus: "resolved",
+      comparisonStatus: "ambiguous",
+      legacyCandidateCount: 2,
+    });
+    expect(create).not.toHaveProperty("payload");
+    expect(create).not.toHaveProperty("signature");
+    expect(update).toMatchObject({
+      attemptCount: { increment: 1 },
+    });
+    expect(update).not.toHaveProperty("payloadSha256");
+    expect(update).not.toHaveProperty("comparisonStatus");
+  });
+
+  it("uses the verified payload hash when GitHub omits its delivery id", async () => {
+    await observeGithubWebhookDelivery(
+      {
+        deliveryId: null,
+        eventType: "ping",
+        action: null,
+        payloadSha256: PAYLOAD_SHA,
+        installationId: null,
+        repositoryExternalId: null,
+        legacyRepository: undefined,
+      },
+      store,
+    );
+
+    const [{ create, where }] = store.webhookDelivery.upsert.mock.calls[0];
+    expect(where.provider_deliveryId.deliveryId).toBe(`sha256:${PAYLOAD_SHA}`);
+    expect(create.deliveryIdSource).toBe("payload_sha256");
+  });
+
+  it("increments attempts for a duplicate without treating it as an enforcement decision", async () => {
+    store.webhookDelivery.upsert.mockResolvedValue({
+      attemptCount: 2,
+      payloadSha256: PAYLOAD_SHA,
+    });
+
+    const result = await observeGithubWebhookDelivery(
+      {
+        deliveryId: "delivery-123",
+        eventType: "pull_request",
+        action: "opened",
+        payloadSha256: PAYLOAD_SHA,
+        installationId: 222,
+        repositoryExternalId: "9001",
+        legacyRepository: { id: "repo_b", organizationId: "org_b" },
+      },
+      store,
+    );
+
+    expect(result.recorded).toBe(true);
+    expect(result.attemptCount).toBe(2);
+    expect(result.payloadHashCollision).toBe(false);
+    expect(store.webhookDelivery.update).not.toHaveBeenCalled();
+    const [{ update }] = store.webhookDelivery.upsert.mock.calls[0];
+    expect(update.attemptCount).toEqual({ increment: 1 });
+    expect(update).not.toHaveProperty("processingStatus");
+  });
+
+  it("preserves first evidence and flags a changed payload for the same delivery id", async () => {
+    store.webhookDelivery.upsert.mockResolvedValue({
+      attemptCount: 2,
+      payloadSha256: PAYLOAD_SHA,
+    });
+
+    const result = await observeGithubWebhookDelivery(
+      {
+        deliveryId: "delivery-123",
+        eventType: "pull_request",
+        action: "synchronize",
+        payloadSha256: "b".repeat(64),
+        installationId: 333,
+        repositoryExternalId: "9001",
+        legacyRepository: { id: "repo_changed", organizationId: "org_changed" },
+      },
+      store,
+    );
+
+    const [{ update }] = store.webhookDelivery.upsert.mock.calls[0];
+    expect(update).toEqual({
+      attemptCount: { increment: 1 },
+      lastSeenAt: expect.any(Date),
+    });
+    expect(store.webhookDelivery.update).toHaveBeenCalledWith({
+      where: {
+        provider_deliveryId: {
+          provider: "github",
+          deliveryId: "delivery-123",
+        },
+      },
+      data: { payloadHashCollisionCount: { increment: 1 } },
+      select: { payloadHashCollisionCount: true },
+    });
+    expect(result.payloadHashCollision).toBe(true);
+  });
+
+  it("uses a tenant snapshot captured before an installation deletion", async () => {
+    const tenantResolution = {
+      provider: "github" as const,
+      status: "installation_only" as const,
+      organizationId: "org_b",
+      repositoryId: null,
+    };
+
+    await observeGithubWebhookDelivery(
+      {
+        deliveryId: "delivery-uninstall",
+        eventType: "installation",
+        action: "deleted",
+        payloadSha256: PAYLOAD_SHA,
+        installationId: 222,
+        repositoryExternalId: null,
+        legacyRepository: undefined,
+        tenantResolution,
+      },
+      store,
+    );
+
+    expect(store.organization.findUnique).not.toHaveBeenCalled();
+    const [{ create }] = store.webhookDelivery.upsert.mock.calls[0];
+    expect(create).toMatchObject({
+      resolvedOrganizationId: "org_b",
+      resolutionStatus: "installation_only",
+      comparisonStatus: "not_applicable",
+    });
+  });
+
+  it("keeps a ledger failure non-fatal and logs no database error details", async () => {
+    store.webhookDelivery.upsert.mockRejectedValueOnce(
+      new Error("query failed with sensitive detail"),
+    );
+    const logger = {
+      info: mock((_message: string) => undefined),
+      warn: mock((_message: string) => undefined),
+    };
+
+    const result = await observeGithubWebhookDeliveryInShadowMode(
+      {
+        deliveryId: "delivery-123",
+        eventType: "pull_request",
+        action: "opened",
+        payloadSha256: PAYLOAD_SHA,
+        installationId: 222,
+        repositoryExternalId: "9001",
+        legacyRepository: { id: "repo_b", organizationId: "org_b" },
+      },
+      store,
+      logger,
+    );
+
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[webhook] GitHub delivery observation failed; legacy routing continued (Error)",
+    );
+    expect(logger.warn.mock.calls[0]?.[0]).not.toContain("sensitive detail");
+  });
+});
+
+describe("GitHub webhook boundary wiring", () => {
+  it("registers trusted observation only after signature verification", async () => {
+    const routeSource = await Bun.file(
+      new URL("../../app/api/github/webhook/route.ts", import.meta.url),
+    ).text();
+    const signatureGuard = routeSource.indexOf(
+      "if (!(await verifySignature(body, signature)))",
+    );
+    const payloadParse = routeSource.indexOf("const payload = JSON.parse(body)");
+    const observationCall = routeSource.indexOf(
+      "observeGithubWebhookDeliveryInShadowMode({",
+      payloadParse,
+    );
+
+    expect(signatureGuard).toBeGreaterThan(-1);
+    expect(payloadParse).toBeGreaterThan(signatureGuard);
+    expect(observationCall).toBeGreaterThan(payloadParse);
+  });
+});
+
+describe("enforceWebhookDeliveryRetention", () => {
+  it("deletes rows whose last delivery attempt is outside the window", async () => {
+    const store = createStore();
+    store.webhookDelivery.deleteMany.mockResolvedValue({ count: 4 });
+    const before = Date.now();
+
+    const deleted = await enforceWebhookDeliveryRetention(30, store);
+
+    const after = Date.now();
+    expect(deleted).toBe(4);
+    const [{ where }] = store.webhookDelivery.deleteMany.mock.calls[0];
+    const cutoff = where.lastSeenAt.lt.getTime();
+    const retentionMs = 30 * 24 * 60 * 60 * 1000;
+    expect(cutoff).toBeGreaterThanOrEqual(before - retentionMs);
+    expect(cutoff).toBeLessThanOrEqual(after - retentionMs);
+  });
+
+  it("skips cleanup for an invalid configured window", async () => {
+    const store = createStore();
+    const logger = {
+      info: mock((_message: string) => undefined),
+      warn: mock((_message: string) => undefined),
+    };
+
+    const deleted = await enforceWebhookDeliveryRetention(0, store, logger);
+
+    expect(deleted).toBe(0);
+    expect(store.webhookDelivery.deleteMany).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/__tests__/webhook-tenant.test.ts
+++ b/apps/web/lib/__tests__/webhook-tenant.test.ts
@@ -381,6 +381,14 @@ describe("observeGithubWebhookDelivery", () => {
 });
 
 describe("GitHub webhook boundary wiring", () => {
+  it("keeps the installation tenant authority unique in the Prisma schema", async () => {
+    const schema = await Bun.file(
+      new URL("../../../../packages/db/prisma/schema.prisma", import.meta.url),
+    ).text();
+
+    expect(schema).toMatch(/githubInstallationId\s+Int\?\s+@unique\b/);
+  });
+
   it("registers trusted observation only after signature verification", async () => {
     const routeSource = await Bun.file(
       new URL("../../app/api/github/webhook/route.ts", import.meta.url),

--- a/apps/web/lib/__tests__/webhook-tenant.test.ts
+++ b/apps/web/lib/__tests__/webhook-tenant.test.ts
@@ -395,17 +395,26 @@ describe("enforceWebhookDeliveryRetention", () => {
     expect(cutoff).toBeLessThanOrEqual(after - retentionMs);
   });
 
-  it("skips cleanup for an invalid configured window", async () => {
+  it("fails fast for invalid environment retention windows", async () => {
     const store = createStore();
-    const logger = {
-      info: mock((_message: string) => undefined),
-      warn: mock((_message: string) => undefined),
-    };
+    const previous = process.env.WEBHOOK_DELIVERY_RETENTION_DAYS;
 
-    const deleted = await enforceWebhookDeliveryRetention(0, store, logger);
-
-    expect(deleted).toBe(0);
-    expect(store.webhookDelivery.deleteMany).not.toHaveBeenCalled();
-    expect(logger.warn).toHaveBeenCalledTimes(1);
+    try {
+      for (const invalidValue of ["0", "not-a-number"]) {
+        process.env.WEBHOOK_DELIVERY_RETENTION_DAYS = invalidValue;
+        await expect(
+          enforceWebhookDeliveryRetention(undefined, store),
+        ).rejects.toThrow(
+          "Invalid webhook delivery retention window; expected a positive integer number of days",
+        );
+      }
+      expect(store.webhookDelivery.deleteMany).not.toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.WEBHOOK_DELIVERY_RETENTION_DAYS;
+      } else {
+        process.env.WEBHOOK_DELIVERY_RETENTION_DAYS = previous;
+      }
+    }
   });
 });

--- a/apps/web/lib/__tests__/webhook-tenant.test.ts
+++ b/apps/web/lib/__tests__/webhook-tenant.test.ts
@@ -231,6 +231,28 @@ describe("observeGithubWebhookDelivery", () => {
     expect(create.deliveryIdSource).toBe("payload_sha256");
   });
 
+  it("skips the legacy collision query when the route did not perform a lookup", async () => {
+    await observeGithubWebhookDelivery(
+      {
+        deliveryId: "delivery-no-legacy-lookup",
+        eventType: "push",
+        action: null,
+        payloadSha256: PAYLOAD_SHA,
+        installationId: 222,
+        repositoryExternalId: "9001",
+        legacyRepository: undefined,
+      },
+      store,
+    );
+
+    expect(store.repository.count).not.toHaveBeenCalled();
+    const [{ create }] = store.webhookDelivery.upsert.mock.calls[0];
+    expect(create).toMatchObject({
+      comparisonStatus: "not_applicable",
+      legacyCandidateCount: 0,
+    });
+  });
+
   it("increments attempts for a duplicate without treating it as an enforcement decision", async () => {
     store.webhookDelivery.upsert.mockResolvedValue({
       attemptCount: 2,
@@ -400,15 +422,34 @@ describe("enforceWebhookDeliveryRetention", () => {
     const previous = process.env.WEBHOOK_DELIVERY_RETENTION_DAYS;
 
     try {
-      for (const invalidValue of ["0", "not-a-number"]) {
+      for (const invalidValue of ["0", "366", "not-a-number"]) {
         process.env.WEBHOOK_DELIVERY_RETENTION_DAYS = invalidValue;
         await expect(
           enforceWebhookDeliveryRetention(undefined, store),
         ).rejects.toThrow(
-          "Invalid webhook delivery retention window; expected a positive integer number of days",
+          "Invalid webhook delivery retention window; expected an integer from 1 to 365 days",
         );
       }
       expect(store.webhookDelivery.deleteMany).not.toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.WEBHOOK_DELIVERY_RETENTION_DAYS;
+      } else {
+        process.env.WEBHOOK_DELIVERY_RETENTION_DAYS = previous;
+      }
+    }
+  });
+
+  it("accepts the maximum environment retention window", async () => {
+    const store = createStore();
+    const previous = process.env.WEBHOOK_DELIVERY_RETENTION_DAYS;
+
+    try {
+      process.env.WEBHOOK_DELIVERY_RETENTION_DAYS = "365";
+      await expect(
+        enforceWebhookDeliveryRetention(undefined, store),
+      ).resolves.toBe(0);
+      expect(store.webhookDelivery.deleteMany).toHaveBeenCalledTimes(1);
     } finally {
       if (previous === undefined) {
         delete process.env.WEBHOOK_DELIVERY_RETENTION_DAYS;

--- a/apps/web/lib/__tests__/webhook-tenant.test.ts
+++ b/apps/web/lib/__tests__/webhook-tenant.test.ts
@@ -8,6 +8,7 @@ const {
   enforceWebhookDeliveryRetention,
   observeGithubWebhookDelivery,
   observeGithubWebhookDeliveryInShadowMode,
+  resolveWebhookDeliveryRetentionDays,
   resolveWebhookTenant,
 } = await import("@/lib/webhook-tenant");
 
@@ -406,9 +407,35 @@ describe("GitHub webhook boundary wiring", () => {
     expect(payloadParse).toBeGreaterThan(signatureGuard);
     expect(observationCall).toBeGreaterThan(payloadParse);
   });
+
+  it("validates delivery retention before queue startup", async () => {
+    const instrumentationSource = await Bun.file(
+      new URL("../../instrumentation.ts", import.meta.url),
+    ).text();
+    const validationCall = instrumentationSource.indexOf(
+      "resolveWebhookDeliveryRetentionDays();",
+    );
+    const queueStart = instrumentationSource.indexOf("await startQueue()");
+
+    expect(validationCall).toBeGreaterThan(-1);
+    expect(queueStart).toBeGreaterThan(validationCall);
+  });
 });
 
 describe("enforceWebhookDeliveryRetention", () => {
+  it("defaults an unset retention window to 30 days", () => {
+    const previous = process.env.WEBHOOK_DELIVERY_RETENTION_DAYS;
+
+    try {
+      delete process.env.WEBHOOK_DELIVERY_RETENTION_DAYS;
+      expect(resolveWebhookDeliveryRetentionDays()).toBe(30);
+    } finally {
+      if (previous !== undefined) {
+        process.env.WEBHOOK_DELIVERY_RETENTION_DAYS = previous;
+      }
+    }
+  });
+
   it("deletes rows whose last delivery attempt is outside the window", async () => {
     const store = createStore();
     store.webhookDelivery.deleteMany.mockResolvedValue({ count: 4 });

--- a/apps/web/lib/queue-workers.ts
+++ b/apps/web/lib/queue-workers.ts
@@ -7,6 +7,7 @@ import {
 } from "./large-review-result";
 import { processCommunityReview, type CommunityReviewJobData } from "./community-review";
 import { enforceAuditLogRetention, enforceActivityEventRetention } from "./audit";
+import { enforceWebhookDeliveryRetention } from "./webhook-tenant";
 import { refreshReleaseCache } from "./releases";
 import { renewDueSubscriptions } from "./subscription";
 import { runOllamaPull } from "./ollama-admin";
@@ -120,6 +121,25 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
         console.log(`[queue] enforce-activity-retention ${job.id}: deleted ${deleted} rows`);
       } catch (err) {
         console.error(`[queue] enforce-activity-retention failed (job ${job.id}):`, err);
+        throw err;
+      }
+    }
+  });
+
+  // Daily signature-verified webhook-delivery retention. The delete is
+  // idempotent, so concurrent workers remain safe.
+  await boss.work("enforce-webhook-delivery-retention", async (jobs) => {
+    for (const job of jobs) {
+      try {
+        const deleted = await enforceWebhookDeliveryRetention();
+        console.log(
+          `[queue] enforce-webhook-delivery-retention ${job.id}: deleted ${deleted} rows`,
+        );
+      } catch (err) {
+        console.error(
+          `[queue] enforce-webhook-delivery-retention failed (job ${job.id}):`,
+          err,
+        );
         throw err;
       }
     }

--- a/apps/web/lib/queue.ts
+++ b/apps/web/lib/queue.ts
@@ -115,6 +115,13 @@ export async function startQueue(): Promise<PgBoss> {
     expireInSeconds: 600, // 10 min — a deleteMany shouldn't take long
   }).catch(() => {});
 
+  // Daily verified-webhook delivery retention. The ledger is rollout telemetry,
+  // not a permanent audit log, so its default window is intentionally shorter.
+  await boss.createQueue("enforce-webhook-delivery-retention", {
+    retryLimit: 1,
+    expireInSeconds: 600,
+  }).catch(() => {});
+
   // Daily self-hosted release-cache refresh (scheduled in instrumentation.ts,
   // worked in queue-workers.ts). Same pg-boss v12 requirement — the queue must
   // exist before schedule()/work() or the cron silently no-ops.

--- a/apps/web/lib/webhook-tenant.ts
+++ b/apps/web/lib/webhook-tenant.ts
@@ -1,0 +1,484 @@
+import "server-only";
+
+import { prisma } from "@octopus/db";
+
+const MAX_DELIVERY_ID_LENGTH = 255;
+const MAX_EVENT_TYPE_LENGTH = 100;
+const MAX_ACTION_LENGTH = 100;
+const MAX_PROVIDER_REPOSITORY_ID_LENGTH = 32;
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+const POSITIVE_DECIMAL = /^[1-9]\d*$/;
+
+export const WEBHOOK_TENANT_RESOLUTION_STATUSES = [
+  "resolved",
+  "installation_only",
+  "missing_installation",
+  "unmapped_installation",
+  "repository_not_owned",
+] as const;
+
+export type WebhookTenantResolutionStatus =
+  (typeof WEBHOOK_TENANT_RESOLUTION_STATUSES)[number];
+
+export const WEBHOOK_TENANT_COMPARISON_STATUSES = [
+  "matched",
+  "mismatch",
+  "ambiguous",
+  "legacy_only",
+  "shadow_only",
+  "unresolved",
+  "not_applicable",
+] as const;
+
+export type WebhookTenantComparisonStatus =
+  (typeof WEBHOOK_TENANT_COMPARISON_STATUSES)[number];
+
+export interface LegacyWebhookRepository {
+  id: string;
+  organizationId: string;
+}
+
+export interface GithubWebhookTenantInput {
+  provider: "github";
+  installationId: unknown;
+  repositoryExternalId?: unknown;
+}
+
+export interface GithubWebhookTenantResolution {
+  provider: "github";
+  status: WebhookTenantResolutionStatus;
+  organizationId: string | null;
+  repositoryId: string | null;
+}
+
+interface OrganizationLookup {
+  findUnique(args: {
+    where: { githubInstallationId: number };
+    select: { id: true };
+  }): Promise<{ id: string } | null>;
+}
+
+interface RepositoryLookup {
+  findUnique(args: {
+    where: {
+      provider_externalId_organizationId: {
+        provider: "github";
+        externalId: string;
+        organizationId: string;
+      };
+    };
+    select: { id: true; organizationId: true };
+  }): Promise<{ id: string; organizationId: string } | null>;
+}
+
+export interface WebhookTenantStore {
+  organization: OrganizationLookup;
+  repository: RepositoryLookup;
+}
+
+interface WebhookDeliveryUpsertArgs {
+  where: {
+    provider_deliveryId: { provider: "github"; deliveryId: string };
+  };
+  create: {
+    provider: "github";
+    deliveryId: string;
+    deliveryIdSource: "provider" | "payload_sha256";
+    eventType: string;
+    action: string | null;
+    payloadSha256: string;
+    providerInstallationId: string | null;
+    providerRepositoryId: string | null;
+    resolvedOrganizationId: string | null;
+    resolvedRepositoryId: string | null;
+    legacyOrganizationId: string | null;
+    legacyRepositoryId: string | null;
+    resolutionStatus: WebhookTenantResolutionStatus;
+    comparisonStatus: WebhookTenantComparisonStatus;
+    legacyCandidateCount: number;
+    lastSeenAt: Date;
+  };
+  update: {
+    attemptCount: { increment: 1 };
+    lastSeenAt: Date;
+  };
+  select: { attemptCount: true; payloadSha256: true };
+}
+
+interface WebhookDeliveryCollisionUpdateArgs {
+  where: {
+    provider_deliveryId: { provider: "github"; deliveryId: string };
+  };
+  data: { payloadHashCollisionCount: { increment: 1 } };
+  select: { payloadHashCollisionCount: true };
+}
+
+export interface WebhookObservationStore extends WebhookTenantStore {
+  repository: RepositoryLookup & {
+    count(args: {
+      where: { provider: "github"; externalId: string };
+    }): Promise<number>;
+  };
+  webhookDelivery: {
+    upsert(args: WebhookDeliveryUpsertArgs): Promise<{
+      attemptCount: number;
+      payloadSha256: string;
+    }>;
+    update(args: WebhookDeliveryCollisionUpdateArgs): Promise<{
+      payloadHashCollisionCount: number;
+    }>;
+  };
+  $transaction(
+    callback: (transaction: {
+      webhookDelivery: WebhookObservationStore["webhookDelivery"];
+    }) => Promise<{
+      attemptCount: number;
+      payloadHashCollision: boolean;
+    }>,
+  ): Promise<{
+    attemptCount: number;
+    payloadHashCollision: boolean;
+  }>;
+}
+
+export interface GithubWebhookObservationInput {
+  deliveryId: unknown;
+  eventType: unknown;
+  action: unknown;
+  payloadSha256: string;
+  installationId: unknown;
+  repositoryExternalId: unknown;
+  // `undefined` means the legacy route did not perform a repository lookup.
+  // `null` means it performed the lookup but found no row.
+  legacyRepository: LegacyWebhookRepository | null | undefined;
+  // Installation lifecycle routes already resolve the binding before a delete
+  // mutation. Passing that snapshot prevents post-response observation from
+  // misclassifying a successful uninstall as an unmapped installation.
+  tenantResolution?: GithubWebhookTenantResolution;
+}
+
+export interface GithubWebhookObservationResult {
+  recorded: true;
+  attemptCount: number;
+  payloadHashCollision: boolean;
+  resolutionStatus: WebhookTenantResolutionStatus;
+  comparisonStatus: WebhookTenantComparisonStatus;
+}
+
+export interface WebhookObservationLogger {
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+export interface WebhookDeliveryRetentionStore {
+  webhookDelivery: {
+    deleteMany(args: {
+      where: { lastSeenAt: { lt: Date } };
+    }): Promise<{ count: number }>;
+  };
+}
+
+export const WEBHOOK_DELIVERY_DEFAULT_RETENTION_DAYS = 30;
+
+function boundedString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized || normalized.length > maxLength) return null;
+  return normalized;
+}
+
+function normalizeInstallationId(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? value : null;
+  }
+  if (typeof value !== "string" || !POSITIVE_DECIMAL.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function normalizeRepositoryExternalId(value: unknown): string | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? String(value) : null;
+  }
+  const normalized = boundedString(value, MAX_PROVIDER_REPOSITORY_ID_LENGTH);
+  return normalized && POSITIVE_DECIMAL.test(normalized) ? normalized : null;
+}
+
+export async function resolveWebhookTenant(
+  input: GithubWebhookTenantInput,
+  store: WebhookTenantStore = prisma,
+): Promise<GithubWebhookTenantResolution> {
+  const installationId = normalizeInstallationId(input.installationId);
+  if (installationId === null) {
+    return {
+      provider: "github",
+      status: "missing_installation",
+      organizationId: null,
+      repositoryId: null,
+    };
+  }
+
+  // The signed installation ID is the sole tenant authority. Repository-level
+  // installationId is intentionally ignored because the legacy route mutates it.
+  const organization = await store.organization.findUnique({
+    where: { githubInstallationId: installationId },
+    select: { id: true },
+  });
+  if (!organization) {
+    return {
+      provider: "github",
+      status: "unmapped_installation",
+      organizationId: null,
+      repositoryId: null,
+    };
+  }
+
+  const repositoryExternalId = normalizeRepositoryExternalId(
+    input.repositoryExternalId,
+  );
+  if (repositoryExternalId === null) {
+    return {
+      provider: "github",
+      status: "installation_only",
+      organizationId: organization.id,
+      repositoryId: null,
+    };
+  }
+
+  const repository = await store.repository.findUnique({
+    where: {
+      provider_externalId_organizationId: {
+        provider: "github",
+        externalId: repositoryExternalId,
+        organizationId: organization.id,
+      },
+    },
+    select: { id: true, organizationId: true },
+  });
+  if (!repository) {
+    return {
+      provider: "github",
+      status: "repository_not_owned",
+      organizationId: organization.id,
+      repositoryId: null,
+    };
+  }
+
+  return {
+    provider: "github",
+    status: "resolved",
+    organizationId: organization.id,
+    repositoryId: repository.id,
+  };
+}
+
+export function compareWebhookTenantResolution(
+  resolution: GithubWebhookTenantResolution,
+  legacyRepository: LegacyWebhookRepository | null | undefined,
+  legacyCandidateCount: number,
+): WebhookTenantComparisonStatus {
+  if (legacyRepository === undefined) return "not_applicable";
+  if (legacyCandidateCount > 1) return "ambiguous";
+  if (legacyRepository === null && resolution.repositoryId === null) {
+    return "unresolved";
+  }
+  if (legacyRepository === null) return "shadow_only";
+  if (resolution.repositoryId === null) return "legacy_only";
+  if (
+    legacyRepository.id === resolution.repositoryId &&
+    legacyRepository.organizationId === resolution.organizationId
+  ) {
+    return "matched";
+  }
+  return "mismatch";
+}
+
+export async function observeGithubWebhookDelivery(
+  input: GithubWebhookObservationInput,
+  store: WebhookObservationStore = prisma,
+): Promise<GithubWebhookObservationResult> {
+  if (!SHA256_HEX.test(input.payloadSha256)) {
+    throw new Error("Invalid webhook payload SHA-256");
+  }
+
+  const providerDeliveryId = boundedString(
+    input.deliveryId,
+    MAX_DELIVERY_ID_LENGTH,
+  );
+  const deliveryId = providerDeliveryId ?? `sha256:${input.payloadSha256}`;
+  const deliveryIdSource = providerDeliveryId ? "provider" : "payload_sha256";
+  const eventType =
+    boundedString(input.eventType, MAX_EVENT_TYPE_LENGTH) ?? "unknown";
+  const action = boundedString(input.action, MAX_ACTION_LENGTH);
+  const installationId = normalizeInstallationId(input.installationId);
+  const repositoryExternalId = normalizeRepositoryExternalId(
+    input.repositoryExternalId,
+  );
+
+  const [resolution, legacyCandidateCount] = await Promise.all([
+    input.tenantResolution
+      ? Promise.resolve(input.tenantResolution)
+      : resolveWebhookTenant(
+          {
+            provider: "github",
+            installationId,
+            repositoryExternalId,
+          },
+          store,
+        ),
+    repositoryExternalId
+      ? store.repository.count({
+          where: { provider: "github", externalId: repositoryExternalId },
+        })
+      : Promise.resolve(0),
+  ]);
+  const comparisonStatus = compareWebhookTenantResolution(
+    resolution,
+    input.legacyRepository,
+    legacyCandidateCount,
+  );
+  const now = new Date();
+  const observation = {
+    eventType,
+    action,
+    payloadSha256: input.payloadSha256,
+    providerInstallationId:
+      installationId === null ? null : String(installationId),
+    providerRepositoryId: repositoryExternalId,
+    resolvedOrganizationId: resolution.organizationId,
+    resolvedRepositoryId: resolution.repositoryId,
+    legacyOrganizationId: input.legacyRepository?.organizationId ?? null,
+    legacyRepositoryId: input.legacyRepository?.id ?? null,
+    resolutionStatus: resolution.status,
+    comparisonStatus,
+    legacyCandidateCount,
+    lastSeenAt: now,
+  };
+
+  const delivery = await store.$transaction(async (transaction) => {
+    const firstObservation = await transaction.webhookDelivery.upsert({
+      where: {
+        provider_deliveryId: { provider: "github", deliveryId },
+      },
+      create: {
+        provider: "github",
+        deliveryId,
+        deliveryIdSource,
+        ...observation,
+      },
+      update: {
+        attemptCount: { increment: 1 },
+        lastSeenAt: now,
+      },
+      select: { attemptCount: true, payloadSha256: true },
+    });
+
+    // Keep the first payload hash immutable, but distinguish a provider
+    // delivery ID collision from a normal byte-for-byte redelivery. Both
+    // counters commit together so collision telemetry cannot be partially lost.
+    const payloadHashCollision =
+      firstObservation.payloadSha256 !== input.payloadSha256;
+    if (payloadHashCollision) {
+      await transaction.webhookDelivery.update({
+        where: {
+          provider_deliveryId: { provider: "github", deliveryId },
+        },
+        data: { payloadHashCollisionCount: { increment: 1 } },
+        select: { payloadHashCollisionCount: true },
+      });
+    }
+
+    return {
+      attemptCount: firstObservation.attemptCount,
+      payloadHashCollision,
+    };
+  });
+
+  return {
+    recorded: true,
+    attemptCount: delivery.attemptCount,
+    payloadHashCollision: delivery.payloadHashCollision,
+    resolutionStatus: resolution.status,
+    comparisonStatus,
+  };
+}
+
+/**
+ * Best-effort shadow wrapper. Delivery storage and comparison must never alter
+ * the legacy webhook response until the enforcement rollout is explicitly enabled.
+ */
+export async function observeGithubWebhookDeliveryInShadowMode(
+  input: GithubWebhookObservationInput,
+  store: WebhookObservationStore = prisma,
+  logger: WebhookObservationLogger = console,
+): Promise<GithubWebhookObservationResult | null> {
+  try {
+    const observation = await observeGithubWebhookDelivery(input, store);
+    if (
+      observation.comparisonStatus === "mismatch" ||
+      observation.comparisonStatus === "ambiguous" ||
+      observation.comparisonStatus === "legacy_only" ||
+      observation.comparisonStatus === "shadow_only"
+    ) {
+      logger.warn(
+        `[webhook] GitHub tenant shadow comparison: ${observation.comparisonStatus} (resolution=${observation.resolutionStatus})`,
+      );
+    }
+    if (observation.attemptCount > 1) {
+      logger.info(
+        `[webhook] GitHub delivery observed ${observation.attemptCount} times; shadow mode continues legacy processing`,
+      );
+    }
+    if (observation.payloadHashCollision) {
+      logger.warn(
+        "[webhook] GitHub delivery ID payload collision detected; shadow mode continues legacy processing",
+      );
+    }
+    return observation;
+  } catch (error) {
+    // Log only the error class. Prisma messages can contain query details, and
+    // this boundary must never copy provider payload data into operational logs.
+    const errorType = error instanceof Error ? error.name : "UnknownError";
+    logger.warn(
+      `[webhook] GitHub delivery observation failed; legacy routing continued (${errorType})`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Delete expired delivery metadata. The window is intentionally short because
+ * this is high-volume rollout telemetry, not a permanent audit log.
+ */
+export async function enforceWebhookDeliveryRetention(
+  retentionDays?: number,
+  store: WebhookDeliveryRetentionStore = prisma,
+  logger: WebhookObservationLogger = console,
+): Promise<number> {
+  const envOverride = process.env.WEBHOOK_DELIVERY_RETENTION_DAYS?.trim();
+  const configuredDays = envOverride && /^\d+$/.test(envOverride)
+    ? Number(envOverride)
+    : Number.NaN;
+  const days = retentionDays ?? (
+    !envOverride
+      ? WEBHOOK_DELIVERY_DEFAULT_RETENTION_DAYS
+      : configuredDays
+  );
+  if (!Number.isFinite(days) || !Number.isInteger(days) || days <= 0) {
+    logger.warn(
+      `[webhook] Invalid delivery retention window (${String(days)} days); cleanup skipped`,
+    );
+    return 0;
+  }
+
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  const { count } = await store.webhookDelivery.deleteMany({
+    where: { lastSeenAt: { lt: cutoff } },
+  });
+  if (count > 0) {
+    logger.info(
+      `[webhook] Deleted ${count} delivery rows older than ${days} days`,
+    );
+  }
+  return count;
+}

--- a/apps/web/lib/webhook-tenant.ts
+++ b/apps/web/lib/webhook-tenant.ts
@@ -181,6 +181,31 @@ export interface WebhookDeliveryRetentionStore {
 export const WEBHOOK_DELIVERY_DEFAULT_RETENTION_DAYS = 30;
 export const WEBHOOK_DELIVERY_MAX_RETENTION_DAYS = 365;
 
+export function resolveWebhookDeliveryRetentionDays(
+  retentionDays?: number,
+): number {
+  const envOverride = process.env.WEBHOOK_DELIVERY_RETENTION_DAYS?.trim();
+  let days = retentionDays;
+  if (days === undefined) {
+    if (!envOverride) {
+      days = WEBHOOK_DELIVERY_DEFAULT_RETENTION_DAYS;
+    } else {
+      days = /^\d+$/.test(envOverride) ? Number(envOverride) : Number.NaN;
+    }
+  }
+  if (
+    !Number.isFinite(days) ||
+    !Number.isInteger(days) ||
+    days <= 0 ||
+    days > WEBHOOK_DELIVERY_MAX_RETENTION_DAYS
+  ) {
+    throw new Error(
+      `Invalid webhook delivery retention window; expected an integer from 1 to ${WEBHOOK_DELIVERY_MAX_RETENTION_DAYS} days`,
+    );
+  }
+  return days;
+}
+
 function boundedString(value: unknown, maxLength: number): string | null {
   if (typeof value !== "string") return null;
   const normalized = value.trim();
@@ -460,25 +485,7 @@ export async function enforceWebhookDeliveryRetention(
   store: WebhookDeliveryRetentionStore = prisma,
   logger: WebhookObservationLogger = console,
 ): Promise<number> {
-  const envOverride = process.env.WEBHOOK_DELIVERY_RETENTION_DAYS?.trim();
-  const configuredDays = envOverride && /^\d+$/.test(envOverride)
-    ? Number(envOverride)
-    : Number.NaN;
-  const days = retentionDays ?? (
-    !envOverride
-      ? WEBHOOK_DELIVERY_DEFAULT_RETENTION_DAYS
-      : configuredDays
-  );
-  if (
-    !Number.isFinite(days) ||
-    !Number.isInteger(days) ||
-    days <= 0 ||
-    days > WEBHOOK_DELIVERY_MAX_RETENTION_DAYS
-  ) {
-    throw new Error(
-      `Invalid webhook delivery retention window; expected an integer from 1 to ${WEBHOOK_DELIVERY_MAX_RETENTION_DAYS} days`,
-    );
-  }
+  const days = resolveWebhookDeliveryRetentionDays(retentionDays);
 
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
   const { count } = await store.webhookDelivery.deleteMany({

--- a/apps/web/lib/webhook-tenant.ts
+++ b/apps/web/lib/webhook-tenant.ts
@@ -305,6 +305,10 @@ export async function observeGithubWebhookDelivery(
     input.deliveryId,
     MAX_DELIVERY_ID_LENGTH,
   );
+  // GitHub's x-github-delivery header is not covered by the body HMAC. It is
+  // an observation-only correlation key here. Any future deduplication or
+  // routing enforcement must use identity derived from the verified body or
+  // signature, never this provider header alone.
   const deliveryId = providerDeliveryId ?? `sha256:${input.payloadSha256}`;
   const deliveryIdSource = providerDeliveryId ? "provider" : "payload_sha256";
   const eventType =
@@ -465,10 +469,9 @@ export async function enforceWebhookDeliveryRetention(
       : configuredDays
   );
   if (!Number.isFinite(days) || !Number.isInteger(days) || days <= 0) {
-    logger.warn(
-      `[webhook] Invalid delivery retention window (${String(days)} days); cleanup skipped`,
+    throw new Error(
+      "Invalid webhook delivery retention window; expected a positive integer number of days",
     );
-    return 0;
   }
 
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);

--- a/apps/web/lib/webhook-tenant.ts
+++ b/apps/web/lib/webhook-tenant.ts
@@ -179,6 +179,7 @@ export interface WebhookDeliveryRetentionStore {
 }
 
 export const WEBHOOK_DELIVERY_DEFAULT_RETENTION_DAYS = 30;
+export const WEBHOOK_DELIVERY_MAX_RETENTION_DAYS = 365;
 
 function boundedString(value: unknown, maxLength: number): string | null {
   if (typeof value !== "string") return null;
@@ -330,7 +331,7 @@ export async function observeGithubWebhookDelivery(
           },
           store,
         ),
-    repositoryExternalId
+    repositoryExternalId && input.legacyRepository !== undefined
       ? store.repository.count({
           where: { provider: "github", externalId: repositoryExternalId },
         })
@@ -468,9 +469,14 @@ export async function enforceWebhookDeliveryRetention(
       ? WEBHOOK_DELIVERY_DEFAULT_RETENTION_DAYS
       : configuredDays
   );
-  if (!Number.isFinite(days) || !Number.isInteger(days) || days <= 0) {
+  if (
+    !Number.isFinite(days) ||
+    !Number.isInteger(days) ||
+    days <= 0 ||
+    days > WEBHOOK_DELIVERY_MAX_RETENTION_DAYS
+  ) {
     throw new Error(
-      "Invalid webhook delivery retention window; expected a positive integer number of days",
+      `Invalid webhook delivery retention window; expected an integer from 1 to ${WEBHOOK_DELIVERY_MAX_RETENTION_DAYS} days`,
     );
   }
 

--- a/packages/db/prisma/migrations/20260801120000_add_webhook_delivery_ledger/migration.sql
+++ b/packages/db/prisma/migrations/20260801120000_add_webhook_delivery_ledger/migration.sql
@@ -1,0 +1,50 @@
+-- SEC-06 shadow-mode foundation. The table stores only bounded metadata for
+-- signature-verified webhook deliveries; raw payloads, signatures, and secrets
+-- are deliberately excluded. IDs are snapshots rather than foreign keys so the
+-- observation remains available after an organization or repository is removed.
+
+-- CreateTable
+CREATE TABLE "webhook_deliveries" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "deliveryId" TEXT NOT NULL,
+    "deliveryIdSource" TEXT NOT NULL DEFAULT 'provider',
+    "eventType" TEXT NOT NULL,
+    "action" TEXT,
+    "payloadSha256" TEXT NOT NULL,
+    "providerInstallationId" TEXT,
+    "providerRepositoryId" TEXT,
+    "resolvedOrganizationId" TEXT,
+    "resolvedRepositoryId" TEXT,
+    "legacyOrganizationId" TEXT,
+    "legacyRepositoryId" TEXT,
+    "resolutionStatus" TEXT NOT NULL,
+    "comparisonStatus" TEXT NOT NULL,
+    "legacyCandidateCount" INTEGER NOT NULL DEFAULT 0,
+    "attemptCount" INTEGER NOT NULL DEFAULT 1,
+    "payloadHashCollisionCount" INTEGER NOT NULL DEFAULT 0,
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "webhook_deliveries_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "webhook_deliveries_provider_deliveryId_key"
+ON "webhook_deliveries"("provider", "deliveryId");
+
+-- CreateIndex
+CREATE INDEX "webhook_deliveries_provider_providerInstallationId_firstSee_idx"
+ON "webhook_deliveries"("provider", "providerInstallationId", "firstSeenAt");
+
+-- CreateIndex
+CREATE INDEX "webhook_deliveries_provider_comparisonStatus_firstSeenAt_idx"
+ON "webhook_deliveries"("provider", "comparisonStatus", "firstSeenAt");
+
+-- CreateIndex
+CREATE INDEX "webhook_deliveries_resolvedOrganizationId_firstSeenAt_idx"
+ON "webhook_deliveries"("resolvedOrganizationId", "firstSeenAt");
+
+-- CreateIndex
+CREATE INDEX "webhook_deliveries_lastSeenAt_idx"
+ON "webhook_deliveries"("lastSeenAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -330,6 +330,39 @@ model Repository {
   @@map("repositories")
 }
 
+// Verified provider deliveries observed at the webhook boundary. This is an
+// append-style metadata ledger: tenant/repository IDs are snapshots rather
+// than foreign keys so evidence survives later tenant or repository deletion.
+model WebhookDelivery {
+  id                        String   @id @default(cuid())
+  provider                  String
+  deliveryId                String
+  deliveryIdSource          String   @default("provider") // provider | payload_sha256
+  eventType                 String
+  action                    String?
+  payloadSha256             String
+  providerInstallationId    String?
+  providerRepositoryId      String?
+  resolvedOrganizationId    String?
+  resolvedRepositoryId      String?
+  legacyOrganizationId      String?
+  legacyRepositoryId        String?
+  resolutionStatus          String
+  comparisonStatus          String
+  legacyCandidateCount      Int      @default(0)
+  attemptCount              Int      @default(1)
+  payloadHashCollisionCount Int      @default(0)
+  firstSeenAt               DateTime @default(now())
+  lastSeenAt                DateTime @default(now())
+
+  @@unique([provider, deliveryId])
+  @@index([provider, providerInstallationId, firstSeenAt])
+  @@index([provider, comparisonStatus, firstSeenAt])
+  @@index([resolvedOrganizationId, firstSeenAt])
+  @@index([lastSeenAt])
+  @@map("webhook_deliveries")
+}
+
 model RepoConfigExtraction {
   id              String   @id @default(cuid())
   repositoryId    String

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -108,6 +108,7 @@ model Organization {
   name                 String
   slug                 String   @unique
   avatarUrl            String?
+  // Signed webhook tenant authority; one GitHub installation maps to one org.
   githubInstallationId Int?     @unique
   needsPermissionGrant Boolean  @default(false)
   openaiApiKey         String?


### PR DESCRIPTION
## Intent

Implement the approved first low-risk SEC-06 shadow-ledger slice without changing authoritative webhook routing or duplicate enforcement: record bounded signature-verified GitHub delivery metadata, resolve tenants by installation ownership, retain telemetry for a bounded window, document it, and update the external security report. Address Octopus review feedback with low-risk changes: document the unsigned delivery header limitation; parse, validate, and cap retention at 1–365 days during node startup with an explicit unset default of 30 days; parse the harness's final nonempty stdout line; skip the legacy collision-count query when no legacy comparison applies; and make the existing Organization.githubInstallationId @unique tenant-authority invariant explicit and regression-tested. Preserve atomic collision/retry accounting, full shadow coverage, and post-response non-fatal behavior; do not introduce sampling or enforcement.

## What Changed

- Added a shadow ledger for GitHub webhook tenant resolution: a new `webhook_deliveries` Prisma model/migration plus `apps/web/lib/webhook-tenant.ts` record bounded, signature-verified delivery metadata and resolve tenants by installation ownership after the webhook response is sent — observation only, with no change to authoritative routing or duplicate enforcement, and ledger failures stay non-fatal to delivery handling.
- Bounded the ledger's retention: `WEBHOOK_DELIVERY_RETENTION_DAYS` (default 30) is parsed and validated to 1–365 days at node startup via `instrumentation.ts`, a queue worker prunes expired rows, and the data-retention docs page, `.env.example`, and CHANGELOG document the new behavior.
- Addressed shadow-ledger review feedback: made the existing `Organization.githubInstallationId @unique` tenant-authority invariant explicit and regression-tested, skipped the legacy collision-count query when no legacy comparison applies, documented the unsigned `x-github-delivery` header limitation, and hardened the test harness stdout parsing — backed by unit tests and an end-to-end route harness (20 tests passing per the pipeline Test stage).

## Risk Assessment

✅ Low: The change is strictly additive shadow-mode telemetry — observation runs after the response, all failures are caught non-fatally, authoritative routing and duplicate handling are untouched (findFirst→findUnique is semantically identical under the existing unique constraint), inputs are bounded and validated, retention is startup-validated and enforced daily, and every intent-required review-feedback item is implemented with matching tests; the only open item is confirming the out-of-repo security report update.</risk_rationale>
</invoke>


## Testing

Ran the webhook-tenant unit suite and the spawned end-to-end shadow-harness test (20/20 pass), then produced product-level evidence: a step-by-step transcript of the real webhook route showing observation-only behavior (401 on bad signature, unchanged routing on collisions, counted-not-suppressed duplicates, non-fatal ledger failure, uninstall snapshot), a startup transcript proving retention is validated to 1–365 days with a 30-day unset default and fails server startup on invalid values, and a screenshot of the rendered data-retention docs page with the new webhook-deliveries row. Only the external security report update could not be verified, as it lives outside this repository.

<details>
<summary>Evidence: Shadow-ledger end-to-end transcript (real route handler)</summary>

```text
=== SEC-06 shadow-ledger end-to-end transcript (real route handler) ===

Setup: GitHub installation 222 is owned by org_b (Organization.githubInstallationId
is @unique). The legacy route's repository lookup returns repo_a in org_a — a
simulated cross-tenant collision. Shadow mode must OBSERVE it, not change routing.

STEP 1 — POST with an invalid X-Hub-Signature-256
  response status: 401 (expected 401)
  observation scheduled: false | ledger writes: 0 | reviews started: 0
  => unsigned/forged deliveries never reach the ledger

STEP 2 — Valid signed pull_request webhook (delivery-123)
  response status: 200
  legacy routing dispatched review to orgId=org_a (unchanged legacy behavior)
  ledger row written post-response via next/server after():
    deliveryId=delivery-123 eventType=pull_request action=opened
    payloadSha256=3daec01b00f062b4… (hash only — payload content never stored)
    resolvedOrganizationId=org_b (installation-ownership truth)
    legacyOrganizationId=org_a legacyCandidateCount=2
    resolutionStatus=resolved comparisonStatus=ambiguous
  => cross-tenant collision recorded as evidence; review still went to org_a

STEP 3 — Same delivery id replayed twice (delivery-replayed)
  reviews dispatched for both replays: 2 (no duplicate ENFORCEMENT in shadow mode)
  ledger attemptCount for delivery-replayed: 2 (duplicates COUNTED atomically)

STEP 4 — Ledger database unavailable during observation
  response status: 200 (ledger failure is non-fatal; webhook unaffected)

STEP 5 — installation.deleted (uninstall) webhook
  response status: 200
  ledger row: resolvedOrganizationId=org_b resolutionStatus=installation_only
  => tenant snapshot captured BEFORE the installation binding was deleted

=== transcript complete: routing and duplicate handling unchanged; ledger observed everything ===
```
</details>
<details>
<summary>Evidence: WEBHOOK_DELIVERY_RETENTION_DAYS startup validation transcript</summary>

```text
=== WEBHOOK_DELIVERY_RETENTION_DAYS startup validation transcript ===
(instrumentation.ts calls resolveWebhookDeliveryRetentionDays() before
 startQueue(); a throw here fails Next.js server startup)

  <unset>    (unset (default)) -> accepted: retention = 30 days
  "30"       (explicit default) -> accepted: retention = 30 days
  "1"        (minimum) -> accepted: retention = 1 days
  "365"      (maximum) -> accepted: retention = 365 days
  "45"       (typical override) -> accepted: retention = 45 days
  "0"        (below minimum) -> STARTUP FAILS: Invalid webhook delivery retention window; expected an integer from 1 to 365 days
  "366"      (above maximum) -> STARTUP FAILS: Invalid webhook delivery retention window; expected an integer from 1 to 365 days
  "-5"       (negative) -> STARTUP FAILS: Invalid webhook delivery retention window; expected an integer from 1 to 365 days
  "1.5"      (non-integer) -> STARTUP FAILS: Invalid webhook delivery retention window; expected an integer from 1 to 365 days
  "abc"      (non-numeric) -> STARTUP FAILS: Invalid webhook delivery retention window; expected an integer from 1 to 365 days
  "  90  "   (whitespace-padded) -> accepted: retention = 90 days
```
</details>
- Evidence: Data-retention docs page screenshot (new Webhook deliveries row) (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KYZQK91T044E27VFP86NYCZK/data-retention-page.png</code>)
<details>
<summary>Evidence: Rendered data-retention page HTML (from worktree source)</summary>

```text
<!doctype html>
<html class="dark">
<head>
<meta charset="utf-8">
<meta name="viewport" content="width=device-width, initial-scale=1">
<title>Data Retention — Octopus (rendered from worktree)</title>
<script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
<style>body{background:#0a0a0a;color:#d4d4d4;font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;}</style>
</head>
<body>
<div class="mx-auto max-w-3xl px-6 py-16">
<article class="max-w-3xl"><div class="mb-8"><div class="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#555]"><span class="size-4" aria-hidden="true">🕓</span>Compliance</div><h1 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">Data Retention</h1><p class="mt-3 text-sm text-[#555]">Last updated: August 2026</p></div><p class="mb-3 text-sm leading-relaxed text-[#888]">This page lists what Octopus stores, for how long, and how to request deletion. Numbers apply to <strong>hosted</strong> Octopus by default; self-hosters control their own retention.</p><section class="mb-8"><h2 class="mb-3 text-lg font-semibold text-white">Retention by category</h2><div class="mb-3 overflow-x-auto"><table class="w-full text-left text-xs text-[#888]"><thead class="text-[#555]"><tr class="border-b border-[#222]"><th class="py-2 pr-3 font-semibold">Category</th><th class="py-2 pr-3 font-semibold">What</th><th class="py-2 pr-3 font-semibold">Retention</th></tr></thead><tbody><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Reviews</td><td class="py-2 pr-3">Posted review bodies + findings on each PR<div class="mt-1 text-[11px] text-[#666]">Findings stay queryable from the dashboard during this window; after, they roll off.</div></td><td class="py-2 pr-3 whitespace-nowrap">For the lifetime of the PR + 90 days after PR close</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Diffs</td><td class="py-2 pr-3">PR diff content used for a single review<div class="mt-1 text-[11px] text-[#666]">Never persisted to durable storage.</div></td><td class="py-2 pr-3 whitespace-nowrap">Discarded after the review completes</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Embeddings</td><td class="py-2 pr-3">Vector chunks indexed from connected repos in Qdrant<div class="mt-1 text-[11px] text-[#666]">On repo disconnect: vectors are deleted within 24 h.</div></td><td class="py-2 pr-3 whitespace-nowrap">For as long as the repo is connected</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Audit log</td><td class="py-2 pr-3">AuditLog rows recording mutating actions<div class="mt-1 text-[11px] text-[#666]">Self-hosted: configurable retention window.</div></td><td class="py-2 pr-3 whitespace-nowrap">365 days (hosted default)</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">AI usage</td><td class="py-2 pr-3">Token-count records for billing and observability<div class="mt-1 text-[11px] text-[#666]">Aggregated monthly summaries retained indefinitely for billing reconciliation.</div></td><td class="py-2 pr-3 whitespace-nowrap">13 months</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Integration tokens</td><td class="py-2 pr-3">OAuth refresh tokens for Slack / Linear / Jira / GitLab<div class="mt-1 text-[11px] text-[#666]">Stored encrypted at rest (apps/web/lib/crypto.ts).</div></td><td class="py-2 pr-3 whitespace-nowrap">Until the user disconnects the integration</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Sessions</td><td class="py-2 pr-3">Auth session tokens + IP + user-agent<div class="mt-1 text-[11px] text-[#666]">Revocable from /settings/sessions.</div></td><td class="py-2 pr-3 whitespace-nowrap">30 days from last activity</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Email send records</td><td class="py-2 pr-3">EmailSend rows for transactional emails</td><td class="py-2 pr-3 whitespace-nowrap">13 months</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Knowledge documents</td><td class="py-2 pr-3">User-uploaded knowledge base docs</td><td class="py-2 pr-3 whitespace-nowrap">Until the user deletes them; soft-deleted with 30-day recovery window</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Backups</td><td class="py-2 pr-3">Encrypted DB snapshots</td><td class="py-2 pr-3 whitespace-nowrap">30 days for hosted; self-hosters control their own</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Webhook deliveries</td><td class="py-2 pr-3">Signature-verified webhook delivery metadata (IDs, event type, payload hash — never payload content)<div class="mt-1 text-[11px] text-[#666]">Pruned daily; WEBHOOK_DELIVERY_RETENTION_DAYS accepts 1–365 days and fails server startup on invalid configuration.</div></td><td class="py-2 pr-3 whitespace-nowrap">30 days (hosted default)</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Activity events</td><td class="py-2 pr-3">Live team-telemetry feed rows (coarse actions only — no content)<div class="mt-1 text-[11px] text-[#666]">Only when an org enables Live Activity. Tunable via ACTIVITY_RETENTION_DAYS; pruned daily.</div></td><td class="py-2 pr-3 whitespace-nowrap">30 days (hosted default)</td></tr><tr class="border-b border-[#191919] align-top"><td class="py-2 pr-3 font-medium text-[#ccc]">Presence</td><td class="py-2 pr-3">Whether a member/agent is currently online + coarse current area<div class="mt-1 text-[11px] text-[#666]">Held in Redis with a TTL (or a short-lived DB row); never archived.</div></td><td class="py-2 pr-3 whitespace-nowrap">Ephemeral — expires ~60s after going offline</td></tr></tbody></table></div></section><section class="mb-8"><h2 class="mb-3 text-lg font-semibold text-white">Account / organisation deletion</h2><p class="mb-3 text-sm leading-relaxed text-[#888]">Org owners can delete their organisation from the <em>Danger Zone</em> card on <code>/settings</code>. Deletion is processed within 24 hours and removes:</p><ul class="mb-3 list-inside list-disc space-y-1.5 text-sm text-[#888]"><li>The organisation record, all repos, reviews, embeddings, audit log, and integration tokens</li><li>Memberships for every member of that organisation</li></ul><p class="mb-3 text-sm leading-relaxed text-[#888]">To delete your <em>user</em> record (and memberships in orgs you do not solely own), email <a href="mailto:privacy@octopus-review.ai" class="text-cyan-400 underline">privacy@octopus-review.ai</a> from the address on the account — the in-app flow only covers org deletion today.</p><p class="mb-3 text-sm leading-relaxed text-[#888]">Backups containing deleted data roll off per the backup retention window (30 days). Anonymised aggregate metrics may persist indefinitely.</p></section><section class="mb-8"><h2 class="mb-3 text-lg font-semibold text-white">Data export (right to portability)</h2><p class="mb-3 text-sm leading-relaxed text-[#888]">For org-wide data export (repositories, reviews, findings, knowledge documents, audit logs, AI usage records), email <a href="mailto:privacy@octopus-review.ai" class="text-cyan-400 underline">privacy@octopus-review.ai</a> from the account address — we respond within 30 days.</p></section><section class="mb-8"><h2 class="mb-3 text-lg font-semibold text-white">GDPR / CCPA requests</h2><p class="mb-3 text-sm leading-relaxed text-[#888]">Right-to-access, right-to-erasure, right-to-portability, and right-to-correction requests can be made by emailing <a href="mailto:privacy@octopus-review.ai" class="text-cyan-400 underline">privacy@octopus-review.ai</a> from the address on the affected account. We respond within 30 days.</p></section><section class="mb-8"><h2 class="mb-3 text-lg font-semibold text-white">Self-hosters</h2><p class="mb-3 text-sm leading-relaxed text-[#888]">Self-hosted Octopus stores everything in your PostgreSQL + Qdrant + object-storage. There is no automatic retention beyond the built-in pruning jobs above (review findings, audit logs, activity events, and webhook delivery metadata — the latter three have configurable windows). Configure retention for your other stored data per your own compliance requirements.</p></section></article>
</div>
</body>
</html>
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (7m7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `CHANGELOG.md:11` - Intent conformance: the user intent requires &#34;update the external security report&#34;, but no security-report artifact is updated anywhere in this branch (the diff touches only CHANGELOG.md, the data-retention docs page, and .env.example; repo files like SECURITY.md and docs/security pages are untouched). If the report is maintained outside this repository the diff cannot contain it, but that cannot be verified from this change — please confirm the external security report was updated as required.
- ℹ️ `apps/web/lib/webhook-tenant.ts:389` - Prisma upsert is not atomic when no matching row exists, so two concurrent webhooks carrying the same delivery ID can race inside the transaction and one will fail with a P2002 unique-constraint error; observeGithubWebhookDeliveryInShadowMode swallows it, so that attempt is silently missing from attemptCount telemetry. Acceptable for shadow-mode observation (non-fatal by design) — noting the known accounting gap; a retry-on-P2002 inside the transaction would close it if attempt counts ever become enforcement inputs.
- ℹ️ `apps/web/lib/webhook-tenant.ts:54` - webhook-tenant.ts hand-rolls ~120 lines of store interfaces (OrganizationLookup, RepositoryLookup, WebhookDeliveryUpsertArgs, WebhookObservationStore, etc.) that mirror Prisma client shapes. This is a deliberate seam for test injection and keeps the module decoupled from generated types, but the same narrowing could be expressed more compactly with Pick&lt;&gt; over PrismaClient if the surface grows in later SEC-06 slices.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ The intent requires updating the external security report, but no security-report file exists in this repository or the change diff — the report appears to live outside the repo (external artifact), so this clause cannot be verified from the worktree. The author should confirm the external report was updated.
- <code>`bun test lib/__tests__/webhook-tenant.test.ts lib/__tests__/github-webhook-tenant-shadow.test.ts` (20 pass, 0 fail — includes the spawned end-to-end route harness, the Organization.githubInstallationId @unique schema regression test, signature-before-observation ordering, legacy collision-query skip, and retention bound tests)</code>
- <code>Manual end-to-end transcript driving the real `POST /api/github/webhook` handler: invalid signature → 401 with zero ledger writes; cross-tenant collision observed (resolved=org_b, legacy=org_a, ambiguous) while the review still routed to the legacy org; duplicate delivery replayed twice → both reviews dispatched, attemptCount=2; ledger DB failure → 200 response; installation.deleted → pre-mutation tenant snapshot recorded</code>
- `Manual startup-validation transcript for WEBHOOK_DELIVERY_RETENTION_DAYS: unset→30, 1/365/45/padded-90 accepted, 0/366/-5/1.5/non-numeric fail startup with the 1–365 error`
- `Rendered the actual data-retention page component from the worktree and captured a full-page screenshot showing the new Webhook deliveries row and updated self-hosters section`
- `Verified migration SQL creates webhook_deliveries with the (provider, deliveryId) unique index; confirmed the unsigned x-github-delivery header limitation is documented in webhook-tenant.ts; confirmed the harness test parses the final nonempty stdout line; worktree left clean after removing temporary evidence scripts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
