### PR TITLE
fix(reviews): reap reviews orphaned by engine restart/crash

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -63,6 +63,12 @@ export async function register() {
       // 30-day window is configurable via WEBHOOK_DELIVERY_RETENTION_DAYS.
       await boss.schedule("enforce-webhook-delivery-retention", "30 4 * * *");
 
+      // Reap reviews orphaned mid-flight (engine restart on deploy, crash, OOM,
+      // or a hang past the timeout) every 5 min: mark them failed with a real
+      // message and auto-retry recent ones. pg-boss dedups the cron across
+      // instances; the worker in queue-workers.ts does the work.
+      await boss.schedule("reap-stuck-reviews", "*/5 * * * *");
+
       // Daily release-cache refresh (05:00 UTC — offset from the retention jobs).
       // Gated to self-hosted: the release-check/update panel only surfaces there
       // (same server-side flag the admin bootstrap above uses). pg-boss dedups

--- a/apps/web/lib/__tests__/reap-stuck-reviews.test.ts
+++ b/apps/web/lib/__tests__/reap-stuck-reviews.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+let orphans: Array<{ id: string; createdAt: Date }> = [];
+let updateCount = 1;
+const findMany = mock(async () => orphans);
+const updateMany = mock(async () => ({ count: updateCount }));
+mock.module("@octopus/db", () => ({
+  prisma: { pullRequest: { findMany, updateMany } },
+}));
+
+const enqueue = mock(async () => "job-id");
+mock.module("@/lib/queue", () => ({
+  enqueue,
+  loadQueueConfig: async () => ({
+    reviewTimeoutSeconds: 900,
+    largeReviewTimeoutSeconds: 1800,
+    reviewConcurrency: 2,
+  }),
+  computeStaleReclaimMs: (s: number) => (s + 300) * 1000,
+}));
+
+const { reapStuckReviews, REAP_FAILED_MESSAGE } = await import(
+  "@/lib/reap-stuck-reviews"
+);
+
+const NOW = new Date("2026-08-06T13:00:00.000Z");
+const minutesAgo = (m: number) => new Date(NOW.getTime() - m * 60 * 1000);
+const daysAgo = (d: number) => new Date(NOW.getTime() - d * 24 * 60 * 60 * 1000);
+
+describe("reapStuckReviews", () => {
+  beforeEach(() => {
+    orphans = [];
+    updateCount = 1;
+    findMany.mockClear();
+    updateMany.mockClear();
+    enqueue.mockClear();
+  });
+
+  it("marks a recent orphan failed and re-queues exactly one throttled retry", async () => {
+    orphans = [{ id: "pr_recent", createdAt: minutesAgo(30) }];
+    const res = await reapStuckReviews(NOW);
+    expect(res).toEqual({ requeued: 1, failed: 0 });
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: "pr_recent", status: { in: ["reviewing", "queued"] } },
+      data: { status: "failed", errorMessage: REAP_FAILED_MESSAGE },
+    });
+    expect(enqueue).toHaveBeenCalledWith(
+      "process-review",
+      { pullRequestId: "pr_recent" },
+      { singletonKey: "reap:pr_recent", singletonSeconds: 3600 },
+    );
+  });
+
+  it("fails an old backlog orphan without re-queuing (no comment spam)", async () => {
+    orphans = [{ id: "pr_old", createdAt: daysAgo(40) }];
+    const res = await reapStuckReviews(NOW);
+    expect(res).toEqual({ requeued: 0, failed: 1 });
+    expect(updateMany).toHaveBeenCalledTimes(1);
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it("skips a row a live worker already finished (update matched nothing)", async () => {
+    orphans = [{ id: "pr_raced", createdAt: minutesAgo(30) }];
+    updateCount = 0;
+    const res = await reapStuckReviews(NOW);
+    expect(res).toEqual({ requeued: 0, failed: 0 });
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/queue-workers.ts
+++ b/apps/web/lib/queue-workers.ts
@@ -11,6 +11,7 @@ import { enforceWebhookDeliveryRetention } from "./webhook-tenant";
 import { refreshReleaseCache } from "./releases";
 import { renewDueSubscriptions } from "./subscription";
 import { runOllamaPull } from "./ollama-admin";
+import { reapStuckReviews } from "./reap-stuck-reviews";
 import type { QueueConfig } from "./queue";
 
 export interface WelcomeEmailJob {
@@ -145,6 +146,25 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     }
   });
 
+  // Reap reviews orphaned mid-flight — scheduled every 5 min in
+  // instrumentation.ts via boss.schedule(). Idempotent (status-guarded update),
+  // so concurrent instances are harmless.
+  await boss.work("reap-stuck-reviews", async (jobs) => {
+    for (const job of jobs) {
+      try {
+        const { requeued, failed } = await reapStuckReviews();
+        if (requeued || failed) {
+          console.log(
+            `[queue] reap-stuck-reviews ${job.id}: requeued=${requeued} failed=${failed}`,
+          );
+        }
+      } catch (err) {
+        console.error(`[queue] reap-stuck-reviews failed (job ${job.id}):`, err);
+        throw err;
+      }
+    }
+  });
+
   // Daily release-cache refresh (self-hosted) — scheduled in instrumentation.ts
   // via boss.schedule(). Keeps SystemConfig.latestRelease warm so the update
   // panel/route serves a fresh answer without a lazy cache miss. Idempotent:
@@ -173,5 +193,5 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     }
   });
 
