### PR TITLE
feat(terraform): harden remote state with encrypted S3 backend bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,33 @@ jobs:
           DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
           BETTER_AUTH_SECRET: "build-time-dummy-secret"
 
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.15.8"
+          terraform_wrapper: false
+
+      - name: Check Terraform formatting
+        run: |
+          terraform fmt -check -recursive terraform/bootstrap/aws-state
+          terraform fmt -check terraform/stacks/aws-ec2/versions.tf
+
+      - name: Test state-backend bootstrap
+        run: |
+          terraform -chdir=terraform/bootstrap/aws-state init -backend=false -input=false
+          terraform -chdir=terraform/bootstrap/aws-state validate
+          terraform -chdir=terraform/bootstrap/aws-state test
+
+      - name: Test AWS application stack
+        run: |
+          terraform -chdir=terraform/stacks/aws-ec2 init -backend=false -input=false
+          terraform -chdir=terraform/stacks/aws-ec2 validate
+          terraform -chdir=terraform/stacks/aws-ec2 test
+
   agent-task-postgres:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
           DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy"
           BETTER_AUTH_SECRET: "build-time-dummy-secret"
 
+      - name: Test Terraform backend hardening regression
+        run: bun test lib/__tests__/terraform-backend-security.test.ts
+        working-directory: apps/web
+
   terraform:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- AWS Terraform deployments now require an encrypted S3 backend with native state locking. A new bootstrap root provisions the versioned, private, KMS-encrypted bucket and generates account-pinned configuration plus least-privilege operator IAM; existing local state has a workspace-safe migration runbook. Common saved-plan filenames are ignored because plans can retain secrets. The HTTPS guide now correctly requires origin TLS before Cloudflare Full or Full (strict).
+
 ## [1.0.101] - 2026-08-06
 
 ### Fixed

--- a/apps/web/lib/__tests__/terraform-backend-security.test.ts
+++ b/apps/web/lib/__tests__/terraform-backend-security.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../../../..");
+const readRepoFile = (path: string) => readFileSync(resolve(repoRoot, path), "utf8");
+
+describe("Terraform production-state boundary", () => {
+  it("requires encrypted native-locking S3 state", () => {
+    const versions = readRepoFile("terraform/stacks/aws-ec2/versions.tf");
+    const backend = versions.match(/^\s*backend\s+"s3"\s*\{([\s\S]*?)^\s*\}/m)?.[1];
+
+    expect(versions).toContain('required_version = ">= 1.11.0"');
+    expect(backend).toBeDefined();
+    expect(backend).toMatch(/^\s*encrypt\s*=\s*true\s*$/m);
+    expect(backend).toMatch(/^\s*use_lockfile\s*=\s*true\s*$/m);
+  });
+
+  it("ships required KMS and account settings without credentials", () => {
+    const config = readRepoFile("terraform/stacks/aws-ec2/backend.conf.example");
+
+    for (const property of [
+      "bucket",
+      "key",
+      "region",
+      "kms_key_id",
+      "allowed_account_ids",
+      "workspace_key_prefix",
+    ]) {
+      expect(config).toMatch(new RegExp(`^\\s*${property}\\s*=`, "m"));
+    }
+
+    expect(config).not.toMatch(/^\s*(?:access_key|secret_key|token)\s*=/m);
+    expect(config).not.toMatch(/^\s*dynamodb_table\s*=/m);
+  });
+
+  it("ships a hardened first-time backend bootstrap", () => {
+    const main = readRepoFile("terraform/bootstrap/aws-state/main.tf");
+    const outputs = readRepoFile("terraform/bootstrap/aws-state/outputs.tf");
+    const versions = readRepoFile("terraform/bootstrap/aws-state/versions.tf");
+    const workflow = readRepoFile(".github/workflows/ci.yml");
+
+    expect(versions).toContain('version = "= 5.100.0"');
+    expect(versions).toContain("allowed_account_ids = [var.expected_account_id]");
+    expect(main).toContain('resource "aws_kms_key" "state"');
+    expect(main).toMatch(/^\s*enable_key_rotation\s*=\s*true\s*$/m);
+    expect(main).toContain('resource "aws_s3_bucket_public_access_block" "state"');
+    expect(main).toContain('resource "aws_s3_bucket_versioning" "state"');
+    expect(main).toContain('resource "aws_s3_bucket_server_side_encryption_configuration" "state"');
+    expect(main).toContain('Sid       = "DenyInsecureTransport"');
+    expect(main).toContain('Sid       = "DenyUploadsWithoutSSEKMS"');
+    expect(main).toContain('Sid       = "DenyUploadsWithWrongKMSKey"');
+    expect(outputs).toContain('Sid      = "ManageNativeStateLock"');
+    expect(outputs).toContain('Sid      = "ManageWorkspaceState"');
+    expect(outputs).toContain('"kms:GenerateDataKey"');
+    expect(outputs).toContain('output "recovery_iam_policy_json"');
+    expect(workflow).toContain("hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e");
+    expect(workflow).toContain("terraform -chdir=terraform/bootstrap/aws-state test");
+  });
+
+  it("documents guarded migration and secret-bearing plan naming", () => {
+    const readme = readRepoFile("terraform/README.md");
+    const gitignore = readRepoFile("terraform/.gitignore");
+
+    expect(readme).toContain("terraform init -migrate-state -backend-config=backend.conf");
+    expect(readme).toMatch(/Stop if\s+initialization shows an empty or different state/);
+    expect(readme).toMatch(/Do not use\s+`-reconfigure`\s+for the\s+first migration/);
+    expect(readme).toContain("always use a `.tfplan`");
+    expect(readme).toContain("keep `dynamodb_table` alongside the");
+    expect(readme).toContain("identical bucket, key, and workspace prefix");
+    expect(readme).toContain("revoke write and lock permissions for the old backend");
+    expect(gitignore).toContain("*.tfstate.*");
+    expect(gitignore).toContain("*.tfplan");
+    expect(gitignore).toContain("*.plan");
+  });
+});

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -2,17 +2,28 @@
 *.tfvars
 *.tfvars.json
 
-# Backend config (may contain bucket names / credentials)
+# Backend config (deployment-specific identifiers; credentials are forbidden)
 *.conf
 
 # Local state
 *.tfstate
-*.tfstate.backup
+*.tfstate.*
 .terraform.tfstate.lock.info
+
+# Saved plans can contain plaintext secrets
+tfplan
+tfplan.*
+*.tfplan
+*.tfplan.*
+*.plan
+*.plan.*
 
 # Terraform working directories
 **/.terraform/
 **/.terraform.lock.hcl
+
+# The security-boundary bootstrap pins its reviewed provider checksums.
+!bootstrap/aws-state/.terraform.lock.hcl
 
 # Crash log files
 crash.log

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -31,9 +31,9 @@ Self-host Octopus on AWS with a single `terraform apply`. This sets up an EC2 in
 
 Install these before you start:
 
-- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.11
 - [Docker](https://docs.docker.com/get-docker/) (to build and push the app image)
-- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) — run `aws configure` with your access key and secret
+- [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) — authenticate with an AWS SSO/profile session or an assigned role
 - A registered domain (you'll point its DNS to the server IP after deploy)
 - A GitHub account (to create the GitHub App and OAuth App)
 
@@ -172,10 +172,60 @@ The minimum you need to fill in:
 
 ## Step 4 — Deploy
 
-```bash
-# Initialize Terraform (downloads the AWS provider)
-terraform init
+### Configure encrypted remote state
 
+Production deployments require an existing private, versioned S3 bucket and a
+customer-managed KMS key. The bucket must block public access, deny non-TLS
+requests, and use the KMS key for default encryption. Give the Terraform
+operator only these permissions:
+
+- `s3:ListBucket` on the state bucket, restricted to the default state/lock
+  keys and workspace prefix
+- `s3:GetObject` and `s3:PutObject` on the default state object
+- `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on non-default
+  workspace state objects
+- `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on `.tflock` objects
+- `kms:Encrypt`, `kms:Decrypt`, `kms:GenerateDataKey`, and `kms:DescribeKey` on
+  the configured key
+
+Supply AWS credentials through a profile, environment, or role — never in the
+backend configuration.
+
+Create the boundary with the included bootstrap root. Its local state contains
+no application secrets, but keep and back it up on an encrypted filesystem
+because it controls the bucket and KMS key.
+
+```bash
+cd ../../bootstrap/aws-state
+cp terraform.tfvars.example terraform.tfvars
+# Set a globally unique bucket_name and the expected 12-digit AWS account ID.
+# Confirm the account and region before continuing.
+terraform init
+terraform plan -out=backend.tfplan
+terraform apply backend.tfplan
+
+# Attach this least-privilege policy to the application Terraform operator.
+terraform output -raw operator_iam_policy_json
+
+umask 077
+terraform output -raw backend_conf > ../../stacks/aws-ec2/backend.conf
+cd ../../stacks/aws-ec2
+```
+
+If you use an existing bucket and KMS key instead, verify every control and IAM
+permission above before copying `backend.conf.example`.
+
+```bash
+# The bootstrap generated backend.conf. If using an existing boundary, copy
+# backend.conf.example and set every required deployment-specific value.
+terraform init -backend-config=backend.conf
+```
+
+The backend block enforces encryption and native S3 state locking. The supplied
+configuration also pins KMS and the expected AWS account; keep both settings.
+Do not start an apply until initialization succeeds against that account.
+
+```bash
 # Preview what will be created
 terraform plan
 
@@ -235,16 +285,22 @@ The app responds on port 80 immediately after the EC2 instance finishes booting 
 
 ## Step 6 — Set up HTTPS
 
-The server listens on HTTP (port 80). To serve HTTPS, the easiest option is **Cloudflare** (free plan):
+The default stack listens on HTTP (port 80). Before putting it into production,
+add HTTPS at the origin using an AWS ALB with ACM, Caddy, or an nginx
+certificate. Then configure Cloudflare for **Full (strict)** so both the
+browser-to-edge and edge-to-origin connections are encrypted.
 
-1. Add your domain to Cloudflare (free plan is fine)
-2. Create the DNS A record in Cloudflare (same as Step 5) — make sure the cloud icon is **orange** (proxied)
-3. In Cloudflare: **SSL/TLS** → set mode to **Full** (not Full Strict, since nginx uses plain HTTP)
-4. Done — Cloudflare terminates TLS for you at no cost
+Cloudflare **Full** and **Full (strict)** require the origin to accept HTTPS;
+they do not encrypt a plaintext HTTP origin. Cloudflare **Flexible** can proxy
+this stack before origin TLS is installed, but the edge-to-origin connection
+remains plaintext and is not recommended for production.
 
-Alternatively:
-- **AWS ALB + ACM**: more involved, requires a separate load balancer module
-- **Caddy sidecar**: add a Caddy container to the docker-compose template with a volume for certs
+After origin HTTPS is configured:
+
+1. Add the domain to Cloudflare and create the proxied DNS A record.
+2. Select **SSL/TLS → Full (strict)**.
+3. Verify the public URL and GitHub webhook delivery before removing any
+   temporary HTTP compatibility path.
 
 ---
 
@@ -374,17 +430,81 @@ The web container is allocated 5 GB RAM (4 GB for the Node.js heap). With Qdrant
 
 ---
 
-## Remote State (optional)
+## Migrating an existing local state
 
-For team use, store Terraform state in S3:
+The repository previously defaulted to local state. Before checking out this
+backend change, capture the authoritative inventory and backup in an exclusive
+maintenance window. Do not allow concurrent Terraform operations until the
+migration is verified.
 
 ```bash
-cp backend.conf.example backend.conf
-# Edit backend.conf with your S3 bucket and DynamoDB table
-terraform init -backend-config=backend.conf
+# Run on the old configuration. Record every workspace, select each one, and
+# repeat workspace show, state list, and state pull.
+set -e
+terraform workspace list
+terraform workspace show
+terraform state list
+umask 077
+OCTOPUS_STATE_WORKSPACE=$(terraform workspace show)
+OCTOPUS_STATE_TEMP=$(mktemp "/encrypted/offline/path/octopus-${OCTOPUS_STATE_WORKSPACE}-XXXXXX")
+OCTOPUS_STATE_BACKUP="${OCTOPUS_STATE_TEMP}.tfstate"
+terraform state pull > "${OCTOPUS_STATE_TEMP}"
+test -s "${OCTOPUS_STATE_TEMP}"
+terraform show -json "${OCTOPUS_STATE_TEMP}" > /dev/null
+mv "${OCTOPUS_STATE_TEMP}" "${OCTOPUS_STATE_BACKUP}"
+shasum -a 256 "${OCTOPUS_STATE_BACKUP}"
 ```
 
-The `backend.conf.example` file includes the AWS CLI commands to create the bucket and lock table.
+After the backups and inventories are recorded, check out the new version and
+run from `terraform/stacks/aws-ec2`:
+
+```bash
+# Generate backend.conf from the bootstrap root above, or copy the example and
+# populate every value for a separately verified existing boundary.
+test -s backend.conf
+# If the old S3 backend uses DynamoDB locking and the old and new configurations
+# have the identical bucket, key, and workspace prefix, keep its dynamodb_table
+# setting here temporarily so old and upgraded clients share both locks.
+terraform init -migrate-state -backend-config=backend.conf
+
+# Confirm the migrated inventory, then require a non-destructive plan.
+terraform workspace list
+terraform workspace show
+terraform state list
+terraform plan
+```
+
+Create backups only on an encrypted filesystem outside the repository; set
+`umask 077` before each file is created. If the authoritative state is
+already remote, use that backend's documented recovery process. Compare every
+workspace's pre-migration inventory with its migrated inventory. Select and
+repeat `workspace show`, `state list`, and `plan` for every workspace. Stop if
+initialization shows an empty or different state, or if any plan proposes an
+unexpected create, destroy, or replacement. Do not use `-reconfigure` for the
+first migration: it can select the new backend without copying the existing
+state.
+
+If the old backend used DynamoDB locking and the migration keeps the identical
+bucket, key, and workspace prefix, keep `dynamodb_table` alongside the new
+native S3 lock until every operator and automation client uses Terraform 1.11+
+and this configuration. After confirming there are no old or active DynamoDB
+locks, remove the setting, reinitialize the same S3 backend, verify all
+workspace inventories and no-change plans again, and only then retire the lock
+table.
+
+If the bucket, key, or workspace prefix changes, the DynamoDB and native S3
+locks do not coordinate. Drain every operator and automation client, then
+revoke write and lock permissions for the old backend before migrating. Do not
+restore those permissions or let an old configuration resume after cutover.
+
+Keep the restricted backup until the remote state and a no-change plan are
+verified. Then account for and securely remove obsolete local states, backups,
+and saved plan files. Do not resume from a stale local copy. Prior S3 versions
+are intentionally unavailable to the day-to-day operator: a bootstrap
+administrator must temporarily attach the generated break-glass recovery
+policy to retrieve a known-good version, then remove it. Rotate credentials
+only if an old copy was exposed or cannot be accounted for, or as part of the
+later secret-delivery cutover.
 
 ---
 
@@ -397,6 +517,12 @@ The `backend.conf.example` file includes the AWS CLI commands to create the buck
 - Root EBS volume encrypted at rest
 - `.env` file on the instance is `chmod 600`
 - Never commit `terraform.tfvars` — it's gitignored
+- Production state uses an encrypted, versioned S3 backend with native locking;
+  backend credentials must never be stored in `backend.conf`
+- Saved Terraform plans can contain plaintext secrets; always use a `.tfplan`
+  filename so the repository ignore rules apply
+- The default HTTP origin is not end-to-end encrypted; add origin TLS before
+  using Cloudflare Full (strict) in production
 
 ---
 
@@ -404,6 +530,7 @@ The `backend.conf.example` file includes the AWS CLI commands to create the buck
 
 ```
 terraform/
+├── bootstrap/aws-state/   # one-time hardened S3/KMS state boundary
 ├── modules/aws/
 │   ├── vpc/               # VPC, subnets, IGW, optional NAT
 │   ├── ec2-app/           # EC2, security group, IAM, EIP, userdata

--- a/terraform/bootstrap/aws-state/.terraform.lock.hcl
+++ b/terraform/bootstrap/aws-state/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "5.100.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/bootstrap/aws-state/README.md
+++ b/terraform/bootstrap/aws-state/README.md
@@ -1,0 +1,84 @@
+# AWS state bootstrap
+
+This isolated Terraform root creates the security boundary used by the Octopus
+AWS application stack:
+
+- a customer-managed, rotating KMS key and alias;
+- a private, versioned S3 bucket with bucket-owner-enforced ownership;
+- default SSE-KMS encryption plus policy denies for plaintext transport,
+  missing SSE-KMS headers, and the wrong KMS key; and
+- credential-free backend configuration and a least-privilege operator policy.
+
+The bucket and KMS key are protected with `prevent_destroy`. This root must run
+before initializing `terraform/stacks/aws-ec2`; a backend cannot safely create
+the bucket that stores its own initial state.
+
+## Create the backend
+
+Authenticate to the target AWS account with an administrative SSO session or
+role, then run from this directory:
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Set a globally unique bucket_name and the expected 12-digit AWS account;
+# review the region, state key, workspace prefix, and tags.
+terraform init
+terraform plan
+terraform apply
+```
+
+The local bootstrap state contains bucket, KMS, policy, and account metadata,
+but no Octopus application credentials or generated application secrets. It is
+still operationally sensitive: keep it on an encrypted filesystem, restrict it
+to the operator, back it up, and never pass application secrets to this root.
+The committed dependency lock file pins the reviewed AWS provider checksums.
+Both the AWS provider and a resource precondition reject credentials for any
+account other than `expected_account_id` before creating the boundary.
+
+## Configure the application stack
+
+Generate its credential-free backend file:
+
+```bash
+terraform output -raw backend_conf > ../../stacks/aws-ec2/backend.conf
+terraform output -raw operator_iam_policy_json
+```
+
+Attach the printed IAM policy to the role or identity that will operate the
+application stack. It grants only:
+
+- `s3:ListBucket`, limited to the default state/lock keys and the workspace
+  prefix;
+- `s3:GetObject` and `s3:PutObject` on the default state object;
+- `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on non-default
+  workspace state objects (required for workspace deletion);
+- `s3:GetObject`, `s3:PutObject`, and `s3:DeleteObject` on their `.tflock`
+  objects; and
+- `kms:Encrypt`, `kms:Decrypt`, `kms:GenerateDataKey`, and `kms:DescribeKey` on
+  the dedicated key.
+
+Then initialize a fresh application stack:
+
+```bash
+terraform -chdir=../../stacks/aws-ec2 init -backend-config=backend.conf
+```
+
+For an existing local application state, take a restricted, workspace-aware
+backup before checking out the backend change, establish an exclusive
+maintenance window, and use `terraform init -migrate-state` from the
+application stack. Never use `-reconfigure` for the first migration.
+
+The day-to-day operator policy intentionally cannot enumerate or retrieve prior
+state versions. During recovery only, a bootstrap administrator can print and
+temporarily attach `terraform output -raw recovery_iam_policy_json`; it grants
+scoped `s3:ListBucketVersions`, `s3:GetObjectVersion`, and KMS decrypt access.
+Remove it immediately after recovering a known-good version.
+
+## Test
+
+The native tests use a mocked AWS provider and make no network calls:
+
+```bash
+terraform init -backend=false
+terraform test
+```

--- a/terraform/bootstrap/aws-state/main.tf
+++ b/terraform/bootstrap/aws-state/main.tf
@@ -1,0 +1,157 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+locals {
+  lock_key                   = "${var.state_key}.tflock"
+  bucket_arn                 = "arn:${data.aws_partition.current.partition}:s3:::${var.bucket_name}"
+  state_object_arn           = "${local.bucket_arn}/${var.state_key}"
+  lock_object_arn            = "${local.bucket_arn}/${local.lock_key}"
+  workspace_state_object_arn = "${local.bucket_arn}/${var.workspace_key_prefix}/*/${var.state_key}"
+  workspace_lock_object_arn  = "${local.bucket_arn}/${var.workspace_key_prefix}/*/${local.lock_key}"
+  kms_alias_name             = "alias/octopus-${replace(var.bucket_name, ".", "-")}-tfstate"
+
+  resource_tags = merge(var.tags, {
+    ManagedBy = "Terraform"
+    Purpose   = "Octopus Terraform state"
+  })
+}
+
+resource "aws_kms_key" "state" {
+  description              = "Encrypts Octopus Terraform state and lock objects"
+  deletion_window_in_days  = 30
+  enable_key_rotation      = true
+  is_enabled               = true
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid       = "EnableAccountAdministration"
+      Effect    = "Allow"
+      Principal = { AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root" }
+      Action    = "kms:*"
+      Resource  = "*"
+    }]
+  })
+
+  tags = merge(local.resource_tags, {
+    Name = "octopus-terraform-state"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+
+    precondition {
+      condition     = data.aws_caller_identity.current.account_id == var.expected_account_id
+      error_message = "Authenticated AWS account does not match expected_account_id; refusing to create the state boundary."
+    }
+  }
+}
+
+resource "aws_kms_alias" "state" {
+  name          = local.kms_alias_name
+  target_key_id = aws_kms_key.state.key_id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket" "state" {
+  bucket        = var.bucket_name
+  force_destroy = false
+
+  tags = merge(local.resource_tags, {
+    Name = var.bucket_name
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.state.arn
+      sse_algorithm     = "aws:kms"
+    }
+
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_policy" "state" {
+  bucket = aws_s3_bucket.state.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = { AWS = "*" }
+        Action    = "s3:*"
+        Resource  = [local.bucket_arn, "${local.bucket_arn}/*"]
+        Condition = {
+          Bool = { "aws:SecureTransport" = "false" }
+        }
+      },
+      {
+        Sid       = "DenyUploadsWithoutSSEKMS"
+        Effect    = "Deny"
+        Principal = { AWS = "*" }
+        Action    = "s3:PutObject"
+        Resource  = "${local.bucket_arn}/*"
+        Condition = {
+          StringNotEquals = { "s3:x-amz-server-side-encryption" = "aws:kms" }
+        }
+      },
+      {
+        Sid       = "DenyUploadsWithWrongKMSKey"
+        Effect    = "Deny"
+        Principal = { AWS = "*" }
+        Action    = "s3:PutObject"
+        Resource  = "${local.bucket_arn}/*"
+        Condition = {
+          StringNotEquals = { "s3:x-amz-server-side-encryption-aws-kms-key-id" = aws_kms_key.state.arn }
+        }
+      }
+    ]
+  })
+
+  depends_on = [
+    aws_s3_bucket_ownership_controls.state,
+    aws_s3_bucket_public_access_block.state,
+    aws_s3_bucket_server_side_encryption_configuration.state,
+    aws_s3_bucket_versioning.state,
+  ]
+}

--- a/terraform/bootstrap/aws-state/outputs.tf
+++ b/terraform/bootstrap/aws-state/outputs.tf
@@ -1,0 +1,137 @@
+locals {
+  backend_conf = <<-EOT
+    bucket               = "${var.bucket_name}"
+    key                  = "${var.state_key}"
+    region               = "${var.region}"
+    kms_key_id           = "${aws_kms_key.state.arn}"
+    allowed_account_ids  = ["${data.aws_caller_identity.current.account_id}"]
+    workspace_key_prefix = "${var.workspace_key_prefix}"
+  EOT
+
+  operator_iam_policy = {
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ListOnlyTheStateKeys"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = [local.bucket_arn]
+        Condition = {
+          StringLike = {
+            "s3:prefix" = [
+              var.state_key,
+              local.lock_key,
+              "${var.workspace_key_prefix}/*",
+            ]
+          }
+        }
+      },
+      {
+        Sid      = "ReadWriteStateWithoutDelete"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject"]
+        Resource = [local.state_object_arn]
+      },
+      {
+        Sid      = "ManageWorkspaceState"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = [local.workspace_state_object_arn]
+      },
+      {
+        Sid      = "ManageNativeStateLock"
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = [local.lock_object_arn, local.workspace_lock_object_arn]
+      },
+      {
+        Sid    = "UseStateEncryptionKey"
+        Effect = "Allow"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:DescribeKey",
+        ]
+        Resource = [aws_kms_key.state.arn]
+      },
+    ]
+  }
+
+  recovery_iam_policy = {
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ListStateVersions"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucketVersions"]
+        Resource = [local.bucket_arn]
+        Condition = {
+          StringLike = {
+            "s3:prefix" = [
+              var.state_key,
+              "${var.workspace_key_prefix}/*",
+            ]
+          }
+        }
+      },
+      {
+        Sid      = "ReadPriorStateVersions"
+        Effect   = "Allow"
+        Action   = ["s3:GetObjectVersion"]
+        Resource = [local.state_object_arn, local.workspace_state_object_arn]
+      },
+      {
+        Sid      = "DecryptPriorStateVersions"
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt", "kms:DescribeKey"]
+        Resource = [aws_kms_key.state.arn]
+      },
+    ]
+  }
+}
+
+output "backend_conf" {
+  description = "Credential-free backend.conf content for the Octopus application stack."
+  value       = local.backend_conf
+}
+
+output "operator_iam_policy_json" {
+  description = "Least-privilege IAM policy for an operator of the exact state and lock objects."
+  value       = jsonencode(local.operator_iam_policy)
+}
+
+output "recovery_iam_policy_json" {
+  description = "Read-only, break-glass policy for retrieving prior state versions; do not attach persistently."
+  value       = jsonencode(local.recovery_iam_policy)
+}
+
+output "backend_metadata" {
+  description = "Non-secret identifiers for the provisioned application-state backend."
+  value = {
+    account_id           = data.aws_caller_identity.current.account_id
+    region               = var.region
+    bucket_name          = aws_s3_bucket.state.id
+    bucket_arn           = local.bucket_arn
+    state_key            = var.state_key
+    lock_key             = local.lock_key
+    workspace_key_prefix = var.workspace_key_prefix
+    kms_key_arn          = aws_kms_key.state.arn
+    kms_alias_name       = aws_kms_alias.state.name
+  }
+}
+
+output "bucket_name" {
+  description = "State bucket name."
+  value       = aws_s3_bucket.state.id
+}
+
+output "state_key" {
+  description = "Application state object key."
+  value       = var.state_key
+}
+
+output "aws_account_id" {
+  description = "AWS account pinned in the generated backend configuration."
+  value       = data.aws_caller_identity.current.account_id
+}

--- a/terraform/bootstrap/aws-state/terraform.tfvars.example
+++ b/terraform/bootstrap/aws-state/terraform.tfvars.example
@@ -1,0 +1,10 @@
+bucket_name          = "your-org-octopus-tfstate"
+region               = "us-east-1"
+expected_account_id  = "123456789012"
+state_key            = "aws-ec2/production/terraform.tfstate"
+workspace_key_prefix = "env:"
+
+tags = {
+  Environment = "production"
+  Project     = "octopus"
+}

--- a/terraform/bootstrap/aws-state/tests/security.tftest.hcl
+++ b/terraform/bootstrap/aws-state/tests/security.tftest.hcl
@@ -1,0 +1,278 @@
+# Runs entirely against the mocked AWS provider; no credentials or live
+# infrastructure are used.
+mock_provider "aws" {
+  override_during = plan
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:user/test"
+      id         = "123456789012"
+    }
+  }
+
+  mock_data "aws_partition" {
+    defaults = {
+      partition = "aws"
+    }
+  }
+
+  mock_resource "aws_kms_key" {
+    defaults = {
+      arn    = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
+      key_id = "00000000-0000-0000-0000-000000000000"
+    }
+  }
+}
+
+variables {
+  bucket_name          = "example-octopus-tfstate"
+  region               = "us-east-1"
+  expected_account_id  = "123456789012"
+  state_key            = "aws-ec2/production/terraform.tfstate"
+  workspace_key_prefix = "env:"
+}
+
+run "hardened_state_boundary" {
+  command = plan
+
+  assert {
+    condition     = aws_kms_key.state.enable_key_rotation && aws_kms_key.state.deletion_window_in_days == 30
+    error_message = "The state KMS key must rotate and retain the maximum deletion window."
+  }
+
+  assert {
+    condition     = !aws_s3_bucket.state.force_destroy
+    error_message = "The state bucket must never force-delete state versions."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_ownership_controls.state.rule[0].object_ownership == "BucketOwnerEnforced"
+    error_message = "The state bucket must disable ACL ownership with BucketOwnerEnforced."
+  }
+
+  assert {
+    condition = (
+      aws_s3_bucket_public_access_block.state.block_public_acls &&
+      aws_s3_bucket_public_access_block.state.block_public_policy &&
+      aws_s3_bucket_public_access_block.state.ignore_public_acls &&
+      aws_s3_bucket_public_access_block.state.restrict_public_buckets
+    )
+    error_message = "Every S3 public-access-block control must remain enabled."
+  }
+
+  assert {
+    condition     = aws_s3_bucket_versioning.state.versioning_configuration[0].status == "Enabled"
+    error_message = "State versioning must remain enabled for recovery."
+  }
+
+  assert {
+    condition = (
+      tolist(aws_s3_bucket_server_side_encryption_configuration.state.rule)[0].apply_server_side_encryption_by_default[0].sse_algorithm == "aws:kms" &&
+      tolist(aws_s3_bucket_server_side_encryption_configuration.state.rule)[0].apply_server_side_encryption_by_default[0].kms_master_key_id == aws_kms_key.state.arn &&
+      tolist(aws_s3_bucket_server_side_encryption_configuration.state.rule)[0].bucket_key_enabled
+    )
+    error_message = "Default encryption must use the dedicated KMS key with S3 bucket keys enabled."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyInsecureTransport"
+      ]).Effect == "Deny" &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyInsecureTransport"
+      ]).Principal.AWS == "*" &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyInsecureTransport"
+      ]).Action == "s3:*" &&
+      toset(one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyInsecureTransport"
+        ]).Resource) == toset([
+        "arn:aws:s3:::example-octopus-tfstate",
+        "arn:aws:s3:::example-octopus-tfstate/*",
+      ]) &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyInsecureTransport"
+      ]).Condition.Bool["aws:SecureTransport"] == "false"
+    )
+    error_message = "The bucket policy must deny every S3 action over plaintext transport on the bucket and its objects."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyUploadsWithoutSSEKMS"
+      ]).Effect == "Deny" &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyUploadsWithoutSSEKMS"
+      ]).Principal.AWS == "*" &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyUploadsWithoutSSEKMS"
+      ]).Action == "s3:PutObject" &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyUploadsWithoutSSEKMS"
+      ]).Resource == "arn:aws:s3:::example-octopus-tfstate/*" &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyUploadsWithoutSSEKMS"
+      ]).Condition.StringNotEquals["s3:x-amz-server-side-encryption"] == "aws:kms"
+    )
+    error_message = "The bucket policy must reject every object upload that does not request SSE-KMS."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyUploadsWithWrongKMSKey"
+      ]).Effect == "Deny" &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyUploadsWithWrongKMSKey"
+      ]).Principal.AWS == "*" &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyUploadsWithWrongKMSKey"
+      ]).Action == "s3:PutObject" &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyUploadsWithWrongKMSKey"
+      ]).Resource == "arn:aws:s3:::example-octopus-tfstate/*" &&
+      one([
+        for statement in jsondecode(aws_s3_bucket_policy.state.policy).Statement : statement
+        if statement.Sid == "DenyUploadsWithWrongKMSKey"
+      ]).Condition.StringNotEquals["s3:x-amz-server-side-encryption-aws-kms-key-id"] == aws_kms_key.state.arn
+    )
+    error_message = "The bucket policy must reject every object upload that uses a different KMS key."
+  }
+
+  assert {
+    condition = (
+      strcontains(output.backend_conf, "kms_key_id") &&
+      strcontains(output.backend_conf, "allowed_account_ids") &&
+      strcontains(output.backend_conf, "workspace_key_prefix") &&
+      !strcontains(output.backend_conf, "access_key") &&
+      !strcontains(output.backend_conf, "secret_key")
+    )
+    error_message = "backend.conf must pin KMS/account identifiers without embedding credentials."
+  }
+
+  assert {
+    condition = toset(one([
+      for statement in jsondecode(output.operator_iam_policy_json).Statement : statement.Condition.StringLike["s3:prefix"]
+      if statement.Sid == "ListOnlyTheStateKeys"
+      ])) == toset([
+      "aws-ec2/production/terraform.tfstate",
+      "aws-ec2/production/terraform.tfstate.tflock",
+      "env:/*",
+    ])
+    error_message = "ListBucket must be limited to the default and non-default workspace state/lock prefixes."
+  }
+
+  assert {
+    condition = toset(one([
+      for statement in jsondecode(output.operator_iam_policy_json).Statement : statement.Resource
+      if statement.Sid == "ReadWriteStateWithoutDelete"
+      ])) == toset([
+      "arn:aws:s3:::example-octopus-tfstate/aws-ec2/production/terraform.tfstate",
+    ])
+    error_message = "Default state read/write must cover only the configured state object."
+  }
+
+  assert {
+    condition = (
+      toset(one([
+        for statement in jsondecode(output.operator_iam_policy_json).Statement : statement.Action
+        if statement.Sid == "ManageWorkspaceState"
+      ])) == toset(["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]) &&
+      toset(one([
+        for statement in jsondecode(output.operator_iam_policy_json).Statement : statement.Resource
+        if statement.Sid == "ManageWorkspaceState"
+      ])) == toset(["arn:aws:s3:::example-octopus-tfstate/env:/*/aws-ec2/production/terraform.tfstate"])
+    )
+    error_message = "Non-default workspace state must support the S3 backend's scoped create/update/delete lifecycle."
+  }
+
+  assert {
+    condition = toset(one([
+      for statement in jsondecode(output.operator_iam_policy_json).Statement : statement.Action
+      if statement.Sid == "ManageNativeStateLock"
+    ])) == toset(["s3:GetObject", "s3:PutObject", "s3:DeleteObject"])
+    error_message = "The operator policy must allow lock deletion without granting state deletion."
+  }
+
+  assert {
+    condition = toset(one([
+      for statement in jsondecode(output.operator_iam_policy_json).Statement : statement.Resource
+      if statement.Sid == "ManageNativeStateLock"
+      ])) == toset([
+      "arn:aws:s3:::example-octopus-tfstate/aws-ec2/production/terraform.tfstate.tflock",
+      "arn:aws:s3:::example-octopus-tfstate/env:/*/aws-ec2/production/terraform.tfstate.tflock",
+    ])
+    error_message = "Lock management must cover only default and non-default workspace lock objects."
+  }
+
+  assert {
+    condition = !contains(one([
+      for statement in jsondecode(output.operator_iam_policy_json).Statement : statement.Action
+      if statement.Sid == "ReadWriteStateWithoutDelete"
+    ]), "s3:DeleteObject")
+    error_message = "The operator policy must not allow deletion of the state object."
+  }
+
+  assert {
+    condition = toset(one([
+      for statement in jsondecode(output.operator_iam_policy_json).Statement : statement.Action
+      if statement.Sid == "UseStateEncryptionKey"
+    ])) == toset(["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey", "kms:DescribeKey"])
+    error_message = "The operator policy must contain only the KMS actions needed by the S3 backend."
+  }
+
+  assert {
+    condition = (
+      toset(one([
+        for statement in jsondecode(output.recovery_iam_policy_json).Statement : statement.Action
+        if statement.Sid == "ListStateVersions"
+      ])) == toset(["s3:ListBucketVersions"]) &&
+      toset(one([
+        for statement in jsondecode(output.recovery_iam_policy_json).Statement : statement.Action
+        if statement.Sid == "ReadPriorStateVersions"
+      ])) == toset(["s3:GetObjectVersion"]) &&
+      toset(one([
+        for statement in jsondecode(output.recovery_iam_policy_json).Statement : statement.Action
+        if statement.Sid == "DecryptPriorStateVersions"
+      ])) == toset(["kms:Decrypt", "kms:DescribeKey"])
+    )
+    error_message = "The break-glass policy must be read-only and limited to version listing, retrieval, and KMS decryption."
+  }
+}
+
+run "wildcard_state_key_is_rejected" {
+  command = plan
+
+  variables {
+    state_key = "aws-ec2/*/terraform.tfstate"
+  }
+
+  expect_failures = [var.state_key]
+}
+
+run "wrong_aws_account_is_rejected" {
+  command = plan
+
+  variables {
+    expected_account_id = "999999999999"
+  }
+
+  expect_failures = [aws_kms_key.state]
+}

--- a/terraform/bootstrap/aws-state/variables.tf
+++ b/terraform/bootstrap/aws-state/variables.tf
@@ -1,0 +1,82 @@
+variable "bucket_name" {
+  description = "Globally unique S3 bucket name for the Octopus application state."
+  type        = string
+
+  validation {
+    condition = (
+      length(var.bucket_name) >= 3 &&
+      length(var.bucket_name) <= 63 &&
+      can(regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$", var.bucket_name)) &&
+      !strcontains(var.bucket_name, "..") &&
+      !can(regex("^[0-9]{1,3}(\\.[0-9]{1,3}){3}$", var.bucket_name))
+    )
+    error_message = "bucket_name must be a 3-63 character, lowercase DNS-compatible S3 bucket name, not an IPv4 address."
+  }
+}
+
+variable "region" {
+  description = "AWS region for the state bucket and KMS key."
+  type        = string
+  default     = "us-east-1"
+
+  validation {
+    condition     = can(regex("^[a-z]{2}(-[a-z]+)+-[0-9]+$", var.region))
+    error_message = "region must be a valid AWS region name such as us-east-1."
+  }
+}
+
+variable "expected_account_id" {
+  description = "Twelve-digit AWS account that is allowed to receive the state boundary."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.expected_account_id))
+    error_message = "expected_account_id must be a 12-digit AWS account ID."
+  }
+}
+
+variable "state_key" {
+  description = "Exact object key used by the Octopus application stack in the default Terraform workspace."
+  type        = string
+  default     = "aws-ec2/production/terraform.tfstate"
+
+  validation {
+    condition = (
+      length(var.state_key) >= 3 &&
+      length(var.state_key) <= 1024 &&
+      can(regex("^[A-Za-z0-9][A-Za-z0-9._/-]*[A-Za-z0-9]$", var.state_key)) &&
+      !startswith(var.state_key, "/") &&
+      !endswith(var.state_key, "/") &&
+      !strcontains(var.state_key, "//") &&
+      !strcontains(var.state_key, "*") &&
+      !strcontains(var.state_key, "?")
+    )
+    error_message = "state_key must be a literal, relative S3 object key without wildcards, repeated slashes, or control characters."
+  }
+}
+
+variable "workspace_key_prefix" {
+  description = "S3 key prefix for non-default Terraform workspaces."
+  type        = string
+  default     = "env:"
+
+  validation {
+    condition = (
+      length(var.workspace_key_prefix) >= 1 &&
+      length(var.workspace_key_prefix) <= 256 &&
+      can(regex("^[A-Za-z0-9._:/-]+$", var.workspace_key_prefix)) &&
+      !startswith(var.workspace_key_prefix, "/") &&
+      !endswith(var.workspace_key_prefix, "/") &&
+      !strcontains(var.workspace_key_prefix, "//") &&
+      !strcontains(var.workspace_key_prefix, "*") &&
+      !strcontains(var.workspace_key_prefix, "?")
+    )
+    error_message = "workspace_key_prefix must be a literal, relative S3 prefix without wildcards, repeated slashes, or control characters."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to apply to the state bucket and KMS key."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/bootstrap/aws-state/versions.tf
+++ b/terraform/bootstrap/aws-state/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.11.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 5.100.0"
+    }
+  }
+}
+
+provider "aws" {
+  region              = var.region
+  allowed_account_ids = [var.expected_account_id]
+}

--- a/terraform/examples/aws-ec2/versions.tf
+++ b/terraform/examples/aws-ec2/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.11.0"
 
   required_providers {
     aws = {

--- a/terraform/stacks/aws-ec2/backend.conf.example
+++ b/terraform/stacks/aws-ec2/backend.conf.example
@@ -1,18 +1,24 @@
-# S3 remote backend configuration.
-# Copy to backend.conf and fill in your values, then run:
-#   terraform init -backend-config=backend.conf
+# Production S3 backend configuration.
 #
-# Create the S3 bucket and DynamoDB table first:
-#   aws s3 mb s3://your-org-octopus-tfstate --region us-east-1
-#   aws dynamodb create-table \
-#     --table-name octopus-tfstate-lock \
-#     --attribute-definitions AttributeName=LockID,AttributeType=S \
-#     --key-schema AttributeName=LockID,KeyType=HASH \
-#     --billing-mode PAY_PER_REQUEST \
-#     --region us-east-1
+# The bucket and KMS key must already exist. Before using them, verify that:
+# - S3 Block Public Access is fully enabled;
+# - bucket versioning is enabled;
+# - the bucket policy denies non-TLS requests;
+# - default encryption uses the KMS key below; and
+# - the Terraform operator has s3:ListBucket on the bucket; GetObject and
+#   PutObject on the default state object; GetObject, PutObject, and
+#   DeleteObject on non-default workspace states and .tflock files; and
+#   kms:Encrypt, kms:Decrypt, kms:GenerateDataKey, and kms:DescribeKey on the
+#   KMS key.
+#
+# Encryption and native S3 locking are enforced in versions.tf. KMS and account
+# pinning are required deployment-specific settings in this template.
+# Authentication must come from an AWS profile, environment, or role. Never add
+# credentials to this file.
 
-bucket         = "your-org-octopus-tfstate"
-key            = "aws-ec2/production/terraform.tfstate"
-region         = "us-east-1"
-dynamodb_table = "octopus-tfstate-lock"
-encrypt        = true
+bucket               = "your-org-octopus-tfstate"
+key                  = "aws-ec2/production/terraform.tfstate"
+region               = "us-east-1"
+kms_key_id           = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
+allowed_account_ids  = ["123456789012"]
+workspace_key_prefix = "env:"

--- a/terraform/stacks/aws-ec2/tests/network_trust.tftest.hcl
+++ b/terraform/stacks/aws-ec2/tests/network_trust.tftest.hcl
@@ -1,5 +1,6 @@
 # SEC-10 network-trust regression tests.
 # Runs entirely against mocked providers — no AWS credentials required:
+#   terraform -chdir=terraform/stacks/aws-ec2 init -backend=false
 #   terraform -chdir=terraform/stacks/aws-ec2 test
 #
 # terraform test cannot address resources inside child modules (only their

--- a/terraform/stacks/aws-ec2/versions.tf
+++ b/terraform/stacks/aws-ec2/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.11.0"
 
   required_providers {
     aws = {
@@ -12,8 +12,11 @@ terraform {
     }
   }
 
-  # Uncomment and configure after creating the S3 bucket and DynamoDB table.
-  # See backend.conf.example for setup instructions.
-  #
-  # backend "s3" {}
+  # Production state can contain generated credentials. Keep encryption and
+  # native S3 locking mandatory; supply only deployment-specific identifiers
+  # through backend.conf (see backend.conf.example).
+  backend "s3" {
+    encrypt      = true
+    use_lockfile = true
+  }
 }


### PR DESCRIPTION
## Intent

Implement SEC-10 remote Terraform state hardening: bootstrap a private versioned KMS-encrypted S3 backend with native locking, fail-closed account pinning, least-privilege operator and break-glass recovery policies, safe workspace-aware migration guidance, CI validation, and regression tests; preserve production state by leaving migration as a controlled post-deploy operation.

## What Changed
- Added a `terraform/bootstrap/aws-state` module that provisions a private, versioned, KMS-encrypted S3 state bucket with native lockfile locking, fail-closed AWS account pinning, least-privilege operator and break-glass recovery IAM policies, plus `tftest` security tests covering the rendered backend config and policies.
- Hardened the `terraform/stacks/aws-ec2` backend: `encrypt` and `use_lockfile` are now mandatory, `required_version` is raised to `>= 1.11.0` (the example wrapper aligned to match), and `backend.conf.example` and the README were rewritten with workspace-aware migration guidance — state migration itself stays a documented manual post-deploy operation.
- Added a CI terraform job that runs `init`/`validate`/`test` for the bootstrap module and stack, and wired the new `terraform-backend-security.test.ts` regression test into CI so future PRs cannot silently weaken the backend hardening.

## Risk Assessment

✅ Low: The only delta since the previous round is a four-line CI step that wires the existing regression test into the ci job, exactly matching the pattern already used for other test files, and it resolves the prior round's only actionable finding.

## Testing

Ran the CI-equivalent validation locally on Terraform 1.15.8 (matching the pinned CI version): the bun regression test plus terraform validate/test for the bootstrap state module and the aws-ec2 stack all pass, and verbose plan evidence demonstrates the hardened bucket/KMS resources, credential-free backend.conf, least-privilege operator and read-only recovery policies, and the fail-closed wrong-account rejection end-to-end; skipped only the CI fmt-check step per the no-linters rule. No visual evidence applies since the change has no UI surface.

<details>
<summary>Evidence: Verbose terraform test output: rendered backend.conf, operator/recovery IAM policies, fail-closed account rejection</summary>

```text
tests/security.tftest.hcl... in progress
  run "hardened_state_boundary"... pass

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_kms_alias.state will be created
  + resource "aws_kms_alias" "state" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/octopus-example-octopus-tfstate-tfstate"
      + name_prefix    = (known after apply)
      + target_key_arn = (known after apply)
      + target_key_id  = "00000000-0000-0000-0000-000000000000"
    }

  # aws_kms_key.state will be created
  + resource "aws_kms_key" "state" {
      + arn                      = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
      + customer_master_key_spec = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days  = 30
      + description              = "Encrypts Octopus Terraform state and lock objects"
      + enable_key_rotation      = true
      + id                       = "jt7r9e4t"
      + is_enabled               = true
      + key_id                   = "00000000-0000-0000-0000-000000000000"
      + key_usage                = "ENCRYPT_DECRYPT"
      + multi_region             = false
      + policy                   = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::123456789012:root"
                        }
                      + Resource  = "*"
                      + Sid       = "EnableAccountAdministration"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + rotation_period_in_days  = 0
      + tags                     = {
          + "ManagedBy" = "Terraform"
          + "Name"      = "octopus-terraform-state"
          + "Purpose"   = "Octopus Terraform state"
        }
      + tags_all                 = {}
    }

  # aws_s3_bucket.state will be created
  + resource "aws_s3_bucket" "state" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "example-octopus-tfstate"
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = {
          + "ManagedBy" = "Terraform"
          + "Name"      = "example-octopus-tfstate"
          + "Purpose"   = "Octopus Terraform state"
        }
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)
    }

  # aws_s3_bucket_ownership_controls.state will be created
  + resource "aws_s3_bucket_ownership_controls" "state" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + object_ownership = "BucketOwnerEnforced"
        }
    }

  # aws_s3_bucket_policy.state will be created
  + resource "aws_s3_bucket_policy" "state" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "s3:*"
                      + Condition = {
                          + Bool = {
                              + "aws:SecureTransport" = "false"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = [
                          + "arn:aws:s3:::example-octopus-tfstate",
                          + "arn:aws:s3:::example-octopus-tfstate/*",
                        ]
                      + Sid       = "DenyInsecureTransport"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringNotEquals = {
                              + "s3:x-amz-server-side-encryption" = "aws:kms"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = "arn:aws:s3:::example-octopus-tfstate/*"
                      + Sid       = "DenyUploadsWithoutSSEKMS"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringNotEquals = {
                              + "s3:x-amz-server-side-encryption-aws-kms-key-id" = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = "arn:aws:s3:::example-octopus-tfstate/*"
                      + Sid       = "DenyUploadsWithWrongKMSKey"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
    }

  # aws_s3_bucket_public_access_block.state will be created
  + resource "aws_s3_bucket_public_access_block" "state" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

  # aws_s3_bucket_server_side_encryption_configuration.state will be created
  + resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + bucket_key_enabled = true

          + apply_server_side_encryption_by_default {
              + kms_master_key_id = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
              + sse_algorithm     = "aws:kms"
            }
        }
    }

  # aws_s3_bucket_versioning.state will be created
  + resource "aws_s3_bucket_versioning" "state" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + versioning_configuration {
          + mfa_delete = (known after apply)
          + status     = "Enabled"
        }
    }

