### PR TITLE
fix(sentry): filter browser-translation DOM noise

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -31,6 +31,17 @@ Sentry.init({
     }),
   ],
   sendDefaultPii: false,
+  // Browser auto-translation (Google Translate et al.) rewrites text nodes out
+  // from under React, producing these DOM-manipulation errors that aren't app
+  // bugs. Filtering keeps Sentry signal-rich; genuine React failures surface
+  // with different messages. (Hydration errors are intentionally NOT filtered —
+  // those can be real.)
+  ignoreErrors: [
+    "Failed to execute 'removeChild' on 'Node'",
+    "Failed to execute 'insertBefore' on 'Node'",
+    "The node to be removed is not a child of this node",
+    "The node before which the new node is to be inserted is not a child of this node",
+  ],
   beforeSend: (event) => scrubEvent(event),
 });
 


### PR DESCRIPTION
## Context
First client errors captured in Sentry (project octopus-review) were browser **auto-translation**-induced DOM errors — `removeChild`/`insertBefore` DOMExceptions with locale/geo mismatch (e.g. zh-CN locale, user in Australia), 100% minified React reconciler frames, 0 users impacted. Google Translate rewrites text nodes out from under React; not app bugs.

## Change
Add `ignoreErrors` to the client Sentry init (`instrumentation-client.ts`) for those DOM-mutation messages, so Sentry stays signal-rich. **Hydration errors are deliberately left unfiltered** — those can be genuine SSR/CSR mismatches.

Takes effect on the next client build/deploy. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)