### PR TITLE
feat(terraform): managed ALB/ACM origin TLS with staged cutover for AWS EC2 stacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           lib/__tests__/terraform-runtime-secrets-security.test.ts
           lib/__tests__/terraform-runtime-env-renderer.test.ts
           lib/__tests__/terraform-runtime-secret-refresh.test.ts
+          lib/__tests__/terraform-origin-tls-security.test.ts
         working-directory: apps/web
 
   terraform:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- AWS self-hosted deployments now support a staged managed origin-TLS boundary using an Application Load Balancer, an operator-provisioned ACM certificate, and explicit operator-maintained trusted-edge IPv4 ranges. The documented `preflight` to `enforced` cutover is health-gated and keeps rollback ordering explicit. This repository change does not alter the current WDC/datacenter deployment or cut over production traffic; Full (strict), database/migration compatibility, and the intended application image must be verified separately before an operator changes traffic.
+
 ## [1.0.103] - 2026-08-09
 
 ### Security

--- a/apps/web/lib/__tests__/terraform-origin-tls-security.test.ts
+++ b/apps/web/lib/__tests__/terraform-origin-tls-security.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../../../..");
+const readRepoFile = (path: string) => readFileSync(resolve(repoRoot, path), "utf8");
+
+const stackMain = readRepoFile("terraform/stacks/aws-ec2/main.tf");
+const stackVariables = readRepoFile("terraform/stacks/aws-ec2/variables.tf");
+const stackOutputs = readRepoFile("terraform/stacks/aws-ec2/outputs.tf");
+const stackVersions = readRepoFile("terraform/stacks/aws-ec2/versions.tf");
+const stackTfvarsExample = readRepoFile("terraform/stacks/aws-ec2/terraform.tfvars.example");
+const quickstartExample = readRepoFile("terraform/examples/aws-ec2/main.tf");
+const dockerCompose = readRepoFile(
+  "terraform/stacks/aws-ec2/templates/docker-compose.yml.tpl",
+);
+const runtimeInstaller = readRepoFile(
+  "terraform/modules/aws/ec2-app/templates/runtime-installer.sh.tpl",
+);
+const refreshSecrets = readRepoFile(
+  "terraform/modules/aws/ec2-app/templates/refresh-secrets.sh.tpl",
+);
+const terraformReadme = readRepoFile("terraform/README.md");
+const workflow = readRepoFile(".github/workflows/ci.yml");
+
+describe("Terraform origin-TLS and trusted-edge boundary", () => {
+  it("requires an explicit staged cutover, exact ACM ARN, and bounded edge CIDRs", () => {
+    expect(stackMain).toContain(
+      "origin_name_suffix = substr(sha256(var.name_prefix), 0, 12)",
+    );
+    expect(stackMain).toContain('origin_lb_name     = "oct-origin-${local.origin_name_suffix}"');
+    expect(stackMain).toContain('origin_tg_name     = "oct-app-${local.origin_name_suffix}"');
+    expect(stackMain).toContain("name                       = local.origin_lb_name");
+    expect(stackMain).toContain("name                 = local.origin_tg_name");
+    expect(stackVariables).not.toContain("length(var.name_prefix) <= 25");
+    expect(stackMain).not.toMatch(/name\s*=\s*substr\("\$\{var\.name_prefix\}-(?:origin|app)"/);
+    expect(stackVariables).toMatch(/variable\s+"origin_tls_cutover_stage"\s*\{/);
+    expect(stackVariables).toContain(
+      'contains(["preflight", "enforced"], var.origin_tls_cutover_stage)',
+    );
+    expect(stackVariables).toMatch(/variable\s+"origin_tls_certificate_arn"\s*\{/);
+    expect(stackVariables).toMatch(/:acm:/);
+    expect(stackVariables).toContain("var.aws_region");
+    expect(stackVariables).toMatch(/variable\s+"trusted_edge_ipv4_cidrs"\s*\{/);
+    expect(stackVariables).toContain("cidrnetmask");
+    expect(stackVariables).toContain('!= "0.0.0.0/0"');
+    expect(stackVariables).toMatch(/length\(var\.trusted_edge_ipv4_cidrs\)\s*>\s*0/);
+  });
+
+  it("terminates HTTPS on a hardened ALB in both public subnets", () => {
+    expect(stackMain).toContain('resource "aws_lb" "origin"');
+    expect(stackMain).toMatch(/^\s*subnets\s*=\s*module\.vpc\.public_subnet_ids\s*$/m);
+    expect(stackMain).toMatch(/^\s*idle_timeout\s*=\s*900\s*$/m);
+    expect(stackMain).toMatch(/^\s*preserve_host_header\s*=\s*true\s*$/m);
+    expect(stackMain).toMatch(/^\s*drop_invalid_header_fields\s*=\s*true\s*$/m);
+    expect(stackMain).toMatch(/depends_on\s*=\s*\[[\s\S]*?module\.vpc[\s\S]*?aws_vpc_security_group_ingress_rule\.origin_https[\s\S]*?\]/);
+
+    expect(stackMain).toContain('resource "aws_lb_listener" "https"');
+    expect(stackMain).toMatch(/^\s*port\s*=\s*443\s*$/m);
+    expect(stackMain).toMatch(/^\s*protocol\s*=\s*"HTTPS"\s*$/m);
+    expect(stackMain).toMatch(
+      /^\s*certificate_arn\s*=\s*var\.origin_tls_certificate_arn\s*$/m,
+    );
+    expect(stackMain).toMatch(
+      /^\s*ssl_policy\s*=\s*"ELBSecurityPolicy-TLS13-1-2-2021-06"\s*$/m,
+    );
+    expect(stackMain).toMatch(/default_action\s*\{[\s\S]*?type\s*=\s*"fixed-response"[\s\S]*?status_code\s*=\s*"403"/);
+    expect(stackMain).toContain('resource "aws_lb_listener_rule" "app_host"');
+    expect(stackMain).toMatch(/host_header\s*\{[\s\S]*?values\s*=\s*\[var\.app_domain\]/);
+  });
+
+  it("allows only trusted edge HTTPS and only ALB-to-application HTTP", () => {
+    expect(stackMain).toContain('resource "aws_security_group" "origin_edge"');
+    expect(stackMain).toContain(
+      'resource "aws_vpc_security_group_ingress_rule" "origin_https"',
+    );
+    expect(stackMain).toMatch(
+      /^\s*for_each\s*=\s*toset\(var\.trusted_edge_ipv4_cidrs\)\s*$/m,
+    );
+    expect(stackMain).toMatch(/^\s*cidr_ipv4\s*=\s*each\.value\s*$/m);
+    expect(stackMain).toContain(
+      'resource "aws_vpc_security_group_egress_rule" "origin_to_app"',
+    );
+    expect(stackMain).toMatch(
+      /^\s*referenced_security_group_id\s*=\s*module\.ec2\.security_group_id\s*$/m,
+    );
+    expect(stackMain).not.toContain("# Ingress rules: always open 80 + 443");
+    expect(stackMain).toContain('var.origin_tls_cutover_stage == "preflight"');
+    expect(stackMain).toContain("aws_security_group.origin_edge.id");
+    expect(stackMain).not.toMatch(/data\s+"http"/);
+    expect(stackVersions).not.toMatch(/source\s*=\s*"hashicorp\/http"/);
+    expect(stackVersions).not.toMatch(/source\s*=\s*"cloudflare\/cloudflare"/);
+  });
+
+  it("health-gates the current EC2 instance without changing the application port", () => {
+    expect(stackMain).toContain('resource "aws_lb_target_group" "app"');
+    expect(stackMain).toMatch(/health_check\s*\{[\s\S]*?path\s*=\s*"\/api\/health"/);
+    expect(stackMain).toMatch(/health_check\s*\{[\s\S]*?matcher\s*=\s*"200"/);
+    expect(stackMain).toMatch(/health_check\s*\{[\s\S]*?timeout\s*=\s*[4-9]/);
+    expect(stackMain).toContain('resource "aws_lb_target_group_attachment" "app"');
+    expect(stackMain).toMatch(/^\s*target_id\s*=\s*module\.ec2\.instance_id\s*$/m);
+    expect(stackMain).toMatch(/target_id\s*=\s*module\.ec2\.instance_id[\s\S]*?port\s*=\s*80/);
+  });
+
+  it("preserves the edge HTTPS signal and reconciles nginx config changes", () => {
+    expect(stackMain).not.toContain("proxy_set_header X-Forwarded-Proto $scheme;");
+    expect(stackMain).not.toContain(
+      "proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;",
+    );
+    expect(stackMain).toContain(
+      "proxy_set_header X-Forwarded-Proto $forwarded_proto;",
+    );
+    expect(stackMain).toMatch(
+      /geo\s+\$trusted_origin_proxy\s*\{[\s\S]*?default\s+0;[\s\S]*?\$\{var\.vpc_cidr\}\s+1;[\s\S]*?\}/,
+    );
+    expect(stackMain).toMatch(
+      /map\s+"\$trusted_origin_proxy:\$http_x_forwarded_proto"\s+\$forwarded_proto\s*\{[\s\S]*?default\s+\$scheme;[\s\S]*?"1:https"\s+https;[\s\S]*?\}/,
+    );
+
+    const composeHashReconciliation =
+      /(?:nginx_config_(?:hash|sha256)|config-sha256)/.test(dockerCompose) &&
+      /nginx_config_(?:hash|sha256)/.test(stackMain);
+    const validatedReload =
+      /nginx\s+-t/.test(runtimeInstaller) &&
+      /(?:nginx\s+-s\s+reload|force-recreate[^\n]*nginx)/.test(
+        `${runtimeInstaller}\n${refreshSecrets}`,
+      );
+
+    expect(composeHashReconciliation || validatedReload).toBe(true);
+  });
+
+  it("keeps certificate and private-key values outside Terraform state", () => {
+    const productionTerraform = [
+      stackMain,
+      stackVariables,
+      stackOutputs,
+      stackTfvarsExample,
+      quickstartExample,
+    ].join("\n");
+
+    expect(productionTerraform).not.toMatch(/variable\s+"(?:origin_)?tls_(?:certificate|private_key)"/);
+    expect(productionTerraform).not.toMatch(/resource\s+"aws_acm_certificate"/);
+    expect(productionTerraform).not.toMatch(/^\s*(?:certificate_body|private_key)\s*=/m);
+    expect(stackVariables).toMatch(/variable\s+"origin_tls_certificate_arn"\s*\{/);
+  });
+
+  it("publishes edge DNS outputs and wires every operator-facing example", () => {
+    expect(stackOutputs).toContain('output "origin_dns_name"');
+    expect(stackOutputs).toContain('output "origin_hosted_zone_id"');
+    expect(stackOutputs).toMatch(
+      /output\s+"public_ip"\s*\{[\s\S]*?description\s*=\s*"[^"]*(?:diagnostic|rollback)[^"]*"/i,
+    );
+    for (const example of [stackTfvarsExample, quickstartExample]) {
+      expect(example).toContain("origin_tls_cutover_stage");
+      expect(example).toMatch(/origin_tls_cutover_stage\s*=\s*"enforced"/);
+      expect(example).toContain("origin_tls_certificate_arn");
+      expect(example).toContain("trusted_edge_ipv4_cidrs");
+    }
+  });
+
+  it("documents the health-gated DNS cutover and rollback before enforcement", () => {
+    expect(terraformReadme).toContain("Application Load Balancer");
+    expect(terraformReadme).toContain("ACM");
+    expect(terraformReadme).toContain("origin_tls_cutover_stage");
+    expect(terraformReadme).toContain("Full (strict)");
+    expect(terraformReadme).toContain("origin_dns_name");
+    expect(terraformReadme).toMatch(/target health/i);
+    expect(terraformReadme).toMatch(/rollback/i);
+    expect(terraformReadme).toMatch(/preflight[\s\S]*enforced/i);
+    expect(terraformReadme).toMatch(/public ACM certificate|Cloudflare Origin CA/i);
+    expect(terraformReadme).toMatch(/ACM Private CA[^\n]*not trusted/i);
+    expect(terraformReadme).toMatch(/Fresh deployment[\s\S]*origin_tls_cutover_stage = "enforced"/);
+    expect(terraformReadme).toContain("do not cryptographically");
+    expect(terraformReadme).toContain("address ranges are shared");
+    expect(terraformReadme).toContain(
+      "per-hostname custom Authenticated Origin Pulls/mTLS",
+    );
+
+    const migrationsStep = terraformReadme.indexOf(
+      "## Step 5 — Run database migrations",
+    );
+    const edgeCutoverStep = terraformReadme.indexOf(
+      "## Step 6 — Stage origin HTTPS and edge restriction",
+    );
+    expect(migrationsStep).toBeGreaterThan(-1);
+    expect(edgeCutoverStep).toBeGreaterThan(migrationsStep);
+    expect(terraformReadme).toMatch(
+      /do not route Full \(strict\)[\s\S]{0,100}Elastic IP/i,
+    );
+  });
+
+  it("runs the static and native Terraform regressions in CI", () => {
+    expect(workflow).toContain("terraform-origin-tls-security.test.ts");
+    expect(workflow).toContain("terraform -chdir=terraform/stacks/aws-ec2 test");
+  });
+});

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -460,6 +460,11 @@ stack does not provision that operator-owned certificate boundary.
    group, and security-group rules without replacing EC2, RDS, or Redis.
    Preflight keeps direct EC2 HTTP available for diagnostics and
    pre-enforcement recovery only; it is not a Full (strict) traffic rollback.
+   Preflight also keeps the pre-existing public HTTPS ingress on the instance,
+   so a deployment that terminates TLS on EC2 (for example Caddy or an nginx
+   certificate) keeps serving while you stage the ALB. Stage 2 removes both
+   public ports, so move that edge origin to `origin_dns_name` before
+   enforcing.
 3. Wait for healthy ALB target health on `/api/health`. Stop if the target is
    unhealthy or the plan proposes an unexpected replacement or deletion.
 4. Configure the Cloudflare/edge AWS origin to use `origin_dns_name` on HTTPS
@@ -473,9 +478,12 @@ stack does not provision that operator-owned certificate boundary.
 
 ### Existing AWS stack · Stage 2 — enforced
 
-1. Change only `origin_tls_cutover_stage` to `"enforced"`.
-2. Review the plan. It should remove direct public EC2 HTTP ingress while
-   retaining the ALB-to-EC2 path and should not replace EC2, RDS, or Redis.
+1. Confirm no edge origin or DNS record still targets the Elastic IP or an
+   instance-terminated TLS listener, then change only `origin_tls_cutover_stage`
+   to `"enforced"`.
+2. Review the plan. It should remove direct public EC2 HTTP and HTTPS ingress
+   while retaining the ALB-to-EC2 path and should not replace EC2, RDS, or
+   Redis.
 3. Apply, repeat the health, login, webhook, and real-review checks, then move
    production traffic only after all checks pass.
 
@@ -692,7 +700,8 @@ later secret-delivery cutover.
 - Saved Terraform plans can contain plaintext secrets; always use a `.tfplan`
   filename so the repository ignore rules apply
 - The managed origin terminates HTTPS on the ALB; enforced mode removes direct
-  public EC2 HTTP ingress, and Full (strict) must never target the Elastic IP
+  public EC2 HTTP and HTTPS ingress, and Full (strict) must never target the
+  Elastic IP
 
 ---
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -366,7 +366,7 @@ The first plan must add the data-access security group and attach it to EC2 with
 When `apply` finishes, you'll see output like:
 
 ```
-origin_dns_name       = "octopus-production-origin-123456.us-east-1.elb.amazonaws.com"
+origin_dns_name       = "oct-origin-5633c9b8af6d-123456789.us-east-1.elb.amazonaws.com"
 origin_hosted_zone_id = "Z35SXDOTRQ7X7K"
 public_ip             = "54.123.45.67"
 app_url               = "https://octopus.example.com"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,29 +1,30 @@
 # Octopus — Terraform
 
-Self-host Octopus on AWS with a single `terraform apply`. This sets up an EC2 instance running the Octopus app, an RDS PostgreSQL database, and optional ElastiCache Redis — all in a private VPC.
+Self-host Octopus on AWS. The stack creates an EC2 instance running the Octopus
+app, an RDS PostgreSQL database, optional ElastiCache Redis, and an Application
+Load Balancer that terminates origin HTTPS with an operator-provisioned ACM
+certificate.
 
 ## Architecture
 
 ```
-┌──────────────────────────────────────────────────────────┐
-│  VPC (10.0.0.0/16)                                       │
-│                                                          │
-│  Public subnet          Private subnets                  │
-│  ┌────────────────┐     ┌───────────────────────────┐   │
-│  │  EC2 (t3.xlarge│     │  RDS PostgreSQL 17         │   │
-│  │                │────▶│  ElastiCache Redis (opt.)  │   │
-│  │  nginx         │     └───────────────────────────┘   │
-│  │  web (Next.js) │                                      │
-│  │  qdrant        │                                      │
-│  └────────┬───────┘                                      │
-└───────────┼──────────────────────────────────────────────┘
-            │ Elastic IP
-        Internet
+Internet
+   │
+   ▼
+Cloudflare or another trusted edge
+   │ HTTPS :443 (explicit trusted edge IPv4 CIDRs only)
+   ▼
+Application Load Balancer + ACM certificate
+   │ HTTP :80 (application security group only)
+   ▼
+EC2: nginx + web + qdrant ─────▶ RDS PostgreSQL / optional Redis
+   └── Elastic IP (diagnostic and pre-enforcement recovery only)
 ```
 
 **What runs on EC2 (Docker Compose):** nginx + Octopus web app + Qdrant vector database
 
-**Managed AWS services:** RDS PostgreSQL 17 (app database) · ElastiCache Redis (optional, for queues)
+**Managed AWS services:** Application Load Balancer · ACM certificate reference ·
+RDS PostgreSQL 17 (app database) · ElastiCache Redis (optional, for queues)
 
 ---
 
@@ -34,7 +35,10 @@ Install these before you start:
 - [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.11
 - [Docker](https://docs.docker.com/get-docker/) (to build and push the app image)
 - [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) — authenticate with an AWS SSO/profile session or an assigned role
-- A registered domain (you'll point its DNS to the server IP after deploy)
+- A registered domain served through Cloudflare or another trusted edge
+- An issued ACM certificate in the deployment region that covers the public
+  application hostname and is trusted by the edge: a public ACM certificate,
+  or an imported Cloudflare Origin CA certificate when using Cloudflare
 - A GitHub account (to create the GitHub App and OAuth App)
 
 ---
@@ -190,6 +194,9 @@ The minimum you need to fill in:
 |----------|----------------|
 | `app_image` | The image URL from Step 1 |
 | `app_domain` | Your domain (e.g. `octopus.example.com`) |
+| `origin_tls_certificate_arn` | ARN of an issued, edge-trusted ACM certificate in `aws_region` that covers `app_domain`; use public ACM or imported Cloudflare Origin CA for Cloudflare Full (strict), not ACM Private CA |
+| `origin_tls_cutover_stage` | `enforced` for a fresh deployment; only an existing AWS stack starts with `preflight` for the Step 6 compatibility cutover |
+| `trusted_edge_ipv4_cidrs` | Explicit, operator-verified IPv4 origin ranges for Cloudflare or your trusted edge; never `0.0.0.0/0` |
 | `application_secret_arn` | Exact ARN of the JSON secret created above |
 | `runtime_secret_cutover_stage` | `enforced` for a new deployment; existing AWS deployments must start with `preflight` as documented below |
 | `github_app_id` | From Step 2A (the number) |
@@ -359,52 +366,26 @@ The first plan must add the data-access security group and attach it to EC2 with
 When `apply` finishes, you'll see output like:
 
 ```
-public_ip  = "54.123.45.67"
-app_url    = "https://octopus.example.com"
+origin_dns_name       = "octopus-production-origin-123456.us-east-1.elb.amazonaws.com"
+origin_hosted_zone_id = "Z35SXDOTRQ7X7K"
+public_ip             = "54.123.45.67"
+app_url               = "https://octopus.example.com"
 ```
 
 Terraform outputs the database secret ARN, never the database password. Read
 or rotate secret values through Secrets Manager under your operational access
-policy, not through Terraform outputs.
+policy, not through Terraform outputs. `public_ip` is diagnostic and
+pre-enforcement recovery information; after enforcement it is not a
+web-traffic destination.
 
 ---
 
-## Step 5 — Point DNS
+## Step 5 — Run database migrations
 
-Create an **A record** in your DNS provider:
-
-```
-octopus.example.com  →  A  →  <public_ip from apply output>
-```
-
-The app responds on port 80 immediately after the EC2 instance finishes booting (2–3 minutes after `apply`).
-
----
-
-## Step 6 — Set up HTTPS
-
-The default stack listens on HTTP (port 80). Before putting it into production,
-add HTTPS at the origin using an AWS ALB with ACM, Caddy, or an nginx
-certificate. Then configure Cloudflare for **Full (strict)** so both the
-browser-to-edge and edge-to-origin connections are encrypted.
-
-Cloudflare **Full** and **Full (strict)** require the origin to accept HTTPS;
-they do not encrypt a plaintext HTTP origin. Cloudflare **Flexible** can proxy
-this stack before origin TLS is installed, but the edge-to-origin connection
-remains plaintext and is not recommended for production.
-
-After origin HTTPS is configured:
-
-1. Add the domain to Cloudflare and create the proxied DNS A record.
-2. Select **SSL/TLS → Full (strict)**.
-3. Verify the public URL and GitHub webhook delivery before removing any
-   temporary HTTP compatibility path.
-
----
-
-## Step 7 — Run database migrations
-
-On first deploy, run Prisma migrations before the app serves traffic.
+Run Prisma migrations against the exact `app_image` before the application
+receives any canary or user traffic. `/api/health` proves database connectivity,
+not schema compatibility. Repeat this step after every image change and before
+moving traffic.
 
 **If you enabled SSH** (`key_name` and trusted `ssh_cidr_blocks` are set in tfvars):
 ```bash
@@ -428,9 +409,94 @@ sudo docker compose run --rm web sh -c "npx prisma migrate deploy"
 
 ---
 
-## Step 8 — Verify the deployment
+## Step 6 — Stage origin HTTPS and edge restriction
 
-1. Open `http://<public_ip>` (or `https://<domain>` if Cloudflare is set up) — you should see the login page
+This is an operator-controlled cutover. Terraform prepares the AWS origin, but
+does not change Cloudflare, DNS, or the current WDC/datacenter deployment. A
+code merge, tag, or Terraform plan is not a production traffic cutover.
+
+Complete these prerequisites before changing edge traffic:
+
+1. Verify the current WDC/datacenter origin has a certificate valid for
+   `app_domain`. Cloudflare **Full (strict)** applies to every origin serving
+   the hostname; do not enable it while a rollback origin is HTTP-only.
+2. Decide and test the database topology and migration path. This AWS stack
+   creates its own RDS database; do not assume it shares the WDC database.
+   Complete Step 5 against the exact application image before canary traffic.
+3. Push the intended application image and confirm `app_image` references that
+   exact deployable tag. A release tag alone does not update the EC2 image.
+4. Confirm `origin_tls_certificate_arn` is issued, is in `aws_region`, covers
+   `app_domain`, and chains to a CA accepted by the edge. Cloudflare Full
+   (strict) accepts public CA certificates and Cloudflare Origin CA
+   certificates; an ACM Private CA certificate is not trusted by Cloudflare.
+5. Compare `trusted_edge_ipv4_cidrs` with the edge provider's authoritative
+   origin IPv4 list. The stack deliberately does not fetch this list
+   dynamically; operators must review and update it when the provider changes
+   its ranges. Never use `0.0.0.0/0`.
+
+CIDR and Host restrictions reduce origin exposure but do not cryptographically
+authenticate a Cloudflare zone because Cloudflare's address ranges are shared.
+Deployments requiring exclusive edge-tenant authentication should add
+per-hostname custom Authenticated Origin Pulls/mTLS before enforcement; this
+stack does not provision that operator-owned certificate boundary.
+
+### Fresh deployment — enforced from first apply
+
+1. Set `origin_tls_cutover_stage = "enforced"` before the Step 4 apply. The
+   plan must expose EC2 port 80 only to the ALB security group; it must not add
+   public EC2 HTTP ingress.
+2. Complete Step 5 migrations, then wait for healthy ALB target health on
+   `/api/health`.
+3. Configure the Cloudflare/edge origin to use `origin_dns_name` on HTTPS port
+   443 with `app_domain` as the host name and certificate verification enabled.
+4. Enable Full (strict), send canary traffic, and verify health, login, GitHub
+   webhook delivery, and one real review before moving production traffic.
+
+### Existing AWS stack · Stage 1 — preflight
+
+1. Set `origin_tls_cutover_stage = "preflight"`, then run `terraform plan` and
+   `terraform apply`.
+2. The plan should add the Application Load Balancer, HTTPS listener, target
+   group, and security-group rules without replacing EC2, RDS, or Redis.
+   Preflight keeps direct EC2 HTTP available for diagnostics and
+   pre-enforcement recovery only; it is not a Full (strict) traffic rollback.
+3. Wait for healthy ALB target health on `/api/health`. Stop if the target is
+   unhealthy or the plan proposes an unexpected replacement or deletion.
+4. Configure the Cloudflare/edge AWS origin to use `origin_dns_name` on HTTPS
+   port 443 with `app_domain` as the host name. Use an HTTPS health monitor for
+   `/api/health` with certificate verification enabled.
+5. Confirm Step 5 migrations succeeded for the exact running image. After the
+   WDC/datacenter TLS prerequisite is verified, set Cloudflare to
+   **Full (strict)** and send only canary traffic to AWS.
+6. Verify target health, the public health endpoint, login, GitHub webhook
+   delivery, and one real review. Do not proceed on a partial pass.
+
+### Existing AWS stack · Stage 2 — enforced
+
+1. Change only `origin_tls_cutover_stage` to `"enforced"`.
+2. Review the plan. It should remove direct public EC2 HTTP ingress while
+   retaining the ALB-to-EC2 path and should not replace EC2, RDS, or Redis.
+3. Apply, repeat the health, login, webhook, and real-review checks, then move
+   production traffic only after all checks pass.
+
+The Elastic IP may remain for diagnostics, SSM/SSH operations, outbound access,
+and pre-enforcement HTTP recovery. Do not configure it as a Cloudflare origin
+or public DNS target under Full (strict).
+
+### Rollback
+
+If the ALB path fails, keep edge traffic on the last healthy TLS-capable origin.
+You may set `origin_tls_cutover_stage = "preflight"`, plan, and apply to restore
+direct HTTP for diagnostics, but do not route Full (strict) traffic to the
+Elastic IP. Move Cloudflare or DNS only to a verified TLS-capable
+WDC/datacenter origin whose database, migrations, and image are compatible.
+Keep the ALB and ACM certificate until the TLS rollback is verified.
+
+---
+
+## Step 7 — Verify the deployment
+
+1. Open `https://<domain>` through the configured edge — you should see the login page
 2. Click **Sign in with GitHub** and log in with the email in `admin_emails`
 3. Go to **Settings** → **Integrations** — confirm the GitHub App is installed
 4. Open a test PR in one of your repos and mention `@<github-app-slug>` in a comment — Octopus should post a review
@@ -491,11 +557,12 @@ Running on default settings in `us-east-1`:
 | Resource | Type | ~$/month |
 |----------|------|----------|
 | EC2 | t3.xlarge (on-demand) | $120 |
+| Application Load Balancer | base charge plus LCUs | ~$16 + usage |
 | RDS | db.t3.medium, single-AZ, 50 GB | $54 |
 | EBS | 100 GB gp3 | $8 |
 | Elastic IP | (always attached) | $0 |
 | Data transfer | ~50 GB out | $5 |
-| **Total** | | **~$187/mo** |
+| **Total** | | **~$203/mo + ALB usage** |
 
 > Switching to Reserved Instances (1-year, no upfront) saves ~35% — roughly $65/mo.
 
@@ -624,8 +691,8 @@ later secret-delivery cutover.
   backend credentials must never be stored in `backend.conf`
 - Saved Terraform plans can contain plaintext secrets; always use a `.tfplan`
   filename so the repository ignore rules apply
-- The default HTTP origin is not end-to-end encrypted; add origin TLS before
-  using Cloudflare Full (strict) in production
+- The managed origin terminates HTTPS on the ALB; enforced mode removes direct
+  public EC2 HTTP ingress, and Full (strict) must never target the Elastic IP
 
 ---
 

--- a/terraform/examples/aws-ec2/main.tf
+++ b/terraform/examples/aws-ec2/main.tf
@@ -14,6 +14,33 @@ module "octopus" {
   application_secret_arn       = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123"
   runtime_secret_cutover_stage = "enforced"
 
+  # Fresh deployments enforce the managed origin boundary immediately. The
+  # ACM ARN must reference a certificate trusted by the edge (public ACM or
+  # imported Cloudflare Origin CA for Full strict). Preflight is only for
+  # upgrading an existing AWS stack.
+  origin_tls_cutover_stage   = "enforced"
+  origin_tls_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
+
+  # Operator-maintained Cloudflare example. Verify every range against the
+  # authoritative provider list before deploy; Terraform does not fetch it.
+  trusted_edge_ipv4_cidrs = [
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "141.101.64.0/18",
+    "108.162.192.0/18",
+    "190.93.240.0/20",
+    "188.114.96.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+    "162.158.0.0/15",
+    "104.16.0.0/13",
+    "104.24.0.0/14",
+    "172.64.0.0/13",
+    "131.0.72.0/22",
+  ]
+
   # GitHub App (required for PR reviews) — see README Step 2
   github_app_id        = "123456"
   github_app_slug      = "your-app-slug"
@@ -24,7 +51,18 @@ module "octopus" {
 }
 
 output "public_ip" {
-  value = module.octopus.public_ip
+  description = "Diagnostic and pre-enforcement HTTP recovery address; never use as a Full (strict) origin."
+  value       = module.octopus.public_ip
+}
+
+output "origin_dns_name" {
+  description = "Application Load Balancer DNS name for the trusted edge origin."
+  value       = module.octopus.origin_dns_name
+}
+
+output "origin_hosted_zone_id" {
+  description = "Application Load Balancer hosted zone ID for an external alias record."
+  value       = module.octopus.origin_hosted_zone_id
 }
 
 output "app_url" {

--- a/terraform/modules/aws/ec2-app/variables.tf
+++ b/terraform/modules/aws/ec2-app/variables.tf
@@ -59,22 +59,7 @@ variable "ingress_rules" {
     cidr_blocks     = optional(list(string), [])
     security_groups = optional(list(string), [])
   }))
-  default = [
-    {
-      description = "HTTP"
-      from_port   = 80
-      to_port     = 80
-      protocol    = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]
-    },
-    {
-      description = "HTTPS"
-      from_port   = 443
-      to_port     = 443
-      protocol    = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]
-    },
-  ]
+  default = []
 }
 
 variable "additional_security_group_ids" {

--- a/terraform/stacks/aws-ec2/main.tf
+++ b/terraform/stacks/aws-ec2/main.tf
@@ -1,5 +1,8 @@
 locals {
-  redis_url = var.enable_redis ? module.redis[0].connection_url : ""
+  redis_url          = var.enable_redis ? module.redis[0].connection_url : ""
+  origin_name_suffix = substr(sha256(var.name_prefix), 0, 12)
+  origin_lb_name     = "oct-origin-${local.origin_name_suffix}"
+  origin_tg_name     = "oct-app-${local.origin_name_suffix}"
 
   # Production nginx.conf — both upstreams point to the web container.
   # Webhook and heavy CLI routes keep their own location blocks so they
@@ -15,6 +18,19 @@ locals {
       proxy_connect_timeout 10s;
       proxy_read_timeout 900s;
       proxy_send_timeout 900s;
+
+      # The ALB is the only trusted proxy after origin enforcement. During the
+      # preflight compatibility window, direct internet clients can still reach
+      # nginx, so preserve X-Forwarded-Proto only for VPC-sourced requests.
+      geo $trusted_origin_proxy {
+        default 0;
+        ${var.vpc_cidr} 1;
+      }
+
+      map "$trusted_origin_proxy:$http_x_forwarded_proto" $forwarded_proto {
+        default $scheme;
+        "1:https" https;
+      }
 
       add_header X-Content-Type-Options "nosniff" always;
       add_header X-Frame-Options "SAMEORIGIN" always;
@@ -77,7 +93,7 @@ locals {
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
   PROXY
 
   runtime_environment = merge({
@@ -106,27 +122,32 @@ locals {
   }
 
   docker_compose = templatefile("${path.module}/templates/docker-compose.yml.tpl", {
-    app_image = var.app_image
+    app_image           = var.app_image
+    nginx_config_sha256 = sha256("${local.nginx_conf}\n${local.proxy_params}")
   })
 
-  # Ingress rules: always open 80 + 443; add SSH only when a key pair is configured.
-  # Defined as a local to keep types consistent for concat().
-  base_ingress_rules = [
+  # Existing stacks retain their direct HTTP compatibility path only during
+  # preflight. It is not a Full (strict) rollback origin: nginx has no local
+  # certificate. Enforcement removes it after the managed HTTPS origin is healthy.
+  legacy_origin_ingress_rules = var.origin_tls_cutover_stage == "preflight" ? [
     {
-      description     = "HTTP"
+      description     = "Legacy public HTTP during origin TLS preflight"
       from_port       = 80
       to_port         = 80
       protocol        = "tcp"
       cidr_blocks     = ["0.0.0.0/0"]
       security_groups = []
     },
+  ] : []
+
+  managed_origin_ingress_rule = [
     {
-      description     = "HTTPS"
-      from_port       = 443
-      to_port         = 443
+      description     = "HTTP from managed origin load balancer"
+      from_port       = 80
+      to_port         = 80
       protocol        = "tcp"
-      cidr_blocks     = ["0.0.0.0/0"]
-      security_groups = []
+      cidr_blocks     = []
+      security_groups = [aws_security_group.origin_edge.id]
     },
   ]
 
@@ -141,7 +162,11 @@ locals {
     }
   ] : []
 
-  ingress_rules = concat(local.base_ingress_rules, local.ssh_ingress_rule)
+  ingress_rules = concat(
+    local.legacy_origin_ingress_rules,
+    local.managed_origin_ingress_rule,
+    local.ssh_ingress_rule,
+  )
 }
 
 # ── VPC ───────────────────────────────────────────────────────────────────────
@@ -168,6 +193,116 @@ resource "aws_security_group" "app_data_access" {
   }
 
   tags = merge({ Name = "${var.name_prefix}-app-data-sg" }, var.tags)
+}
+
+# Dedicated public edge for authenticated TLS termination. The security group
+# has no implicit public rule: callers must originate from a configured trusted
+# edge CIDR, and egress is separately constrained to the application SG.
+resource "aws_security_group" "origin_edge" {
+  name_prefix = "${var.name_prefix}-origin-edge-"
+  description = "Trusted edge access to the Octopus HTTPS origin"
+  vpc_id      = module.vpc.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge({ Name = "${var.name_prefix}-origin-edge-sg" }, var.tags)
+}
+
+resource "aws_vpc_security_group_ingress_rule" "origin_https" {
+  for_each = toset(var.trusted_edge_ipv4_cidrs)
+
+  security_group_id = aws_security_group.origin_edge.id
+  description       = "HTTPS from trusted edge ${each.value}"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_ipv4         = each.value
+}
+
+resource "aws_lb" "origin" {
+  name                       = local.origin_lb_name
+  internal                   = false
+  load_balancer_type         = "application"
+  security_groups            = [aws_security_group.origin_edge.id]
+  subnets                    = module.vpc.public_subnet_ids
+  ip_address_type            = "ipv4"
+  idle_timeout               = 900
+  preserve_host_header       = true
+  drop_invalid_header_fields = true
+
+  tags = merge({ Name = "${var.name_prefix}-origin" }, var.tags)
+
+  depends_on = [
+    module.vpc,
+    aws_vpc_security_group_ingress_rule.origin_https,
+  ]
+}
+
+resource "aws_lb_target_group" "app" {
+  name                 = local.origin_tg_name
+  port                 = 80
+  protocol             = "HTTP"
+  protocol_version     = "HTTP1"
+  target_type          = "instance"
+  vpc_id               = module.vpc.vpc_id
+  deregistration_delay = 900
+
+  health_check {
+    enabled             = true
+    path                = "/api/health"
+    port                = "traffic-port"
+    protocol            = "HTTP"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  tags = merge({ Name = "${var.name_prefix}-app-origin" }, var.tags)
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.origin.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = var.origin_tls_certificate_arn
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Forbidden"
+      status_code  = "403"
+    }
+  }
+
+  tags = merge({ Name = "${var.name_prefix}-origin-https" }, var.tags)
+}
+
+# Cloudflare address ranges are shared across customers. This Host gate rejects
+# unintended virtual hosts but is not tenant authentication: deployments that
+# require cryptographic zone ownership must add per-hostname custom AOP/mTLS.
+resource "aws_lb_listener_rule" "app_host" {
+  listener_arn = aws_lb_listener.https.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+
+  condition {
+    host_header {
+      values = [var.app_domain]
+    }
+  }
+
+  tags = merge({ Name = "${var.name_prefix}-origin-app-host" }, var.tags)
 }
 
 # ── RDS PostgreSQL ────────────────────────────────────────────────────────────
@@ -233,4 +368,24 @@ module "ec2" {
   additional_security_group_ids = [aws_security_group.app_data_access.id]
 
   tags = var.tags
+}
+
+# Keep the load-balancer security group free of its default allow-all egress.
+# This separate rule avoids a dependency cycle while constraining the only
+# origin path to the EC2 application security group on HTTP port 80.
+resource "aws_vpc_security_group_egress_rule" "origin_to_app" {
+  security_group_id            = aws_security_group.origin_edge.id
+  description                  = "HTTP to Octopus application targets"
+  ip_protocol                  = "tcp"
+  from_port                    = 80
+  to_port                      = 80
+  referenced_security_group_id = module.ec2.security_group_id
+}
+
+resource "aws_lb_target_group_attachment" "app" {
+  target_group_arn = aws_lb_target_group.app.arn
+  target_id        = module.ec2.instance_id
+  port             = 80
+
+  depends_on = [aws_vpc_security_group_egress_rule.origin_to_app]
 }

--- a/terraform/stacks/aws-ec2/main.tf
+++ b/terraform/stacks/aws-ec2/main.tf
@@ -126,14 +126,25 @@ locals {
     nginx_config_sha256 = sha256("${local.nginx_conf}\n${local.proxy_params}")
   })
 
-  # Existing stacks retain their direct HTTP compatibility path only during
-  # preflight. It is not a Full (strict) rollback origin: nginx has no local
-  # certificate. Enforcement removes it after the managed HTTPS origin is healthy.
+  # Existing stacks retain their pre-cutover public ingress only during
+  # preflight: direct HTTP, plus HTTPS because operator-managed instance TLS
+  # (Caddy, an nginx certificate) may still be the live Full (strict) origin.
+  # The stack-managed nginx has no local certificate, so port 443 is inert
+  # unless the operator terminates TLS on the instance. Enforcement removes
+  # both after the managed HTTPS origin is healthy.
   legacy_origin_ingress_rules = var.origin_tls_cutover_stage == "preflight" ? [
     {
       description     = "Legacy public HTTP during origin TLS preflight"
       from_port       = 80
       to_port         = 80
+      protocol        = "tcp"
+      cidr_blocks     = ["0.0.0.0/0"]
+      security_groups = []
+    },
+    {
+      description     = "Legacy public HTTPS during origin TLS preflight"
+      from_port       = 443
+      to_port         = 443
       protocol        = "tcp"
       cidr_blocks     = ["0.0.0.0/0"]
       security_groups = []

--- a/terraform/stacks/aws-ec2/outputs.tf
+++ b/terraform/stacks/aws-ec2/outputs.tf
@@ -1,5 +1,5 @@
 output "public_ip" {
-  description = "Public IP address of the Octopus server."
+  description = "EC2 public IP retained for diagnostics and pre-enforcement HTTP recovery; never use it as a Full (strict) origin."
   value       = module.ec2.public_ip
 }
 
@@ -24,8 +24,18 @@ output "redis_url" {
 }
 
 output "app_url" {
-  description = "Application URL. Point your DNS A record to public_ip."
+  description = "Application URL served through the managed HTTPS origin."
   value       = "https://${var.app_domain}"
+}
+
+output "origin_dns_name" {
+  description = "DNS name of the managed HTTPS origin load balancer."
+  value       = aws_lb.origin.dns_name
+}
+
+output "origin_hosted_zone_id" {
+  description = "Canonical hosted-zone ID of the managed HTTPS origin load balancer."
+  value       = aws_lb.origin.zone_id
 }
 
 output "vpc_id" {

--- a/terraform/stacks/aws-ec2/templates/docker-compose.yml.tpl
+++ b/terraform/stacks/aws-ec2/templates/docker-compose.yml.tpl
@@ -3,6 +3,8 @@ services:
     image: nginx:alpine
     ports:
       - "80:80"
+    labels:
+      octopus.nginx.config-sha256: "${nginx_config_sha256}"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./proxy_params:/etc/nginx/proxy_params:ro

--- a/terraform/stacks/aws-ec2/terraform.tfvars.example
+++ b/terraform/stacks/aws-ec2/terraform.tfvars.example
@@ -22,9 +22,42 @@ aws_region = "us-east-1"
 #   Hub   → youruser/octopus:latest
 app_image  = "ghcr.io/your-org/octopus:latest"
 
-# Public domain that will serve the app.
-# Point its DNS A record to the output public_ip after apply.
+# Public domain that will serve the app through Cloudflare or another trusted
+# edge. Do not point public DNS at the EC2 public_ip.
 app_domain = "octopus.example.com"
+
+# ── Managed origin HTTPS ─────────────────────────────────────────────────────
+# ARN of an issued ACM certificate in aws_region that covers app_domain. For
+# Cloudflare Full (strict), use a public ACM certificate or an imported
+# Cloudflare Origin CA certificate; an ACM Private CA certificate is not trusted.
+origin_tls_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
+
+# Fresh deployments use "enforced" so EC2 HTTP is never public. Only an
+# existing AWS stack uses "preflight" for the documented compatibility stage.
+origin_tls_cutover_stage = "enforced"
+
+# Explicit IPv4 origin ranges allowed to reach the ALB. These example
+# Cloudflare ranges are intentionally versioned here rather than fetched during
+# terraform apply. Before every deployment, compare them with Cloudflare's
+# authoritative list and update them when Cloudflare publishes a change.
+# Never use 0.0.0.0/0. For another edge, replace this entire list.
+trusted_edge_ipv4_cidrs = [
+  "173.245.48.0/20",
+  "103.21.244.0/22",
+  "103.22.200.0/22",
+  "103.31.4.0/22",
+  "141.101.64.0/18",
+  "108.162.192.0/18",
+  "190.93.240.0/20",
+  "188.114.96.0/20",
+  "197.234.240.0/22",
+  "198.41.128.0/17",
+  "162.158.0.0/15",
+  "104.16.0.0/13",
+  "104.24.0.0/14",
+  "172.64.0.0/13",
+  "131.0.72.0/22",
+]
 
 # ── Runtime secrets ───────────────────────────────────────────────────────────
 # Create one Secrets Manager JSON secret before running Terraform, then provide
@@ -76,7 +109,9 @@ restrict_data_access_to_app = true
 # ── EC2 ───────────────────────────────────────────────────────────────────────
 instance_type       = "t3.xlarge"  # min 4 vCPU / 16 GB for small teams
 root_volume_size_gb = 100
-create_eip          = true
+# The EIP is for diagnostics, SSM/SSH, outbound access, and pre-enforcement HTTP
+# recovery. It is not a TLS origin or public DNS target under Full (strict).
+create_eip = true
 
 # SSH access — leave null to disable entirely (use SSM Session Manager instead)
 key_name        = null

--- a/terraform/stacks/aws-ec2/tests/network_trust.tftest.hcl
+++ b/terraform/stacks/aws-ec2/tests/network_trust.tftest.hcl
@@ -47,11 +47,41 @@ override_resource {
   }
 }
 
+override_resource {
+  target = aws_lb.origin
+  values = {
+    arn      = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/octopus-origin/50dc6c495c0c9188"
+    dns_name = "octopus-origin-123456.us-east-1.elb.amazonaws.com"
+    zone_id  = "Z35SXDOTRQ7X7K"
+  }
+}
+
+override_resource {
+  target = aws_lb_target_group.app
+  values = {
+    arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/octopus-app/6d0ecf831eec9f09"
+  }
+}
+
+override_resource {
+  target = aws_lb_listener.https
+  values = {
+    arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/octopus-origin/50dc6c495c0c9188/f2f7dc8efc522ab2"
+  }
+}
+
 variables {
   app_image                    = "ghcr.io/example/octopus:test"
   app_domain                   = "octopus.example.com"
   application_secret_arn       = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123"
   runtime_secret_cutover_stage = "enforced"
+
+  origin_tls_cutover_stage   = "preflight"
+  origin_tls_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
+  trusted_edge_ipv4_cidrs = [
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+  ]
 }
 
 # ── Stack: the app identity SG exists and carries no rules of its own ─────────

--- a/terraform/stacks/aws-ec2/tests/origin_tls.tftest.hcl
+++ b/terraform/stacks/aws-ec2/tests/origin_tls.tftest.hcl
@@ -1,0 +1,359 @@
+# SEC-10 origin-TLS and trusted-edge regression tests.
+# Runs entirely against mocked providers — no AWS credentials required:
+#   terraform -chdir=terraform/stacks/aws-ec2 init -backend=false
+#   terraform -chdir=terraform/stacks/aws-ec2 test
+#
+# The root-stack runs prove the ALB/ACM/edge boundary. The EC2 module run
+# inspects the application security group directly because Terraform tests
+# cannot address resources inside a child module from a root-stack run.
+
+mock_provider "aws" {}
+
+override_data {
+  target = module.vpc.data.aws_availability_zones.available
+  values = {
+    names = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  }
+}
+
+override_data {
+  target = module.ec2.data.aws_ami.ubuntu
+  values = {
+    id = "ami-00000000000000000"
+  }
+}
+
+override_resource {
+  target = module.rds.aws_db_instance.this
+  values = {
+    address  = "db.internal"
+    port     = 5432
+    db_name  = "octopus"
+    username = "octopus"
+    master_user_secret = [{
+      kms_key_id    = ""
+      secret_arn    = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-ABC123"
+      secret_status = "active"
+    }]
+  }
+}
+
+override_resource {
+  target = module.ec2.aws_ssm_document.runtime_secrets
+  values = {
+    default_version = "1"
+  }
+}
+
+override_resource {
+  target = aws_lb.origin
+  values = {
+    arn      = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/octopus-origin/50dc6c495c0c9188"
+    dns_name = "octopus-origin-123456.us-east-1.elb.amazonaws.com"
+    zone_id  = "Z35SXDOTRQ7X7K"
+  }
+}
+
+override_resource {
+  target = aws_lb_target_group.app
+  values = {
+    arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/octopus-app/6d0ecf831eec9f09"
+  }
+}
+
+override_resource {
+  target = aws_lb_listener.https
+  values = {
+    arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/octopus-origin/50dc6c495c0c9188/f2f7dc8efc522ab2"
+  }
+}
+
+variables {
+  app_image                    = "ghcr.io/example/octopus:test"
+  app_domain                   = "octopus.example.com"
+  application_secret_arn       = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123"
+  runtime_secret_cutover_stage = "enforced"
+
+  origin_tls_cutover_stage   = "preflight"
+  origin_tls_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
+  trusted_edge_ipv4_cidrs = [
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+  ]
+}
+
+run "preflight_provisions_managed_tls_without_removing_rollback_path" {
+  command = apply
+
+  variables {
+    origin_tls_cutover_stage = "preflight"
+  }
+
+  assert {
+    condition = (
+      aws_lb.origin.name == local.origin_lb_name &&
+      length(aws_lb.origin.name) <= 32 &&
+      !aws_lb.origin.internal &&
+      aws_lb.origin.load_balancer_type == "application" &&
+      toset(aws_lb.origin.subnets) == toset(module.vpc.public_subnet_ids) &&
+      contains(aws_lb.origin.security_groups, aws_security_group.origin_edge.id)
+    )
+    error_message = "Origin TLS must use an internet-facing ALB across both public subnets with only the dedicated edge security group."
+  }
+
+  assert {
+    condition = (
+      length(local.legacy_origin_ingress_rules) == 1 &&
+      length(local.ingress_rules) == 2 &&
+      one([
+        for rule in local.ingress_rules : rule
+        if rule.from_port == 80 && contains(rule.cidr_blocks, "0.0.0.0/0")
+      ]).to_port == 80 &&
+      one([
+        for rule in local.ingress_rules : rule
+        if rule.from_port == 80 && contains(rule.security_groups, aws_security_group.origin_edge.id)
+      ]).to_port == 80 &&
+      alltrue([
+        for rule in local.ingress_rules : rule.from_port != 443
+      ])
+    )
+    error_message = "Preflight must retain public HTTP compatibility and add ALB-to-EC2 port 80 without opening the inert EC2 HTTPS port."
+  }
+
+  assert {
+    condition = (
+      aws_lb.origin.idle_timeout >= 900 &&
+      aws_lb.origin.preserve_host_header &&
+      aws_lb.origin.drop_invalid_header_fields
+    )
+    error_message = "The ALB must preserve the Host header, reject invalid headers, and retain long-running reviews with a 900-second-or-longer idle timeout."
+  }
+
+  assert {
+    condition = (
+      aws_lb_listener.https.load_balancer_arn == aws_lb.origin.arn &&
+      aws_lb_listener.https.port == 443 &&
+      aws_lb_listener.https.protocol == "HTTPS" &&
+      aws_lb_listener.https.certificate_arn == var.origin_tls_certificate_arn &&
+      aws_lb_listener.https.ssl_policy == "ELBSecurityPolicy-TLS13-1-2-2021-06" &&
+      one(aws_lb_listener.https.default_action).type == "fixed-response" &&
+      one(one(aws_lb_listener.https.default_action).fixed_response).status_code == "403" &&
+      aws_lb_listener_rule.app_host.listener_arn == aws_lb_listener.https.arn &&
+      one(aws_lb_listener_rule.app_host.action).target_group_arn == aws_lb_target_group.app.arn &&
+      toset(one(one(aws_lb_listener_rule.app_host.condition).host_header).values) == toset([var.app_domain])
+    )
+    error_message = "The HTTPS listener must use the exact ACM certificate, reject unknown hosts, and forward only app_domain to the app target group."
+  }
+
+  assert {
+    condition = (
+      length(aws_vpc_security_group_ingress_rule.origin_https) == length(var.trusted_edge_ipv4_cidrs) &&
+      alltrue([
+        for rule in values(aws_vpc_security_group_ingress_rule.origin_https) :
+        rule.security_group_id == aws_security_group.origin_edge.id &&
+        rule.ip_protocol == "tcp" &&
+        rule.from_port == 443 &&
+        rule.to_port == 443 &&
+        contains(var.trusted_edge_ipv4_cidrs, rule.cidr_ipv4)
+      ])
+    )
+    error_message = "ALB HTTPS ingress must contain exactly one port-443 rule per trusted edge CIDR and no public catch-all."
+  }
+
+  assert {
+    condition = (
+      aws_vpc_security_group_egress_rule.origin_to_app.security_group_id == aws_security_group.origin_edge.id &&
+      aws_vpc_security_group_egress_rule.origin_to_app.ip_protocol == "tcp" &&
+      aws_vpc_security_group_egress_rule.origin_to_app.from_port == 80 &&
+      aws_vpc_security_group_egress_rule.origin_to_app.to_port == 80 &&
+      aws_vpc_security_group_egress_rule.origin_to_app.referenced_security_group_id == module.ec2.security_group_id
+    )
+    error_message = "The ALB may send only HTTP port 80 to the application security group."
+  }
+
+  assert {
+    condition = (
+      aws_lb_target_group.app.name == local.origin_tg_name &&
+      length(aws_lb_target_group.app.name) <= 32 &&
+      aws_lb_target_group.app.protocol == "HTTP" &&
+      aws_lb_target_group.app.port == 80 &&
+      aws_lb_target_group.app.target_type == "instance" &&
+      one(aws_lb_target_group.app.health_check).path == "/api/health" &&
+      one(aws_lb_target_group.app.health_check).matcher == "200" &&
+      one(aws_lb_target_group.app.health_check).timeout >= 4 &&
+      one(aws_lb_target_group.app.health_check).unhealthy_threshold >= 2
+    )
+    error_message = "The ALB target group must health-gate the instance on HTTP /api/health with bounds above the application's two-second DB probe."
+  }
+
+  assert {
+    condition = (
+      aws_lb_target_group_attachment.app.target_group_arn == aws_lb_target_group.app.arn &&
+      aws_lb_target_group_attachment.app.target_id == module.ec2.instance_id &&
+      aws_lb_target_group_attachment.app.port == 80
+    )
+    error_message = "The current EC2 instance must be registered on target port 80 without replacement."
+  }
+
+  assert {
+    condition = (
+      output.origin_dns_name == aws_lb.origin.dns_name &&
+      output.origin_hosted_zone_id == aws_lb.origin.zone_id
+    )
+    error_message = "The stack must output the ALB DNS name and hosted-zone ID used for the edge DNS cutover."
+  }
+}
+
+run "enforced_keeps_the_managed_tls_boundary" {
+  command = apply
+
+  variables {
+    origin_tls_cutover_stage = "enforced"
+  }
+
+  assert {
+    condition = (
+      aws_lb_listener.https.protocol == "HTTPS" &&
+      length(aws_vpc_security_group_ingress_rule.origin_https) == length(var.trusted_edge_ipv4_cidrs) &&
+      length(local.legacy_origin_ingress_rules) == 0 &&
+      length(local.ingress_rules) == 1 &&
+      one(local.ingress_rules).from_port == 80 &&
+      one(local.ingress_rules).to_port == 80 &&
+      length(one(local.ingress_rules).cidr_blocks) == 0 &&
+      contains(one(local.ingress_rules).security_groups, aws_security_group.origin_edge.id) &&
+      alltrue([
+        for rule in local.ingress_rules :
+        !contains(rule.cidr_blocks, "0.0.0.0/0")
+      ])
+    )
+    error_message = "Enforcement must retain trusted-edge HTTPS while removing public EC2 web ingress and leaving only ALB-to-EC2 port 80."
+  }
+}
+
+run "ec2_module_enforced_origin_is_alb_only" {
+  command = apply
+
+  module {
+    source = "../../modules/aws/ec2-app"
+  }
+
+  variables {
+    name_prefix                   = "octopus"
+    vpc_id                        = "vpc-00000000000000000"
+    subnet_id                     = "subnet-00000000000000001"
+    ami_id                        = "ami-00000000000000000"
+    aws_region                    = "us-east-1"
+    docker_compose_content        = "services: {}"
+    application_secret_arn        = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123"
+    database_secret_arn           = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-ABC123"
+    runtime_secret_preflight_only = false
+    runtime_environment           = { NEXT_PUBLIC_APP_URL = "https://octopus.example.com" }
+    database_config               = { host = "db.internal", port = 5432, database = "octopus" }
+    nginx_conf_content            = ""
+    proxy_params_content          = ""
+    ingress_rules = [{
+      description     = "HTTP from managed origin load balancer"
+      from_port       = 80
+      to_port         = 80
+      protocol        = "tcp"
+      cidr_blocks     = []
+      security_groups = ["sg-origin0000000001"]
+    }]
+  }
+
+  override_resource {
+    target = aws_ssm_document.runtime_secrets
+    values = {
+      default_version = "1"
+    }
+  }
+
+  assert {
+    condition = (
+      length(aws_security_group.this.ingress) == 1 &&
+      one(aws_security_group.this.ingress).from_port == 80 &&
+      one(aws_security_group.this.ingress).to_port == 80 &&
+      contains(one(aws_security_group.this.ingress).security_groups, "sg-origin0000000001") &&
+      try(length(one(aws_security_group.this.ingress).cidr_blocks), 0) == 0
+    )
+    error_message = "Enforced EC2 application ingress must be only ALB-security-group traffic on port 80, with no public CIDR path."
+  }
+}
+
+run "invalid_cutover_stage_is_rejected" {
+  command = plan
+
+  variables {
+    origin_tls_cutover_stage = "disabled"
+  }
+
+  expect_failures = [var.origin_tls_cutover_stage]
+}
+
+run "non_acm_certificate_arn_is_rejected" {
+  command = plan
+
+  variables {
+    origin_tls_certificate_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:not-a-certificate"
+  }
+
+  expect_failures = [var.origin_tls_certificate_arn]
+}
+
+run "wrong_region_certificate_arn_is_rejected" {
+  command = plan
+
+  variables {
+    origin_tls_certificate_arn = "arn:aws:acm:eu-west-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
+  }
+
+  expect_failures = [var.origin_tls_certificate_arn]
+}
+
+run "legacy_long_prefix_derives_safe_origin_names" {
+  command = plan
+
+  variables {
+    name_prefix = "octopus-production-eu-west"
+  }
+
+  assert {
+    condition = (
+      startswith(aws_lb.origin.name, "oct-origin-") &&
+      startswith(aws_lb_target_group.app.name, "oct-app-") &&
+      length(aws_lb.origin.name) <= 32 &&
+      length(aws_lb_target_group.app.name) <= 32
+    )
+    error_message = "Legacy long prefixes must remain plannable while deriving deterministic ALB-safe names."
+  }
+}
+
+run "internet_wide_edge_cidr_is_rejected" {
+  command = plan
+
+  variables {
+    trusted_edge_ipv4_cidrs = ["0.0.0.0/0"]
+  }
+
+  expect_failures = [var.trusted_edge_ipv4_cidrs]
+}
+
+run "malformed_edge_cidr_is_rejected" {
+  command = plan
+
+  variables {
+    trusted_edge_ipv4_cidrs = ["173.245.48.1"]
+  }
+
+  expect_failures = [var.trusted_edge_ipv4_cidrs]
+}
+
+run "empty_edge_cidr_set_is_rejected" {
+  command = plan
+
+  variables {
+    trusted_edge_ipv4_cidrs = []
+  }
+
+  expect_failures = [var.trusted_edge_ipv4_cidrs]
+}

--- a/terraform/stacks/aws-ec2/tests/origin_tls.tftest.hcl
+++ b/terraform/stacks/aws-ec2/tests/origin_tls.tftest.hcl
@@ -103,21 +103,22 @@ run "preflight_provisions_managed_tls_without_removing_rollback_path" {
 
   assert {
     condition = (
-      length(local.legacy_origin_ingress_rules) == 1 &&
-      length(local.ingress_rules) == 2 &&
+      length(local.legacy_origin_ingress_rules) == 2 &&
+      length(local.ingress_rules) == 3 &&
       one([
         for rule in local.ingress_rules : rule
         if rule.from_port == 80 && contains(rule.cidr_blocks, "0.0.0.0/0")
       ]).to_port == 80 &&
       one([
         for rule in local.ingress_rules : rule
+        if rule.from_port == 443 && contains(rule.cidr_blocks, "0.0.0.0/0")
+      ]).to_port == 443 &&
+      one([
+        for rule in local.ingress_rules : rule
         if rule.from_port == 80 && contains(rule.security_groups, aws_security_group.origin_edge.id)
-      ]).to_port == 80 &&
-      alltrue([
-        for rule in local.ingress_rules : rule.from_port != 443
-      ])
+      ]).to_port == 80
     )
-    error_message = "Preflight must retain public HTTP compatibility and add ALB-to-EC2 port 80 without opening the inert EC2 HTTPS port."
+    error_message = "Preflight must retain the pre-cutover public HTTP and HTTPS compatibility ingress and add ALB-to-EC2 port 80."
   }
 
   assert {
@@ -343,6 +344,16 @@ run "malformed_edge_cidr_is_rejected" {
 
   variables {
     trusted_edge_ipv4_cidrs = ["173.245.48.1"]
+  }
+
+  expect_failures = [var.trusted_edge_ipv4_cidrs]
+}
+
+run "host_bits_edge_cidr_is_rejected" {
+  command = plan
+
+  variables {
+    trusted_edge_ipv4_cidrs = ["173.245.48.1/20"]
   }
 
   expect_failures = [var.trusted_edge_ipv4_cidrs]

--- a/terraform/stacks/aws-ec2/variables.tf
+++ b/terraform/stacks/aws-ec2/variables.tf
@@ -41,6 +41,47 @@ variable "restrict_data_access_to_app" {
   default     = true
 }
 
+variable "origin_tls_cutover_stage" {
+  description = "Origin TLS rollout stage. Existing stacks apply preflight before enforced; new stacks use enforced."
+  type        = string
+
+  validation {
+    condition     = contains(["preflight", "enforced"], var.origin_tls_cutover_stage)
+    error_message = "origin_tls_cutover_stage must be either preflight or enforced."
+  }
+}
+
+variable "origin_tls_certificate_arn" {
+  description = "Exact ARN of the pre-provisioned, edge-trusted ACM certificate for the public application domain."
+  type        = string
+
+  validation {
+    condition = try(
+      can(regex("^arn:[^:]+:acm:[^:]+:[0-9]{12}:certificate/[0-9A-Fa-f-]+$", var.origin_tls_certificate_arn)) &&
+      split(":", var.origin_tls_certificate_arn)[3] == var.aws_region,
+      false
+    )
+    error_message = "origin_tls_certificate_arn must be a complete ACM certificate ARN in aws_region."
+  }
+}
+
+variable "trusted_edge_ipv4_cidrs" {
+  description = "IPv4 CIDRs of the trusted edge permitted to reach the managed HTTPS origin."
+  type        = list(string)
+
+  validation {
+    condition = (
+      length(var.trusted_edge_ipv4_cidrs) > 0 &&
+      length(distinct(var.trusted_edge_ipv4_cidrs)) == length(var.trusted_edge_ipv4_cidrs) &&
+      alltrue([
+        for cidr in var.trusted_edge_ipv4_cidrs :
+        try(cidrnetmask(cidr) != "" && cidrsubnet(cidr, 0, 0) != "0.0.0.0/0", false)
+      ])
+    )
+    error_message = "trusted_edge_ipv4_cidrs must contain unique valid IPv4 CIDRs narrower than 0.0.0.0/0."
+  }
+}
+
 # ── EC2 ───────────────────────────────────────────────────────────────────────
 variable "instance_type" {
   description = "EC2 instance type. Minimum recommended: t3.xlarge (4 vCPU, 16 GB)."

--- a/terraform/stacks/aws-ec2/variables.tf
+++ b/terraform/stacks/aws-ec2/variables.tf
@@ -75,10 +75,10 @@ variable "trusted_edge_ipv4_cidrs" {
       length(distinct(var.trusted_edge_ipv4_cidrs)) == length(var.trusted_edge_ipv4_cidrs) &&
       alltrue([
         for cidr in var.trusted_edge_ipv4_cidrs :
-        try(cidrnetmask(cidr) != "" && cidrsubnet(cidr, 0, 0) != "0.0.0.0/0", false)
+        try(cidrnetmask(cidr) != "" && cidrsubnet(cidr, 0, 0) == cidr && cidr != "0.0.0.0/0", false)
       ])
     )
-    error_message = "trusted_edge_ipv4_cidrs must contain unique valid IPv4 CIDRs narrower than 0.0.0.0/0."
+    error_message = "trusted_edge_ipv4_cidrs must contain unique canonical IPv4 network CIDRs narrower than 0.0.0.0/0."
   }
 }
 


### PR DESCRIPTION
## Intent

Complete the approved SEC-10 origin-TLS slice for AWS self-hosted deployments without changing or cutting over the current WDC/datacenter production. Add managed ALB and ACM HTTPS, operator-maintained trusted-edge IPv4 CIDRs, an app-domain listener gate, ALB-only EC2 ingress in enforced mode, trusted proxy scheme handling, and health/migration-gated operator procedures. Fresh stacks must start enforced; only existing AWS stacks use a temporary preflight HTTP compatibility path. Rollback traffic must use a verified TLS-capable origin. Keep Redis authentication as a separate later slice, and document shared Cloudflare CIDRs as residual network trust with optional per-hostname AOP/mTLS hardening.

## What Changed

- The `aws-ec2` stack now provisions a managed origin TLS boundary: an internet-facing ALB with an ACM HTTPS listener gated to the app domain, listener ingress restricted to operator-maintained `trusted_edge_ipv4_cidrs` (with validation rejecting `0.0.0.0/0` and host-bits CIDRs), and nginx trusting `X-Forwarded-Proto` only from VPC-internal proxy sources.
- A new required `origin_tls_cutover_stage` variable stages the migration: `preflight` keeps the existing public 80/443 instance ingress (so instance-terminated TLS keeps serving) alongside the new ALB path, while `enforced` locks EC2 ingress to the ALB security group only; fresh stacks (`terraform.tfvars.example`, `examples/aws-ec2`) pin `enforced`, and Redis auth is untouched as a separate slice.
- Added `origin_tls.tftest.hcl` (plus a `network_trust` guard) covering both stages with mocked AWS, a `terraform-origin-tls-security.test.ts` suite wired into CI, and a rewritten README with health/migration-gated cutover and rollback procedures documenting shared Cloudflare CIDRs as residual trust with optional per-hostname AOP/mTLS hardening.

## Risk Assessment

✅ Low: The fix commit cleanly resolves the round-1 preflight 443 breakage and tightens CIDR validation with matching test and doc updates, leaving only previously acknowledged informational tradeoffs, and the branch conforms to every required intent criterion.

## Testing

Ran the exact CI commands — terraform init/validate/test for the aws-ec2 stack (20/20 mocked-apply runs pass) and the five-file bun security-regression suite (34/34 pass) — then captured verbose applied-state evidence proving the enforced ALB-only EC2 ingress, ACM TLS 1.3 listener with host gating, trusted-edge-only 443 rules, preflight rollback path, and CIDR/ARN validation rejections; no visual artifact because this is Terraform infrastructure with no rendered UI surface.

<details>
<summary>Evidence: terraform test — full aws-ec2 suite (20 pass)</summary>

```text
tests/network_trust.tftest.hcl... in progress
  run "stack_app_data_access_sg_is_identity_only"... pass
  run "rds_module_restricted_to_identity_sg"... pass
  run "rds_module_preflight_keeps_cidr_and_password_unmanaged"... pass
  run "redis_module_restricted_to_identity_sg"... pass
  run "redis_module_compat_keeps_cidr_and_identity"... pass
  run "ec2_module_preflight_reads_only_application_secret"... pass
  run "ec2_module_attaches_additional_identity_sg"... pass
  run "ssh_internet_wide_cidr_rejected"... pass
  run "ssh_malformed_cidr_rejected"... pass
tests/network_trust.tftest.hcl... tearing down
tests/network_trust.tftest.hcl... pass
tests/origin_tls.tftest.hcl... in progress
  run "preflight_provisions_managed_tls_without_removing_rollback_path"... pass
  run "enforced_keeps_the_managed_tls_boundary"... pass
  run "ec2_module_enforced_origin_is_alb_only"... pass
  run "invalid_cutover_stage_is_rejected"... pass
  run "non_acm_certificate_arn_is_rejected"... pass
  run "wrong_region_certificate_arn_is_rejected"... pass
  run "legacy_long_prefix_derives_safe_origin_names"... pass
  run "internet_wide_edge_cidr_is_rejected"... pass
  run "malformed_edge_cidr_is_rejected"... pass
  run "host_bits_edge_cidr_is_rejected"... pass
  run "empty_edge_cidr_set_is_rejected"... pass
tests/origin_tls.tftest.hcl... tearing down
tests/origin_tls.tftest.hcl... pass

Success! 20 passed, 0 failed.
```
</details>
<details>
<summary>Evidence: Applied-state boundary excerpt (enforced SG, HTTPS listener, edge CIDRs, ALB hardening)</summary>

<code>--- run enforced: EC2 application security group ingress (ALB-only, no public CIDR) ---&#10;ingress = [&#10;{&#10;cidr_blocks = []&#10;description = &#34;HTTP from managed origin load balancer&#34;&#10;from_port = 80&#10;protocol = &#34;tcp&#34;&#10;security_groups = [&#34;sg-origin0000000001&#34;]&#10;to_port = 80&#10;},&#10;]&#10;&#10;--- run preflight: HTTPS listener ---&#10;certificate_arn = &#34;arn:aws:acm:us-east-1:123456789012:certificate/1111...&#34;&#10;port = 443, protocol = &#34;HTTPS&#34;, ssl_policy = &#34;ELBSecurityPolicy-TLS13-1-2-2021-06&#34;&#10;default_action: fixed-response 403; app_host rule forwards only app_domain&#10;&#10;--- trusted-edge 443 ingress: one rule per CIDR (103.21.244.0/22, 173.245.48.0/20), tcp 443 only&#10;--- ALB hardening: drop_invalid_header_fields=true, idle_timeout=900, preserve_host_header=true</code>

```text
=== Applied state excerpts from 'terraform test -verbose' (mocked AWS) ===

--- run enforced: EC2 application security group ingress (ALB-only, no public CIDR) ---
    ingress     = [
        {
            cidr_blocks     = []
            description     = "HTTP from managed origin load balancer"
            from_port       = 80
            protocol        = "tcp"
            security_groups = [
                "sg-origin0000000001",
            ]
            to_port         = 80
        },
    ]

--- run preflight: HTTPS listener (ACM cert, TLS1.3 policy, default 403, host-gated forward) ---
    certificate_arn                                                       = "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
    port                                                                  = 443
    protocol                                                              = "HTTPS"
    ssl_policy                                                            = "ELBSecurityPolicy-TLS13-1-2-2021-06"
        type  = "fixed-response"
            status_code  = "403"
        target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/octopus-app/6d0ecf831eec9f09"
        type             = "forward"
            values = [

--- run preflight: trusted-edge 443 ingress rules on ALB security group ---
resource "aws_vpc_security_group_ingress_rule" "origin_https" {
    cidr_ipv4              = "103.21.244.0/22"
    from_port              = 443
    ip_protocol            = "tcp"
    to_port                = 443
resource "aws_vpc_security_group_ingress_rule" "origin_https" {
    cidr_ipv4              = "173.245.48.0/20"
    from_port              = 443
    ip_protocol            = "tcp"
    to_port                = 443

--- run preflight: ALB hardening ---
    drop_invalid_header_fields                                   = true
    idle_timeout                                                 = 900
    internal                                                     = false
    load_balancer_type                                           = "application"
    preserve_host_header                                         = true
```
</details>
<details>
<summary>Evidence: terraform test -verbose full applied state (origin_tls)</summary>

```text
tests/origin_tls.tftest.hcl... in progress
  run "preflight_provisions_managed_tls_without_removing_rollback_path"... pass

# aws_lb.origin:
resource "aws_lb" "origin" {
    arn                                                          = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/octopus-origin/50dc6c495c0c9188"
    arn_suffix                                                   = "i97aye42"
    dns_name                                                     = "octopus-origin-123456.us-east-1.elb.amazonaws.com"
    drop_invalid_header_fields                                   = true
    enforce_security_group_inbound_rules_on_private_link_traffic = "hw0eor6r"
    id                                                           = "fed3pdgs"
    idle_timeout                                                 = 900
    internal                                                     = false
    ip_address_type                                              = "ipv4"
    load_balancer_type                                           = "application"
    name                                                         = "oct-origin-5633c9b8af6d"
    name_prefix                                                  = "h03jmq29"
    preserve_host_header                                         = true
    security_groups                                              = [
        "6r5js4cu",
    ]
    subnets                                                      = [
        "89dk335n",
        "o43yeaxd",
    ]
    tags                                                         = {
        "Name" = "octopus-origin"
    }
    tags_all                                                     = {}
    vpc_id                                                       = "jr05mpk9"
    zone_id                                                      = "Z35SXDOTRQ7X7K"
}

# aws_lb_listener.https:
resource "aws_lb_listener" "https" {
    arn                                                                   = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/octopus-origin/50dc6c495c0c9188/f2f7dc8efc522ab2"
    certificate_arn                                                       = "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
    id                                                                    = "rkdelv4w"
    load_balancer_arn                                                     = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/octopus-origin/50dc6c495c0c9188"
    port                                                                  = 443
    protocol                                                              = "HTTPS"
    routing_http_request_x_amzn_mtls_clientcert_header_name               = "1zm1tlfi"
    routing_http_request_x_amzn_mtls_clientcert_issuer_header_name        = "w0px93bm"
    routing_http_request_x_amzn_mtls_clientcert_leaf_header_name          = "29uopl6a"
    routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name = "sj0fweot"
    routing_http_request_x_amzn_mtls_clientcert_subject_header_name       = "ynhal6f0"
    routing_http_request_x_amzn_mtls_clientcert_validity_header_name      = "a5fsvnr6"
    routing_http_request_x_amzn_tls_cipher_suite_header_name              = "ll39bwhx"
    routing_http_request_x_amzn_tls_version_header_name                   = "3nrovifl"
    routing_http_response_access_control_allow_credentials_header_value   = "4cw79bd0"
    routing_http_response_access_control_allow_headers_header_value       = "esv8jhkz"
    routing_http_response_access_control_allow_methods_header_value       = "5borzykt"
    routing_http_response_access_control_allow_origin_header_value        = "flnqfw7f"
    routing_http_response_access_control_expose_headers_header_value      = "gcqxfbvb"
    routing_http_response_access_control_max_age_header_value             = "0vnps8wt"
    routing_http_response_content_security_policy_header_value            = "g2fgmfit"
    routing_http_response_server_enabled                                  = false
    routing_http_response_strict_transport_security_header_value          = "yt3vcehk"
    routing_http_response_x_content_type_options_header_value             = "5qm9rows"
    routing_http_response_x_frame_options_header_value                    = "inxl0gkq"
    ssl_policy                                                            = "ELBSecurityPolicy-TLS13-1-2-2021-06"
    tags                                                                  = {
        "Name" = "octopus-origin-https"
    }
    tags_all                                                              = {}
    tcp_idle_timeout_seconds                                              = 0

    default_action {
        order = 0
        type  = "fixed-response"

        fixed_response {
            content_type = "text/plain"
            message_body = "Forbidden"
            status_code  = "403"
        }
    }
}

# aws_lb_listener_rule.app_host:
resource "aws_lb_listener_rule" "app_host" {
    arn          = "d7zog86s"
    id           = "bceo4l0t"
    listener_arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/octopus-origin/50dc6c495c0c9188/f2f7dc8efc522ab2"
    priority     = 100
    tags         = {
        "Name" = "octopus-origin-app-host"
    }
    tags_all     = {}

    action {
        order            = 0
        target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/octopus-app/6d0ecf831eec9f09"
        type             = "forward"
    }

    condition {
        host_header {
            values = [
                "octopus.example.com",
            ]
        }
    }
}

# aws_lb_target_group.app:
resource "aws_lb_target_group" "app" {
    arn                               = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/octopus-app/6d0ecf831eec9f09"
    arn_suffix                        = "5ajpa6qm"
    connection_termination            = false
    deregistration_delay              = "900"
    id                                = "1flpzp5j"
    ip_address_type                   = "lqr9eufv"
    load_balancer_arns                = []
    load_balancing_algorithm_type     = "k5dqjt2r"
    load_balancing_anomaly_mitigation = "mm0jsx1j"
    load_balancing_cross_zone_enabled = "d79mrjxl"
    name                              = "oct-app-5633c9b8af6d"
    name_prefix                       = "l8kygq79"
    port                              = 80
    preserve_client_ip                = "fgirkq1c"
    protocol                          = "HTTP"
    protocol_version                  = "HTTP1"
    tags                              = {
        "Name" = "octopus-app-origin"
    }
    tags_all                          = {}
    target_type                       = "instance"
    vpc_id                            = "gcmvph4y"

    health_check {
        enabled             = true
        healthy_threshold   = 2
        interval            = 30
        matcher             = "200"
        path                = "/api/health"
        port                = "traffic-port"
        protocol            = "HTTP"
        timeout             = 5
        unhealthy_threshold = 2
    }
}

# aws_lb_target_group_attachment.app:
resource "aws_lb_target_group_attachment" "app" {
    id               = "v0spsd78"
    port             = 80
    target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/octopus-app/6d0ecf831eec9f09"
    target_id        = "qpiucoe4"
}

# aws_security_group.app_data_access:
resource "aws_security_group" "app_data_access" {
    arn         = "oeawpd6a"
    description = "Octopus application identity for private data-service access"
    egress      = []
    id          = "ke26mioj"
    ingress     = []
    name        = "hkzsle8o"
    name_prefix = "octopus-app-data-"
    owner_id    = "tqi9osn5"
    tags        = {
        "Name" = "octopus-app-data-sg"
    }
    tags_all    = {}
    vpc_id      = "gcmvph4y"
}

# aws_security_group.origin_edge:
resource "aws_security_group" "origin_edge" {
    arn         = "75iioyov"
    description = "Trusted edge access to the Octopus HT

... [257194 bytes truncated] ...

" {
        id                                  = "o43yeaxd"
      ~ tags                                = {
          ~ "Name" = "octopus-public-us-east-1b" -> "octopus-production-eu-west-public-us-east-1b"
        }
        # (10 unchanged attributes hidden)
    }

  # module.vpc.aws_vpc.this will be updated in-place
  ~ resource "aws_vpc" "this" {
        id                                   = "gcmvph4y"
      ~ tags                                 = {
          ~ "Name" = "octopus-vpc" -> "octopus-production-eu-west-vpc"
        }
        # (15 unchanged attributes hidden)
    }

Plan: 0 to add, 26 to change, 0 to destroy.

  run "internet_wide_edge_cidr_is_rejected"... pass

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform planned the following actions, but then encountered a problem:

  # module.ec2.aws_security_group.this will be updated in-place
  ~ resource "aws_security_group" "this" {
        id          = "9ryu8p7i"
      ~ ingress     = [
          + {
              + cidr_blocks     = [
                  + "0.0.0.0/0",
                ]
              + description     = "Legacy public HTTP during origin TLS preflight"
              + from_port       = 80
              + protocol        = "tcp"
              + security_groups = []
              + to_port         = 80
            },
          + {
              + cidr_blocks     = [
                  + "0.0.0.0/0",
                ]
              + description     = "Legacy public HTTPS during origin TLS preflight"
              + from_port       = 443
              + protocol        = "tcp"
              + security_groups = []
              + to_port         = 443
            },
            # (1 unchanged element hidden)
        ]
        name        = "dm5d6bhs"
        tags        = {
            "Name" = "octopus-app-sg"
        }
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.


Error: Invalid value for variable

  on tests/origin_tls.tftest.hcl line 336, in run "internet_wide_edge_cidr_is_rejected":
 336:     trusted_edge_ipv4_cidrs = ["0.0.0.0/0"]
    ├────────────────
    │ var.trusted_edge_ipv4_cidrs is list of string with 1 element

trusted_edge_ipv4_cidrs must contain unique canonical IPv4 network CIDRs
narrower than 0.0.0.0/0.

This was checked by the validation rule at variables.tf:72,3-13.
  run "malformed_edge_cidr_is_rejected"... pass

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform planned the following actions, but then encountered a problem:

  # module.ec2.aws_security_group.this will be updated in-place
  ~ resource "aws_security_group" "this" {
        id          = "9ryu8p7i"
      ~ ingress     = [
          + {
              + cidr_blocks     = [
                  + "0.0.0.0/0",
                ]
              + description     = "Legacy public HTTP during origin TLS preflight"
              + from_port       = 80
              + protocol        = "tcp"
              + security_groups = []
              + to_port         = 80
            },
          + {
              + cidr_blocks     = [
                  + "0.0.0.0/0",
                ]
              + description     = "Legacy public HTTPS during origin TLS preflight"
              + from_port       = 443
              + protocol        = "tcp"
              + security_groups = []
              + to_port         = 443
            },
            # (1 unchanged element hidden)
        ]
        name        = "dm5d6bhs"
        tags        = {
            "Name" = "octopus-app-sg"
        }
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.


Error: Invalid value for variable

  on tests/origin_tls.tftest.hcl line 346, in run "malformed_edge_cidr_is_rejected":
 346:     trusted_edge_ipv4_cidrs = ["173.245.48.1"]
    ├────────────────
    │ var.trusted_edge_ipv4_cidrs is list of string with 1 element

trusted_edge_ipv4_cidrs must contain unique canonical IPv4 network CIDRs
narrower than 0.0.0.0/0.

This was checked by the validation rule at variables.tf:72,3-13.
  run "host_bits_edge_cidr_is_rejected"... pass

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform planned the following actions, but then encountered a problem:

  # module.ec2.aws_security_group.this will be updated in-place
  ~ resource "aws_security_group" "this" {
        id          = "9ryu8p7i"
      ~ ingress     = [
          + {
              + cidr_blocks     = [
                  + "0.0.0.0/0",
                ]
              + description     = "Legacy public HTTP during origin TLS preflight"
              + from_port       = 80
              + protocol        = "tcp"
              + security_groups = []
              + to_port         = 80
            },
          + {
              + cidr_blocks     = [
                  + "0.0.0.0/0",
                ]
              + description     = "Legacy public HTTPS during origin TLS preflight"
              + from_port       = 443
              + protocol        = "tcp"
              + security_groups = []
              + to_port         = 443
            },
            # (1 unchanged element hidden)
        ]
        name        = "dm5d6bhs"
        tags        = {
            "Name" = "octopus-app-sg"
        }
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.


Error: Invalid value for variable

  on tests/origin_tls.tftest.hcl line 356, in run "host_bits_edge_cidr_is_rejected":
 356:     trusted_edge_ipv4_cidrs = ["173.245.48.1/20"]
    ├────────────────
    │ var.trusted_edge_ipv4_cidrs is list of string with 1 element

trusted_edge_ipv4_cidrs must contain unique canonical IPv4 network CIDRs
narrower than 0.0.0.0/0.

This was checked by the validation rule at variables.tf:72,3-13.
  run "empty_edge_cidr_set_is_rejected"... pass

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform planned the following actions, but then encountered a problem:

  # module.ec2.aws_security_group.this will be updated in-place
  ~ resource "aws_security_group" "this" {
        id          = "9ryu8p7i"
      ~ ingress     = [
          + {
              + cidr_blocks     = [
                  + "0.0.0.0/0",
                ]
              + description     = "Legacy public HTTP during origin TLS preflight"
              + from_port       = 80
              + protocol        = "tcp"
              + security_groups = []
              + to_port         = 80
            },
          + {
              + cidr_blocks     = [
                  + "0.0.0.0/0",
                ]
              + description     = "Legacy public HTTPS during origin TLS preflight"
              + from_port       = 443
              + protocol        = "tcp"
              + security_groups = []
              + to_port         = 443
            },
            # (1 unchanged element hidden)
        ]
        name        = "dm5d6bhs"
        tags        = {
            "Name" = "octopus-app-sg"
        }
        # (7 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.


Error: Invalid value for variable

  on tests/origin_tls.tftest.hcl line 366, in run "empty_edge_cidr_set_is_rejected":
 366:     trusted_edge_ipv4_cidrs = []
    ├────────────────
    │ var.trusted_edge_ipv4_cidrs is empty list of string

trusted_edge_ipv4_cidrs must contain unique canonical IPv4 network CIDRs
narrower than 0.0.0.0/0.

This was checked by the validation rule at variables.tf:72,3-13.
tests/origin_tls.tftest.hcl... tearing down
tests/origin_tls.tftest.hcl... pass

Success! 11 passed, 0 failed.
```
</details>
<details>
<summary>Evidence: bun terraform-origin-tls-security.test.ts (9 pass)</summary>

```text
bun test v1.3.13 (bf2e2cec)

 9 pass
 0 fail
 89 expect() calls
Ran 9 tests across 1 file. [90.00ms]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 5 infos</summary>

- ⚠️ `terraform/stacks/aws-ec2/main.tf:132` - Preflight stage removes the previously-default public 443 ingress on EC2. The old README&#39;s Step 6 told operators to add origin HTTPS on the instance (&#39;AWS ALB with ACM, Caddy, or an nginx certificate&#39;); an existing stack terminating TLS on EC2:443 under Cloudflare Full (strict) loses its live TLS path on the very first `preflight` apply — before any cutover step — contradicting the intent that &#39;only existing AWS stacks use a temporary preflight HTTP compatibility path&#39; and that &#39;rollback traffic must use a verified TLS-capable origin&#39;. The removal is intentional (origin_tls.tftest.hcl asserts `rule.from_port != 443` in preflight), so it needs an author decision: keep 443 open during preflight, or add an explicit Stage 1 warning that instance-level TLS setups break on the preflight apply.
- ℹ️ `terraform/stacks/aws-ec2/variables.tf:44` - Upgrade is a hard-breaking apply gate for existing stacks: `origin_tls_cutover_stage`, `origin_tls_certificate_arn`, and `trusted_edge_ipv4_cidrs` have no defaults, so no plan/apply succeeds until an ACM certificate is provisioned and trusted-edge CIDRs are chosen. This matches the intent (fresh stacks enforced, explicit staging for existing stacks) and is documented in the README, but operators cannot even apply unrelated changes until they complete the TLS prerequisites.
- ℹ️ `terraform/stacks/aws-ec2/variables.tf:78` - The `trusted_edge_ipv4_cidrs` guardrail only rejects the literal `0.0.0.0/0`; near-universal ranges (e.g. `0.0.0.0/1` + `128.0.0.0/1`) and host-bits-set CIDRs like `173.245.48.1/20` pass validation, so the error message (&#39;narrower than 0.0.0.0/0&#39;) overstates the protection. Operator input remains authoritative and the README says never to widen the list, so this is residual guardrail weakness rather than a defect.
- ℹ️ `terraform/stacks/aws-ec2/main.tf:25` - nginx trusts the entire `vpc_cidr` (not just the ALB) as an X-Forwarded-Proto source in the `geo` block. External TCP sources cannot spoof a VPC address and enforced mode limits port 80 to the ALB security group, so exposure is limited to preflight-window VPC-internal actors; scoping to the public-subnet CIDRs would be marginally tighter.
- ℹ️ `terraform/stacks/aws-ec2/main.tf:224` - The production origin ALB does not set `enable_deletion_protection`, so a stray `terraform destroy` (or plan approving replacement) removes the enforced-mode TLS origin in one step. Worth considering as a follow-up hardening once the cutover is complete; it does complicate intentional teardown of test stacks.

🔧 Fix: retain public 443 during origin TLS preflight; canonical edge CIDRs
5 infos still open:
- ℹ️ `terraform/stacks/aws-ec2/main.tf:144` - Resolved from round 1: preflight now retains the pre-existing public 443 ingress so instance-terminated TLS origins (Caddy / nginx certificate per the old README) keep serving through Stage 1; README Stage 1/Stage 2 and origin_tls.tftest.hcl were updated consistently, and enforced mode still removes both public ports, preserving the intent&#39;s ALB-only enforced ingress and TLS-capable rollback requirements.
- ℹ️ `terraform/stacks/aws-ec2/variables.tf:78` - Residual guardrail weakness (previously acknowledged, partially tightened): the `trusted_edge_ipv4_cidrs` validation now rejects host-bits CIDRs via `cidrsubnet(cidr, 0, 0) == cidr` but still only rejects the literal `0.0.0.0/0`, so near-universal ranges like `0.0.0.0/1` + `128.0.0.0/1` pass. Operator input remains authoritative and the README forbids widening the list.
- ℹ️ `terraform/stacks/aws-ec2/main.tf:25` - Unchanged from round 1: nginx trusts the entire `vpc_cidr` (not just the ALB) as an X-Forwarded-Proto source. External TCP sources cannot spoof VPC addresses and enforced mode limits port 80 to the ALB security group, so exposure is limited to preflight-window VPC-internal actors.
- ℹ️ `terraform/stacks/aws-ec2/main.tf:224` - Unchanged from round 1: the production origin ALB does not set `enable_deletion_protection`, so a stray `terraform destroy` removes the enforced-mode TLS origin in one step. Worth considering as post-cutover hardening; it does complicate intentional teardown of test stacks, so it needs an author decision if desired.
- ℹ️ `terraform/stacks/aws-ec2/variables.tf:44` - Unchanged from round 1: `origin_tls_cutover_stage`, `origin_tls_certificate_arn`, and `trusted_edge_ipv4_cidrs` have no defaults, so existing stacks cannot plan/apply anything until an ACM certificate is provisioned and edge CIDRs are chosen. Intentional per the intent (fresh stacks enforced, explicit staging) and documented in the README.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `terraform -chdir=terraform/stacks/aws-ec2 init -backend=false -input=false && terraform -chdir=terraform/stacks/aws-ec2 validate`
- <code>`terraform -chdir=terraform/stacks/aws-ec2 test` — 20/20 runs pass (origin_tls.tftest.hcl + network_trust.tftest.hcl, mocked AWS, includes apply of preflight and enforced stages)</code>
- <code>`terraform -chdir=terraform/stacks/aws-ec2 test -filter=tests/origin_tls.tftest.hcl -verbose` — captured full applied state as evidence</code>
- <code>`bun test lib/__tests__/terraform-backend-security.test.ts lib/__tests__/terraform-runtime-secrets-security.test.ts lib/__tests__/terraform-runtime-env-renderer.test.ts lib/__tests__/terraform-runtime-secret-refresh.test.ts lib/__tests__/terraform-origin-tls-security.test.ts` (apps/web, CI command) — 34/34 pass</code>
- <code>Manual check: `origin_tls_cutover_stage` has no default (operators must choose) and both operator-facing examples (`terraform.tfvars.example`, `examples/aws-ec2/main.tf`) pin `&#34;enforced&#34;` for fresh stacks; Redis auth untouched per passing network-trust suite</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `terraform/modules/aws/elasticache-redis/main.tf:55` - Pre-existing `terraform fmt` drift (argument alignment in the replication-group block). Not introduced by this change and deliberately left unfixed to keep the diff scoped; note the CI fmt step also omits this module from its check list, which is why the drift persists on master. A follow-up could run `terraform fmt` on the module and add `terraform fmt -check terraform/modules/aws/elasticache-redis` (or a recursive modules check) to .github/workflows/ci.yml.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