Plan: 8 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + aws_account_id           = "123456789012"
  + backend_conf             = <<-EOT
        bucket               = "example-octopus-tfstate"
        key                  = "aws-ec2/production/terraform.tfstate"
        region               = "us-east-1"
        kms_key_id           = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
        allowed_account_ids  = ["123456789012"]
        workspace_key_prefix = "env:"
    EOT
  + backend_metadata         = {
      + account_id           = "123456789012"
      + bucket_arn           = "arn:aws:s3:::example-octopus-tfstate"
      + bucket_name          = (known after apply)
      + kms_alias_name       = "alias/octopus-example-octopus-tfstate-tfstate"
      + kms_key_arn          = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
      + lock_key             = "aws-ec2/production/terrafo

... [7827 bytes truncated] ...

r apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = {
          + "ManagedBy" = "Terraform"
          + "Name"      = "example-octopus-tfstate"
          + "Purpose"   = "Octopus Terraform state"
        }
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)
    }

  # aws_s3_bucket_ownership_controls.state will be created
  + resource "aws_s3_bucket_ownership_controls" "state" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + object_ownership = "BucketOwnerEnforced"
        }
    }

  # aws_s3_bucket_policy.state will be created
  + resource "aws_s3_bucket_policy" "state" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "s3:*"
                      + Condition = {
                          + Bool = {
                              + "aws:SecureTransport" = "false"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = [
                          + "arn:aws:s3:::example-octopus-tfstate",
                          + "arn:aws:s3:::example-octopus-tfstate/*",
                        ]
                      + Sid       = "DenyInsecureTransport"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringNotEquals = {
                              + "s3:x-amz-server-side-encryption" = "aws:kms"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = "arn:aws:s3:::example-octopus-tfstate/*"
                      + Sid       = "DenyUploadsWithoutSSEKMS"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringNotEquals = {
                              + "s3:x-amz-server-side-encryption-aws-kms-key-id" = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = {
                          + AWS = "*"
                        }
                      + Resource  = "arn:aws:s3:::example-octopus-tfstate/*"
                      + Sid       = "DenyUploadsWithWrongKMSKey"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
    }

  # aws_s3_bucket_public_access_block.state will be created
  + resource "aws_s3_bucket_public_access_block" "state" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

  # aws_s3_bucket_server_side_encryption_configuration.state will be created
  + resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + bucket_key_enabled = true

          + apply_server_side_encryption_by_default {
              + kms_master_key_id = "arn:aws:kms:us-east-1:123456789012:key/00000000-0000-0000-0000-000000000000"
              + sse_algorithm     = "aws:kms"
            }
        }
    }

  # aws_s3_bucket_versioning.state will be created
  + resource "aws_s3_bucket_versioning" "state" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + versioning_configuration {
          + mfa_delete = (known after apply)
          + status     = "Enabled"
        }
    }

