### PR TITLE
fix(terraform): restrict data-service network trust to app identity and drop internet-wide SSH default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- AWS Terraform deployments now identify the application with a dedicated data-access security group, so RDS and optional Redis no longer trust every workload in the VPC. Existing stacks have a documented two-stage cutover that attaches the identity before removing legacy CIDR ingress. SSH stays unreachable unless an operator both configures a key pair and explicitly supplies trusted CIDRs; internet-wide SSH CIDRs are rejected.
+
 ## [1.0.96] - 2026-08-05
 
 ### Security

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -183,6 +183,26 @@ terraform plan
 terraform apply
 ```
 
+### Existing deployments: stage the data-access cutover
+
+Deployments created before the dedicated application identity must attach it before removing the legacy VPC-wide database/cache rule. For the first apply after upgrading, keep both paths temporarily:
+
+Before planning, replace any legacy `ssh_cidr_blocks = ["0.0.0.0/0"]` value with trusted CIDRs (for example, one administrator `/32`) or `[]`; internet-wide SSH now fails validation.
+
+```bash
+terraform plan -var='restrict_data_access_to_app=false'
+terraform apply -var='restrict_data_access_to_app=false'
+```
+
+Verify the running application can still reach PostgreSQL and Redis (when enabled). Then remove the temporary compatibility rule with the secure default:
+
+```bash
+terraform plan
+terraform apply
+```
+
+The first plan must add the data-access security group and attach it to EC2 without replacing EC2, RDS, or Redis. The second must remove only the VPC-CIDR ingress rules. Stop if either plan proposes a managed data-resource replacement.
+
 When `apply` finishes, you'll see output like:
 
 ```
@@ -371,6 +391,8 @@ The `backend.conf.example` file includes the AWS CLI commands to create the buck
 ## Security Notes
 
 - RDS is in private subnets — not reachable from the internet
+- RDS and Redis (when enabled) accept traffic only from the identity-only data-access security group attached to the EC2 application, not the full VPC CIDR
+- SSH is disabled by default; setting a key pair still requires explicit trusted CIDRs in `ssh_cidr_blocks`
 - IMDSv2 enforced on EC2 (prevents SSRF credential theft)
 - Root EBS volume encrypted at rest
 - `.env` file on the instance is `chmod 600`

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -252,7 +252,7 @@ Alternatively:
 
 On first deploy, run Prisma migrations before the app serves traffic.
 