-  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review, enforce-audit-retention, enforce-activity-retention, refresh-release-cache, pull-ollama-model");
+  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review, enforce-audit-retention, enforce-activity-retention, refresh-release-cache, reap-stuck-reviews, pull-ollama-model");
 }

--- a/apps/web/lib/queue.ts
+++ b/apps/web/lib/queue.ts
@@ -89,6 +89,13 @@ export async function startQueue(): Promise<PgBoss> {
     expireInSeconds: 300,
   }).catch(() => {});
 
+  // Reaper for reviews orphaned mid-flight (engine restart on deploy, crash,
+  // OOM, or a hang past the timeout). Scheduled every 5 min in instrumentation.ts.
+  await boss.createQueue("reap-stuck-reviews", {
+    retryLimit: 1,
+    expireInSeconds: 300,
+  }).catch(() => {});
+
   // Community-tier (no API key) async review pipeline.
   // Indexing can take minutes for first-touch repos, so the action enqueues
   // and polls; the worker indexes + reviews and writes the result back to

--- a/apps/web/lib/reap-stuck-reviews.ts
+++ b/apps/web/lib/reap-stuck-reviews.ts
@@ -1,0 +1,72 @@
+import { prisma } from "@octopus/db";
+import { enqueue, loadQueueConfig, computeStaleReclaimMs } from "./queue";
+
+// Reviews that die mid-flight (engine restart on deploy, crash, OOM, or a hang
+// past the job timeout) are left in "reviewing"/"queued" forever: the finalize
+// path never runs, so no error is written, and pg-boss's own retries hit the
+// claim guard inside the stale-reclaim window and get skipped. Without this
+// reaper they accumulate as permanent silent orphans (observed: 37 days' worth).
+//
+// The reaper marks every orphan `failed` with a real message — `failed` is
+// re-claimable, so a future push / @octopus re-review works cleanly — and, for
+// PRs young enough that a re-review is still wanted, enqueues one auto-retry.
+// The singletonKey throttles that to at most one reaper-requeue per PR per hour,
+// so a genuinely poison PR can't be re-reviewed in a tight loop.
+
+const REQUEUE_MAX_AGE_MS =
+  (Number(process.env.OCTOPUS_REAP_REQUEUE_MAX_AGE_HOURS) || 6) * 60 * 60 * 1000;
+
+export const REAP_FAILED_MESSAGE =
+  "Review interrupted by a server restart or timeout. Push a new commit or comment @octopus to retry.";
+
+export async function reapStuckReviews(
+  now: Date = new Date(),
+): Promise<{ requeued: number; failed: number }> {
+  const config = await loadQueueConfig();
+  // Same two windows as the claim guard (reviewer.ts): "reviewing" uses the
+  // in-process timeout, "queued" the longer internal-cli timeout. Both exceed
+  // the pg-boss job timeout, so a row past the window is genuinely dead — a live
+  // worker would have been killed by pg-boss before its updatedAt got this old.
+  const reviewingStale = new Date(
+    now.getTime() - computeStaleReclaimMs(config.reviewTimeoutSeconds),
+  );
+  const queuedStale = new Date(
+    now.getTime() - computeStaleReclaimMs(config.largeReviewTimeoutSeconds),
+  );
+
+  const orphans = await prisma.pullRequest.findMany({
+    where: {
+      OR: [
+        { status: "reviewing", updatedAt: { lt: reviewingStale } },
+        { status: "queued", updatedAt: { lt: queuedStale } },
+      ],
+    },
+    select: { id: true, createdAt: true },
+  });
+
+  const requeueCutoff = new Date(now.getTime() - REQUEUE_MAX_AGE_MS);
+  let requeued = 0;
+  let failed = 0;
+
+  for (const pr of orphans) {
+    // Guard on status so we never clobber a review a live worker just finished.
+    const updated = await prisma.pullRequest.updateMany({
+      where: { id: pr.id, status: { in: ["reviewing", "queued"] } },
+      data: { status: "failed", errorMessage: REAP_FAILED_MESSAGE },
+    });
+    if (updated.count === 0) continue;
+
+    if (pr.createdAt > requeueCutoff) {
+      await enqueue(
+        "process-review",
+        { pullRequestId: pr.id },
+        { singletonKey: `reap:${pr.id}`, singletonSeconds: 3600 },
+      );
+      requeued++;
+    } else {
+      failed++;
+    }
+  }
+
+  return { requeued, failed };
+}