Plan: 8 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + aws_account_id = "123456789012"
  + bucket_name    = (known after apply)


Error: Invalid value for variable

  on tests/security.tftest.hcl line 264, in run "wildcard_state_key_is_rejected":
 264:     state_key = "aws-ec2/*/terraform.tfstate"
    ├────────────────
    │ var.state_key is "aws-ec2/*/terraform.tfstate"

state_key must be a literal, relative S3 object key without wildcards,
repeated slashes, or control characters.

This was checked by the validation rule at variables.tf:43,3-13.
  run "wrong_aws_account_is_rejected"... pass

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform planned the following actions, but then encountered a problem:

  # aws_s3_bucket.state will be created
  + resource "aws_s3_bucket" "state" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "example-octopus-tfstate"
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = {
          + "ManagedBy" = "Terraform"
          + "Name"      = "example-octopus-tfstate"
          + "Purpose"   = "Octopus Terraform state"
        }
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)
    }

  # aws_s3_bucket_ownership_controls.state will be created
  + resource "aws_s3_bucket_ownership_controls" "state" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + object_ownership = "BucketOwnerEnforced"
        }
    }

  # aws_s3_bucket_public_access_block.state will be created
  + resource "aws_s3_bucket_public_access_block" "state" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

  # aws_s3_bucket_versioning.state will be created
  + resource "aws_s3_bucket_versioning" "state" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + versioning_configuration {
          + mfa_delete = (known after apply)
          + status     = "Enabled"
        }
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + aws_account_id = "123456789012"
  + bucket_name    = (known after apply)
  + state_key      = "aws-ec2/production/terraform.tfstate"