-**If you enabled SSH** (`key_name` is set in tfvars):
+**If you enabled SSH** (`key_name` and trusted `ssh_cidr_blocks` are set in tfvars):
 ```bash
 ssh -i your-key.pem ubuntu@<public_ip>
 cd /opt/octopus

--- a/terraform/modules/aws/ec2-app/main.tf
+++ b/terraform/modules/aws/ec2-app/main.tf
@@ -81,7 +81,7 @@ resource "aws_instance" "this" {
   ami                    = coalesce(var.ami_id, data.aws_ami.ubuntu.id)
   instance_type          = var.instance_type
   subnet_id              = var.subnet_id
-  vpc_security_group_ids = [aws_security_group.this.id]
+  vpc_security_group_ids = concat([aws_security_group.this.id], var.additional_security_group_ids)
   iam_instance_profile   = aws_iam_instance_profile.this.name
   key_name               = var.key_name
 

--- a/terraform/modules/aws/ec2-app/variables.tf
+++ b/terraform/modules/aws/ec2-app/variables.tf
@@ -77,6 +77,12 @@ variable "ingress_rules" {
   ]
 }
 
+variable "additional_security_group_ids" {
+  description = "Additional security group IDs to attach to the application instance, such as identity-only groups for private service access."
+  type        = list(string)
+  default     = []
+}
+
 variable "docker_compose_content" {
   description = "Contents of the docker-compose.yml to be written on the instance."
   type        = string

--- a/terraform/stacks/aws-ec2/main.tf
+++ b/terraform/stacks/aws-ec2/main.tf
@@ -179,7 +179,7 @@ locals {
     },
   ]
 
-  ssh_ingress_rule = var.key_name != null ? [
+  ssh_ingress_rule = var.key_name != null && length(var.ssh_cidr_blocks) > 0 ? [
     {
       description     = "SSH"
       from_port       = 22
@@ -203,22 +203,37 @@ module "vpc" {
   tags               = var.tags
 }
 
+# Identity-only security group for application access to private data services.
+# It intentionally grants no ingress or egress by itself; the EC2 app security
+# group retains the workload's network rules, while this group is only a stable
+# source identity for RDS and Redis ingress.
+resource "aws_security_group" "app_data_access" {
+  name_prefix = "${var.name_prefix}-app-data-"
+  description = "Octopus application identity for private data-service access"
+  vpc_id      = module.vpc.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge({ Name = "${var.name_prefix}-app-data-sg" }, var.tags)
+}
+
 # ── RDS PostgreSQL ────────────────────────────────────────────────────────────
-# Using VPC CIDR (not EC2 SG) to avoid a circular dependency between rds and ec2 modules.
-# Only EC2 instances within this VPC can reach the RDS instance.
 module "rds" {
   source = "../../modules/aws/rds-postgres"
 
-  name_prefix          = var.name_prefix
-  vpc_id               = module.vpc.vpc_id
-  subnet_ids           = module.vpc.private_subnet_ids
-  allowed_cidr_blocks  = [var.vpc_cidr]
-  db_password          = local.db_password
-  instance_class       = var.db_instance_class
-  allocated_storage_gb = var.db_allocated_storage_gb
-  multi_az             = var.db_multi_az
-  deletion_protection  = var.db_deletion_protection
-  tags                 = var.tags
+  name_prefix                = var.name_prefix
+  vpc_id                     = module.vpc.vpc_id
+  subnet_ids                 = module.vpc.private_subnet_ids
+  allowed_security_group_ids = [aws_security_group.app_data_access.id]
+  allowed_cidr_blocks        = var.restrict_data_access_to_app ? [] : [var.vpc_cidr]
+  db_password                = local.db_password
+  instance_class             = var.db_instance_class
+  allocated_storage_gb       = var.db_allocated_storage_gb
+  multi_az                   = var.db_multi_az
+  deletion_protection        = var.db_deletion_protection
+  tags                       = var.tags
 }
 
 # ── ElastiCache Redis (optional) ──────────────────────────────────────────────
@@ -226,12 +241,13 @@ module "redis" {
   count  = var.enable_redis ? 1 : 0
   source = "../../modules/aws/elasticache-redis"
 
-  name_prefix         = var.name_prefix
-  vpc_id              = module.vpc.vpc_id
-  subnet_ids          = module.vpc.private_subnet_ids
-  allowed_cidr_blocks = [var.vpc_cidr]
-  node_type           = var.redis_node_type
-  tags                = var.tags
+  name_prefix                = var.name_prefix
+  vpc_id                     = module.vpc.vpc_id
+  subnet_ids                 = module.vpc.private_subnet_ids
+  allowed_security_group_ids = [aws_security_group.app_data_access.id]
+  allowed_cidr_blocks        = var.restrict_data_access_to_app ? [] : [var.vpc_cidr]
+  node_type                  = var.redis_node_type
+  tags                       = var.tags
 }
 
 # ── EC2 Application ───────────────────────────────────────────────────────────
@@ -253,7 +269,8 @@ module "ec2" {
   nginx_conf_content     = local.nginx_conf
   proxy_params_content   = local.proxy_params
 
-  ingress_rules = local.ingress_rules
+  ingress_rules                 = local.ingress_rules
+  additional_security_group_ids = [aws_security_group.app_data_access.id]
 
   tags = var.tags
 }

--- a/terraform/stacks/aws-ec2/terraform.tfvars.example
+++ b/terraform/stacks/aws-ec2/terraform.tfvars.example
@@ -78,8 +78,9 @@ environment = "production"
 name_prefix = "octopus"
 
 # ── Networking ────────────────────────────────────────────────────────────────
-vpc_cidr           = "10.0.0.0/16"
-enable_nat_gateway = false
+vpc_cidr                    = "10.0.0.0/16"
+enable_nat_gateway          = false
+restrict_data_access_to_app = true
 
 # ── EC2 ───────────────────────────────────────────────────────────────────────
 instance_type       = "t3.xlarge"  # min 4 vCPU / 16 GB for small teams
@@ -88,7 +89,7 @@ create_eip          = true
 
 # SSH access — leave null to disable entirely (use SSM Session Manager instead)
 key_name        = null
-ssh_cidr_blocks = ["0.0.0.0/0"]  # Restrict to your IP: ["1.2.3.4/32"]
+ssh_cidr_blocks = [] # When enabling SSH, explicitly allow trusted IPs: ["1.2.3.4/32"]
 
 # ── Container Registry ────────────────────────────────────────────────────────
 # Only needed for private AWS ECR images. Leave empty for GHCR / Docker Hub.

--- a/terraform/stacks/aws-ec2/tests/network_trust.tftest.hcl
+++ b/terraform/stacks/aws-ec2/tests/network_trust.tftest.hcl
@@ -1,0 +1,242 @@
+# SEC-10 network-trust regression tests.
+# Runs entirely against mocked providers — no AWS credentials required:
+#   terraform -chdir=terraform/stacks/aws-ec2 test
+#
+# terraform test cannot address resources inside child modules (only their
+# outputs), so rule-level assertions run against the rds-postgres,
+# elasticache-redis, and ec2-app modules directly with the same inputs the
+# stack wires up in main.tf. Stack-level runs cover the root identity SG and
+# the ssh_cidr_blocks validation.
+
+mock_provider "aws" {}
+mock_provider "random" {}
+
+override_data {
+  target = module.vpc.data.aws_availability_zones.available
+  values = {
+    names = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  }
+}
+
+override_data {
+  target = module.ec2.data.aws_ami.ubuntu
+  values = {
+    id = "ami-00000000000000000"
+  }
+}
+
+variables {
+  app_image  = "ghcr.io/example/octopus:test"
+  app_domain = "octopus.example.com"
+}
+
+# ── Stack: the app identity SG exists and carries no rules of its own ─────────
+run "stack_app_data_access_sg_is_identity_only" {
+  command = apply
+
+  variables {
+    enable_redis = true
+  }
+
+  assert {
+    condition     = length(aws_security_group.app_data_access.ingress) == 0 && length(aws_security_group.app_data_access.egress) == 0
+    error_message = "The app data-access SG must be identity-only: no ingress or egress rules of its own."
+  }
+}
+
+# ── RDS module, restricted inputs (stack default): identity-only ingress ──────
+run "rds_module_restricted_to_identity_sg" {
+  command = apply
+
+  module {
+    source = "../../modules/aws/rds-postgres"
+  }
+
+  variables {
+    name_prefix                = "octopus"
+    vpc_id                     = "vpc-00000000000000000"
+    subnet_ids                 = ["subnet-00000000000000001", "subnet-00000000000000002"]
+    allowed_security_group_ids = ["sg-appdata0000000001"]
+    allowed_cidr_blocks        = []
+    db_password                = "mock-password-123456"
+  }
+
+  assert {
+    condition     = length(aws_security_group.this.ingress) == 1
+    error_message = "Restricted RDS must have exactly one ingress rule (the app-identity rule)."
+  }
+
+  assert {
+    condition = anytrue([
+      for r in aws_security_group.this.ingress :
+      try(contains(r.security_groups, "sg-appdata0000000001"), false) && r.from_port == 5432
+    ])
+    error_message = "RDS ingress must reference the app data-access SG on port 5432."
+  }
+
+  assert {
+    condition = alltrue([
+      for r in aws_security_group.this.ingress : r.cidr_blocks == null || length(r.cidr_blocks) == 0
+    ])
+    error_message = "Restricted RDS must not allow any CIDR-based ingress (no VPC-wide trust)."
+  }
+}
+
+# ── RDS module, compat inputs (stage-1 cutover): identity SG plus legacy CIDR ─
+run "rds_module_compat_keeps_cidr_and_identity" {
+  command = apply
+
+  module {
+    source = "../../modules/aws/rds-postgres"
+  }
+
+  variables {
+    name_prefix                = "octopus"
+    vpc_id                     = "vpc-00000000000000000"
+    subnet_ids                 = ["subnet-00000000000000001", "subnet-00000000000000002"]
+    allowed_security_group_ids = ["sg-appdata0000000001"]
+    allowed_cidr_blocks        = ["10.0.0.0/16"]
+    db_password                = "mock-password-123456"
+  }
+
+  assert {
+    condition     = length(aws_security_group.this.ingress) == 2
+    error_message = "Compat mode must keep the legacy VPC-CIDR rule alongside the new app-identity rule on RDS."
+  }
+
+  assert {
+    condition = anytrue([
+      for r in aws_security_group.this.ingress : try(contains(r.cidr_blocks, "10.0.0.0/16"), false)
+    ])
+    error_message = "Compat mode must retain VPC-CIDR ingress to RDS so the running app is not interrupted."
+  }
+
+  assert {
+    condition = anytrue([
+      for r in aws_security_group.this.ingress : try(contains(r.security_groups, "sg-appdata0000000001"), false)
+    ])
+    error_message = "Compat mode must already attach the app-identity ingress to RDS."
+  }
+}
+
+# ── Redis module, restricted inputs (stack default): identity-only ingress ────
+run "redis_module_restricted_to_identity_sg" {
+  command = apply
+
+  module {
+    source = "../../modules/aws/elasticache-redis"
+  }
+
+  variables {
+    name_prefix                = "octopus"
+    vpc_id                     = "vpc-00000000000000000"
+    subnet_ids                 = ["subnet-00000000000000001", "subnet-00000000000000002"]
+    allowed_security_group_ids = ["sg-appdata0000000001"]
+    allowed_cidr_blocks        = []
+  }
+
+  assert {
+    condition     = length(aws_security_group.this.ingress) == 1
+    error_message = "Restricted Redis must have exactly one ingress rule (the app-identity rule)."
+  }
+
+  assert {
+    condition = anytrue([
+      for r in aws_security_group.this.ingress :
+      try(contains(r.security_groups, "sg-appdata0000000001"), false) && r.from_port == 6379
+    ])
+    error_message = "Redis ingress must reference the app data-access SG on port 6379."
+  }
+
+  assert {
+    condition = alltrue([
+      for r in aws_security_group.this.ingress : r.cidr_blocks == null || length(r.cidr_blocks) == 0
+    ])
+    error_message = "Restricted Redis must not allow any CIDR-based ingress (no VPC-wide trust)."
+  }
+}
+
+# ── Redis module, compat inputs: identity SG plus legacy CIDR ─────────────────
+run "redis_module_compat_keeps_cidr_and_identity" {
+  command = apply
+
+  module {
+    source = "../../modules/aws/elasticache-redis"
+  }
+
+  variables {
+    name_prefix                = "octopus"
+    vpc_id                     = "vpc-00000000000000000"
+    subnet_ids                 = ["subnet-00000000000000001", "subnet-00000000000000002"]
+    allowed_security_group_ids = ["sg-appdata0000000001"]
+    allowed_cidr_blocks        = ["10.0.0.0/16"]
+  }
+
+  assert {
+    condition     = length(aws_security_group.this.ingress) == 2
+    error_message = "Compat mode must keep the legacy VPC-CIDR rule alongside the new app-identity rule on Redis."
+  }
+
+  assert {
+    condition = anytrue([
+      for r in aws_security_group.this.ingress : try(contains(r.cidr_blocks, "10.0.0.0/16"), false)
+    ])
+    error_message = "Compat mode must retain VPC-CIDR ingress to Redis so the running app is not interrupted."
+  }
+}
+
+# ── EC2 module: the instance carries the extra identity SG ────────────────────
+run "ec2_module_attaches_additional_identity_sg" {
+  command = apply
+
+  module {
+    source = "../../modules/aws/ec2-app"
+  }
+
+  variables {
+    name_prefix                   = "octopus"
+    vpc_id                        = "vpc-00000000000000000"
+    subnet_id                     = "subnet-00000000000000001"
+    ami_id                        = "ami-00000000000000000"
+    app_domain                    = "octopus.example.com"
+    docker_compose_content        = "services: {}"
+    env_content                   = ""
+    nginx_conf_content            = ""
+    proxy_params_content          = ""
+    additional_security_group_ids = ["sg-appdata0000000001"]
+  }
+
+  assert {
+    condition     = contains(aws_instance.this.vpc_security_group_ids, "sg-appdata0000000001")
+    error_message = "The EC2 application instance must carry the data-access identity SG."
+  }
+
+  assert {
+    condition     = contains(aws_instance.this.vpc_security_group_ids, aws_security_group.this.id)
+    error_message = "Attaching the identity SG must not displace the app's own security group."
+  }
+}
+
+# ── SSH: internet-wide CIDR is rejected at validation time ────────────────────
+run "ssh_internet_wide_cidr_rejected" {
+  command = plan
+
+  variables {
+    key_name        = "ops-keypair"
+    ssh_cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  expect_failures = [var.ssh_cidr_blocks]
+}
+
+# ── SSH: malformed CIDR is rejected at validation time ────────────────────────
+run "ssh_malformed_cidr_rejected" {
+  command = plan
+
+  variables {
+    key_name        = "ops-keypair"
+    ssh_cidr_blocks = ["203.0.113.5"]
+  }
+
+  expect_failures = [var.ssh_cidr_blocks]
+}

--- a/terraform/stacks/aws-ec2/variables.tf
+++ b/terraform/stacks/aws-ec2/variables.tf
@@ -35,6 +35,12 @@ variable "enable_nat_gateway" {
   default     = false
 }
 
+variable "restrict_data_access_to_app" {
+  description = "Restrict RDS and Redis ingress to the EC2 application identity. Keep true for new deployments. Existing deployments must perform the documented two-stage cutover before their first restricted apply."
+  type        = bool
+  default     = true
+}
+
 # ── EC2 ───────────────────────────────────────────────────────────────────────
 variable "instance_type" {
   description = "EC2 instance type. Minimum recommended: t3.xlarge (4 vCPU, 16 GB)."
@@ -126,9 +132,17 @@ variable "db_deletion_protection" {
 
 # ── SSH ───────────────────────────────────────────────────────────────────────
 variable "ssh_cidr_blocks" {
-  description = "CIDR blocks allowed to reach port 22. Ignored when key_name is null. Restrict to your IP for security (e.g. [\"203.0.113.5/32\"])."
+  description = "CIDR blocks allowed to reach port 22 when key_name is set. Leave empty to keep SSH unreachable; explicitly restrict access to trusted IPs (e.g. [\"203.0.113.5/32\"])."
   type        = list(string)
-  default     = ["0.0.0.0/0"]
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for cidr in var.ssh_cidr_blocks :
+      try(cidrnetmask(cidr) != "" && cidrsubnet(cidr, 0, 0) != "0.0.0.0/0", false)
+    ])
+    error_message = "Every ssh_cidr_blocks entry must be a valid IPv4 CIDR narrower than 0.0.0.0/0. Public SSH from the entire internet is not supported."
+  }
 }
 
 # ── Registry ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Intent

Harden SEC-10 Terraform network trust without risking the running platform: restrict RDS and optional Redis to the application workload identity, make existing-stack rollout interruption-safe, and eliminate internet-wide SSH defaults while leaving higher-risk secret, state, TLS, and Redis-auth migrations for separate slices.

## What Changed

- RDS and optional Redis security groups now trust only the application workload's identity security group instead of the whole VPC CIDR, controlled by a new `restrict_data_access_to_app` variable (default `true`); a compat mode keeps the legacy VPC-CIDR rule alongside the identity rule so existing stacks can do the two-stage cutover documented in `terraform/README.md`.
- The SSH ingress default changed from `["0.0.0.0/0"]` to `[]` — the SSH rule is only created when trusted CIDRs are supplied, and a variable validation rejects `0.0.0.0/0` outright, so enabling SSH now requires explicit trusted CIDRs (operators relying on the old open default must set them, per the README).
- Added `terraform/stacks/aws-ec2/tests/network_trust.tftest.hcl` (8 passing runs against mocked providers) covering identity-only trust, compat mode, EC2 SG attachment, and the SSH validation failures; `terraform.tfvars.example` and the changelog were updated to match.

## Risk Assessment

✅ Low: Well-bounded Terraform hardening that fully satisfies the stated intent: the identity SG wiring uses pre-existing module inputs, all changes are in-place (no resource replacements), the SSH validation fails closed, and the only residual risks are documented operational cutover concerns.

## Testing

Ran terraform validate plus a newly added 8-run terraform test suite (mocked AWS providers, no credentials) covering the identity-only data-access SG, restricted and compat-mode RDS/Redis ingress, EC2 SG attachment, and SSH CIDR validation — all pass; also captured operator-facing transcripts showing SSH stays closed without explicit trusted CIDRs and that terraform plan rejects 0.0.0.0/0 SSH with the documented error. Mocked providers cannot prove the in-place (non-replacing) SG attach on a live stack, but that is standard AWS provider behavior for vpc_security_group_ids and the README's cutover instructions tell operators to stop if replacement is proposed. No visual evidence applies — this is an infrastructure-as-code change with no rendered UI surface.

<details>
<summary>Evidence: terraform validate + test transcript (8/8 network-trust runs pass, mocked providers)</summary>

```text
$ terraform -chdir=terraform/stacks/aws-ec2 validate
Success! The configuration is valid.


