### PR TITLE
fix(webhooks): enforce tenant-owned webhook routing for GitHub and GitLab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
-- Webhook tenant isolation is now enforced (previously shadow-mode observation only). GitHub repository events route solely through the signed installation ID and the organization-scoped repository lookup, and events whose repository does not belong to that installation's organization are dropped. GitLab webhooks authenticate the per-organization hook token before the request body is read and fail closed on unknown, ambiguous, inactive, or dismissed project mappings. GitHub delivery IDs and retry telemetry remain observation-only and never influence routing. No schema change.
+- Webhook tenant isolation is now enforced (previously shadow-mode observation only). GitHub repository events route solely through the signed installation ID and the organization-scoped repository lookup, and events whose repository does not belong to that installation's organization are dropped. GitLab webhooks authenticate the per-organization hook token before the request body is read and fail closed on unknown, ambiguous, inactive, or dismissed project mappings. GitHub delivery IDs and retry telemetry remain observation-only and never influence routing. No schema behavior change beyond a new index on the GitLab webhook token lookup.
 
 ## [1.0.95] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Webhook tenant isolation is now enforced (previously shadow-mode observation only). GitHub repository events route solely through the signed installation ID and the organization-scoped repository lookup, and events whose repository does not belong to that installation's organization are dropped. GitLab webhooks authenticate the per-organization hook token before the request body is read and fail closed on unknown, ambiguous, inactive, or dismissed project mappings. GitHub delivery IDs and retry telemetry remain observation-only and never influence routing. No schema change.
+
 ## [1.0.95] - 2026-08-04
 
 ### Security