Error: Resource precondition failed

  on main.tf line 47, in resource "aws_kms_key" "state":
  47:       condition     = data.aws_caller_identity.current.account_id == var.expected_account_id
    ├────────────────
    │ data.aws_caller_identity.current.account_id is "123456789012"
    │ var.expected_account_id is "999999999999"

Authenticated AWS account does not match expected_account_id; refusing to
create the state boundary.
tests/security.tftest.hcl... tearing down
tests/security.tftest.hcl... pass

Success! 3 passed, 0 failed.
```
</details>
<details>
<summary>Evidence: CI-equivalent local run transcript (bun regression test + terraform validate/test for both modules)</summary>

<code>bun test: 4 pass, 0 fail&#10;bootstrap/aws-state: terraform test — 3 passed, 0 failed (incl. wrong_aws_account_is_rejected, wildcard_state_key_is_rejected)&#10;stacks/aws-ec2: terraform test — 8 passed, 0 failed&#10;&#10;Fail-closed pinning error shown to operator:&#10;Error: Resource precondition failed&#10;│ data.aws_caller_identity.current.account_id is &#34;123456789012&#34;&#10;│ var.expected_account_id is &#34;999999999999&#34;&#10;Authenticated AWS account does not match expected_account_id; refusing to create the state boundary.</code>

```text
== CI-equivalent local run (terraform 1.15.8, matches .github/workflows/ci.yml) ==

