### PR TITLE
fix(github): route all GitHub App install links through the signed install start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Every GitHub App installation entry point — the dashboard "Grant Access" button, the indexing-log recovery link, and the hosted CLI's repo wizard — now starts from the server-signed `/api/github/install` route instead of linking straight to GitHub, so all installs carry the browser- and user-bound signed state. Starting an install while signed out resumes the install after login, and starting one before a GitHub App is configured redirects to the integrations settings page with an explanation instead of a raw API error. A repository-wide test now enforces that raw `github.com/apps/…` install URLs appear only in the two server-owned redirect routes.
+
 ## [1.0.94] - 2026-08-04
 
 ### Security

--- a/apps/cli/src/steps/RepoStep.tsx
+++ b/apps/cli/src/steps/RepoStep.tsx
@@ -75,7 +75,7 @@ export function RepoStep({ onNext }: RepoStepProps) {
       }
 
       setInstallUrl(
-        `${creds.baseUrl}/api/github/install?returnTo=${encodeURIComponent("/repositories")}`,
+        `${creds.baseUrl}/api/github/install?orgId=${encodeURIComponent(creds.orgId)}&returnTo=${encodeURIComponent("/repositories")}`,
       );
 
       const res = await getJson<{ repos: Repo[] }>(`${creds.baseUrl}/api/cli/repos`, {

--- a/apps/cli/src/steps/RepoStep.tsx
+++ b/apps/cli/src/steps/RepoStep.tsx
@@ -5,8 +5,6 @@ import { loadCredentials } from "../lib/credentials.js";
 import { getJson } from "../lib/api.js";
 import { openBrowser } from "../lib/auth.js";
 
-const GITHUB_APP_SLUG = process.env.OCTOPUS_GITHUB_APP_SLUG ?? "octopus-review";
-
 export type RepoStepProps = {
   onNext: () => void;
 };
@@ -28,8 +26,9 @@ type Phase = "loading" | "no-creds" | "loaded" | "failed";
  *
  * Today's scope: list the org's already-connected repos (via /api/cli/repos)
  * with their index/review status. If the user wants to add a new repo we
- * link them to the GitHub App install page; we don't fetch their GitHub
- * repo list (that needs a different OAuth scope and is a separate epic).
+ * link them through the signed GitHub App install-start route; we don't fetch
+ * their GitHub repo list (that needs a different OAuth scope and is a separate
+ * epic).
  *
  * Self-hosted: skipped — repos there are added via the web UI's GitHub
  * integration page, not via this wizard.
@@ -45,10 +44,10 @@ export function RepoStep({ onNext }: RepoStepProps) {
     if (key.escape && phase !== "loading") onNext();
   });
 
-  // Open the GitHub App install page in the system browser (reusing the same
-  // shell-free helper the PKCE auth step uses). The URL stays on screen as a
-  // fallback, so a spawn failure is non-fatal — we just tell the user to open
-  // it themselves rather than claiming success.
+  // Open the signed GitHub App install-start route in the system browser
+  // (reusing the same shell-free helper the PKCE auth step uses). The URL stays
+  // on screen as a fallback, so a spawn failure is non-fatal — we just tell the
+  // user to open it themselves rather than claiming success.
   const handleSelect = async (value: string) => {
     if (value === "install") {
       const opened = await openBrowser(installUrl);
@@ -75,7 +74,9 @@ export function RepoStep({ onNext }: RepoStepProps) {
         return;
       }
 
-      setInstallUrl(`https://github.com/apps/${GITHUB_APP_SLUG}/installations/new`);
+      setInstallUrl(
+        `${creds.baseUrl}/api/github/install?returnTo=${encodeURIComponent("/repositories")}`,
+      );
 
       const res = await getJson<{ repos: Repo[] }>(`${creds.baseUrl}/api/cli/repos`, {
         headers: { authorization: `Bearer ${creds.token}` },

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -639,7 +639,6 @@ export default async function DashboardPage({
             })),
           }))}
           orgId={org.id}
-          githubAppSlug={githubAppSlug ?? null}
         />
       </div>
     </div>

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -1,7 +1,6 @@
 import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
-import { getGithubAppConfig } from "@/lib/github-app-config";
 import { prisma } from "@octopus/db";
 import { AppSidebar, MobileHeader } from "@/components/app-sidebar";
 import { ChatWrapper } from "@/components/chat-wrapper";
