### PR TITLE
fix(mention): advertise @octopus-review so the mention links to the bot

### DIFF
--- a/apps/web/app/(app)/settings/reviews/blocked-authors-form.tsx
+++ b/apps/web/app/(app)/settings/reviews/blocked-authors-form.tsx
@@ -51,7 +51,7 @@ export function BlockedAuthorsForm({
         <CardTitle>Blocked Authors</CardTitle>
         <CardDescription>
           PRs from these authors will not trigger reviews, even when mentioned
-          with @octopus. Use this to skip bot PRs or specific users.
+          with @octopus-review. Use this to skip bot PRs or specific users.
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/apps/web/lib/large-review-result.ts
+++ b/apps/web/lib/large-review-result.ts
@@ -75,7 +75,7 @@ export async function handleLargeReviewResult(
       ">",
       `> \`${data.error}\``,
       ">",
-      "> Please try again by commenting `@octopus` on this PR.",
+      "> Please try again by commenting `@octopus-review` on this PR.",
     ].join("\n");
 
     if (reviewCommentId) {

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1368,7 +1368,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
         "> - All changed files are excluded by `.octopusignore`",
         "> - The PR branch is already up to date with the base branch",
         ">",
-        "> If you believe this is a mistake, please update the PR and comment `@octopus` to retry.",
+        "> If you believe this is a mistake, please update the PR and comment `@octopus-review` to retry.",
       ].join("\n");
 
       if (reviewCommentId) {
@@ -2680,7 +2680,7 @@ Rules:
     if (reviewCommentId) {
       await providerUpdateComment(
         reviewCommentId,
-        `> 🐙 **Octopus Review** encountered an error while analyzing this pull request.\n>\n> \`${errorMessage}\`\n>\n> Please try again by commenting \`@octopus\` on this PR.`,
+        `> 🐙 **Octopus Review** encountered an error while analyzing this pull request.\n>\n> \`${errorMessage}\`\n>\n> Please try again by commenting \`@octopus-review\` on this PR.`,
       ).catch((e) => console.error("[reviewer] Failed to update placeholder with error:", e));
     }
 


### PR DESCRIPTION
## Context
When a user mentions the bot, GitHub hyperlinks the literal **`@octopus`** to an **unrelated GitHub account named `octopus`** (avatar/hovercard: 1 repo, 0 members), not our reviewer. Our bot's real handle is **`@octopus-review`** (App slug `octopus-review` → `octopus-review[bot]`), which links to the actual bot **and** triggers a review. The trigger already fires on both — only the rendered *link* was wrong.

## Change
Switch the user-facing copy that tells people what to mention, from `@octopus` → `@octopus-review`:
- The bot's own PR comments: the "comment to retry" error/skip messages (`reviewer.ts`, `large-review-result.ts`).
- The **Blocked Authors** settings help text.

**Trigger regex unchanged** — `/@octopus(?:review|-review)?\b/i` in all three providers (GitHub/GitLab/Bitbucket) + `review-helpers.ts` — so plain `@octopus` keeps working as a silent alias and no existing user breaks. Internal code comments, logs, dev scripts, and the LLM system prompt were left as-is.

## Verification
`bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)