$ bun test lib/__tests__/terraform-backend-security.test.ts  (in apps/web)
bun test v1.3.13 (bf2e2cec)

 4 pass
 0 fail
 38 expect() calls
Ran 4 tests across 1 file. [87.00ms]

$ terraform -chdir=terraform/bootstrap/aws-state validate && test
Success! The configuration is valid.

tests/security.tftest.hcl... in progress
  run "hardened_state_boundary"... pass
  run "wildcard_state_key_is_rejected"... pass
  run "wrong_aws_account_is_rejected"... pass
tests/security.tftest.hcl... tearing down
tests/security.tftest.hcl... pass

Success! 3 passed, 0 failed.

$ terraform -chdir=terraform/stacks/aws-ec2 validate && test
Success! The configuration is valid.

tests/network_trust.tftest.hcl... in progress
  run "stack_app_data_access_sg_is_identity_only"... pass
  run "rds_module_restricted_to_identity_sg"... pass
  run "rds_module_compat_keeps_cidr_and_identity"... pass
  run "redis_module_restricted_to_identity_sg"... pass
  run "redis_module_compat_keeps_cidr_and_identity"... pass
  run "ec2_module_attaches_additional_identity_sg"... pass
  run "ssh_internet_wide_cidr_rejected"... pass
  run "ssh_malformed_cidr_rejected"... pass