### PR DESCRIPTION
## What & why

Three reviews across three orgs froze at the same minute today (`unified-crm` #501, `Acme-C6/payops` #181, `nightshift-saas` #206) — a review-engine restart from the v1.0.100 rolling deploy orphaned everything in-flight. Investigating showed it's chronic: a long tail of orphaned `reviewing` rows going back **37 days**.

**Root cause:** a review is claimed via an atomic `updateMany` (`reviewer.ts`); in-flight reviews are only re-claimable once `updatedAt` is older than `reviewTimeoutSeconds + 300s` (~20 min). When the engine dies mid-review, pg-boss re-queues the job but the retry fires *inside* that 20-min window, so the claim returns 0 and the job is consumed as a skip (`already claimed by another server, skipping`). Nothing re-fires after the window opens, so the review sits in `reviewing` forever — no error, no user feedback. pg-boss's own `retryLimit` exhausts against the same guard.

## Fix

A `reap-stuck-reviews` pg-boss cron (every 5 min):
- Finds reviews stuck in `reviewing`/`queued` past the **same** stale windows the claim guard uses (reviewing → `reviewTimeoutSeconds`, queued → `largeReviewTimeoutSeconds`, both +300s). A row past the window is genuinely dead — a live worker would have been killed by pg-boss first.
- Marks each `failed` (status-guarded, so it never clobbers a review a live worker just finished) with an actionable message. `failed` is re-claimable, so a future push / `@octopus` re-review works cleanly.
- Enqueues **one** auto-retry for PRs newer than `OCTOPUS_REAP_REQUEUE_MAX_AGE_HOURS` (default 6h). A `singletonKey` throttles that to at most one reaper-requeue per PR per hour so a poison PR can't loop; the age window skips the 37-day backlog so old PRs aren't re-reviewed and spammed.

No schema change. Swarm `stop_grace_period` (360s) already exceeds the app's 5-min graceful pg-boss drain, so the infra is fine — the gap was purely the missing reaper.

## Verification
- `bun test lib/__tests__/reap-stuck-reviews.test.ts` — recent→requeue, old→fail, race→skip (3/3 pass).
- `tsc --noEmit` (0 errors) + eslint clean on changed files.
- On deploy, the first reap recovers today's three (recent → auto-retried) and cleans the backlog (old → `failed` with the message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p