$ terraform -chdir=terraform/stacks/aws-ec2 test   # mocked AWS providers, no credentials
tests/network_trust.tftest.hcl... in progress
  run "stack_app_data_access_sg_is_identity_only"... pass
  run "rds_module_restricted_to_identity_sg"... pass
  run "rds_module_compat_keeps_cidr_and_identity"... pass
  run "redis_module_restricted_to_identity_sg"... pass
  run "redis_module_compat_keeps_cidr_and_identity"... pass
  run "ec2_module_attaches_additional_identity_sg"... pass
  run "ssh_internet_wide_cidr_rejected"... pass
  run "ssh_malformed_cidr_rejected"... pass
tests/network_trust.tftest.hcl... tearing down
tests/network_trust.tftest.hcl... pass

Success! 8 passed, 0 failed.
```
</details>
<details>
<summary>Evidence: SSH gating transcript: console eval of ssh_ingress_rule + plan rejecting 0.0.0.0/0</summary>

<code>### terraform plan with legacy ssh_cidr_blocks = [&#34;0.0.0.0/0&#34;] -&gt; rejected at validation&#10;&#10;Error: Invalid value for variable&#10;&#10;on variables.tf line 134:&#10;134: variable &#34;ssh_cidr_blocks&#34; {&#10;│ var.ssh_cidr_blocks is list of string with 1 element&#10;&#10;Every ssh_cidr_blocks entry must be a valid IPv4 CIDR narrower than&#10;0.0.0.0/0. Public SSH from the entire internet is not supported.</code>

```text
# SSH gating in the aws-ec2 stack (local.ssh_ingress_rule via terraform console)