tests/network_trust.tftest.hcl... tearing down
tests/network_trust.tftest.hcl... pass

Success! 8 passed, 0 failed.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `apps/web/lib/__tests__/terraform-backend-security.test.ts:1` - The new regression test apps/web/lib/__tests__/terraform-backend-security.test.ts is never executed in CI. The `ci` job runs only lint/typecheck/build, and the `agent-task-postgres` job runs only two explicitly named test files (agent-task-security*.test.ts). A future PR that weakens the backend hardening (e.g. removes `encrypt = true` or `use_lockfile = true`) would pass CI. Add a step that runs this test file (e.g. `bun test lib/__tests__/terraform-backend-security.test.ts` in the ci job, or in the new terraform job after checkout).
- ℹ️ `terraform/README.md:286` - The Step 6 HTTPS/Cloudflare documentation rewrite (and its CHANGELOG mention) is outside the stated SEC-10 remote-state scope. It is a genuine correction — the previous doc instructed selecting Cloudflare &#34;Full&#34; against a plaintext HTTP origin, which fails — and it is explicitly declared in the changelog, but confirm bundling this unrelated docs change into the remote-state PR is intended.

🔧 Fix: run terraform backend regression test in CI
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun test lib/__tests__/terraform-backend-security.test.ts` in apps/web (4 pass)</code>
- <code>`terraform -chdir=terraform/bootstrap/aws-state init -backend=false &amp;&amp; validate &amp;&amp; test` with Terraform 1.15.8 (3 runs pass, mocked AWS provider, no credentials)</code>
- <code>`terraform -chdir=terraform/bootstrap/aws-state test -verbose` to capture rendered backend.conf, operator IAM policy, break-glass policy, and the wrong-account fail-closed error</code>
- <code>`terraform -chdir=terraform/stacks/aws-ec2 init -backend=false &amp;&amp; validate &amp;&amp; test` (8 runs pass) confirming the stack validates with mandatory encrypt/use_lockfile backend settings</code>
- <code>Manual check that no code or CI step executes `terraform init -migrate-state`; migration stays a documented guarded manual operation</code>
- <code>Removed test-created `.terraform` provider caches; `git status` clean</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `terraform/examples/aws-ec2/versions.tf:2` - terraform/examples/aws-ec2/versions.tf still declares required_version &#34;&gt;= 1.5.0&#34;, but the example wraps terraform/stacks/aws-ec2 as a module, which now requires &#34;&gt;= 1.11.0&#34;. Terraform enforces the module&#39;s stricter constraint, so the example works but its own constraint understates the effective minimum version. Aligning it to &#34;&gt;= 1.11.0&#34; is a functional .tf edit outside this docs/lint pass.

🔧 Fix: align example terraform version with hardened stack requirement
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