--- a/apps/web/app/(landing)/docs/security-overview/page.tsx
+++ b/apps/web/app/(landing)/docs/security-overview/page.tsx
@@ -28,7 +28,7 @@ export default function SecurityOverviewPage() {
           customer&apos;s own infrastructure (self-hosted Octopus).
         </P>
         <UL>
-          <li><strong>Webhook</strong> — GitHub, GitLab, or Bitbucket POSTs a PR/MR event; we verify the HMAC signature before processing.</li>
+          <li><strong>Webhook</strong> — GitHub, GitLab, or Bitbucket POSTs a PR/MR event; we verify GitHub and Bitbucket HMAC signatures or GitLab&apos;s per-organisation hook token before processing.</li>
           <li><strong>Clone</strong> — we clone the repository into a per-job temporary directory; never persisted beyond the job.</li>
           <li><strong>Index</strong> — file contents are chunked and embedded into Qdrant for vector search. Source files are not stored as plaintext outside the indexing window.</li>
           <li><strong>Review</strong> — relevant chunks plus the diff are sent to the configured LLM provider. Provider choice and BYOK key live on the organisation.</li>

--- a/apps/web/app/(landing)/docs/security-overview/page.tsx
+++ b/apps/web/app/(landing)/docs/security-overview/page.tsx
@@ -75,7 +75,7 @@ export default function SecurityOverviewPage() {
           <li><strong>Session management</strong> — short-lived bearer tokens with refresh; sessions revocable from <code>/settings/sessions</code>.</li>
           <li><strong>Role-based access</strong> — per-organisation roles (owner / admin / member); the audit log records role transitions.</li>
           <li><strong>CLI tokens</strong> — issued via the device-code flow, scoped to one organisation, revocable per-token.</li>
-          <li><strong>Webhook secrets</strong> — set per-organisation; HMAC verification on every inbound payload.</li>
+          <li><strong>Webhook secrets</strong> — set per-organisation; every inbound payload is verified via HMAC signature (GitHub, Bitbucket) or constant-time hook-token comparison (GitLab).</li>
         </UL>
       </Section>
 

--- a/apps/web/app/(landing)/docs/security-overview/page.tsx
+++ b/apps/web/app/(landing)/docs/security-overview/page.tsx
@@ -75,7 +75,7 @@ export default function SecurityOverviewPage() {
           <li><strong>Session management</strong> — short-lived bearer tokens with refresh; sessions revocable from <code>/settings/sessions</code>.</li>
           <li><strong>Role-based access</strong> — per-organisation roles (owner / admin / member); the audit log records role transitions.</li>
           <li><strong>CLI tokens</strong> — issued via the device-code flow, scoped to one organisation, revocable per-token.</li>
-          <li><strong>Webhook secrets</strong> — set per-organisation; every inbound payload is verified via HMAC signature (GitHub, Bitbucket) or constant-time hook-token comparison (GitLab).</li>
+          <li><strong>Webhook secrets</strong> — set per-organisation; every inbound payload is verified via HMAC signature (GitHub, Bitbucket) or per-organisation hook-token comparison (GitLab).</li>
         </UL>
       </Section>
 

--- a/apps/web/app/api/github/webhook/route.ts
+++ b/apps/web/app/api/github/webhook/route.ts
@@ -15,10 +15,26 @@ import {
 import { startReviewFlow } from "@/lib/webhook-shared";
 import { getGithubAppConfig } from "@/lib/github-app-config";
 import {
-  observeGithubWebhookDeliveryInShadowMode,
-  type LegacyWebhookRepository,
+  observeGithubWebhookDeliveryBestEffort,
+  resolveGithubWebhookTenant,
   type GithubWebhookTenantResolution,
 } from "@/lib/webhook-tenant";
+
+type ResolvedGithubWebhookTenant = GithubWebhookTenantResolution & {
+  status: "resolved";
+  organizationId: string;
+  repositoryId: string;
+};
+
+function isResolvedRepositoryTenant(
+  resolution: GithubWebhookTenantResolution,
+): resolution is ResolvedGithubWebhookTenant {
+  return (
+    resolution.status === "resolved" &&
+    resolution.organizationId !== null &&
+    resolution.repositoryId !== null
+  );
+}
 
 async function verifySignature(payload: string, signature: string | null): Promise<boolean> {
   if (!signature) return false;
@@ -48,25 +64,38 @@ export async function POST(request: NextRequest) {
   const deliveryId = request.headers.get("x-github-delivery");
   const payloadSha256 = crypto.createHash("sha256").update(body).digest("hex");
   const payload = JSON.parse(body);
-  let legacyRepository: LegacyWebhookRepository | null | undefined;
-  let tenantResolution: GithubWebhookTenantResolution | undefined;
+  const tenantResolution = await resolveGithubWebhookTenant({
+    provider: "github",
+    installationId: payload.installation?.id,
+    repositoryExternalId: payload.repository?.id,
+  });
+  const resolvedRepositoryTenant = isResolvedRepositoryTenant(tenantResolution)
+    ? tenantResolution
+    : null;
 
-  // SEC-06 shadow mode: observe only signature-verified delivery metadata and
-  // compare the installation-scoped result with the route's existing lookup.
-  // The callback runs after the response and never changes routing or rejects a
-  // duplicate; enforcement follows only after production mismatches are understood.
+  // Record only after signature verification. Telemetry remains best-effort:
+  // retries and GitHub's unsigned delivery ID never influence routing.
   after(async () => {
-    await observeGithubWebhookDeliveryInShadowMode({
+    await observeGithubWebhookDeliveryBestEffort({
       deliveryId,
       eventType: event,
       action: payload.action,
       payloadSha256,
       installationId: payload.installation?.id,
       repositoryExternalId: payload.repository?.id,
-      legacyRepository,
       tenantResolution,
     });
   });
+
+  // A signature proves the GitHub App emitted the body; the installation ID
+  // inside that signed body selects the tenant. Never route a repository event
+  // through a provider/external-ID lookup that omits the selected organization.
+  if (payload.repository?.id !== undefined && !resolvedRepositoryTenant) {
+    console.warn(
+      `[webhook] Dropping GitHub repository event: ${tenantResolution.status}`,
+    );
+    return NextResponse.json({ ok: true });
+  }
 
   if (event === "installation" || event === "installation_repositories") {
     const installationId = payload.installation?.id as number | undefined;
@@ -74,23 +103,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true });
     }
 
-    // Find the org linked to this installation
-    const org = await prisma.organization.findUnique({
-      where: { githubInstallationId: installationId },
-      select: { id: true },
-    });
-
-    if (!org) {
+    if (!tenantResolution.organizationId) {
       return NextResponse.json({ ok: true });
     }
-
-    // Snapshot before an `installation.deleted` event clears the binding below.
-    tenantResolution = {
-      provider: "github",
-      status: "installation_only",
-      organizationId: org.id,
-      repositoryId: null,
-    };
+    const org = { id: tenantResolution.organizationId };
 
     // Sync repos from GitHub
     try {
@@ -233,6 +249,9 @@ export async function POST(request: NextRequest) {
     if (!installationId) {
       return NextResponse.json({ ok: true });
     }
+    if (!resolvedRepositoryTenant) {
+      return NextResponse.json({ ok: true });
+    }
 
     const repoFullName: string = payload.repository?.full_name ?? "";
     const repoExternalId = String(payload.repository?.id ?? "");
@@ -247,15 +266,12 @@ export async function POST(request: NextRequest) {
     console.log(`[webhook] pull_request ${payload.action} — ${repoFullName}#${prNumber}`);
 
     // Find repository in DB and check autoReview
-    const repo = await prisma.repository.findFirst({
-      where: { provider: "github", externalId: repoExternalId },
+    const repo = await prisma.repository.findUnique({
+      where: { id: resolvedRepositoryTenant.repositoryId },
       select: { id: true, organizationId: true, autoReview: true, installationId: true },
     });
-    legacyRepository = repo
-      ? { id: repo.id, organizationId: repo.organizationId }
-      : null;
 
-    if (!repo) {
+    if (!repo || repo.organizationId !== resolvedRepositoryTenant.organizationId) {
       console.warn(`[webhook] Repo not found in DB — externalId: ${repoExternalId}`);
       return NextResponse.json({ ok: true });
     }
@@ -349,19 +365,19 @@ export async function POST(request: NextRequest) {
     payload.action === "closed" &&
     payload.pull_request?.merged === true
   ) {
-    const repoExternalId = String(payload.repository?.id ?? "");
     const prNumber: number = payload.pull_request?.number;
     const installationId = payload.installation?.id as number | undefined;
 
-    const repo = await prisma.repository.findFirst({
-      where: { provider: "github", externalId: repoExternalId },
+    if (!resolvedRepositoryTenant) {
+      return NextResponse.json({ ok: true });
+    }
+
+    const repo = await prisma.repository.findUnique({
+      where: { id: resolvedRepositoryTenant.repositoryId },
       select: { id: true, fullName: true, defaultBranch: true, indexStatus: true, organizationId: true },
     });
-    legacyRepository = repo
-      ? { id: repo.id, organizationId: repo.organizationId }
-      : null;
 
-    if (repo) {
+    if (repo && repo.organizationId === resolvedRepositoryTenant.organizationId) {
       await prisma.pullRequest.updateMany({
         where: { repositoryId: repo.id, number: prNumber },
         data: { mergedAt: new Date() },
@@ -461,6 +477,9 @@ export async function POST(request: NextRequest) {
         console.warn("[webhook] No installationId found, skipping");
         return NextResponse.json({ ok: true });
       }
+      if (!resolvedRepositoryTenant) {
+        return NextResponse.json({ ok: true });
+      }
 
       const repoFullName: string = payload.repository?.full_name ?? "";
       const repoExternalId = String(payload.repository?.id ?? "");
@@ -470,15 +489,12 @@ export async function POST(request: NextRequest) {
       console.log(`[webhook] @octopus mention detected — repo: ${repoFullName}, PR #${prNumber}, commentId: ${commentId}, installationId: ${installationId}`);
 
       // Find repository in DB
-      const repo = await prisma.repository.findFirst({
-        where: { provider: "github", externalId: repoExternalId },
+      const repo = await prisma.repository.findUnique({
+        where: { id: resolvedRepositoryTenant.repositoryId },
         select: { id: true, organizationId: true, installationId: true },
       });
-      legacyRepository = repo
-        ? { id: repo.id, organizationId: repo.organizationId }
-        : null;
 
-      if (!repo) {
+      if (!repo || repo.organizationId !== resolvedRepositoryTenant.organizationId) {
         console.warn(`[webhook] Repo not found in DB — externalId: ${repoExternalId}, fullName: ${repoFullName}`);
         return NextResponse.json({ ok: true });
       }

--- a/apps/web/app/api/gitlab/webhook/route.ts
+++ b/apps/web/app/api/gitlab/webhook/route.ts
@@ -1,17 +1,36 @@
-import crypto from "node:crypto";
+import "server-only";
+
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@octopus/db";
 import { getPullRequestDetails } from "@/lib/gitlab";
 import { startReviewFlow } from "@/lib/webhook-shared";
+import {
+  resolveGitlabWebhookIntegration,
+  resolveGitlabWebhookTenant,
+} from "@/lib/webhook-tenant";
 
 export async function POST(request: NextRequest) {
-  const body = await request.text();
   const event = request.headers.get("x-gitlab-event");
   const tokenHeader = request.headers.get("x-gitlab-token");
 
   if (!event) {
     return NextResponse.json({ error: "Missing event header" }, { status: 400 });
   }
+
+  // Authenticate the tenant boundary before buffering or parsing an
+  // attacker-controlled request body.
+  const integrationResolution = await resolveGitlabWebhookIntegration({
+    provider: "gitlab",
+    token: tokenHeader,
+  });
+  if (
+    integrationResolution.status !== "resolved" ||
+    !integrationResolution.organizationId
+  ) {
+    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
+  }
+
+  const body = await request.text();
 
   let payload: Record<string, unknown>;
   try {
@@ -26,35 +45,27 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Missing project id" }, { status: 400 });
   }
 
-  // Look up repository by external id, then the integration via its org
-  const repo = await prisma.repository.findFirst({
-    where: { provider: "gitlab", externalId: String(projectId) },
-    select: { id: true, organizationId: true, autoReview: true, fullName: true },
+  // The per-organization hook secret selects the tenant before the project ID
+  // is resolved through the provider/external-ID/organization compound key.
+  const tenantResolution = await resolveGitlabWebhookTenant({
+    provider: "gitlab",
+    organizationId: integrationResolution.organizationId,
+    repositoryExternalId: projectId,
   });
-
-  if (!repo) {
-    console.warn(`[gitlab-webhook] No repo found for project ${projectId}`);
+  if (
+    tenantResolution.status !== "resolved" ||
+    !tenantResolution.organizationId ||
+    !tenantResolution.repository
+  ) {
+    console.warn(
+      `[gitlab-webhook] Dropping project ${projectId}: ${tenantResolution.status}`,
+    );
     return NextResponse.json({ ok: true });
   }
 
-  const integration = await prisma.gitlabIntegration.findUnique({
-    where: { organizationId: repo.organizationId },
-    select: { webhookSecret: true },
-  });
+  const repo = tenantResolution.repository;
 
-  if (!integration?.webhookSecret) {
-    console.error(`[gitlab-webhook] No webhook secret for org ${repo.organizationId}`);
-    return NextResponse.json({ error: "Webhook secret not configured" }, { status: 500 });
-  }
-
-  // GitLab uses a shared-secret token, not an HMAC signature.
-  const expected = Buffer.from(integration.webhookSecret, "utf8");
-  const actual = Buffer.from(tokenHeader ?? "", "utf8");
-  if (expected.length !== actual.length || !crypto.timingSafeEqual(expected, actual)) {
-    return NextResponse.json({ error: "Invalid token" }, { status: 401 });
-  }
-
-  const orgId = repo.organizationId;
+  const orgId = tenantResolution.organizationId;
   const repoFullName = repo.fullName;
 
   // ── Merge Request open/update → auto-review ──
@@ -62,54 +73,45 @@ export async function POST(request: NextRequest) {
     const objectAttrs = payload.object_attributes as Record<string, unknown> | undefined;
     const action = objectAttrs?.action as string | undefined;
     const state = objectAttrs?.state as string | undefined;
+    const isReviewAction =
+      action === "open" || action === "reopen" || action === "update";
+    const hasNewCommits = action !== "update" || Boolean(objectAttrs?.oldrev);
+    const isOpen = state !== "merged" && state !== "closed";
 
-    // Trigger on open, reopen, or push updates
-    if (!objectAttrs || (action !== "open" && action !== "reopen" && action !== "update")) {
-      return NextResponse.json({ ok: true });
+    if (objectAttrs && isReviewAction && hasNewCommits && isOpen) {
+      const mrIid = objectAttrs.iid as number | undefined;
+      if (!mrIid || typeof mrIid !== "number") {
+        return NextResponse.json({ error: "Missing MR iid" }, { status: 400 });
+      }
+
+      const user = payload.user as Record<string, string> | undefined;
+      const prTitle = (objectAttrs.title as string) ?? `MR !${mrIid}`;
+      const prUrl = (objectAttrs.url as string) ?? "";
+      const prAuthor = user?.name ?? user?.username ?? "unknown";
+      const headSha = (objectAttrs.last_commit as Record<string, string> | undefined)?.id ?? "";
+
+      if (!repo.autoReview) {
+        console.log(`[gitlab-webhook] Auto-review disabled for ${repoFullName}, skipping`);
+        return NextResponse.json({ ok: true });
+      }
+
+      await startReviewFlow({
+        provider: "gitlab",
+        organizationId: orgId,
+        repoFullName,
+        repoId: repo.id,
+        orgId,
+        prNumber: mrIid,
+        prTitle,
+        prUrl,
+        prAuthor,
+        headSha,
+        triggerCommentId: 0,
+        triggerCommentBody: "",
+      });
+
+      console.log(`[gitlab-webhook] Auto-review triggered for ${repoFullName}!${mrIid}`);
     }
-
-    // For "update" events, only re-review when the source branch was pushed (new commits).
-    // GitLab signals this via oldrev being present in object_attributes.
-    if (action === "update" && !objectAttrs.oldrev) {
-      return NextResponse.json({ ok: true });
-    }
-
-    if (state === "merged" || state === "closed") {
-      return NextResponse.json({ ok: true });
-    }
-
-    const mrIid = objectAttrs.iid as number | undefined;
-    if (!mrIid || typeof mrIid !== "number") {
-      return NextResponse.json({ error: "Missing MR iid" }, { status: 400 });
-    }
-
-    const user = payload.user as Record<string, string> | undefined;
-    const prTitle = (objectAttrs.title as string) ?? `MR !${mrIid}`;
-    const prUrl = (objectAttrs.url as string) ?? "";
-    const prAuthor = user?.name ?? user?.username ?? "unknown";
-    const headSha = (objectAttrs.last_commit as Record<string, string> | undefined)?.id ?? "";
-
-    if (!repo.autoReview) {
-      console.log(`[gitlab-webhook] Auto-review disabled for ${repoFullName}, skipping`);
-      return NextResponse.json({ ok: true });
-    }
-
-    await startReviewFlow({
-      provider: "gitlab",
-      organizationId: orgId,
-      repoFullName,
-      repoId: repo.id,
-      orgId,
-      prNumber: mrIid,
-      prTitle,
-      prUrl,
-      prAuthor,
-      headSha,
-      triggerCommentId: 0,
-      triggerCommentBody: "",
-    });
-
-    console.log(`[gitlab-webhook] Auto-review triggered for ${repoFullName}!${mrIid}`);
   }
 
   // ── MR merged → mark as merged ──

--- a/apps/web/app/api/gitlab/webhook/route.ts
+++ b/apps/web/app/api/gitlab/webhook/route.ts
@@ -111,6 +111,7 @@ export async function POST(request: NextRequest) {
       });
 
       console.log(`[gitlab-webhook] Auto-review triggered for ${repoFullName}!${mrIid}`);
+      return NextResponse.json({ ok: true });
     }
   }
 

--- a/apps/web/app/api/gitlab/webhook/route.ts
+++ b/apps/web/app/api/gitlab/webhook/route.ts
@@ -126,8 +126,8 @@ export async function POST(request: NextRequest) {
           where: { repositoryId: repo.id, number: mrIid },
           data: { mergedAt: new Date() },
         }),
-        prisma.repository.update({
-          where: { id: repo.id },
+        prisma.repository.updateMany({
+          where: { id: repo.id, indexStatus: "indexed" },
           data: { indexStatus: "stale" },
         }),
       ]);

--- a/apps/web/lib/__tests__/fixtures/github-webhook-tenant-enforcement-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/github-webhook-tenant-enforcement-harness.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { mock } from "bun:test";
 
-const WEBHOOK_SECRET = "github-webhook-shadow-test-secret";
+const WEBHOOK_SECRET = "github-webhook-enforcement-test-secret";
 
 type AfterCallback = () => void | Promise<void>;
 type DeliveryUpsertArgs = {
@@ -13,11 +13,12 @@ type DeliveryUpsertArgs = {
 };
 
 const afterCallbacks: AfterCallback[] = [];
-const deliveryAttempts = new Map<string, number>();
-const deliveryPayloadHashes = new Map<string, string>();
 const deliveryWrites: DeliveryUpsertArgs[] = [];
 const reviewCalls: Array<Record<string, unknown>> = [];
+const mutationCalls: Array<{ kind: string; args: Record<string, unknown> }> = [];
 let failNextLedgerWrite = false;
+let installationBindingCleared = false;
+let legacyRepositoryLookups = 0;
 
 const webhookDeliveryStore = {
   upsert: (args: DeliveryUpsertArgs) => {
@@ -26,13 +27,10 @@ const webhookDeliveryStore = {
       return Promise.reject(new Error("ledger unavailable"));
     }
     deliveryWrites.push(args);
-    const key = `${args.where.provider_deliveryId.provider}:${args.where.provider_deliveryId.deliveryId}`;
-    const attemptCount = (deliveryAttempts.get(key) ?? 0) + 1;
-    deliveryAttempts.set(key, attemptCount);
-    const payloadSha256 = deliveryPayloadHashes.get(key) ??
-      String(args.create.payloadSha256);
-    deliveryPayloadHashes.set(key, payloadSha256);
-    return Promise.resolve({ attemptCount, payloadSha256 });
+    return Promise.resolve({
+      attemptCount: 1,
+      payloadSha256: String(args.create.payloadSha256),
+    });
   },
   update: () => Promise.resolve({ payloadHashCollisionCount: 1 }),
 };
@@ -71,29 +69,68 @@ mock.module("@octopus/db", () => ({
         where: { githubInstallationId?: number; id?: string };
       }) => {
         if (args.where.githubInstallationId === 222) {
+          if (installationBindingCleared) return Promise.resolve(null);
           return Promise.resolve({ id: "org_b" });
         }
-        if (args.where.id === "org_a") {
+        if (args.where.id === "org_b") {
           return Promise.resolve({ blockedAuthors: [] });
         }
         return Promise.resolve(null);
       },
-      updateMany: () => Promise.resolve({ count: 1 }),
+      updateMany: () => {
+        installationBindingCleared = true;
+        return Promise.resolve({ count: 1 });
+      },
     },
     repository: {
-      findFirst: () =>
-        Promise.resolve({
+      findFirst: () => {
+        legacyRepositoryLookups += 1;
+        return Promise.resolve({
           id: "repo_a",
           organizationId: "org_a",
           autoReview: true,
           installationId: 222,
-        }),
-      findUnique: () =>
-        Promise.resolve({ id: "repo_b", organizationId: "org_b" }),
+        });
+      },
+      findUnique: (args: {
+        where: {
+          id?: string;
+          provider_externalId_organizationId?: {
+            provider: string;
+            externalId: string;
+            organizationId: string;
+          };
+        };
+      }) => {
+        if (args.where.provider_externalId_organizationId) {
+          return Promise.resolve({ id: "repo_b", organizationId: "org_b" });
+        }
+        if (args.where.id === "repo_b") {
+          return Promise.resolve({
+            id: "repo_b",
+            organizationId: "org_b",
+            autoReview: true,
+            installationId: 222,
+            fullName: "shared/repository",
+            defaultBranch: "main",
+            indexStatus: "pending",
+          });
+        }
+        return Promise.resolve(null);
+      },
       findMany: () => Promise.resolve([]),
       count: () => Promise.resolve(2),
-      update: () => Promise.resolve({}),
+      update: (args: Record<string, unknown>) => {
+        mutationCalls.push({ kind: "repository.update", args });
+        return Promise.resolve({});
+      },
       upsert: () => Promise.resolve({}),
+    },
+    pullRequest: {
+      updateMany: (args: Record<string, unknown>) => {
+        mutationCalls.push({ kind: "pullRequest.updateMany", args });
+        return Promise.resolve({ count: 1 });
+      },
     },
     systemConfig: {
       findUnique: () => Promise.resolve({ blockedAuthors: [] }),
@@ -121,6 +158,38 @@ function pullRequestBody() {
       user: { login: "contributor" },
       head: { sha: "abc123" },
       draft: false,
+    },
+  });
+}
+
+function mergedPullRequestBody() {
+  return JSON.stringify({
+    action: "closed",
+    installation: { id: 222 },
+    repository: { id: 9001, full_name: "shared/repository" },
+    pull_request: {
+      number: 18,
+      merged: true,
+    },
+  });
+}
+
+function issueCommentBody() {
+  return JSON.stringify({
+    action: "created",
+    installation: { id: 222 },
+    repository: { id: 9001, full_name: "shared/repository" },
+    issue: {
+      number: 19,
+      title: "Mention review",
+      html_url: "https://github.test/shared/repository/pull/19",
+      user: { login: "contributor" },
+      pull_request: {},
+    },
+    comment: {
+      id: 88,
+      body: "@octopus review this",
+      user: { type: "User", login: "contributor" },
     },
   });
 }
@@ -180,30 +249,67 @@ try {
 
   const collisionResponse = await POST(webhookRequest(pullRequestBody()));
   assert(collisionResponse.status === 200, "valid collision response failed");
-  assert(reviewCalls[0]?.orgId === "org_a", "shadow mode changed legacy routing");
+  assert(reviewCalls[0]?.orgId === "org_b", "signed installation did not select tenant");
+  assert(reviewCalls[0]?.repoId === "repo_b", "compound tenant/repository lookup was not enforced");
   await runAfterCallbacks();
   const collision = deliveryWrites.at(-1)?.create;
   assert(collision?.resolvedOrganizationId === "org_b", "trusted tenant was not recorded");
-  assert(collision?.legacyOrganizationId === "org_a", "legacy tenant was not recorded");
-  assert(collision?.comparisonStatus === "ambiguous", "collision was not marked ambiguous");
+  assert(
+    collision?.legacyOrganizationId === null,
+    "legacy repository unexpectedly remained routing input",
+  );
+  assert(
+    collision?.comparisonStatus === "not_applicable",
+    "post-enforcement telemetry unexpectedly compared legacy routing",
+  );
 
-  const reviewsBeforeReplay = reviewCalls.length;
-  await POST(
-    webhookRequest(pullRequestBody(), { deliveryId: "delivery-replayed" }),
+  const reviewsBeforeUnmapped = reviewCalls.length;
+  const unmappedBody = JSON.stringify({
+    ...JSON.parse(pullRequestBody()),
+    installation: { id: 999 },
+  });
+  const unmappedResponse = await POST(
+    webhookRequest(unmappedBody, { deliveryId: "delivery-unmapped" }),
   );
   await runAfterCallbacks();
-  await POST(
-    webhookRequest(pullRequestBody(), { deliveryId: "delivery-replayed" }),
+  assert(unmappedResponse.status === 200, "unmapped installation response failed");
+  assert(
+    reviewCalls.length === reviewsBeforeUnmapped,
+    "unmapped installation was not dropped",
+  );
+
+  const mergedResponse = await POST(
+    webhookRequest(mergedPullRequestBody(), {
+      deliveryId: "delivery-merged",
+    }),
   );
   await runAfterCallbacks();
+  assert(mergedResponse.status === 200, "merged PR response failed");
   assert(
-    reviewCalls.length === reviewsBeforeReplay + 2,
-    "duplicate delivery was incorrectly suppressed in shadow mode",
+    mutationCalls.some(
+      (call) =>
+        call.kind === "pullRequest.updateMany" &&
+        (call.args.where as { repositoryId?: string })?.repositoryId === "repo_b",
+    ),
+    "merged PR did not mutate only the installation-owned repository",
   );
+
+  const reviewsBeforeMention = reviewCalls.length;
+  const mentionResponse = await POST(
+    webhookRequest(issueCommentBody(), {
+      deliveryId: "delivery-mention",
+      eventType: "issue_comment",
+    }),
+  );
+  await runAfterCallbacks();
+  assert(mentionResponse.status === 200, "issue comment response failed");
   assert(
-    deliveryAttempts.get("github:delivery-replayed") === 2,
-    "duplicate attempt count was not incremented",
+    reviewCalls.length === reviewsBeforeMention + 1 &&
+      reviewCalls.at(-1)?.orgId === "org_b" &&
+      reviewCalls.at(-1)?.repoId === "repo_b",
+    "issue comment did not route through the installation-owned repository",
   );
+  assert(legacyRepositoryLookups === 0, "legacy repository-only lookup was used");
 
   failNextLedgerWrite = true;
   const failureResponse = await POST(
@@ -230,11 +336,13 @@ try {
       uninstall?.resolutionStatus === "installation_only",
     "uninstall lost its pre-mutation tenant snapshot",
   );
+  assert(installationBindingCleared, "uninstall did not clear the installation binding");
 
   originalConsole.log(JSON.stringify({
     invalidSignatureRejected: true,
-    legacyRoutingPreserved: true,
-    duplicateAttemptCount: 2,
+    trustedRoutingEnforced: true,
+    unmappedInstallationDropped: true,
+    mergedAndMentionScoped: true,
     ledgerFailureNonFatal: true,
     uninstallTenantCaptured: true,
   }));

--- a/apps/web/lib/__tests__/fixtures/gitlab-webhook-tenant-enforcement-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/gitlab-webhook-tenant-enforcement-harness.ts
@@ -156,6 +156,7 @@ try {
   assert(reviewCalls.length === 1, "valid webhook did not start one review");
   assert(reviewCalls[0]?.orgId === "org_current", "wrong GitLab tenant selected");
   assert(reviewCalls[0]?.repoId === "repo_current", "wrong GitLab repository selected");
+  assert(mutationCalls.length === 0, "open MR fell through into merge mutations");
 
   let unauthenticatedBodyRead = false;
   const guardedInvalidRequest = {

--- a/apps/web/lib/__tests__/fixtures/gitlab-webhook-tenant-enforcement-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/gitlab-webhook-tenant-enforcement-harness.ts
@@ -73,6 +73,10 @@ mock.module("@octopus/db", () => ({
         mutationCalls.push({ kind: "repository.update", args });
         return Promise.resolve({});
       },
+      updateMany: (args: Record<string, unknown>) => {
+        mutationCalls.push({ kind: "repository.updateMany", args });
+        return Promise.resolve({ count: 1 });
+      },
     },
     gitlabIntegration: {
       // Legacy route control: the stale repository selects the wrong secret.
@@ -199,6 +203,14 @@ try {
           "repo_current",
     ),
     "merged MR did not mutate only the resolved repository",
+  );
+  assert(
+    mutationCalls.some((call) => {
+      if (call.kind !== "repository.updateMany") return false;
+      const where = call.args.where as { id?: string; indexStatus?: string };
+      return where?.id === "repo_current" && where?.indexStatus === "indexed";
+    }),
+    "merged MR stale marking was not scoped to an indexed resolved repository",
   );
 
   const noteResponse = await POST(

--- a/apps/web/lib/__tests__/fixtures/gitlab-webhook-tenant-enforcement-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/gitlab-webhook-tenant-enforcement-harness.ts
@@ -1,0 +1,244 @@
+import { mock } from "bun:test";
+
+type RepositoryRecord = {
+  id: string;
+  organizationId: string;
+  autoReview: boolean;
+  fullName: string;
+  isActive: boolean;
+  dismissedAt: Date | null;
+};
+
+const currentRepository: RepositoryRecord = {
+  id: "repo_current",
+  organizationId: "org_current",
+  autoReview: true,
+  fullName: "current/project",
+  isActive: true,
+  dismissedAt: null,
+};
+const staleRepository: RepositoryRecord = {
+  id: "repo_stale",
+  organizationId: "org_stale",
+  autoReview: true,
+  fullName: "stale/project",
+  isActive: true,
+  dismissedAt: null,
+};
+
+const reviewCalls: Array<Record<string, unknown>> = [];
+const mutationCalls: Array<{ kind: string; args: Record<string, unknown> }> = [];
+let integrationAmbiguous = false;
+let repositoryMode: "resolved" | "missing" | "inactive" = "resolved";
+
+mock.module("server-only", () => ({}));
+mock.module("next/server", () => ({
+  NextRequest: Request,
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) => Response.json(body, init),
+  },
+}));
+mock.module("@/lib/gitlab", () => ({
+  getPullRequestDetails: () =>
+    Promise.resolve({
+      title: "Resolved MR",
+      url: "https://gitlab.test/current/project/-/merge_requests/18",
+      author: "contributor",
+      headSha: "def456",
+    }),
+}));
+mock.module("@/lib/webhook-shared", () => ({
+  startReviewFlow: (input: Record<string, unknown>) => {
+    reviewCalls.push(input);
+    return Promise.resolve();
+  },
+}));
+mock.module("@octopus/db", () => ({
+  prisma: {
+    repository: {
+      // Legacy route control: a repository-first lookup selects the wrong tenant.
+      findFirst: () => Promise.resolve(staleRepository),
+      findUnique: () => {
+        if (repositoryMode === "missing") return Promise.resolve(null);
+        if (repositoryMode === "inactive") {
+          return Promise.resolve({
+            ...currentRepository,
+            isActive: false,
+            dismissedAt: new Date("2026-08-05T00:00:00Z"),
+          });
+        }
+        return Promise.resolve(currentRepository);
+      },
+      update: (args: Record<string, unknown>) => {
+        mutationCalls.push({ kind: "repository.update", args });
+        return Promise.resolve({});
+      },
+    },
+    gitlabIntegration: {
+      // Legacy route control: the stale repository selects the wrong secret.
+      findUnique: () => Promise.resolve({ webhookSecret: "stale-secret" }),
+      findMany: ({ where }: { where: { webhookSecret: string } }) => {
+        if (where.webhookSecret !== "current-secret") return Promise.resolve([]);
+        if (integrationAmbiguous) {
+          return Promise.resolve([
+            { organizationId: "org_current", webhookSecret: "current-secret" },
+            { organizationId: "org_other", webhookSecret: "current-secret" },
+          ]);
+        }
+        return Promise.resolve([
+          { organizationId: "org_current", webhookSecret: "current-secret" },
+        ]);
+      },
+    },
+    pullRequest: {
+      updateMany: (args: Record<string, unknown>) => {
+        mutationCalls.push({ kind: "pullRequest.updateMany", args });
+        return Promise.resolve({ count: 1 });
+      },
+    },
+  },
+}));
+
+const { POST } = await import("@/app/api/gitlab/webhook/route");
+
+function mergeRequestPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    project: { id: 9001, path_with_namespace: "current/project" },
+    object_attributes: {
+      action: "open",
+      state: "opened",
+      iid: 17,
+      title: "Tenant boundary regression",
+      url: "https://gitlab.test/current/project/-/merge_requests/17",
+      last_commit: { id: "abc123" },
+      ...overrides,
+    },
+    user: { username: "contributor" },
+  };
+}
+
+function webhookRequest(options: {
+  token?: string;
+  event?: string;
+  payload?: Record<string, unknown>;
+} = {}) {
+  return new Request("https://app.test/api/gitlab/webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-gitlab-event": options.event ?? "Merge Request Hook",
+      "x-gitlab-token": options.token ?? "current-secret",
+    },
+    body: JSON.stringify(options.payload ?? mergeRequestPayload()),
+  }) as never;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const originalConsole = {
+  log: console.log,
+  warn: console.warn,
+  error: console.error,
+};
+console.log = () => undefined;
+console.warn = () => undefined;
+console.error = () => undefined;
+
+try {
+  const accepted = await POST(webhookRequest());
+  assert(accepted.status === 200, "current integration secret was rejected");
+  assert(reviewCalls.length === 1, "valid webhook did not start one review");
+  assert(reviewCalls[0]?.orgId === "org_current", "wrong GitLab tenant selected");
+  assert(reviewCalls[0]?.repoId === "repo_current", "wrong GitLab repository selected");
+
+  let unauthenticatedBodyRead = false;
+  const guardedInvalidRequest = {
+    headers: new Headers({
+      "x-gitlab-event": "Merge Request Hook",
+      "x-gitlab-token": "invalid-secret",
+    }),
+    text: () => {
+      unauthenticatedBodyRead = true;
+      throw new Error("unauthenticated body was read");
+    },
+  } as never;
+  const invalid = await POST(guardedInvalidRequest);
+  assert(invalid.status === 401, "invalid GitLab token was not rejected");
+  assert(!unauthenticatedBodyRead, "invalid token was checked after reading the body");
+  assert(reviewCalls.length === 1, "invalid token started a review");
+
+  integrationAmbiguous = true;
+  const ambiguousResponse = await POST(webhookRequest());
+  assert(ambiguousResponse.status === 401, "ambiguous GitLab token was not rejected");
+  assert(reviewCalls.length === 1, "ambiguous token started a review");
+  integrationAmbiguous = false;
+
+  repositoryMode = "missing";
+  const missingResponse = await POST(webhookRequest());
+  repositoryMode = "inactive";
+  const inactiveResponse = await POST(webhookRequest());
+  assert(missingResponse.status === 200, "unowned project was not acknowledged");
+  assert(inactiveResponse.status === 200, "inactive project was not acknowledged");
+  assert(reviewCalls.length === 1, "unowned or inactive project started a review");
+  assert(mutationCalls.length === 0, "unowned or inactive project mutated state");
+  repositoryMode = "resolved";
+
+  const mergedResponse = await POST(
+    webhookRequest({
+      payload: mergeRequestPayload({ action: "merge", state: "merged" }),
+    }),
+  );
+  assert(mergedResponse.status === 200, "merged MR response failed");
+  assert(
+    mutationCalls.some(
+      (call) =>
+        call.kind === "pullRequest.updateMany" &&
+        (call.args.where as { repositoryId?: string })?.repositoryId ===
+          "repo_current",
+    ),
+    "merged MR did not mutate only the resolved repository",
+  );
+
+  const noteResponse = await POST(
+    webhookRequest({
+      event: "Note Hook",
+      payload: {
+        project: { id: 9001 },
+        object_attributes: {
+          noteable_type: "MergeRequest",
+          note: "@octopus review this",
+          id: 88,
+        },
+        merge_request: {
+          iid: 18,
+          title: "Mention review",
+          url: "https://gitlab.test/current/project/-/merge_requests/18",
+          last_commit: { id: "def456" },
+        },
+        user: { username: "contributor" },
+      },
+    }),
+  );
+  assert(noteResponse.status === 200, "note webhook response failed");
+  assert(reviewCalls.length === 2, "note mention did not start one review");
+  assert(reviewCalls[1]?.orgId === "org_current", "note used the wrong tenant");
+  assert(reviewCalls[1]?.repoId === "repo_current", "note used the wrong repository");
+
+  originalConsole.log(JSON.stringify({
+    tenantSecretSelectedRepository: true,
+    tokenCheckedBeforeBody: true,
+    invalidTokenRejected: true,
+    ambiguousTokenRejected: true,
+    unownedAndInactiveDropped: true,
+    mergedAndNoteScoped: true,
+  }));
+} catch (error) {
+  originalConsole.error(error);
+  process.exitCode = 1;
+} finally {
+  console.log = originalConsole.log;
+  console.warn = originalConsole.warn;
+  console.error = originalConsole.error;
+}

--- a/apps/web/lib/__tests__/github-webhook-tenant-enforcement.test.ts
+++ b/apps/web/lib/__tests__/github-webhook-tenant-enforcement.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+describe("GitHub webhook tenant enforcement", () => {
+  it("routes by the signed installation while preserving telemetry and lifecycle behavior", async () => {
+    const harnessPath = fileURLToPath(
+      new URL("./fixtures/github-webhook-tenant-enforcement-harness.ts", import.meta.url),
+    );
+    const process = Bun.spawn([globalThis.process.execPath, harnessPath], {
+      cwd: globalThis.process.cwd(),
+      env: globalThis.process.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      process.exited,
+      new Response(process.stdout).text(),
+      new Response(process.stderr).text(),
+    ]);
+
+    expect(exitCode, stderr).toBe(0);
+    const resultLine = stdout
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0)
+      .at(-1);
+    expect(resultLine).toBeDefined();
+    expect(JSON.parse(resultLine!)).toEqual({
+      invalidSignatureRejected: true,
+      trustedRoutingEnforced: true,
+      unmappedInstallationDropped: true,
+      mergedAndMentionScoped: true,
+      ledgerFailureNonFatal: true,
+      uninstallTenantCaptured: true,
+    });
+  });
+});

--- a/apps/web/lib/__tests__/gitlab-webhook-tenant-enforcement.test.ts
+++ b/apps/web/lib/__tests__/gitlab-webhook-tenant-enforcement.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { fileURLToPath } from "node:url";
 
-describe("GitHub webhook tenant shadow mode", () => {
-  it("preserves routing while observing verified collisions, retries, and uninstall", async () => {
+describe("GitLab webhook tenant enforcement", () => {
+  it("authenticates the integration before selecting its repository", async () => {
     const harnessPath = fileURLToPath(
-      new URL("./fixtures/github-webhook-shadow-harness.ts", import.meta.url),
+      new URL("./fixtures/gitlab-webhook-tenant-enforcement-harness.ts", import.meta.url),
     );
     const process = Bun.spawn([globalThis.process.execPath, harnessPath], {
       cwd: globalThis.process.cwd(),
@@ -25,11 +25,12 @@ describe("GitHub webhook tenant shadow mode", () => {
       .at(-1);
     expect(resultLine).toBeDefined();
     expect(JSON.parse(resultLine!)).toEqual({
-      invalidSignatureRejected: true,
-      legacyRoutingPreserved: true,
-      duplicateAttemptCount: 2,
-      ledgerFailureNonFatal: true,
-      uninstallTenantCaptured: true,
+      tenantSecretSelectedRepository: true,
+      tokenCheckedBeforeBody: true,
+      invalidTokenRejected: true,
+      ambiguousTokenRejected: true,
+      unownedAndInactiveDropped: true,
+      mergedAndNoteScoped: true,
     });
   });
 });

--- a/apps/web/lib/__tests__/webhook-tenant.test.ts
+++ b/apps/web/lib/__tests__/webhook-tenant.test.ts
@@ -7,9 +7,11 @@ const {
   compareWebhookTenantResolution,
   enforceWebhookDeliveryRetention,
   observeGithubWebhookDelivery,
-  observeGithubWebhookDeliveryInShadowMode,
+  observeGithubWebhookDeliveryBestEffort,
+  resolveGitlabWebhookIntegration,
+  resolveGitlabWebhookTenant,
   resolveWebhookDeliveryRetentionDays,
-  resolveWebhookTenant,
+  resolveGithubWebhookTenant,
 } = await import("@/lib/webhook-tenant");
 
 const PAYLOAD_SHA = "a".repeat(64);
@@ -45,11 +47,42 @@ function createStore() {
   };
 }
 
-describe("resolveWebhookTenant", () => {
+function createGitlabStore() {
+  return {
+    gitlabIntegration: {
+      findMany: mock(() =>
+        Promise.resolve([
+          { organizationId: "org_current", webhookSecret: "current-secret" },
+        ]),
+      ),
+    },
+    repository: {
+      findUnique: mock(() =>
+        Promise.resolve({
+          id: "repo_current",
+          organizationId: "org_current",
+          autoReview: true,
+          fullName: "current/project",
+          isActive: true,
+          dismissedAt: null,
+        } as {
+          id: string;
+          organizationId: string;
+          autoReview: boolean;
+          fullName: string;
+          isActive: boolean;
+          dismissedAt: Date | null;
+        } | null),
+      ),
+    },
+  };
+}
+
+describe("resolveGithubWebhookTenant", () => {
   it("resolves a GitHub repository only inside the installation-owned organization", async () => {
     const store = createStore();
 
-    const result = await resolveWebhookTenant(
+    const result = await resolveGithubWebhookTenant(
       {
         provider: "github",
         installationId: 222,
@@ -84,7 +117,7 @@ describe("resolveWebhookTenant", () => {
     const store = createStore();
     store.organization.findUnique.mockResolvedValue(null);
 
-    const result = await resolveWebhookTenant(
+    const result = await resolveGithubWebhookTenant(
       {
         provider: "github",
         installationId: 999,
@@ -105,7 +138,7 @@ describe("resolveWebhookTenant", () => {
   it("supports installation events that do not carry a repository", async () => {
     const store = createStore();
 
-    const result = await resolveWebhookTenant(
+    const result = await resolveGithubWebhookTenant(
       { provider: "github", installationId: 222, repositoryExternalId: null },
       store,
     );
@@ -117,6 +150,162 @@ describe("resolveWebhookTenant", () => {
       repositoryId: null,
     });
     expect(store.repository.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveGitlabWebhookTenant", () => {
+  it("selects the organization by hook secret before the compound repository lookup", async () => {
+    const store = createGitlabStore();
+
+    const integration = await resolveGitlabWebhookIntegration(
+      {
+        provider: "gitlab",
+        token: "current-secret",
+      },
+      store,
+    );
+    expect(integration).toEqual({
+      provider: "gitlab",
+      status: "resolved",
+      organizationId: "org_current",
+    });
+
+    const result = await resolveGitlabWebhookTenant(
+      {
+        provider: "gitlab",
+        organizationId: "org_current",
+        repositoryExternalId: 9001,
+      },
+      store,
+    );
+
+    expect(result).toEqual({
+      provider: "gitlab",
+      status: "resolved",
+      organizationId: "org_current",
+      repository: {
+        id: "repo_current",
+        organizationId: "org_current",
+        autoReview: true,
+        fullName: "current/project",
+        isActive: true,
+        dismissedAt: null,
+      },
+    });
+    expect(store.gitlabIntegration.findMany).toHaveBeenCalledWith({
+      where: { webhookSecret: "current-secret" },
+      select: { organizationId: true, webhookSecret: true },
+      take: 2,
+    });
+    expect(store.repository.findUnique).toHaveBeenCalledWith({
+      where: {
+        provider_externalId_organizationId: {
+          provider: "gitlab",
+          externalId: "9001",
+          organizationId: "org_current",
+        },
+      },
+      select: {
+        id: true,
+        organizationId: true,
+        autoReview: true,
+        fullName: true,
+        isActive: true,
+        dismissedAt: true,
+      },
+    });
+  });
+
+  it("rejects unknown and duplicated hook secrets before repository access", async () => {
+    const store = createGitlabStore();
+    store.gitlabIntegration.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { organizationId: "org_a", webhookSecret: "shared-secret" },
+        { organizationId: "org_b", webhookSecret: "shared-secret" },
+      ]);
+
+    await expect(
+      resolveGitlabWebhookIntegration(
+        { provider: "gitlab", token: "unknown" },
+        store,
+      ),
+    ).resolves.toMatchObject({ status: "unmapped_token", organizationId: null });
+    await expect(
+      resolveGitlabWebhookIntegration(
+        {
+          provider: "gitlab",
+          token: "shared-secret",
+        },
+        store,
+      ),
+    ).resolves.toMatchObject({ status: "ambiguous_token", organizationId: null });
+    expect(store.repository.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("requires the hook secret to match exactly", async () => {
+    const store = createGitlabStore();
+    store.gitlabIntegration.findMany.mockResolvedValue([]);
+
+    await expect(
+      resolveGitlabWebhookIntegration(
+        {
+          provider: "gitlab",
+          token: " current-secret ",
+        },
+        store,
+      ),
+    ).resolves.toMatchObject({ status: "unmapped_token" });
+    expect(store.gitlabIntegration.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { webhookSecret: " current-secret " } }),
+    );
+  });
+
+  it("never falls back to another tenant when the authenticated organization does not own the project", async () => {
+    const store = createGitlabStore();
+    store.repository.findUnique.mockResolvedValue(null);
+
+    const result = await resolveGitlabWebhookTenant(
+      {
+        provider: "gitlab",
+        organizationId: "org_current",
+        repositoryExternalId: 9001,
+      },
+      store,
+    );
+
+    expect(result).toMatchObject({
+      status: "repository_not_owned",
+      organizationId: "org_current",
+      repository: null,
+    });
+  });
+
+  it("rejects inactive or dismissed repositories", async () => {
+    const store = createGitlabStore();
+    store.repository.findUnique.mockResolvedValue({
+      id: "repo_current",
+      organizationId: "org_current",
+      autoReview: true,
+      fullName: "current/project",
+      isActive: false,
+      dismissedAt: new Date("2026-08-05T00:00:00Z"),
+    });
+
+    await expect(
+      resolveGitlabWebhookTenant(
+        {
+          provider: "gitlab",
+          organizationId: "org_current",
+          repositoryExternalId: 9001,
+        },
+        store,
+      ),
+    ).resolves.toMatchObject({
+      status: "repository_inactive",
+      organizationId: "org_current",
+      repository: null,
+    });
   });
 });
 
@@ -359,7 +548,7 @@ describe("observeGithubWebhookDelivery", () => {
       warn: mock((_message: string) => undefined),
     };
 
-    const result = await observeGithubWebhookDeliveryInShadowMode(
+    const result = await observeGithubWebhookDeliveryBestEffort(
       {
         deliveryId: "delivery-123",
         eventType: "pull_request",
@@ -375,7 +564,7 @@ describe("observeGithubWebhookDelivery", () => {
 
     expect(result).toBeNull();
     expect(logger.warn).toHaveBeenCalledWith(
-      "[webhook] GitHub delivery observation failed; legacy routing continued (Error)",
+      "[webhook] GitHub delivery observation failed; enforced routing continued (Error)",
     );
     expect(logger.warn.mock.calls[0]?.[0]).not.toContain("sensitive detail");
   });
@@ -399,7 +588,7 @@ describe("GitHub webhook boundary wiring", () => {
     );
     const payloadParse = routeSource.indexOf("const payload = JSON.parse(body)");
     const observationCall = routeSource.indexOf(
-      "observeGithubWebhookDeliveryInShadowMode({",
+      "observeGithubWebhookDeliveryBestEffort({",
       payloadParse,
     );
 

--- a/apps/web/lib/webhook-tenant.ts
+++ b/apps/web/lib/webhook-tenant.ts
@@ -1,11 +1,13 @@
 import "server-only";
 
+import crypto from "node:crypto";
 import { prisma } from "@octopus/db";
 
 const MAX_DELIVERY_ID_LENGTH = 255;
 const MAX_EVENT_TYPE_LENGTH = 100;
 const MAX_ACTION_LENGTH = 100;
 const MAX_PROVIDER_REPOSITORY_ID_LENGTH = 32;
+const MAX_WEBHOOK_TOKEN_LENGTH = 512;
 const SHA256_HEX = /^[a-f0-9]{64}$/;
 const POSITIVE_DECIMAL = /^[1-9]\d*$/;
 
@@ -51,6 +53,51 @@ export interface GithubWebhookTenantResolution {
   repositoryId: string | null;
 }
 
+export const GITLAB_WEBHOOK_TENANT_RESOLUTION_STATUSES = [
+  "resolved",
+  "missing_token",
+  "unmapped_token",
+  "ambiguous_token",
+  "repository_not_owned",
+  "repository_inactive",
+] as const;
+
+export type GitlabWebhookTenantResolutionStatus =
+  (typeof GITLAB_WEBHOOK_TENANT_RESOLUTION_STATUSES)[number];
+
+export interface GitlabWebhookIntegrationInput {
+  provider: "gitlab";
+  token: unknown;
+}
+
+export interface GitlabWebhookIntegrationResolution {
+  provider: "gitlab";
+  status: "resolved" | "missing_token" | "unmapped_token" | "ambiguous_token";
+  organizationId: string | null;
+}
+
+export interface GitlabWebhookTenantInput {
+  provider: "gitlab";
+  organizationId: string;
+  repositoryExternalId: unknown;
+}
+
+export interface GitlabWebhookRepository {
+  id: string;
+  organizationId: string;
+  autoReview: boolean;
+  fullName: string;
+  isActive: boolean;
+  dismissedAt: Date | null;
+}
+
+export interface GitlabWebhookTenantResolution {
+  provider: "gitlab";
+  status: GitlabWebhookTenantResolutionStatus;
+  organizationId: string | null;
+  repository: GitlabWebhookRepository | null;
+}
+
 interface OrganizationLookup {
   findUnique(args: {
     where: { githubInstallationId: number };
@@ -74,6 +121,35 @@ interface RepositoryLookup {
 export interface WebhookTenantStore {
   organization: OrganizationLookup;
   repository: RepositoryLookup;
+}
+
+export interface GitlabWebhookTenantStore {
+  gitlabIntegration: {
+    findMany(args: {
+      where: { webhookSecret: string };
+      select: { organizationId: true; webhookSecret: true };
+      take: 2;
+    }): Promise<Array<{ organizationId: string; webhookSecret: string | null }>>;
+  };
+  repository: {
+    findUnique(args: {
+      where: {
+        provider_externalId_organizationId: {
+          provider: "gitlab";
+          externalId: string;
+          organizationId: string;
+        };
+      };
+      select: {
+        id: true;
+        organizationId: true;
+        autoReview: true;
+        fullName: true;
+        isActive: true;
+        dismissedAt: true;
+      };
+    }): Promise<GitlabWebhookRepository | null>;
+  };
 }
 
 interface WebhookDeliveryUpsertArgs {
@@ -150,7 +226,7 @@ export interface GithubWebhookObservationInput {
   repositoryExternalId: unknown;
   // `undefined` means the legacy route did not perform a repository lookup.
   // `null` means it performed the lookup but found no row.
-  legacyRepository: LegacyWebhookRepository | null | undefined;
+  legacyRepository?: LegacyWebhookRepository | null;
   // Installation lifecycle routes already resolve the binding before a delete
   // mutation. Passing that snapshot prevents post-response observation from
   // misclassifying a successful uninstall as an unmapped installation.
@@ -213,6 +289,13 @@ function boundedString(value: unknown, maxLength: number): string | null {
   return normalized;
 }
 
+function boundedSecret(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string" || value.length === 0 || value.length > maxLength) {
+    return null;
+  }
+  return value;
+}
+
 function normalizeInstallationId(value: unknown): number | null {
   if (typeof value === "number") {
     return Number.isSafeInteger(value) && value > 0 ? value : null;
@@ -230,7 +313,16 @@ function normalizeRepositoryExternalId(value: unknown): string | null {
   return normalized && POSITIVE_DECIMAL.test(normalized) ? normalized : null;
 }
 
-export async function resolveWebhookTenant(
+function secretsMatch(expected: string, actual: string): boolean {
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const actualBuffer = Buffer.from(actual, "utf8");
+  return (
+    expectedBuffer.length === actualBuffer.length &&
+    crypto.timingSafeEqual(expectedBuffer, actualBuffer)
+  );
+}
+
+export async function resolveGithubWebhookTenant(
   input: GithubWebhookTenantInput,
   store: WebhookTenantStore = prisma,
 ): Promise<GithubWebhookTenantResolution> {
@@ -298,6 +390,109 @@ export async function resolveWebhookTenant(
   };
 }
 
+export async function resolveGitlabWebhookIntegration(
+  input: GitlabWebhookIntegrationInput,
+  store: GitlabWebhookTenantStore = prisma,
+): Promise<GitlabWebhookIntegrationResolution> {
+  const token = boundedSecret(input.token, MAX_WEBHOOK_TOKEN_LENGTH);
+  if (token === null) {
+    return {
+      provider: "gitlab",
+      status: "missing_token",
+      organizationId: null,
+    };
+  }
+
+  const integrations = await store.gitlabIntegration.findMany({
+    where: { webhookSecret: token },
+    select: { organizationId: true, webhookSecret: true },
+    take: 2,
+  });
+  if (integrations.length === 0) {
+    return {
+      provider: "gitlab",
+      status: "unmapped_token",
+      organizationId: null,
+    };
+  }
+  if (
+    integrations.length !== 1 ||
+    !integrations[0]?.webhookSecret ||
+    !secretsMatch(integrations[0].webhookSecret, token)
+  ) {
+    return {
+      provider: "gitlab",
+      status: "ambiguous_token",
+      organizationId: null,
+    };
+  }
+
+  return {
+    provider: "gitlab",
+    status: "resolved",
+    organizationId: integrations[0].organizationId,
+  };
+}
+
+export async function resolveGitlabWebhookTenant(
+  input: GitlabWebhookTenantInput,
+  store: GitlabWebhookTenantStore = prisma,
+): Promise<GitlabWebhookTenantResolution> {
+  const organizationId = input.organizationId;
+  const repositoryExternalId = normalizeRepositoryExternalId(
+    input.repositoryExternalId,
+  );
+  if (repositoryExternalId === null) {
+    return {
+      provider: "gitlab",
+      status: "repository_not_owned",
+      organizationId,
+      repository: null,
+    };
+  }
+
+  const repository = await store.repository.findUnique({
+    where: {
+      provider_externalId_organizationId: {
+        provider: "gitlab",
+        externalId: repositoryExternalId,
+        organizationId,
+      },
+    },
+    select: {
+      id: true,
+      organizationId: true,
+      autoReview: true,
+      fullName: true,
+      isActive: true,
+      dismissedAt: true,
+    },
+  });
+  if (!repository) {
+    return {
+      provider: "gitlab",
+      status: "repository_not_owned",
+      organizationId,
+      repository: null,
+    };
+  }
+  if (!repository.isActive || repository.dismissedAt !== null) {
+    return {
+      provider: "gitlab",
+      status: "repository_inactive",
+      organizationId,
+      repository: null,
+    };
+  }
+
+  return {
+    provider: "gitlab",
+    status: "resolved",
+    organizationId,
+    repository,
+  };
+}
+
 export function compareWebhookTenantResolution(
   resolution: GithubWebhookTenantResolution,
   legacyRepository: LegacyWebhookRepository | null | undefined,
@@ -348,7 +543,7 @@ export async function observeGithubWebhookDelivery(
   const [resolution, legacyCandidateCount] = await Promise.all([
     input.tenantResolution
       ? Promise.resolve(input.tenantResolution)
-      : resolveWebhookTenant(
+      : resolveGithubWebhookTenant(
           {
             provider: "github",
             installationId,
@@ -434,10 +629,10 @@ export async function observeGithubWebhookDelivery(
 }
 
 /**
- * Best-effort shadow wrapper. Delivery storage and comparison must never alter
- * the legacy webhook response until the enforcement rollout is explicitly enabled.
+ * Best-effort telemetry wrapper. Delivery storage, retry counting, and provider
+ * delivery IDs are observational only and must never become routing authority.
  */
-export async function observeGithubWebhookDeliveryInShadowMode(
+export async function observeGithubWebhookDeliveryBestEffort(
   input: GithubWebhookObservationInput,
   store: WebhookObservationStore = prisma,
   logger: WebhookObservationLogger = console,
@@ -451,17 +646,17 @@ export async function observeGithubWebhookDeliveryInShadowMode(
       observation.comparisonStatus === "shadow_only"
     ) {
       logger.warn(
-        `[webhook] GitHub tenant shadow comparison: ${observation.comparisonStatus} (resolution=${observation.resolutionStatus})`,
+        `[webhook] GitHub tenant comparison: ${observation.comparisonStatus} (resolution=${observation.resolutionStatus})`,
       );
     }
     if (observation.attemptCount > 1) {
       logger.info(
-        `[webhook] GitHub delivery observed ${observation.attemptCount} times; shadow mode continues legacy processing`,
+        `[webhook] GitHub delivery observed ${observation.attemptCount} times; telemetry remains observation-only`,
       );
     }
     if (observation.payloadHashCollision) {
       logger.warn(
-        "[webhook] GitHub delivery ID payload collision detected; shadow mode continues legacy processing",
+        "[webhook] GitHub delivery ID payload collision detected; telemetry remains observation-only",
       );
     }
     return observation;
@@ -470,7 +665,7 @@ export async function observeGithubWebhookDeliveryInShadowMode(
     // this boundary must never copy provider payload data into operational logs.
     const errorType = error instanceof Error ? error.name : "UnknownError";
     logger.warn(
-      `[webhook] GitHub delivery observation failed; legacy routing continued (${errorType})`,
+      `[webhook] GitHub delivery observation failed; enforced routing continued (${errorType})`,
     );
     return null;
   }

--- a/packages/db/prisma/migrations/20260805143000_index_gitlab_webhook_secret/migration.sql
+++ b/packages/db/prisma/migrations/20260805143000_index_gitlab_webhook_secret/migration.sql
@@ -1,0 +1,3 @@
+-- Bound the unauthenticated GitLab webhook token lookup to an indexed equality scan.
+CREATE INDEX "gitlab_integrations_webhookSecret_idx"
+ON "gitlab_integrations"("webhookSecret");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -632,6 +632,7 @@ model GitlabIntegration {
   organizationId String       @unique
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
+  @@index([webhookSecret])
   @@map("gitlab_integrations")
 }
 


### PR DESCRIPTION
## Intent

Enforce SEC-06 webhook tenant isolation after clean production telemetry. Use signed GitHub installation IDs as the sole tenant authority and resolve repositories through the organization-scoped compound key. Authenticate GitLab with its per-organization hook token before reading the body, then resolve the project within that organization and fail closed for unknown, duplicate, inactive, or dismissed mappings. Keep GitHub delivery IDs and retry telemetry observation-only. Preserve installation lifecycle events, PR and MR reviews, merge updates, and comment-triggered reviews. The externally managed stale duplicate cleanup is non-blocking. No schema behavior change beyond indexing the GitLab webhook token lookup.

## What Changed

- GitHub webhook deliveries now resolve repositories solely from the signed installation ID via the organization-scoped compound key, with delivery IDs and retry telemetry kept observation-only; the legacy repository-lookup fallback is removed from the route.
- GitLab webhook deliveries authenticate the per-organization hook token before the request body is read, then resolve the project within that organization and fail closed on unknown, duplicate, inactive, or dismissed mappings; merged-MR stale marking is scoped to indexed repositories, and a new Prisma index on `GitlabIntegration.webhookSecret` (with migration) backs the token lookup.
- Adds end-to-end enforcement test harnesses and suites for both providers (signed-request GitHub scenarios and token-before-body GitLab scenarios), expands `webhook-tenant` unit tests, and updates the changelog and security-overview docs accordingly.

## Risk Assessment

✅ Low: The delta commit only corrects the two documentation inaccuracies flagged in round 1; the enforcement code is unchanged from the previously verified, intent-conformant, well-tested state, leaving no outstanding concerns.

## Testing

Ran the committed GitHub/GitLab webhook tenant-enforcement harnesses (which POST signed/tokened HTTP requests at the real route handlers) plus the full apps/web unit suite — all 817 tests pass after fixing a missing-dependency setup issue with bun install — and captured annotated per-request transcripts demonstrating installation-ID-only GitHub routing, GitLab token-before-body auth with fail-closed mapping checks, observation-only delivery telemetry, preserved lifecycle/merge/comment flows, and the index-only schema diff.

<details>
<summary>Evidence: GitHub webhook enforcement transcript (7 scenarios: invalid signature, tenant collision, unmapped installation, merged PR, comment mention, ledger failure, uninstall)</summary>

```text
=== GitHub webhook tenant-enforcement transcript (SEC-06) ===
DB fixture: repository payload 'shared/repository' matches org_a/repo_a via the legacy
repository-first lookup, but the SIGNED installation id 222 is bound to org_b, whose
compound (provider, externalId, organizationId) key resolves repo_b.

[1] POST pull_request with an INVALID x-hub-signature-256
    -> HTTP 401; no ledger write, no review

[2] POST pull_request (opened) with a VALID signature — tenant-collision payload
    -> HTTP 200; review routed to org=org_b repo=repo_b (signed installation, NOT legacy org_a/repo_a)
       ledger row: resolvedOrganizationId=org_b, legacyOrganizationId=null, comparisonStatus=not_applicable (observation-only)

[3] POST pull_request signed for an UNMAPPED installation id 999
    -> HTTP 200; acknowledged but dropped — no review started

[4] POST pull_request (closed, merged=true)
    -> HTTP 200; merge mutation scoped to installation-owned repo_b

[5] POST issue_comment '@octopus review this'
    -> HTTP 200; comment-triggered review routed to org=org_b repo=repo_b; legacy repository-only lookups used: 0

[6] POST pull_request while the delivery-ledger DB write FAILS
    -> HTTP 200; delivery-id/retry telemetry stays observation-only and never blocks the webhook

[7] POST installation (action=deleted) — uninstall lifecycle
    -> HTTP 200; tenant snapshot captured (resolvedOrganizationId=org_b, resolutionStatus=installation_only); installation binding cleared=true

RESULT:
{"invalidSignatureRejected":true,"trustedRoutingEnforced":true,"unmappedInstallationDropped":true,"mergedAndMentionScoped":true,"ledgerFailureNonFatal":true,"uninstallTenantCaptured":true}
```
</details>
<details>
<summary>Evidence: GitLab webhook enforcement transcript (6 scenarios: tenant selection by hook token, token-before-body 401, ambiguous token, unknown/inactive mapping drops, merged MR scoping, note mention)</summary>

```text
=== GitLab webhook tenant-enforcement transcript (SEC-06) ===
DB fixture: legacy repository-first lookup would select STALE tenant org_stale/repo_stale;
the org-scoped hook token 'current-secret' belongs to org_current.

[1] POST Merge Request Hook (action=open) with x-gitlab-token=current-secret
    -> HTTP 200; review started for org=org_current repo=repo_current (token-owned tenant, NOT the stale repo-first match)

[2] POST with x-gitlab-token=invalid-secret (request body rigged to throw if read)
    -> HTTP 401; body was never read (bodyRead=false); no review started

[3] POST with a token that matches TWO organizations (ambiguous mapping)
    -> HTTP 401; duplicate mapping fails closed, no review started

[4] POST for a project UNKNOWN in the token's org, then for an INACTIVE/dismissed mapping
    -> HTTP 200 (unknown) / HTTP 200 (inactive): acknowledged but dropped — 0 reviews, 0 DB mutations

[5] POST Merge Request Hook (action=merge, state=merged)
    -> HTTP 200; merge mutations scoped to resolved repo: pullRequest.updateMany(where.id/repositoryId=repo_current), repository.updateMany(where.id/repositoryId=repo_current)

[6] POST Note Hook with '@octopus review this' comment
    -> HTTP 200; comment-triggered review started for org=org_current repo=repo_current

RESULT:
{"tenantSecretSelectedRepository":true,"tokenCheckedBeforeBody":true,"invalidTokenRejected":true,"ambiguousTokenRejected":true,"unownedAndInactiveDropped":true,"mergedAndNoteScoped":true}
```
</details>
<details>
<summary>Evidence: Schema/migration diff — only change is the gitlab_integrations.webhookSecret index</summary>

```text
Schema/migration diff (base ea67448 -> target 8aab649) — intent constraint: no schema behavior change beyond indexing the GitLab webhook token lookup

diff --git a/packages/db/prisma/migrations/20260805143000_index_gitlab_webhook_secret/migration.sql b/packages/db/prisma/migrations/20260805143000_index_gitlab_webhook_secret/migration.sql
new file mode 100644
index 0000000..b3045cd
--- /dev/null
+++ b/packages/db/prisma/migrations/20260805143000_index_gitlab_webhook_secret/migration.sql
@@ -0,0 +1,3 @@
+-- Bound the unauthenticated GitLab webhook token lookup to an indexed equality scan.
+CREATE INDEX "gitlab_integrations_webhookSecret_idx"
+ON "gitlab_integrations"("webhookSecret");
diff --git a/packages/db/prisma/schema.prisma b/packages/db/prisma/schema.prisma
index e20fee6..b9cd24e 100644
--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -632,6 +632,7 @@ model GitlabIntegration {
   organizationId String       @unique
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
+  @@index([webhookSecret])
   @@map("gitlab_integrations")
 }
 
```
</details>
<details>
<summary>Evidence: Webhook tenant test run (26 tests pass)</summary>

```text
$ bun test lib/__tests__/github-webhook-tenant-enforcement.test.ts lib/__tests__/gitlab-webhook-tenant-enforcement.test.ts lib/__tests__/webhook-tenant.test.ts
bun test v1.3.13 (bf2e2cec)

lib/__tests__/webhook-tenant.test.ts:
[webhook] Deleted 4 delivery rows older than 30 days

 26 pass
 0 fail
 69 expect() calls
Ran 26 tests across 3 files. [47.00ms]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `CHANGELOG.md:11` - CHANGELOG entry ends with &#34;No schema change.&#34; but the branch adds a Prisma migration (packages/db/prisma/migrations/20260805143000_index_gitlab_webhook_secret/migration.sql) and an @@index on GitlabIntegration.webhookSecret. The user intent permits exactly this index (&#34;No schema behavior change beyond indexing the GitLab webhook token lookup&#34;), so the changelog sentence contradicts the actual diff and could lead an operator to skip running migrations on deploy. Reword to something like &#34;No schema behavior change beyond a new index on the GitLab webhook token lookup.&#34;
- ℹ️ `apps/web/lib/webhook-tenant.ts:407` - resolveGitlabWebhookIntegration authenticates by a DB equality lookup on the plaintext token (findMany where webhookSecret = token); the subsequent crypto.timingSafeEqual only re-validates a row already found by equality, so the comparison as a whole is not constant-time (the docs page now claims &#34;constant-time hook-token comparison&#34;). With server-generated 32-byte random secrets this is not practically exploitable, but a follow-up could store and index sha256(webhookSecret) and look up by hash — making the timing question moot and removing the index on a plaintext secret.
- ℹ️ `apps/web/lib/webhook-tenant.ts:496` - The legacy-comparison telemetry path is now vestigial: the GitHub route no longer supplies legacyRepository, so compareWebhookTenantResolution always returns &#34;not_applicable&#34; and legacyCandidateCount is always 0 in production. compareWebhookTenantResolution, the legacyRepository/legacyCandidateCount plumbing in observeGithubWebhookDelivery, and the LegacyWebhookRepository type can be removed in a follow-up simplification once the enforcement rollout is considered final.
- ℹ️ `apps/web/lib/webhook-tenant.ts:366` - Asymmetry between providers: resolveGitlabWebhookTenant fails closed on isActive=false or dismissedAt!=null, while resolveGithubWebhookTenant does not check either flag, so inactive/dismissed GitHub repositories still receive reviews and merge processing. This matches legacy GitHub behavior and the intent only requires the inactive/dismissed fail-closed for GitLab, but the inconsistency is worth tracking as a possible follow-up.

🔧 Fix: correct changelog schema note and docs token-comparison claim
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun test lib/__tests__/github-webhook-tenant-enforcement.test.ts lib/__tests__/gitlab-webhook-tenant-enforcement.test.ts lib/__tests__/webhook-tenant.test.ts` (26 tests, all pass)</code>
- <code>`bun test` over all webhook/GitHub/GitLab suites in apps/web (54 tests, all pass after `bun install` fixed missing worktree dependencies)</code>
- <code>`bun test` full apps/web unit suite — 807 pass, 10 skip, 0 fail across 74 files</code>
- `Manual end-to-end transcript: ran the GitHub enforcement harness (real route handler, HMAC-signed requests, mocked DB) capturing per-request HTTP status and routing for invalid signature, tenant-collision, unmapped installation, merged PR, @octopus comment, ledger-write failure, and uninstall scenarios`
- `Manual end-to-end transcript: ran the GitLab enforcement harness capturing token-before-body enforcement (body rigged to throw if read), invalid/ambiguous token 401s, unknown/inactive mapping drops with zero mutations, merged-MR scoping, and note-mention routing`
- <code>Verified via `git diff ea67448 8aab649 -- packages/db` that the only schema change is the new gitlab_integrations.webhookSecret index plus its migration</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