### Defaults: key_name = null, ssh_cidr_blocks = [] -> no SSH ingress
tolist([])

### key_name = "ops-keypair", ssh_cidr_blocks = [] -> key pair alone must NOT open SSH
tolist([])

### key_name = "ops-keypair", ssh_cidr_blocks = ["203.0.113.5/32"] -> SSH open only to the trusted CIDR
tolist([
  {
    "cidr_blocks" = tolist([
      "203.0.113.5/32",
    ])
    "description" = "SSH"
    "from_port" = 22
    "protocol" = "tcp"
    "security_groups" = []
    "to_port" = 22
  },
])

### terraform plan with legacy ssh_cidr_blocks = ["0.0.0.0/0"] -> rejected at validation
$ terraform plan -var key_name=ops-keypair -var ssh_cidr_blocks=["0.0.0.0/0"]


Error: Invalid value for variable

  on variables.tf line 134:
 134: variable "ssh_cidr_blocks" {
    ├────────────────
    │ var.ssh_cidr_blocks is list of string with 1 element

Every ssh_cidr_blocks entry must be a valid IPv4 CIDR narrower than
0.0.0.0/0. Public SSH from the entire internet is not supported.

This was checked by the validation rule at variables.tf:139,3-13.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `terraform/stacks/aws-ec2/variables.tf:38` - Existing stacks that skip the documented staging and run a plain `terraform apply` with the default `restrict_data_access_to_app=true` remove the VPC-CIDR ingress and attach the identity SG in the same apply; Terraform does not guarantee the EC2 SG attach completes before the RDS/Redis SG loses its CIDR rule, so a brief database/Redis connectivity gap is possible. The two-stage cutover in terraform/README.md mitigates this and the secure-by-default choice matches the stated intent.
- ℹ️ `terraform/stacks/aws-ec2/main.tf:182` - Operators who previously set `key_name` and relied on the old `ssh_cidr_blocks` default of [&#34;0.0.0.0/0&#34;] will silently lose SSH ingress after upgrading (the SSH rule is now gated on a non-empty list and the default is []). This is fail-secure, required by the intent, and documented in terraform/README.md — noting it only as an operational heads-up.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`terraform -chdir=terraform/stacks/aws-ec2 validate` — configuration valid</code>
- <code>`terraform -chdir=terraform/stacks/aws-ec2 test` — new tests/network_trust.tftest.hcl, 8/8 runs pass against mocked AWS/random providers: identity-only app_data_access SG, RDS/Redis restricted to the identity SG with zero CIDR ingress, compat mode keeping legacy VPC-CIDR + identity rules on both services, EC2 attaching the identity SG without displacing its own SG, and expect_failures for internet-wide and malformed ssh_cidr_blocks</code>
- <code>`terraform console` evaluation of local.ssh_ingress_rule under three configs — no SSH with defaults, no SSH with key pair but empty CIDRs, SSH scoped exactly to 203.0.113.5/32 when supplied</code>
- <code>`terraform plan -var &#39;ssh_cidr_blocks=[&#34;0.0.0.0/0&#34;]&#39;` — plan aborts with the new validation error (&#39;Public SSH from the entire internet is not supported&#39;) before any resource changes</code>
- `Reviewed the full diff to confirm no secret, state backend, TLS, or Redis-auth migrations are included (forbidden scope), and that README/tfvars.example document the two-stage cutover and empty SSH default`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 2 infos</summary>

- ℹ️ `terraform/modules/aws/rds-postgres/main.tf:90` - Pre-existing `terraform fmt` alignment drift in terraform/modules/aws/rds-postgres/main.tf (~line 90, multi_az/publicly_accessible block); file was not touched by this change, so it was left unformatted to keep the diff surgical. A trivial `terraform fmt` follow-up would clear it.
- ℹ️ `terraform/modules/aws/elasticache-redis/main.tf:1` - Pre-existing `terraform fmt` alignment drift in terraform/modules/aws/elasticache-redis/main.tf; file was not touched by this change, so it was left unformatted to keep the diff surgical. Same trivial `terraform fmt` follow-up applies.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