@@ -177,8 +176,6 @@ export default async function AppLayout({
     currentOrg,
     canCreateOrg,
   };
-
-  const githubAppSlug = (await getGithubAppConfig())?.slug ?? undefined;
 
   // Check GitHub for orgs that need permission — auto-clear if already granted
   const flaggedOrgs = orgs.filter((o) => o.needsPermissionGrant && o.githubInstallationId);

--- a/apps/web/app/(app)/settings/integrations/github-integration-card.tsx
+++ b/apps/web/app/(app)/settings/integrations/github-integration-card.tsx
@@ -42,6 +42,7 @@ type GitHubError =
   | "session_required"
   | "state_user_mismatch"
   | "state_browser_mismatch"
+  | "github_app_not_configured"
   | "github_verification_not_configured"
   | "github_authorization_denied"
   | "github_authorization_failed"
@@ -66,6 +67,7 @@ const ERROR_TITLES: Record<Exclude<GitHubError, null>, string> = {
   session_required: "Sign-in required",
   state_user_mismatch: "Install session changed",
   state_browser_mismatch: "Install browser could not be verified",
+  github_app_not_configured: "GitHub App not configured",
   github_verification_not_configured: "GitHub verification needs configuration",
   github_authorization_denied: "GitHub authorization declined",
   github_authorization_failed: "GitHub authorization failed",
@@ -100,6 +102,8 @@ const ERROR_MESSAGES: Record<Exclude<GitHubError, null>, string> = {
     "The signed-in user is not the user who started this installation. Restart the install from Octopus.",
   state_browser_mismatch:
     "This browser did not start the installation, or its install cookie expired. Start again from Octopus.",
+  github_app_not_configured:
+    "No GitHub App is configured for this instance yet. Create the GitHub App below, then start the install again.",
   github_verification_not_configured:
     "Add the GitHub App client ID, client secret, and Octopus callback URL, then restart the install.",
   github_authorization_denied:

--- a/apps/web/app/(app)/settings/integrations/page.tsx
+++ b/apps/web/app/(app)/settings/integrations/page.tsx
@@ -25,6 +25,7 @@ const ALLOWED_GITHUB_ERRORS = [
   "session_required",
   "state_user_mismatch",
   "state_browser_mismatch",
+  "github_app_not_configured",
   "github_verification_not_configured",
   "github_authorization_denied",
   "github_authorization_failed",

--- a/apps/web/app/(landing)/docs/github-app/page.tsx
+++ b/apps/web/app/(landing)/docs/github-app/page.tsx
@@ -176,8 +176,9 @@ GITHUB_APP_CLIENT_SECRET=<the GitHub App client secret>
 NEXT_PUBLIC_GITHUB_APP_SLUG=<the slug from the App's URL>`}</CodeBlock>
         <P>
           Restart the server. The &quot;Install GitHub App&quot; button on{" "}
-          <Mono>/settings/integrations</Mono> should now appear and link to{" "}
-          <Mono>https://github.com/apps/&lt;slug&gt;/installations/new</Mono>.
+          <Mono>/settings/integrations</Mono> should now appear and start the
+          signed installation flow through <Mono>/api/github/install</Mono>,
+          which redirects to GitHub.
         </P>
       </Section>
 

--- a/apps/web/app/api/github/install/route.ts
+++ b/apps/web/app/api/github/install/route.ts
@@ -21,7 +21,10 @@ export async function GET(request: NextRequest) {
 
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) {
-    return NextResponse.redirect(new URL("/login", baseUrl));
+    const resume = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+    return NextResponse.redirect(
+      new URL(`/login?callbackUrl=${encodeURIComponent(resume)}`, baseUrl),
+    );
   }
 
   const cookieStore = await cookies();

--- a/apps/web/app/api/github/install/route.ts
+++ b/apps/web/app/api/github/install/route.ts
@@ -16,7 +16,9 @@ const baseUrl = process.env.BETTER_AUTH_URL || "http://localhost:3000";
 export async function GET(request: NextRequest) {
   const appSlug = (await getGithubAppConfig())?.slug;
   if (!appSlug) {
-    return NextResponse.json({ error: "github_app_not_configured" }, { status: 500 });
+    return NextResponse.redirect(
+      new URL("/settings/integrations?error=github_app_not_configured", baseUrl),
+    );
   }
 
   const session = await auth.api.getSession({ headers: await headers() });

--- a/apps/web/components/dashboard/repo-table.tsx
+++ b/apps/web/components/dashboard/repo-table.tsx
@@ -101,16 +101,16 @@ function formatDate(dateStr: string): string {
 function IndexBadge({
   status,
   repoId,
+  orgId,
   indexedAt: _indexedAt,
   needsAccess,
-  githubAppSlug,
   onIndexStart,
 }: {
   status: string;
   repoId: string;
+  orgId: string;
   indexedAt: string | null;
   needsAccess: boolean;
-  githubAppSlug: string | null;
   onIndexStart: () => void;
 }) {
   const [pending, startTransition] = useTransition();
@@ -189,7 +189,7 @@ function IndexBadge({
           <IconAlertTriangle className="mr-1 size-3" />
           Failed
         </Badge>
-        {needsAccess && githubAppSlug ? (
+        {needsAccess ? (
           <Button
             size="sm"
             variant="outline"
@@ -197,7 +197,7 @@ function IndexBadge({
             asChild
           >
             <a
-              href="/api/github/install?returnTo=/dashboard"
+              href={`/api/github/install?orgId=${encodeURIComponent(orgId)}&returnTo=${encodeURIComponent("/dashboard")}`}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -372,11 +372,9 @@ function PullRequestList({ pullRequests }: { pullRequests: PullRequestItem[] }) 
 export function RepoTable({
   repos,
   orgId,
-  githubAppSlug,
 }: {
   repos: Repo[];
   orgId: string;
-  githubAppSlug: string | null;
 }) {
   const [expandedRepo, setExpandedRepo] = useState<string | null>(null);
   const [statuses, setStatuses] = useState<Record<string, string>>(() =>
@@ -538,9 +536,9 @@ export function RepoTable({
                       <IndexBadge
                         status={status}
                         repoId={repo.id}
+                        orgId={orgId}
                         indexedAt={repo.indexedAt}
                         needsAccess={accessErrors[repo.id] ?? false}
-                        githubAppSlug={githubAppSlug}
                         onIndexStart={() => handleIndexStart(repo.id)}
                       />
                     </td>
@@ -659,9 +657,9 @@ export function RepoTable({
                   <IndexBadge
                     status={status}
                     repoId={repo.id}
+                    orgId={orgId}
                     indexedAt={repo.indexedAt}
                     needsAccess={accessErrors[repo.id] ?? false}
-                    githubAppSlug={githubAppSlug}
                     onIndexStart={() => handleIndexStart(repo.id)}
                   />
                 </span>

--- a/apps/web/components/dashboard/repo-table.tsx
+++ b/apps/web/components/dashboard/repo-table.tsx
@@ -197,7 +197,7 @@ function IndexBadge({
             asChild
           >
             <a
-              href={`https://github.com/apps/${githubAppSlug}/installations/new?state=${encodeURIComponent(`${window.location.origin}/dashboard`)}`}
+              href="/api/github/install?returnTo=/dashboard"
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/apps/web/components/indexing-logs.tsx
+++ b/apps/web/components/indexing-logs.tsx
@@ -166,6 +166,13 @@ export function IndexingLogs({
 
   const isComplete = status === "indexed" || status === "failed";
   const displayLogs = mergeProgressLogs(logs);
+  const needsInstall =
+    status === "failed" &&
+    logs.some(
+      (log) =>
+        log.message.toLowerCase().includes("access") ||
+        log.message.toLowerCase().includes("not found"),
+    );
 
   // Find the index of the last info log to determine which one should spin
   let lastInfoIndex = -1;
@@ -235,21 +242,19 @@ export function IndexingLogs({
           );
         })}
 
-        {status === "failed" &&
-          logs.some((l) => l.message.toLowerCase().includes("access") || l.message.toLowerCase().includes("not found")) &&
-          process.env.NEXT_PUBLIC_GITHUB_APP_SLUG && (
-            <div className="mt-3 border-t border-zinc-800 pt-3">
-              <a
-                href={`/api/github/install?returnTo=${encodeURIComponent(`/repositories?repo=${repoId}`)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded-md bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700"
-              >
-                <IconExternalLink className="size-3" />
-                Grant Access on GitHub
-              </a>
-            </div>
-          )}
+        {needsInstall && (
+          <div className="mt-3 border-t border-zinc-800 pt-3">
+            <a
+              href={`/api/github/install?orgId=${encodeURIComponent(orgId)}&returnTo=${encodeURIComponent(`/repositories?repo=${repoId}`)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-md bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700"
+            >
+              <IconExternalLink className="size-3" />
+              Grant Access on GitHub
+            </a>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/components/indexing-logs.tsx
+++ b/apps/web/components/indexing-logs.tsx
@@ -240,7 +240,7 @@ export function IndexingLogs({
           process.env.NEXT_PUBLIC_GITHUB_APP_SLUG && (
             <div className="mt-3 border-t border-zinc-800 pt-3">
               <a
-                href={`https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_SLUG}/installations/new?state=${encodeURIComponent(`${window.location.origin}/repositories?repo=${repoId}`)}`}
+                href={`/api/github/install?returnTo=${encodeURIComponent(`/repositories?repo=${repoId}`)}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1.5 rounded-md bg-zinc-800 px-3 py-1.5 text-xs font-medium text-zinc-200 transition-colors hover:bg-zinc-700"

--- a/apps/web/lib/__tests__/github-install-security.test.ts
+++ b/apps/web/lib/__tests__/github-install-security.test.ts
@@ -53,15 +53,21 @@ mock.module("@/lib/redis", () => ({
   getRedis: () => ({ set: redisSet }),
 }));
 
+let githubAppConfigured = true;
+
 mock.module("@/lib/github-app-config", () => ({
   getGithubAppConfig: () =>
-    Promise.resolve({
-      appId: "123",
-      slug: "octopus-review",
-      privateKey: TEST_PRIVATE_KEY,
-      clientId: "github-app-client-id",
-      clientSecret: "github-app-client-secret",
-    }),
+    Promise.resolve(
+      githubAppConfigured
+        ? {
+            appId: "123",
+            slug: "octopus-review",
+            privateKey: TEST_PRIVATE_KEY,
+            clientId: "github-app-client-id",
+            clientSecret: "github-app-client-secret",
+          }
+        : null,
+    ),
 }));
 
 const originalFetch = globalThis.fetch;
@@ -130,6 +136,7 @@ function installRequest(params: Record<string, string>) {
 }
 
 beforeEach(() => {
+  githubAppConfigured = true;
   currentSession = { user: { id: "user_victim" } };
   boundInstallationId = null;
   requestCookies = new Map();
@@ -370,6 +377,18 @@ describe("GitHub installation UI entry points", () => {
   it("does not hide signed recovery links behind a public app-slug gate", () => {
     expect(repoTableSource).not.toContain("githubAppSlug");
     expect(indexingLogsSource).not.toContain("NEXT_PUBLIC_GITHUB_APP_SLUG");
+  });
+
+  it("redirects to integrations settings when no GitHub App is configured", async () => {
+    githubAppConfigured = false;
+
+    const response = await GET_INSTALL(
+      installRequest({ orgId: "org_victim", returnTo: "/repositories" }),
+    );
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.pathname).toBe("/settings/integrations");
+    expect(location.searchParams.get("error")).toBe("github_app_not_configured");
   });
 
   it("resumes an unauthenticated install-start request after login", async () => {

--- a/apps/web/lib/__tests__/github-install-security.test.ts
+++ b/apps/web/lib/__tests__/github-install-security.test.ts
@@ -318,7 +318,14 @@ describe("GitHub installation UI entry points", () => {
 
   function sourceFiles(directory: string): string[] {
     return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-      if (entry.name.startsWith(".") || entry.name === "node_modules") return [];
+      if (
+        entry.name.startsWith(".") ||
+        entry.name === "node_modules" ||
+        entry.name === "__tests__" ||
+        /\.(?:test|spec)\.[cm]?[jt]sx?$/.test(entry.name)
+      ) {
+        return [];
+      }
       const path = join(directory, entry.name);
       if (entry.isDirectory()) return sourceFiles(path);
       return /\.[cm]?[jt]sx?$/.test(entry.name) ? [path] : [];
@@ -331,11 +338,7 @@ describe("GitHub installation UI entry points", () => {
       "apps/web/app/api/github/install/route.ts",
       "apps/web/app/api/github/app-manifest/callback/route.ts",
     ]);
-    const sourceRoots = [
-      join(repoRoot, "apps/web/app"),
-      join(repoRoot, "apps/web/components"),
-      join(repoRoot, "apps/cli/src"),
-    ];
+    const sourceRoots = [join(repoRoot, "apps/web"), join(repoRoot, "apps/cli/src")];
 
     const violations = sourceRoots
       .flatMap(sourceFiles)
@@ -354,27 +357,32 @@ describe("GitHub installation UI entry points", () => {
 
   it("routes web and CLI recovery links through the signed install-start endpoint", () => {
     expect(repoTableSource).toContain(
-      'href="/api/github/install?returnTo=/dashboard"',
+      'href={`/api/github/install?orgId=${encodeURIComponent(orgId)}&returnTo=${encodeURIComponent("/dashboard")}`}',
     );
     expect(indexingLogsSource).toContain(
-      "href={`/api/github/install?returnTo=${encodeURIComponent(`/repositories?repo=${repoId}`)}`}",
+      "href={`/api/github/install?orgId=${encodeURIComponent(orgId)}&returnTo=${encodeURIComponent(`/repositories?repo=${repoId}`)}`}",
     );
     expect(cliRepoStepSource).toContain(
-      "`${creds.baseUrl}/api/github/install?returnTo=${encodeURIComponent(\"/repositories\")}`",
+      "`${creds.baseUrl}/api/github/install?orgId=${encodeURIComponent(creds.orgId)}&returnTo=${encodeURIComponent(\"/repositories\")}`",
     );
+  });
+
+  it("does not hide signed recovery links behind a public app-slug gate", () => {
+    expect(repoTableSource).not.toContain("githubAppSlug");
+    expect(indexingLogsSource).not.toContain("NEXT_PUBLIC_GITHUB_APP_SLUG");
   });
 
   it("resumes an unauthenticated install-start request after login", async () => {
     currentSession = null;
 
     const response = await GET_INSTALL(
-      installRequest({ returnTo: "/repositories" }),
+      installRequest({ orgId: "org_victim", returnTo: "/repositories" }),
     );
     const location = new URL(response.headers.get("location")!);
 
     expect(location.pathname).toBe("/login");
     expect(location.searchParams.get("callbackUrl")).toBe(
-      "/api/github/install?returnTo=%2Frepositories",
+      "/api/github/install?orgId=org_victim&returnTo=%2Frepositories",
     );
   });
 });

--- a/apps/web/lib/__tests__/github-install-security.test.ts
+++ b/apps/web/lib/__tests__/github-install-security.test.ts
@@ -1,5 +1,8 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import crypto from "node:crypto";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
 
 process.env.BETTER_AUTH_URL = "https://app.test";
 process.env.GITHUB_STATE_SECRET =
@@ -54,6 +57,7 @@ mock.module("@/lib/github-app-config", () => ({
   getGithubAppConfig: () =>
     Promise.resolve({
       appId: "123",
+      slug: "octopus-review",
       privateKey: TEST_PRIVATE_KEY,
       clientId: "github-app-client-id",
       clientSecret: "github-app-client-secret",
@@ -107,9 +111,18 @@ const {
   signInstallState,
 } = await import("@/lib/github-install-state");
 const { GET } = await import("@/app/api/github/callback/route");
+const { GET: GET_INSTALL } = await import("@/app/api/github/install/route");
 
 function callbackRequest(params: Record<string, string>) {
   const url = new URL("https://app.test/api/github/callback");
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return Object.assign(new Request(url), { nextUrl: url }) as never;
+}
+
+function installRequest(params: Record<string, string>) {
+  const url = new URL("https://app.test/api/github/install");
   for (const [key, value] of Object.entries(params)) {
     url.searchParams.set(key, value);
   }
@@ -285,5 +298,83 @@ describe("safeReturnPath", () => {
     expect(safeReturnPath("/\r/evil.com")).toBe("/settings/integrations");
     expect(safeReturnPath("/\x00evil")).toBe("/settings/integrations");
     expect(safeReturnPath("/\x7fevil")).toBe("/settings/integrations");
+  });
+});
+
+describe("GitHub installation UI entry points", () => {
+  const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+  const repoTableSource = readFileSync(
+    new URL("../../components/dashboard/repo-table.tsx", import.meta.url),
+    "utf8",
+  );
+  const indexingLogsSource = readFileSync(
+    new URL("../../components/indexing-logs.tsx", import.meta.url),
+    "utf8",
+  );
+  const cliRepoStepSource = readFileSync(
+    join(repoRoot, "apps/cli/src/steps/RepoStep.tsx"),
+    "utf8",
+  );
+
+  function sourceFiles(directory: string): string[] {
+    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") return [];
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) return sourceFiles(path);
+      return /\.[cm]?[jt]sx?$/.test(entry.name) ? [path] : [];
+    });
+  }
+
+  it("keeps raw GitHub App URLs inside the two server-owned redirect boundaries", () => {
+    const rawInstallUrl = "https://github.com/apps/";
+    const allowed = new Set([
+      "apps/web/app/api/github/install/route.ts",
+      "apps/web/app/api/github/app-manifest/callback/route.ts",
+    ]);
+    const sourceRoots = [
+      join(repoRoot, "apps/web/app"),
+      join(repoRoot, "apps/web/components"),
+      join(repoRoot, "apps/cli/src"),
+    ];
+
+    const violations = sourceRoots
+      .flatMap(sourceFiles)
+      .map((file) => ({
+        file: relative(repoRoot, file).replaceAll("\\", "/"),
+        source: readFileSync(file, "utf8"),
+      }))
+      .filter(({ file, source }) => source.includes(rawInstallUrl) && !allowed.has(file))
+      .map(({ file }) => file);
+
+    expect(violations).toEqual([]);
+    for (const file of allowed) {
+      expect(readFileSync(join(repoRoot, file), "utf8")).toContain(rawInstallUrl);
+    }
+  });
+
+  it("routes web and CLI recovery links through the signed install-start endpoint", () => {
+    expect(repoTableSource).toContain(
+      'href="/api/github/install?returnTo=/dashboard"',
+    );
+    expect(indexingLogsSource).toContain(
+      "href={`/api/github/install?returnTo=${encodeURIComponent(`/repositories?repo=${repoId}`)}`}",
+    );
+    expect(cliRepoStepSource).toContain(
+      "`${creds.baseUrl}/api/github/install?returnTo=${encodeURIComponent(\"/repositories\")}`",
+    );
+  });
+
+  it("resumes an unauthenticated install-start request after login", async () => {
+    currentSession = null;
+
+    const response = await GET_INSTALL(
+      installRequest({ returnTo: "/repositories" }),
+    );
+    const location = new URL(response.headers.get("location")!);
+
+    expect(location.pathname).toBe("/login");
+    expect(location.searchParams.get("callbackUrl")).toBe(
+      "/api/github/install?returnTo=%2Frepositories",
+    );
   });
 });


### PR DESCRIPTION
## Intent

Continue the security-report remediation after PR #723 by fixing ENG-03. Route every web and hosted-CLI GitHub App installation entry point through the server-owned signed /api/github/install start so raw UI links cannot bypass browser/user/state binding. Preserve dashboard and repository return paths, make unauthenticated starts resume after login, retain the self-hosted CLI skip, update the GitHub App documentation, and add a repository-wide UI/CLI invariant plus focused regression coverage. Keep this an XS, low-break-risk change with no schema or dependency changes.

## What Changed

- Replaced raw `https://github.com/apps/...` install links across the web UI (repo table, indexing logs, dashboard, GitHub App docs) and the hosted-CLI repo wizard with the server-owned signed `/api/github/install` start endpoint, preserving organization context and dashboard/repository return paths, resuming unauthenticated starts after login, and retaining the self-hosted CLI skip.
- Install starts on instances without a configured GitHub App now redirect to `/settings/integrations?error=github_app_not_configured`, where the integrations page shows a proper error dialog instead of surfacing raw JSON from the API route.
- Extended `github-install-security.test.ts` with a repository-wide invariant that raw install URLs appear only in the server-owned redirect routes, plus regression coverage for the entry-point hrefs, unconfigured-app redirect, and login-resume flow (15 tests passing); added a security changelog entry.

## Risk Assessment

✅ Low: The final review-fix commit is a minimal three-spot addition of the new error code to the existing allowlist and dialog maps, resolving the last open finding, and the overall branch remains a well-bounded, test-covered XS change with no schema or dependency changes.

## Testing

Exercised the change with the new focused regression tests plus 799 web and 108 CLI unit tests (all pass), drove the real install and callback route handlers end-to-end to capture an HTTP transcript proving signed-state binding, return-path preservation, login resume, unconfigured-app redirect, and forged-callback rejection, captured a repo-wide scan showing raw GitHub install URLs survive only in the two server-owned routes, and screenshotted the real UI surfaces (dashboard Grant Access, indexing-logs link, integrations card and its new error dialog) rendered in Chrome with live hrefs pointing at /api/github/install.

<details>
<summary>Evidence: HTTP transcript: signed install flow end-to-end (4 scenarios through the real route handlers)</summary>

```text
bun test v1.3.13 (bf2e2cec)

lib/__tests__/__evidence-install-transcript.test.ts:

=== Scenario A: signed-in user clicks the dashboard 'Grant Access' link ===
(link href in UI: /api/github/install?orgId=org_victim&returnTo=%2Fdashboard)

[1] install start (session: user_cem)
  > GET /api/github/install?orgId=org_victim&returnTo=%2Fdashboard
  < 307 redirect
  < location: https://github.com/apps/octopus-review/installations/new?state=eyJ1aWQiOiJ1c2VyX2NlbSIsIm9pZCI6Im9yZ192aWN0aW0iLCJydCI6Ii9kYXNoYm9hcmQiLCJub25jZSI6Iml6MkU3NEN1YUpNVlh0bWVzUjk3X3ciLCJleHAiOjE3ODU4NjU3MjM3MzYsImp0aSI6IkpMMFJRR1FmeU0tMDdUbThpU3FzMXcifQ.W4pD1ux4XgHNiv_MqQeHqlBrvmzICfkVDF4zIKFNAYU
  < set-cookie: gh_install_state=iz2E74CuaJMVXtmesR97_w; Path=/api/github/callback; Expires=Tue, 04 Aug 2026 17:48:43 GMT; Max-Age=600; Secure; HttpOnly; SameSite=lax
  signed state payload: {"uid":"user_cem","oid":"org_victim","rt":"/dashboard","nonce":"iz2E74CuaJMVXtmesR97_w","exp":1785865723736,"jti":"JL0RQGQfyM-07Tm8iSqs1w"}

[2] GitHub → callback (same browser: nonce cookie present)
  > GET /api/github/callback?state=eyJ1aWQiOiJ1c2VyX2NlbSIsIm9pZCI6Im9yZ192aWN0aW0iLCJydCI6Ii9kYXNoYm9hcmQiLCJub25jZSI6Iml6MkU3NEN1YUpNVlh0bWVzUjk3X3ciLCJleHAiOjE3ODU4NjU3MjM3MzYsImp0aSI6IkpMMFJRR1FmeU0tMDdUbThpU3FzMXcifQ.W4pD1ux4XgHNiv_MqQeHqlBrvmzICfkVDF4zIKFNAYU&installation_id=424242
  < 307 redirect
  < location: https://github.com/login/oauth/authorize?client_id=github-app-client-id&redirect_uri=https%3A%2F%2Fapp.test%2Fapi%2Fgithub%2Fcallback&state=eyJ1aWQiOiJ1c2VyX2NlbSIsIm9pZCI6Im9yZ192aWN0aW0iLCJydCI6Ii9kYXNoYm9hcmQiLCJub25jZSI6InhBZVhSVDZVRW5OWXl4NDFpNUNvdEEiLCJpbnN0YWxsYXRpb25JZCI6NDI0MjQyLCJwaGFzZSI6InZlcmlmeV9pbnN0YWxsYXRpb24iLCJleHAiOjE3ODU4NjU3MjM3MzgsImp0aSI6IlJMRzh4R1BJd1hndHhMamc1bHNVMlEifQ.7ZFLh7SeIZTFk52MekcYCd1ZP_ty4l8vN1kN-xdCg9g
  < set-cookie: gh_install_state=xAeXRT6UEnNYyx41i5CotA; Path=/api/github/callback; Expires=Tue, 04 Aug 2026 17:48:43 GMT; Max-Age=600; Secure; HttpOnly; SameSite=lax
  verification state payload: {"uid":"user_cem","oid":"org_victim","rt":"/dashboard","nonce":"xAeXRT6UEnNYyx41i5CotA","installationId":424242,"phase":"verify_installation","exp":1785865723738,"jti":"RLG8xGPIwXgtxLjg5lsU2Q"}

[3] GitHub OAuth → callback (user verified as installation owner)
  > GET /api/github/callback?state=eyJ1aWQiOiJ1c2VyX2NlbSIsIm9pZCI6Im9yZ192aWN0aW0iLCJydCI6Ii9kYXNoYm9hcmQiLCJub25jZSI6InhBZVhSVDZVRW5OWXl4NDFpNUNvdEEiLCJpbnN0YWxsYXRpb25JZCI6NDI0MjQyLCJwaGFzZSI6InZlcmlmeV9pbnN0YWxsYXRpb24iLCJleHAiOjE3ODU4NjU3MjM3MzgsImp0aSI6IlJMRzh4R1BJd1hndHhMamc1bHNVMlEifQ.7ZFLh7SeIZTFk52MekcYCd1ZP_ty4l8vN1kN-xdCg9g&code=one-time-code
  < 307 redirect
  < location: https://app.test/dashboard
  < set-cookie: gh_install_state=; Path=/api/github/callback; Expires=Thu, 01 Jan 1970 00:00:00 GMT
  RESULT: org_victim bound to installation 424242; user returned to the dashboard they started from.

=== Scenario B: hosted-CLI wizard opens the install link in a browser with no session ===
(CLI opens: <baseUrl>/api/github/install?orgId=org_victim&returnTo=%2Frepositories)

[1] install start (no session)
  > GET /api/github/install?orgId=org_victim&returnTo=%2Frepositories
  < 307 redirect
  < location: https://app.test/login?callbackUrl=%2Fapi%2Fgithub%2Finstall%3ForgId%3Dorg_victim%26returnTo%3D%252Frepositories
  login resume target: /api/github/install?orgId=org_victim&returnTo=%2Frepositories

[2] resumed install start (after login)
  > GET /api/github/install?orgId=org_victim&returnTo=%2Frepositories
  < 307 redirect
  < location: https://github.com/apps/octopus-review/installations/new?state=eyJ1aWQiOiJ1c2VyX2NlbSIsIm9pZCI6Im9yZ192aWN0aW0iLCJydCI6Ii9yZXBvc2l0b3JpZXMiLCJub25jZSI6IktGSk5LeWhGYmxNVFZNczNXeGxqZXciLCJleHAiOjE3ODU4NjU3MjM3NDAsImp0aSI6ImE1OFJiZ21EY1FjbGRNU044ZW1zZUEifQ.6gb05wtfEPgOKKsfqUR1lLH_W0QoP4Xenuas92HCjUc
  < set-cookie: gh_install_state=KFJNKyhFblMTVMs3Wxljew; Path=/api/github/callback; Expires=Tue, 04 Aug 2026 17:48:43 GMT; Max-Age=600; Secure; HttpOnly; SameSite=lax
  signed state payload: {"uid":"user_cem","oid":"org_victim","rt":"/repositories","nonce":"KFJNKyhFblMTVMs3Wxljew","exp":1785865723740,"jti":"a58RbgmDcQcldMSN8emseA"}
  RESULT: unauthenticated start resumed after login and reached GitHub with user/org/returnTo bound in signed state.

=== Scenario C: install start clicked before any GitHub App is configured ===

[1] install start (no GitHub App configured)
  > GET /api/github/install?orgId=org_victim&returnTo=%2Frepositories
  < 307 redirect
  < location: https://app.test/settings/integrations?error=github_app_not_configured
  RESULT: user lands on /settings/integrations where the 'GitHub App not configured' dialog explains the fix.

=== Scenario D: attacker-crafted raw install (no signed state) ===

[1] callback without signed state
  > GET /api/github/callback?installation_id=424242
  < 307 redirect
  < location: https://app.test/login?callbackUrl=%2Fapi%2Fgithub%2Finstall%3FreturnTo%3D%252Fsettings%252Fintegrations
  RESULT: installation NOT bound (bound=null); user is bounced through login into the signed start.

 4 pass
 0 fail
Ran 4 tests across 1 file. [114.00ms]
```
</details>
<details>
<summary>Evidence: Repo-wide raw install-URL invariant scan (raw URLs only in the two server routes; all UI/CLI surfaces use /api/github/install)</summary>

```text
$ grep -rn "https://github.com/apps/" apps/web apps/cli/src --include="*.ts" --include="*.tsx" (excluding tests)
apps/web/app/api/github/install/route.ts:59:  const installUrl = new URL(`https://github.com/apps/${appSlug}/installations/new`);
apps/web/app/api/github/app-manifest/callback/route.ts:149:  const installUrl = new URL(`https://github.com/apps/${conv.slug}/installations/new`);

# Only the two server-owned redirect boundaries construct raw GitHub App install URLs.
# Every UI/CLI surface now links to /api/github/install instead:

$ grep -rn "/api/github/install?" apps/web/components apps/web/app apps/cli/src | grep -v __tests__
apps/web/components/permission-banner.tsx:26:          href="/api/github/install?returnTo=/dashboard"
apps/web/components/indexing-logs.tsx:248:              href={`/api/github/install?orgId=${encodeURIComponent(orgId)}&returnTo=${encodeURIComponent(`/repositories?repo=${repoId}`)}`}
apps/web/components/dashboard/repo-table.tsx:200:              href={`/api/github/install?orgId=${encodeURIComponent(orgId)}&returnTo=${encodeURIComponent("/dashboard")}`}
apps/web/components/dashboard/providers-banner.tsx:66:  const githubInstallUrl = githubAppSlug ? "/api/github/install?returnTo=/dashboard" : null;
apps/web/app/(app)/settings/integrations/github-integration-card.tsx:129:const INSTALL_URL = "/api/github/install?returnTo=/settings/integrations";
apps/web/app/(app)/repositories/repositories-content.tsx:2065:                <a href="/api/github/install?returnTo=/repositories">
apps/cli/src/steps/RepoStep.tsx:78:        `${creds.baseUrl}/api/github/install?orgId=${encodeURIComponent(creds.orgId)}&returnTo=${encodeURIComponent("/repositories")}`,
```
</details>
- Evidence: Screenshot: real RepoTable / IndexingLogs / integrations-card components with Grant Access + Install links and their live /api/github/install hrefs (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZ6WV6YY575Q6QGXHP342P56/ui-install-entrypoints.png</code>)
- Evidence: Screenshot: new &#39;GitHub App not configured&#39; error dialog on Settings → Integrations after redirect from /api/github/install (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZ6WV6YY575Q6QGXHP342P56/ui-github-app-not-configured-dialog.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `apps/web/components/indexing-logs.tsx:245` - Removing the app-slug gate (previously `needsAccess &amp;&amp; githubAppSlug` / `NEXT_PUBLIC_GITHUB_APP_SLUG`) means instances without a configured GitHub App now render the &#39;Grant Access on GitHub&#39; recovery link; clicking it opens a new tab with the raw JSON 500 {&#34;error&#34;:&#34;github_app_not_configured&#34;} from /api/github/install. Same applies to repo-table.tsx:192. The new test &#39;does not hide signed recovery links behind a public app-slug gate&#39; locks this in as deliberate, so confirming intent: either accept the degraded UX or make the install route redirect unconfigured instances to /settings/integrations instead of returning JSON.
- ℹ️ `apps/web/lib/__tests__/github-install-security.test.ts:358` - The &#39;routes web and CLI recovery links through the signed install-start endpoint&#39; test asserts exact source substrings (full href template literals including quoting style), so any behavior-preserving reformat (prettier wrap, quote change, extracting the URL to a constant) fails the test. The grep-style invariant test above it already enforces the real boundary; consider loosening these to match on `/api/github/install?` per file instead.
- ℹ️ `apps/cli/src/steps/RepoStep.tsx:77` - CLI install flow: if the user&#39;s browser session belongs to an account that is not a member of creds.orgId, /api/github/install silently redirects to /dashboard with no explanation of why the install did not start. Pre-existing route behavior from PR #723, newly reachable from the CLI wizard; a follow-up could surface an error message on that redirect.

🔧 Fix: redirect unconfigured install starts to integrations settings
1 warning still open:
- ⚠️ `apps/web/app/api/github/install/route.ts:19` - The new unconfigured-instance redirect emits `?error=github_app_not_configured`, but the integrations page validates the error param against ALLOWED_GITHUB_ERRORS (apps/web/app/(app)/settings/integrations/page.tsx:16), which does not include that code — so the param is silently dropped and no error dialog is shown. The landing page itself still communicates the unconfigured state, so impact is minor; to complete the fix, add `github_app_not_configured` to the allowlist and to ERROR_TITLES/ERROR_MESSAGES in github-integration-card.tsx (new user-facing copy), or stop emitting the param.

🔧 Fix: surface github_app_not_configured error on integrations page
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun test lib/__tests__/github-install-security.test.ts` (apps/web) — 15 pass, including the new repo-wide raw-install-URL invariant, entry-point href checks, unconfigured-app redirect, and login-resume tests</code>
- <code>`bun test lib/__tests__/github-install-security.test.ts lib/__tests__/github-app-config.test.ts lib/__tests__/github-manifest.test.ts lib/__tests__/integration-oauth-state.test.ts` — 32 pass (related GitHub flow regression set)</code>
- <code>`bun test` in apps/cli — 108 pass (RepoStep.tsx changed in this diff)</code>
- <code>`bun test` over all 71 non-DB apps/web unit test files — 799 pass</code>
- `Temporary bun-test harness driving the real GET handlers of /api/github/install and /api/github/callback end-to-end: signed start → GitHub redirect with signed state + nonce cookie → callback → OAuth verify → installation bound and user returned to /dashboard; unauthenticated start → /login?callbackUrl resume → proceeds after login; unconfigured app → /settings/integrations?error=github_app_not_configured; forged state-less callback → no binding (transcript captured as evidence)`
- <code>Repo-wide scan: `grep -rn &#34;https://github.com/apps/&#34; apps/web apps/cli/src` shows raw install URLs only in the two server-owned redirect routes, and `grep -rn &#34;/api/github/install?&#34;` shows all 7 UI/CLI entry points using the signed start (captured as evidence)</code>
- `Browser-rendered visual verification: mounted the real RepoTable, IndexingLogs, and GitHubIntegrationCard components with the app's actual globals.css in Chrome and screenshotted the Grant Access button/link hrefs pointing at /api/github/install and the new 'GitHub App not configured' error dialog`
- `Verified the self-hosted CLI skip is retained in apps/cli/src/steps/RepoStep.tsx and that the diff contains no package.json or Prisma schema changes; worktree left clean after removing all temporary harness files`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `apps/web/scripts/review-eval-harness.ts:75` - apps/web `tsc --noEmit` fails in this worktree, but only from environmental/pre-existing causes: the generated Prisma client is absent (db:generate requires DATABASE_URL, not available here) and scripts/review-eval-harness.ts:75 has a pre-existing implicit-any that is byte-identical at the base commit. Nothing introduced by this change; ESLint on all changed files and the apps/cli typecheck are clean.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
