### PR TITLE
fix(terraform): enforce Redis authentication with staged cutover and least-privilege ACLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           terraform fmt -check -recursive terraform/bootstrap/aws-state
           terraform fmt -check terraform/modules/aws/ec2-app
+          terraform fmt -check -recursive terraform/modules/aws/elasticache-redis
           terraform fmt -check terraform/modules/aws/rds-postgres
           terraform fmt -check -recursive terraform/stacks/aws-ec2
 
@@ -71,6 +72,12 @@ jobs:
           terraform -chdir=terraform/bootstrap/aws-state init -backend=false -input=false
           terraform -chdir=terraform/bootstrap/aws-state validate
           terraform -chdir=terraform/bootstrap/aws-state test
+
+      - name: Test ElastiCache Redis module
+        run: |
+          terraform -chdir=terraform/modules/aws/elasticache-redis init -backend=false -input=false
+          terraform -chdir=terraform/modules/aws/elasticache-redis validate
+          terraform -chdir=terraform/modules/aws/elasticache-redis test
 
       - name: Test AWS application stack
         run: |

--- a/apps/web/lib/__tests__/presence.test.ts
+++ b/apps/web/lib/__tests__/presence.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const NOW = 1_800_000_000_000;
+const originalDateNow = Date.now;
+
+const redisSet = mock((..._args: unknown[]) => Promise.resolve("OK"));
+const redisZadd = mock((..._args: unknown[]) => Promise.resolve(1));
+const redisExpire = mock((..._args: unknown[]) => Promise.resolve(1));
+const redisDel = mock((..._args: unknown[]) => Promise.resolve(1));
+const redisZrem = mock((..._args: unknown[]) => Promise.resolve(1));
+const redisZremrangebyscore = mock((..._args: unknown[]) => Promise.resolve(0));
+const redisZrangebyscore = mock((..._args: unknown[]) => Promise.resolve([] as string[]));
+const redisMget = mock((..._args: unknown[]) => Promise.resolve([] as Array<string | null>));
+
+type RedisDouble = {
+  set: typeof redisSet;
+  zadd: typeof redisZadd;
+  expire: typeof redisExpire;
+  del: typeof redisDel;
+  zrem: typeof redisZrem;
+  zremrangebyscore: typeof redisZremrangebyscore;
+  zrangebyscore: typeof redisZrangebyscore;
+  mget: typeof redisMget;
+};
+
+let redisClient: RedisDouble | null = null;
+
+const presenceUpsert = mock(() => Promise.resolve({}));
+const presenceDeleteMany = mock(() => Promise.resolve({ count: 1 }));
+const presenceFindMany = mock(() =>
+  Promise.resolve(
+    [] as Array<{
+      userId: string;
+      currentActivity: string | null;
+      lastSeenAt: Date;
+    }>,
+  ),
+);
+
+mock.module("server-only", () => ({}));
+
+mock.module("@/lib/redis", () => ({
+  getRedis: () => redisClient,
+}));
+
+mock.module("@octopus/db", () => ({
+  prisma: {
+    userPresence: {
+      upsert: presenceUpsert,
+      deleteMany: presenceDeleteMany,
+      findMany: presenceFindMany,
+    },
+  },
+}));
+
+const {
+  PRESENCE_STALE_MS,
+  PRESENCE_TTL_SECONDS,
+  clearPresence,
+  getOnlinePresence,
+  presenceIndexKey,
+  presenceKey,
+  recordPresence,
+} = await import("@/lib/presence");
+
+function connectedRedis(): RedisDouble {
+  return {
+    set: redisSet,
+    zadd: redisZadd,
+    expire: redisExpire,
+    del: redisDel,
+    zrem: redisZrem,
+    zremrangebyscore: redisZremrangebyscore,
+    zrangebyscore: redisZrangebyscore,
+    mget: redisMget,
+  };
+}
+
+beforeEach(() => {
+  Date.now = () => NOW;
+  redisClient = connectedRedis();
+  redisSet.mockClear();
+  redisZadd.mockClear();
+  redisExpire.mockClear();
+  redisDel.mockClear();
+  redisZrem.mockClear();
+  redisZremrangebyscore.mockClear();
+  redisZrangebyscore.mockClear();
+  redisMget.mockClear();
+  presenceUpsert.mockClear();
+  presenceDeleteMany.mockClear();
+  presenceFindMany.mockClear();
+});
+
+afterAll(() => {
+  Date.now = originalDateNow;
+});
+
+describe("Redis presence index", () => {
+  it("does not make a heartbeat wait for Redis", async () => {
+    redisSet.mockImplementationOnce(() => new Promise<string>(() => {}));
+    redisZadd.mockImplementationOnce(() => new Promise<number>(() => {}));
+
+    await expect(recordPresence("org_1", "user_1", null)).resolves.toBeUndefined();
+    expect(redisSet).toHaveBeenCalledTimes(1);
+    expect(redisZadd).toHaveBeenCalledTimes(1);
+  });
+
+  it("records the expiring presence key in an org-scoped sorted set", async () => {
+    await recordPresence("org_1", "user_1", "reviewing");
+
+    const key = presenceKey("org_1", "user_1");
+    expect(redisSet).toHaveBeenCalledWith(
+      key,
+      JSON.stringify({
+        userId: "user_1",
+        currentActivity: "reviewing",
+        lastSeenAt: NOW,
+      }),
+      "EX",
+      PRESENCE_TTL_SECONDS,
+    );
+    expect(redisZadd).toHaveBeenCalledWith(
+      presenceIndexKey("org_1"),
+      NOW + PRESENCE_TTL_SECONDS * 1000,
+      key,
+    );
+    expect(redisExpire).toHaveBeenCalledWith(
+      presenceIndexKey("org_1"),
+      PRESENCE_TTL_SECONDS * 2,
+    );
+    expect(presenceUpsert).not.toHaveBeenCalled();
+  });
+
+  it("removes expired members, MGETs only the active org index, and prunes missing values", async () => {
+    const validKey = presenceKey("org_1", "user_1");
+    const missingKey = presenceKey("org_1", "user_2");
+    const invalidKey = presenceKey("org_1", "user_3");
+    redisZrangebyscore.mockResolvedValueOnce([validKey, missingKey, invalidKey]);
+    redisMget.mockResolvedValueOnce([
+      JSON.stringify({
+        userId: "user_1",
+        currentActivity: "dashboard",
+        lastSeenAt: NOW - 1_000,
+      }),
+      null,
+      "not-json",
+    ]);
+
+    await expect(getOnlinePresence("org_1")).resolves.toEqual([
+      {
+        userId: "user_1",
+        currentActivity: "dashboard",
+        lastSeenAt: NOW - 1_000,
+      },
+    ]);
+
+    const indexKey = presenceIndexKey("org_1");
+    expect(redisZremrangebyscore).toHaveBeenCalledWith(indexKey, "-inf", NOW);
+    expect(redisZrangebyscore).toHaveBeenCalledWith(indexKey, `(${NOW}`, "+inf");
+    expect(redisMget).toHaveBeenCalledWith(validKey, missingKey, invalidKey);
+    expect(redisZrem).toHaveBeenCalledWith(indexKey, missingKey, invalidKey);
+  });
+
+  it("removes the presence key and its index membership on clear", async () => {
+    await clearPresence("org_1", "user_1");
+
+    const key = presenceKey("org_1", "user_1");
+    expect(redisDel).toHaveBeenCalledWith(key);
+    expect(redisZrem).toHaveBeenCalledWith(presenceIndexKey("org_1"), key);
+    expect(presenceDeleteMany).toHaveBeenCalledWith({
+      where: { organizationId: "org_1", userId: "user_1" },
+    });
+  });
+});
+
+describe("presence degraded fallback", () => {
+  it("keeps the Postgres fallback when Redis is unavailable", async () => {
+    redisClient = null;
+    presenceFindMany.mockResolvedValueOnce([
+      {
+        userId: "user_1",
+        currentActivity: null,
+        lastSeenAt: new Date(NOW - 5_000),
+      },
+    ]);
+
+    await recordPresence("org_1", "user_1", null);
+    await expect(getOnlinePresence("org_1")).resolves.toEqual([
+      { userId: "user_1", currentActivity: null, lastSeenAt: NOW - 5_000 },
+    ]);
+
+    expect(presenceUpsert).toHaveBeenCalled();
+    expect(presenceFindMany).toHaveBeenCalledWith({
+      where: {
+        organizationId: "org_1",
+        lastSeenAt: { gte: new Date(NOW - PRESENCE_STALE_MS) },
+      },
+      select: { userId: true, currentActivity: true, lastSeenAt: true },
+    });
+  });
+});

--- a/apps/web/lib/__tests__/terraform-redis-auth-security.test.ts
+++ b/apps/web/lib/__tests__/terraform-redis-auth-security.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../../../..");
+const readRepoFile = (path: string) => readFileSync(resolve(repoRoot, path), "utf8");
+
+const redisMain = readRepoFile("terraform/modules/aws/elasticache-redis/main.tf");
+const redisAuth = readRepoFile("terraform/modules/aws/elasticache-redis/auth.tf");
+const redisVariables = readRepoFile("terraform/modules/aws/elasticache-redis/variables.tf");
+const redisOutputs = readRepoFile("terraform/modules/aws/elasticache-redis/outputs.tf");
+const redisTerraform = [redisMain, redisAuth, redisVariables, redisOutputs].join("\n");
+const stackMain = readRepoFile("terraform/stacks/aws-ec2/main.tf");
+const stackVariables = readRepoFile("terraform/stacks/aws-ec2/variables.tf");
+const stackOutputs = readRepoFile("terraform/stacks/aws-ec2/outputs.tf");
+const stackExample = readRepoFile("terraform/stacks/aws-ec2/terraform.tfvars.example");
+const ec2Main = readRepoFile("terraform/modules/aws/ec2-app/main.tf");
+const ec2Variables = readRepoFile("terraform/modules/aws/ec2-app/variables.tf");
+const refreshScript = readRepoFile(
+  "terraform/modules/aws/ec2-app/templates/refresh-secrets.sh.tpl",
+);
+const preflightScript = readRepoFile(
+  "terraform/modules/aws/ec2-app/templates/preflight-runtime-secrets.sh.tpl",
+);
+const redisProbe = readRepoFile("terraform/modules/aws/ec2-app/scripts/probe_redis.js");
+const redisClient = readRepoFile("apps/web/lib/redis.ts");
+const cancelBus = readRepoFile("apps/web/lib/cancel-bus.ts");
+const terraformReadme = readRepoFile("terraform/README.md");
+
+const terraformBoundary = [
+  redisTerraform,
+  stackMain,
+  stackVariables,
+  stackOutputs,
+  stackExample,
+  ec2Main,
+  ec2Variables,
+].join("\n");
+
+describe("Terraform Redis authentication boundary", () => {
+  it("keeps the Redis password out of Terraform state, plans, outputs, and user data", () => {
+    expect(redisAuth).toContain('resource "aws_cloudformation_stack" "redis_auth"');
+    expect(redisAuth).toContain("{{resolve:secretsmanager:");
+    expect(redisAuth).toContain("redis_auth_secret_version_ids");
+    expect(redisTerraform).not.toMatch(/resource\s+"aws_elasticache_user"/);
+    expect(terraformBoundary).not.toMatch(/(?:data|resource)\s+"aws_secretsmanager_secret_version"/);
+    expect(terraformBoundary).not.toMatch(/^\s*auth_token\s*=/m);
+    expect(terraformBoundary).not.toMatch(/^\s*passwords?\s*=/m);
+    expect(stackOutputs).not.toMatch(/output\s+"redis_url"/);
+    expect(redisOutputs).not.toMatch(/rediss:\/\//);
+    expect(stackMain).not.toContain("module.redis[0].connection_url");
+  });
+
+  it("uses an exact-secret CloudFormation role and a stable RBAC user group", () => {
+    expect(redisAuth).toContain('resource "aws_iam_role" "redis_auth_cloudformation"');
+    expect(redisAuth).toContain("cloudformation.amazonaws.com");
+    expect(redisAuth).toContain("secretsmanager:GetSecretValue");
+    expect(redisAuth).toContain("var.redis_auth_secret_arn");
+    expect(redisAuth).toContain("kms:ViaService");
+    expect(redisAuth).toContain('"AWS::ElastiCache::User"');
+    expect(redisAuth).toContain('"AWS::ElastiCache::UserGroup"');
+    expect(redisMain).toContain("user_group_ids");
+    expect(redisMain).toContain("depends_on");
+  });
+
+  it("attaches compatibility and enforced memberships without replacing Redis", () => {
+    expect(redisVariables).toContain('variable "redis_auth_cutover_stage"');
+    expect(redisVariables).toContain('contains(["preflight", "enforced"]');
+    expect(redisVariables).not.toMatch(
+      /variable "redis_auth_cutover_stage" \{[\s\S]*?default\s*=\s*"preflight"[\s\S]*?\n\}/,
+    );
+    expect(stackVariables).not.toMatch(
+      /variable "redis_auth_cutover_stage" \{[\s\S]*?default\s*=\s*"preflight"[\s\S]*?\n\}/,
+    );
+    expect(ec2Variables).not.toMatch(
+      /variable "redis_auth_cutover_stage" \{[\s\S]*?default\s*=\s*"preflight"[\s\S]*?\n\}/,
+    );
+    expect(redisAuth).toMatch(/redis_auth_cutover_stage\s*==\s*"preflight"/);
+    expect(redisAuth).toContain('"default"');
+    expect(redisAuth).toContain("DisabledDefaultUser");
+    expect(redisAuth).toContain("ApplicationUser");
+    expect(redisAuth).toContain('AccessString = "off ~* -@all"');
+    expect(redisTerraform).not.toMatch(/create_before_destroy\s*=\s*false/);
+    expect(stackVariables).toContain('variable "redis_authenticated_runtime_ready"');
+    expect(stackMain).toContain("var.redis_authenticated_runtime_ready");
+  });
+
+  it("fetches the dedicated Redis secret only at runtime and renders an authenticated URL", () => {
+    expect(stackVariables).toContain('variable "redis_auth_secret_arn"');
+    expect(stackVariables).toContain('variable "redis_auth_secret_version_ids"');
+    expect(ec2Variables).toContain('variable "redis_secret_arn"');
+    expect(ec2Main).toContain("var.redis_secret_arn");
+    expect(refreshScript).toContain("REDIS_SECRET_ARN");
+    expect(refreshScript).toContain('fetch_secret "$REDIS_SECRET_ARN"');
+    expect(refreshScript).toContain("--redis-secret");
+    expect(refreshScript).toContain("--redis-config");
+    expect(refreshScript).toContain("redis_probe_required");
+    expect(refreshScript).toContain("OCTOPUS_REDIS_PROBE_RUN=1");
+    expect(refreshScript).toContain("OCTOPUS_REDIS_AUTH_ENFORCED");
+    expect(refreshScript).toContain("run --rm --no-deps -T");
+    expect(refreshScript).toContain("web node -");
+    expect(preflightScript).toContain("--validate-redis-secret-only");
+    expect(stackMain).not.toMatch(/REDIS_PASSWORD\s*=/);
+  });
+
+  it("keeps ioredis readiness without granting broad CLIENT permissions", () => {
+    expect(redisClient).toContain("disableClientInfo: true");
+    expect(cancelBus.match(/disableClientInfo:\s*true/g)).toHaveLength(2);
+    expect(redisAuth).toContain("+info");
+    expect(redisAuth).not.toContain("+client");
+  });
+
+  it("probes authenticated command, key, channel, and denial boundaries", () => {
+    expect(redisProbe).toContain("rl:avatar-upload:redis-probe:");
+    expect(redisProbe).toContain("mx:v1:redis-probe:");
+    expect(redisProbe).toContain("presence:redis-probe:");
+    expect(redisProbe).toContain("presence:index:redis-probe:");
+    expect(redisProbe).toContain("gh:install:state:jti:redis-probe:");
+    expect(redisProbe).toContain('const channel = "octopus:probe"');
+    expect(redisProbe).toContain("foreign:redis-probe:");
+    expect(redisProbe).toContain('error.message.includes("NOPERM")');
+    expect(redisProbe).toContain("OCTOPUS_REDIS_AUTH_ENFORCED");
+    expect(redisProbe).toContain("/^NOAUTH");
+    expect(redisProbe).not.toMatch(/NOAUTH\|WRONGPASS|NOAUTH\|NOPERM/);
+    expect(redisProbe).toContain('this.socket.on("close"');
+    expect(redisProbe).toContain("withDeadline(probe(), 30000)");
+    expect(redisProbe).not.toContain("console.");
+    expect(redisAuth).not.toContain("+scan");
+    for (const command of ["+zadd", "+zrem", "+zremrangebyscore", "+zrangebyscore"]) {
+      expect(redisAuth).toContain(command);
+    }
+  });
+
+  it("documents the compatibility gate, enforcement proof, rollback, and rotation order", () => {
+    expect(stackExample).toContain("redis_auth_cutover_stage");
+    expect(stackExample).toContain("redis_authenticated_runtime_ready");
+    expect(terraformReadme).toContain("Redis authentication cutover");
+    expect(terraformReadme).toContain("unauthenticated");
+    expect(terraformReadme).toContain("Rollback");
+    expect(terraformReadme).toContain("Rotate");
+  });
+});

--- a/apps/web/lib/__tests__/terraform-redis-probe.test.ts
+++ b/apps/web/lib/__tests__/terraform-redis-probe.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import { EventEmitter } from "node:events";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+
+const probePath = resolve(
+  import.meta.dir,
+  "../../../../terraform/modules/aws/ec2-app/scripts/probe_redis.js",
+);
+const requireFromHere = createRequire(import.meta.url);
+type ProbeCredentials = { endpoint: URL; username: string; password: string };
+type SocketOptions = {
+  credentials: ProbeCredentials;
+  socketFactory: () => FakeSocket;
+};
+
+class FakeSocket extends EventEmitter {
+  destroyed = false;
+  writes: Buffer[] = [];
+
+  setTimeout() {}
+
+  write(value: Buffer) {
+    this.writes.push(value);
+    return true;
+  }
+
+  destroy(error?: Error) {
+    this.destroyed = true;
+    if (error) this.emit("error", error);
+    this.emit("close");
+  }
+}
+
+const {
+  RedisConnection,
+  encodeCommand,
+  isAuthenticationRequired,
+  parseReply,
+  withDeadline,
+} = requireFromHere(probePath) as {
+  RedisConnection: new (options: SocketOptions) => {
+    ready: (authenticate?: boolean) => Promise<void>;
+    command: (...parts: unknown[]) => Promise<unknown>;
+  };
+  encodeCommand: (parts: unknown[]) => Buffer;
+  isAuthenticationRequired: (error: unknown) => boolean;
+  parseReply: (
+    buffer: Buffer,
+    offset?: number,
+  ) => { value: unknown; offset: number } | null;
+  withDeadline: <T>(operation: Promise<T>, timeoutMs: number) => Promise<T>;
+};
+
+const credentials: ProbeCredentials = {
+  endpoint: new URL("rediss://octopus:password@redis.internal:6379"),
+  username: "octopus",
+  password: "password",
+};
+
+describe("Terraform authenticated Redis probe protocol", () => {
+  it("encodes RESP commands using byte lengths", () => {
+    expect(encodeCommand(["SET", "presence:test", "✓"]).toString()).toBe(
+      "*3\r\n$3\r\nSET\r\n$13\r\npresence:test\r\n$3\r\n✓\r\n",
+    );
+  });
+
+  it("waits for complete bulk and array responses", () => {
+    expect(parseReply(Buffer.from("$5\r\nhel"))).toBeNull();
+    expect(parseReply(Buffer.from("*3\r\n$7\r\nmessage\r\n$13\r\noctopus:probe\r\n"))).toBeNull();
+
+    const reply = parseReply(
+      Buffer.from("*3\r\n$7\r\nmessage\r\n$13\r\noctopus:probe\r\n$5\r\nnonce\r\n"),
+    );
+    expect(reply?.value).toEqual(["message", "octopus:probe", "nonce"]);
+  });
+
+  it("parses scalar, null, and permission-error responses", () => {
+    expect(parseReply(Buffer.from("+OK\r\n"))?.value).toBe("OK");
+    expect(parseReply(Buffer.from(":7\r\n"))?.value).toBe(7);
+    expect(parseReply(Buffer.from("$-1\r\n"))?.value).toBeNull();
+
+    const denied = parseReply(Buffer.from("-NOPERM denied\r\n"))?.value;
+    expect(denied).toBeInstanceOf(Error);
+    expect((denied as Error).message).toContain("NOPERM");
+  });
+
+  it("fails when TLS closes before the secure handshake", async () => {
+    const socket = new FakeSocket();
+    const connection = new RedisConnection({ credentials, socketFactory: () => socket });
+
+    socket.destroyed = true;
+    socket.emit("close");
+
+    await expect(connection.ready(false)).rejects.toThrow("connection closed");
+  });
+
+  it("rejects pending and later commands when TLS closes cleanly", async () => {
+    const socket = new FakeSocket();
+    const connection = new RedisConnection({ credentials, socketFactory: () => socket });
+    socket.emit("secureConnect");
+    await connection.ready(false);
+
+    const pending = connection.command("GET", "mx:v1:test");
+    socket.destroyed = true;
+    socket.emit("end");
+
+    await expect(pending).rejects.toThrow("connection ended");
+    await expect(connection.command("GET", "mx:v1:test")).rejects.toThrow(
+      "connection ended",
+    );
+  });
+
+  it("fails a probe that exceeds its hard deadline", async () => {
+    await expect(withDeadline(new Promise(() => {}), 5)).rejects.toThrow(
+      "deadline exceeded",
+    );
+  });
+
+  it("accepts only NOAUTH as proof that anonymous Redis access is disabled", () => {
+    expect(isAuthenticationRequired(new Error("NOAUTH Authentication required."))).toBe(
+      true,
+    );
+    expect(isAuthenticationRequired(new Error("NOPERM this user has no permissions"))).toBe(
+      false,
+    );
+    expect(isAuthenticationRequired(new Error("WRONGPASS invalid credentials"))).toBe(
+      false,
+    );
+  });
+});

--- a/apps/web/lib/__tests__/terraform-runtime-env-renderer.test.ts
+++ b/apps/web/lib/__tests__/terraform-runtime-env-renderer.test.ts
@@ -22,6 +22,8 @@ function render(input: {
   applicationSecret?: Record<string, unknown>;
   databaseSecret?: Record<string, unknown>;
   databaseConfig?: Record<string, unknown>;
+  redisConfig?: Record<string, unknown>;
+  redisSecret?: Record<string, unknown>;
 }) {
   const directory = mkdtempSync(resolve(tmpdir(), "octopus-runtime-env-"));
   const paths = {
@@ -29,6 +31,8 @@ function render(input: {
     applicationSecret: resolve(directory, "application.json"),
     databaseSecret: resolve(directory, "database.json"),
     databaseConfig: resolve(directory, "database-config.json"),
+    redisConfig: resolve(directory, "redis-config.json"),
+    redisSecret: resolve(directory, "redis-secret.json"),
     output: resolve(directory, "runtime.env"),
   };
 
@@ -51,7 +55,14 @@ function render(input: {
     ),
   );
 
-  const result = Bun.spawnSync([
+  if (input.redisConfig !== undefined) {
+    writeFileSync(paths.redisConfig, JSON.stringify(input.redisConfig));
+  }
+  if (input.redisSecret !== undefined) {
+    writeFileSync(paths.redisSecret, JSON.stringify(input.redisSecret));
+  }
+
+  const args = [
     "python3",
     renderer,
     "--public-environment",
@@ -62,11 +73,33 @@ function render(input: {
     paths.databaseSecret,
     "--database-config",
     paths.databaseConfig,
-    "--output",
-    paths.output,
-  ]);
+  ];
+  if (input.redisConfig !== undefined) {
+    args.push("--redis-config", paths.redisConfig);
+  }
+  if (input.redisSecret !== undefined) {
+    args.push("--redis-secret", paths.redisSecret);
+  }
+  args.push("--output", paths.output);
+
+  const result = Bun.spawnSync(args);
 
   return { directory, paths, result };
+}
+
+function validateRedisSecret(redisSecret: Record<string, unknown>) {
+  const directory = mkdtempSync(resolve(tmpdir(), "octopus-redis-secret-validation-"));
+  const redisSecretPath = resolve(directory, "redis.json");
+  writeFileSync(redisSecretPath, JSON.stringify(redisSecret));
+
+  const result = Bun.spawnSync([
+    "python3",
+    renderer,
+    "--validate-redis-secret-only",
+    redisSecretPath,
+  ]);
+
+  return { redisSecretPath, result };
 }
 
 function validateApplicationSecret(applicationSecret: Record<string, unknown>) {
@@ -121,6 +154,194 @@ describe("Terraform runtime environment renderer", () => {
       `GITHUB_APP_PRIVATE_KEY=${Buffer.from(pem).toString("base64")}\n`,
     );
     expect(statSync(paths.output).mode & 0o777).toBe(0o600);
+  });
+
+  it("constructs a TLS Redis URL from dedicated config and secret inputs", () => {
+    const redisPassword = "Redis9!&#$^<>-Token";
+    const { paths, result } = render({
+      redisConfig: {
+        enabled: true,
+        host: "octopus-redis.example.cache.amazonaws.com",
+        port: 6379,
+        username: "octopus-app",
+      },
+      redisSecret: { password: redisPassword },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).not.toContain(redisPassword);
+    expect(result.stderr.toString()).not.toContain(redisPassword);
+
+    const output = readFileSync(paths.output, "utf8");
+    expect(output).toContain(
+      "REDIS_URL=rediss://octopus-app:Redis9%21%26%23%24%5E%3C%3E-Token@octopus-redis.example.cache.amazonaws.com:6379\n",
+    );
+    expect(output).not.toContain("REDIS_PASSWORD=");
+  });
+
+  it("omits Redis runtime values when Redis is not configured", () => {
+    const { paths, result } = render({
+      redisConfig: { enabled: false, host: "", port: 0, username: "" },
+    });
+
+    expect(result.exitCode).toBe(0);
+    const output = readFileSync(paths.output, "utf8");
+    expect(output).not.toContain("REDIS_URL=");
+    expect(output).not.toContain("REDIS_PASSWORD=");
+  });
+
+  it("requires an exact Redis config and secret schema when enabled", () => {
+    const cases = [
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal",
+          port: 6379,
+          username: "octopus-app",
+        },
+      },
+      {
+        redisSecret: { password: "Redis9!&#$^<>-Token" },
+      },
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal",
+          port: 6379,
+        },
+        redisSecret: { password: "Redis9!&#$^<>-Token" },
+      },
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal",
+          port: 6379,
+          username: "octopus-app",
+          unexpected: true,
+        },
+        redisSecret: { password: "Redis9!&#$^<>-Token" },
+      },
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal",
+          port: 6379,
+          username: "octopus-app",
+        },
+        redisSecret: {
+          password: "Redis9!&#$^<>-Token",
+          unexpected: "value",
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const { paths, result } = render(testCase);
+      expect(result.exitCode).not.toBe(0);
+      expect(() => readFileSync(paths.output, "utf8")).toThrow();
+    }
+  });
+
+  it("rejects invalid Redis passwords, usernames, hosts, and ports", () => {
+    const validPassword = "Redis9!&#$^<>-Token";
+    const cases = [
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal",
+          port: 6379,
+          username: "octopus-app",
+        },
+        redisSecret: { password: "too-short" },
+      },
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal",
+          port: 6379,
+          username: "octopus-app",
+        },
+        redisSecret: { password: "RedisPasswordWith@ForbiddenCharacter9" },
+      },
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal/path",
+          port: 6379,
+          username: "octopus-app",
+        },
+        redisSecret: { password: validPassword },
+      },
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal",
+          port: 0,
+          username: "octopus-app",
+        },
+        redisSecret: { password: validPassword },
+      },
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal",
+          port: "6379",
+          username: "octopus-app",
+        },
+        redisSecret: { password: validPassword },
+      },
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal",
+          port: 6379,
+          username: "invalid username",
+        },
+        redisSecret: { password: validPassword },
+      },
+      {
+        redisConfig: {
+          enabled: true,
+          host: "redis.internal",
+          port: 6379,
+          username: "a".repeat(41),
+        },
+        redisSecret: { password: validPassword },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const { paths, result } = render(testCase);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr.toString()).not.toContain(validPassword);
+      expect(() => readFileSync(paths.output, "utf8")).toThrow();
+    }
+  });
+
+  it("rejects public or secret attempts to supply a complete Redis URL", () => {
+    const attempts = [
+      render({
+        publicEnvironment: { REDIS_URL: "rediss://:attacker@redis.internal:6379" },
+      }),
+      render({
+        publicEnvironment: { REDIS_PASSWORD: "Redis9!&#$^<>-Token" },
+      }),
+      render({
+        applicationSecret: validApplicationSecret({
+          REDIS_URL: "rediss://:attacker@redis.internal:6379",
+        }),
+      }),
+      render({
+        applicationSecret: validApplicationSecret({
+          REDIS_PASSWORD: "Redis9!&#$^<>-Token",
+        }),
+      }),
+    ];
+
+    for (const { paths, result } of attempts) {
+      expect(result.exitCode).not.toBe(0);
+      expect(() => readFileSync(paths.output, "utf8")).toThrow();
+    }
   });
 
   it("fails closed on unknown secret keys without replacing an existing env", () => {
@@ -200,5 +421,18 @@ describe("Terraform runtime environment renderer", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout.toString()).not.toContain(sentinel);
     expect(result.stderr.toString()).not.toContain(sentinel);
+  });
+
+  it("validates the dedicated Redis secret without render inputs", () => {
+    const password = "Redis9!&#$^<>-Token";
+    const valid = validateRedisSecret({ password });
+    const invalidPassword = validateRedisSecret({ password: "too-short" });
+    const invalidSchema = validateRedisSecret({ password, extra: "value" });
+
+    expect(valid.result.exitCode).toBe(0);
+    expect(invalidPassword.result.exitCode).not.toBe(0);
+    expect(invalidSchema.result.exitCode).not.toBe(0);
+    expect(valid.result.stdout.toString()).not.toContain(password);
+    expect(valid.result.stderr.toString()).not.toContain(password);
   });
 });

--- a/apps/web/lib/__tests__/terraform-runtime-secret-refresh.test.ts
+++ b/apps/web/lib/__tests__/terraform-runtime-secret-refresh.test.ts
@@ -9,6 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
+import { gzipSync } from "node:zlib";
 
 const repoRoot = resolve(import.meta.dir, "../../../..");
 const renderer = resolve(
@@ -19,8 +20,13 @@ const refreshTemplate = readFileSync(
   resolve(repoRoot, "terraform/modules/aws/ec2-app/templates/refresh-secrets.sh.tpl"),
   "utf8",
 );
+const redisProbe = readFileSync(
+  resolve(repoRoot, "terraform/modules/aws/ec2-app/scripts/probe_redis.js"),
+  "utf8",
+);
 
 const encoded = (value: string) => Buffer.from(value).toString("base64");
+const gzipEncoded = (value: string) => gzipSync(value).toString("base64");
 const strongAuthSecret = "a".repeat(32);
 const strongGithubStateSecret = "g".repeat(32);
 
@@ -37,6 +43,7 @@ function createHarness() {
   const appDirectory = resolve(root, "opt/octopus");
   const applicationSecret = resolve(root, "application.json");
   const databaseSecret = resolve(root, "database.json");
+  const redisSecret = resolve(root, "redis.json");
   const dockerCalls = resolve(root, "docker-calls.log");
   const refreshScript = resolve(root, "refresh-secrets.sh");
   mkdirSync(bin, { recursive: true });
@@ -59,6 +66,8 @@ while [ "$#" -gt 0 ]; do
 done
 if [ "$secret_id" = "$FAKE_APPLICATION_SECRET_ARN" ]; then
   /bin/cat "$FAKE_APPLICATION_SECRET_FILE"
+elif [ "$secret_id" = "$FAKE_REDIS_SECRET_ARN" ]; then
+  /bin/cat "$FAKE_REDIS_SECRET_FILE"
 else
   /bin/cat "$FAKE_DATABASE_SECRET_FILE"
 fi
@@ -88,6 +97,9 @@ if [[ "$*" == *" ps "* ]] && [ "$FAKE_STACK_RUNNING" = "1" ]; then
   printf 'nginx\nqdrant\nweb\n'
 elif [[ "$*" == *" ps "* ]] && [ "$FAKE_WEB_RUNNING" = "1" ]; then
   printf 'web\n'
+fi
+if [[ "$*" == *" run "* ]] && [ "$FAKE_REDIS_PROBE_FAIL" = "1" ]; then
+  exit 45
 fi
 if [[ "$*" == *" up "* ]] && [ "$FAKE_DOCKER_UP_FAIL" = "1" ]; then
   exit 42
@@ -125,12 +137,23 @@ exit 1
     NEXT_PUBLIC_APP_URL: "https://octopus.example/${LITERAL}",
   };
   const databaseConfig = { host: "db.internal", port: 5432, database: "octopus" };
+  const redisConfig = {
+    enabled: true,
+    host: "redis.internal",
+    port: 6379,
+    username: "octopus-app",
+  };
+  writeFileSync(redisSecret, JSON.stringify({ password: "Redis9!&#$^<>-Token" }));
   const rendered = refreshTemplate
     .replaceAll("${aws_region_base64}", encoded("us-east-1"))
     .replaceAll("${application_secret_arn_base64}", encoded("arn:application"))
     .replaceAll("${database_secret_arn_base64}", encoded("arn:database"))
+    .replaceAll("${redis_secret_arn_base64}", encoded("arn:redis"))
     .replaceAll("${public_environment_base64}", encoded(JSON.stringify(publicEnvironment)))
     .replaceAll("${database_config_base64}", encoded(JSON.stringify(databaseConfig)))
+    .replaceAll("${redis_config_base64}", encoded(JSON.stringify(redisConfig)))
+    .replaceAll("${redis_probe_base64}", gzipEncoded(redisProbe))
+    .replaceAll("${redis_auth_enforced}", "0")
     .replaceAll("$${", "${")
     .replace("RUNTIME_DIRECTORY=/run/octopus", `RUNTIME_DIRECTORY=${runtimeDirectory}`)
     .replace("APP_DIRECTORY=/opt/octopus", `APP_DIRECTORY=${appDirectory}`)
@@ -143,12 +166,15 @@ exit 1
     FAKE_APPLICATION_SECRET_ARN: "arn:application",
     FAKE_APPLICATION_SECRET_FILE: applicationSecret,
     FAKE_DATABASE_SECRET_FILE: databaseSecret,
+    FAKE_REDIS_SECRET_ARN: "arn:redis",
+    FAKE_REDIS_SECRET_FILE: redisSecret,
     FAKE_DOCKER_CALLS: dockerCalls,
     FAKE_COMPOSE_VERSION: "2.30.0",
     FAKE_DOCKER_CONFIG_FAIL: "0",
     FAKE_DOCKER_FULL_WAIT_FAIL: "0",
     FAKE_DOCKER_UP_FAIL: "0",
     FAKE_DOCKER_WAIT_FAIL: "0",
+    FAKE_REDIS_PROBE_FAIL: "0",
     FAKE_STACK_RUNNING: "1",
     FAKE_WEB_RUNNING: "1",
   };
@@ -165,12 +191,70 @@ exit 1
     dockerCalls,
     environment,
     reconcileStamp: resolve(runtimeDirectory, "reconcile-required"),
+    redisSecret,
     run,
     runtimeEnv: resolve(runtimeDirectory, "runtime.env"),
   };
 }
 
 describe("Terraform runtime secret refresh", () => {
+  it("probes a rotated Redis credential before promoting and recreating web", () => {
+    const harness = createHarness();
+    const oldPassword = "Redis9!&#$^<>-Token";
+    const newPassword = "Redis9!&#$^<>-Rotated";
+    writeFileSync(harness.applicationSecret, JSON.stringify(validApplicationSecret()));
+    writeFileSync(
+      harness.databaseSecret,
+      JSON.stringify({ username: "octopus", password: "valid-database" }),
+    );
+    writeFileSync(harness.redisSecret, JSON.stringify({ password: oldPassword }));
+
+    expect(harness.bootstrap().exitCode).toBe(0);
+    expect(readFileSync(harness.runtimeEnv, "utf8")).toContain(
+      "REDIS_URL=rediss://octopus-app:Redis9%21%26%23%24%5E%3C%3E-Token@redis.internal:6379",
+    );
+
+    writeFileSync(harness.redisSecret, JSON.stringify({ password: newPassword }));
+    const rotated = harness.run();
+
+    expect(rotated.exitCode).toBe(0);
+    expect(rotated.stdout.toString()).not.toContain(newPassword);
+    expect(rotated.stderr.toString()).not.toContain(newPassword);
+    expect(readFileSync(harness.dockerCalls, "utf8")).toContain(
+      "run --rm --no-deps -T -e OCTOPUS_REDIS_PROBE_RUN=1 -e OCTOPUS_REDIS_AUTH_ENFORCED=0 web node -",
+    );
+    expect(readFileSync(harness.dockerCalls, "utf8")).toContain(
+      "up -d --no-deps --force-recreate --wait --wait-timeout 120 web",
+    );
+    expect(readFileSync(harness.runtimeEnv, "utf8")).toContain(
+      "REDIS_URL=rediss://octopus-app:Redis9%21%26%23%24%5E%3C%3E-Rotated@redis.internal:6379",
+    );
+  });
+
+  it("keeps the last-good Redis credential when the authenticated probe fails", () => {
+    const harness = createHarness();
+    const oldPassword = "Redis9!&#$^<>-Token";
+    const rejectedPassword = "Redis9!&#$^<>-Rejected";
+    writeFileSync(harness.applicationSecret, JSON.stringify(validApplicationSecret()));
+    writeFileSync(
+      harness.databaseSecret,
+      JSON.stringify({ username: "octopus", password: "valid-database" }),
+    );
+    writeFileSync(harness.redisSecret, JSON.stringify({ password: oldPassword }));
+    expect(harness.bootstrap().exitCode).toBe(0);
+    const lastGood = readFileSync(harness.runtimeEnv, "utf8");
+
+    writeFileSync(harness.redisSecret, JSON.stringify({ password: rejectedPassword }));
+    harness.environment.FAKE_REDIS_PROBE_FAIL = "1";
+    const failed = harness.run();
+
+    expect(failed.exitCode).not.toBe(0);
+    expect(failed.stderr.toString()).toContain("authenticated Redis probe failed");
+    expect(failed.stdout.toString()).not.toContain(rejectedPassword);
+    expect(failed.stderr.toString()).not.toContain(rejectedPassword);
+    expect(readFileSync(harness.runtimeEnv, "utf8")).toBe(lastGood);
+  });
+
   it("keeps values out of logs and recreates web only when values change", () => {
     const harness = createHarness();
     const applicationSentinel = `${"a".repeat(32)}-$#-\${NOT_EXPANDED}`;

--- a/apps/web/lib/__tests__/terraform-runtime-secrets-security.test.ts
+++ b/apps/web/lib/__tests__/terraform-runtime-secrets-security.test.ts
@@ -143,6 +143,13 @@ describe("Terraform runtime-secret boundary", () => {
     );
     expect(retryTimerStart).toBeGreaterThan(-1);
     expect(immediateRefresh).toBeGreaterThan(retryTimerStart);
+
+    expect(ec2RuntimeInstaller).toMatch(
+      /%\{ if nginx_conf_base64 != "" ~\}[\s\S]*?nginx\.conf[\s\S]*?%\{ endif ~\}/,
+    );
+    expect(ec2RuntimeInstaller).toMatch(
+      /%\{ if proxy_params_base64 != "" ~\}[\s\S]*?proxy_params[\s\S]*?%\{ endif ~\}/,
+    );
   });
 
   it("stages existing-stack validation before enabling managed credentials", () => {

--- a/apps/web/lib/cancel-bus.ts
+++ b/apps/web/lib/cancel-bus.ts
@@ -19,7 +19,12 @@ function getPublisher(): Redis | null {
   if (publisher) return publisher;
   const url = process.env.REDIS_URL;
   if (!url) return null;
-  publisher = new Redis(url, { lazyConnect: false, maxRetriesPerRequest: 2, enableOfflineQueue: false });
+  publisher = new Redis(url, {
+    lazyConnect: false,
+    maxRetriesPerRequest: 2,
+    enableOfflineQueue: false,
+    disableClientInfo: true,
+  });
   publisher.on("error", (err) => console.error("[cancel-bus] publisher error:", err.message));
   return publisher;
 }
@@ -29,7 +34,11 @@ function ensureSubscribed() {
   const url = process.env.REDIS_URL;
   if (!url) return;
   subscribing = true;
-  subscriber = new Redis(url, { lazyConnect: false, maxRetriesPerRequest: null });
+  subscriber = new Redis(url, {
+    lazyConnect: false,
+    maxRetriesPerRequest: null,
+    disableClientInfo: true,
+  });
   subscriber.on("error", (err) => console.error("[cancel-bus] subscriber error:", err.message));
   subscriber.on("message", (_channel, raw) => {
     try {

--- a/apps/web/lib/presence.ts
+++ b/apps/web/lib/presence.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { prisma } from "@octopus/db";
 import { getRedis } from "@/lib/redis";
 
@@ -26,6 +28,10 @@ export function presenceKey(orgId: string, userId: string): string {
   return `presence:${orgId}:${userId}`;
 }
 
+export function presenceIndexKey(orgId: string): string {
+  return `presence:index:${orgId}`;
+}
+
 export async function recordPresence(
   orgId: string,
   userId: string,
@@ -33,12 +39,22 @@ export async function recordPresence(
 ): Promise<void> {
   const redis = getRedis();
   if (redis) {
-    const value = JSON.stringify({ userId, currentActivity, lastSeenAt: Date.now() });
+    const lastSeenAt = Date.now();
+    const key = presenceKey(orgId, userId);
+    const indexKey = presenceIndexKey(orgId);
+    const value = JSON.stringify({ userId, currentActivity, lastSeenAt });
     // Fire-and-forget: the client (enableOfflineQueue:false) rejects awaited
     // commands during a Redis blip, so a heartbeat must never 500 on Redis.
-    redis
-      .set(presenceKey(orgId, userId), value, "EX", PRESENCE_TTL_SECONDS)
-      .catch((err) => console.error("[presence] redis set failed:", err instanceof Error ? err.message : err));
+    void Promise.all([
+      redis.set(key, value, "EX", PRESENCE_TTL_SECONDS),
+      redis.zadd(
+        indexKey,
+        lastSeenAt + PRESENCE_TTL_SECONDS * 1000,
+        key,
+      ),
+      redis.expire(indexKey, PRESENCE_TTL_SECONDS * 2),
+    ])
+      .catch((err) => console.error("[presence] redis write failed:", err instanceof Error ? err.message : err));
     return;
   }
 
@@ -63,9 +79,12 @@ export async function recordPresence(
 export async function clearPresence(orgId: string, userId: string): Promise<void> {
   const redis = getRedis();
   if (redis) {
-    redis
-      .del(presenceKey(orgId, userId))
-      .catch((err) => console.error("[presence] redis del failed:", err instanceof Error ? err.message : err));
+    const key = presenceKey(orgId, userId);
+    void Promise.all([
+      redis.del(key),
+      redis.zrem(presenceIndexKey(orgId), key),
+    ])
+      .catch((err) => console.error("[presence] redis clear failed:", err instanceof Error ? err.message : err));
   }
   try {
     await prisma.userPresence.deleteMany({ where: { organizationId: orgId, userId } });
@@ -75,9 +94,9 @@ export async function clearPresence(orgId: string, userId: string): Promise<void
 }
 
 /**
- * Read the currently-online members for an org. Redis-primary (SCAN — never
- * KEYS, which blocks the server — then MGET); Postgres fallback derives online
- * from lastSeenAt within the staleness window. Returns presence entries WITHOUT
+ * Read the currently-online members for an org. Redis-primary (an org-scoped
+ * expiry index followed by MGET); Postgres fallback derives online from
+ * lastSeenAt within the staleness window. Returns presence entries WITHOUT
  * display info; callers join user name/image. Never throws — returns [] on any
  * backend error so the dashboard degrades gracefully.
  */
@@ -85,26 +104,44 @@ export async function getOnlinePresence(orgId: string): Promise<PresenceEntry[]>
   const redis = getRedis();
   if (redis) {
     try {
-      const pattern = `presence:${orgId}:*`;
-      const keys: string[] = [];
-      let cursor = "0";
-      do {
-        const [next, batch] = await redis.scan(cursor, "MATCH", pattern, "COUNT", 200);
-        cursor = next;
-        keys.push(...batch);
-      } while (cursor !== "0");
+      const now = Date.now();
+      const indexKey = presenceIndexKey(orgId);
+      await redis.zremrangebyscore(indexKey, "-inf", now);
+      const keys = await redis.zrangebyscore(indexKey, `(${now}`, "+inf");
       if (keys.length === 0) return [];
+
       const values = await redis.mget(...keys);
-      return values
-        .filter((v): v is string => v !== null)
-        .map((v) => {
-          try {
-            return JSON.parse(v) as PresenceEntry;
-          } catch {
-            return null;
+      const entries: PresenceEntry[] = [];
+      const staleKeys: string[] = [];
+
+      for (let index = 0; index < values.length; index += 1) {
+        const value = values[index];
+        const key = keys[index];
+        if (value === null) {
+          if (key) staleKeys.push(key);
+          continue;
+        }
+        try {
+          const entry = JSON.parse(value) as PresenceEntry;
+          if (entry && typeof entry.userId === "string") {
+            entries.push(entry);
+          } else if (key) {
+            staleKeys.push(key);
           }
-        })
-        .filter((e): e is PresenceEntry => e !== null && typeof e.userId === "string");
+        } catch {
+          if (key) staleKeys.push(key);
+        }
+      }
+
+      if (staleKeys.length > 0) {
+        // Cleanup should not turn an otherwise successful roster read into an
+        // error when Redis is degraded.
+        void redis
+          .zrem(indexKey, ...staleKeys)
+          .catch((err) => console.error("[presence] redis index cleanup failed:", err instanceof Error ? err.message : err));
+      }
+
+      return entries;
     } catch (err) {
       console.error("[presence] redis read failed:", err instanceof Error ? err.message : err);
       return [];

--- a/apps/web/lib/redis.ts
+++ b/apps/web/lib/redis.ts
@@ -11,6 +11,9 @@ function buildClient(): Redis | null {
     lazyConnect: false,
     maxRetriesPerRequest: 2,
     enableOfflineQueue: false,
+    // Redis 7.1 does not support CLIENT SETINFO. Avoid the ignored handshake
+    // command so the restricted ElastiCache user never needs +client.
+    disableClientInfo: true,
     retryStrategy: (times) => Math.min(times * 200, 2000),
   };
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -381,7 +381,9 @@ runtime-secret cutover first: `runtime_secret_cutover_stage` must be
 WDC/datacenter production does not use this AWS stack, so these steps require
 no action there. `redis_auth_cutover_stage` is deliberately required with no
 default, so removing it after enforcement cannot silently restore passwordless
-access.
+access. Existing stacks must already run Redis OSS 7.0 or newer (the ACL
+policy uses selectors) and use a lowercase, letter-led `name_prefix`; upgrade
+the engine or adjust the prefix first, or the plan fails validation.
 
 #### Stage 1 — preflight (prove authenticated clients)
 
@@ -391,8 +393,12 @@ access.
    disabled replacement default user, and stable user group; attach that group
    to the existing replication group in place; and grant EC2 read access only
    to the dedicated secret. Stop if EC2 or Redis is replaced.
-3. Apply. Preflight deliberately retains the built-in passwordless `default`
-   user alongside the authenticated app user. The SSM association fetches the
+3. Apply. If the first create of the `<name_prefix>-redis-rbac`
+   CloudFormation stack fails, it lands in `ROLLBACK_COMPLETE` outside
+   Terraform state; delete the stack in the CloudFormation console before
+   re-applying. Preflight deliberately retains the built-in passwordless
+   `default` user alongside the authenticated app user. The SSM association
+   fetches the
    dedicated secret at runtime and runs an authenticated TLS probe before
    promoting the environment or recreating web. The probe covers every
    command family, key pattern, and pub/sub path used by Octopus and proves a
@@ -428,13 +434,35 @@ that would terminate working connections without a recovery path.
 
 #### Rotate the Redis password
 
-1. Add a new secret version without moving `AWSCURRENT`; record its exact
-   version ID.
+1. Add a new secret version without moving `AWSCURRENT`. Attach a custom
+   staging label; a plain `put-secret-value` moves `AWSCURRENT` immediately,
+   and a version left with no staging label is deprecated and may be deleted
+   by Secrets Manager, breaking the exact-version CloudFormation reference.
+   Write the new `{"password":"..."}` JSON to a root-only file as when
+   creating the secret, then:
+
+   ```bash
+   aws secretsmanager put-secret-value \
+     --secret-id "$REDIS_AUTH_SECRET_ARN" \
+     --secret-string file:///root/redis-auth-next.json \
+     --version-stages PENDING
+   ```
+
+   Record the returned `VersionId` and securely remove the file.
 2. Set `redis_auth_secret_version_ids = [old_version_id, new_version_id]` and
    apply so ElastiCache accepts both passwords.
-3. Move `AWSCURRENT` to the new version in Secrets Manager. The runtime timer
-   fetches it, runs the authenticated and denial probes, and only then promotes
-   the new URL and recreates web.
+3. Move `AWSCURRENT` to the new version:
+
+   ```bash
+   aws secretsmanager update-secret-version-stage \
+     --secret-id "$REDIS_AUTH_SECRET_ARN" \
+     --version-stage AWSCURRENT \
+     --move-to-version-id "$NEW_VERSION_ID" \
+     --remove-from-version-id "$OLD_VERSION_ID"
+   ```
+
+   The runtime timer fetches it, runs the authenticated and denial probes,
+   and only then promotes the new URL and recreates web.
 4. After the service and a real review pass, set
    `redis_auth_secret_version_ids = [new_version_id]` and apply to retire the
    old password. To roll back, re-add the old version to ElastiCache before

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -24,7 +24,8 @@ EC2: nginx + web + qdrant ─────▶ RDS PostgreSQL / optional Redis
 **What runs on EC2 (Docker Compose):** nginx + Octopus web app + Qdrant vector database
 
 **Managed AWS services:** Application Load Balancer · ACM certificate reference ·
-RDS PostgreSQL 17 (app database) · ElastiCache Redis (optional, for queues)
+RDS PostgreSQL 17 (app database) · ElastiCache Redis (optional, for rate limits,
+replay protection, presence, caches, and cancellation signals)
 
 ---
 
@@ -181,6 +182,29 @@ JSON directly on the command line or in `terraform.tfvars`. Record the exact
 secret ARN, then securely remove the temporary file. Unknown JSON keys are
 rejected by the runtime loader.
 
+### Create the dedicated Redis authentication secret
+
+Do this only when `enable_redis = true`. Keep the Redis password in a separate
+Secrets Manager secret so the CloudFormation execution role cannot read the
+application secret. The Redis secret must contain exactly one JSON key:
+
+```json
+{"password":"a 16-128 character ElastiCache password"}
+```
+
+Use a 64-character hexadecimal value from `openssl rand -hex 32`; it satisfies
+the supported character and length rules. Create the JSON in a root-only file
+outside the repository and use `aws secretsmanager create-secret
+--secret-string file://...`. Record the returned secret ARN and exact
+`VersionId`, then securely remove the file. Never put the password in a
+Terraform variable, saved plan, command argument, output, or user data.
+
+Terraform receives only `redis_auth_secret_arn` and one or two non-secret
+`redis_auth_secret_version_ids`. A dedicated CloudFormation execution role
+resolves exact secret versions directly into ElastiCache; the password is not
+stored in Terraform state or CloudFormation parameters. If the secret uses a
+customer-managed KMS key, also set `redis_auth_secret_kms_key_arn`.
+
 ```bash
 cd terraform/stacks/aws-ec2
 cp terraform.tfvars.example terraform.tfvars
@@ -199,6 +223,10 @@ The minimum you need to fill in:
 | `trusted_edge_ipv4_cidrs` | Explicit, operator-verified IPv4 origin ranges for Cloudflare or your trusted edge; never `0.0.0.0/0` |
 | `application_secret_arn` | Exact ARN of the JSON secret created above |
 | `runtime_secret_cutover_stage` | `enforced` for a new deployment; existing AWS deployments must start with `preflight` as documented below |
+| `redis_auth_secret_arn` | Required only with `enable_redis = true`; exact ARN of the dedicated Redis secret |
+| `redis_auth_secret_version_ids` | Required only with Redis; exact current version ID, plus the next ID temporarily during rotation |
+| `redis_auth_cutover_stage` | Start with `preflight`; use `enforced` only after the authenticated runtime probe passes |
+| `redis_authenticated_runtime_ready` | Keep `false` until runtime-secret enforcement is applied and its authenticated Redis probe passes; then acknowledge readiness before enforcing Redis auth |
 | `github_app_id` | From Step 2A (the number) |
 | `github_app_slug` | From Step 2A |
 | `github_app_client_id` | GitHub App client ID from Step 2A |
@@ -344,6 +372,73 @@ values. Rotate `BETTER_AUTH_SECRET` only after the data-key step above; the
 rotation logs users out. Remove the unused legacy `/opt/octopus/.env` and clear
 old cloud-init user-data copies only after verification and according to your
 recovery policy.
+
+### Redis authentication cutover
+
+Every Redis deployment, new or existing, uses these two stages. Complete the
+runtime-secret cutover first: `runtime_secret_cutover_stage` must be
+`"enforced"` before Redis authentication can be enforced. The current
+WDC/datacenter production does not use this AWS stack, so these steps require
+no action there. `redis_auth_cutover_stage` is deliberately required with no
+default, so removing it after enforcement cannot silently restore passwordless
+access.
+
+#### Stage 1 — preflight (prove authenticated clients)
+
+1. Create the dedicated Redis secret above. Set `enable_redis = true`, its
+   exact ARN and version ID, and `redis_auth_cutover_stage = "preflight"`.
+2. Review the plan. It must create the CloudFormation-managed app user,
+   disabled replacement default user, and stable user group; attach that group
+   to the existing replication group in place; and grant EC2 read access only
+   to the dedicated secret. Stop if EC2 or Redis is replaced.
+3. Apply. Preflight deliberately retains the built-in passwordless `default`
+   user alongside the authenticated app user. The SSM association fetches the
+   dedicated secret at runtime and runs an authenticated TLS probe before
+   promoting the environment or recreating web. The probe covers every
+   command family, key pattern, and pub/sub path used by Octopus and proves a
+   foreign key is denied.
+4. Require a successful `octopus-secrets.service`, healthy containers, login,
+   invitation rate limiting, GitHub installation callback, presence, and one
+   real review before enforcement.
+
+#### Stage 2 — enforced (disable anonymous access)
+
+1. After Stage 1 is applied and its authenticated probe passes, set
+   `redis_authenticated_runtime_ready = true`. This explicit acknowledgement
+   prevents runtime-secret delivery and Redis enforcement from being activated
+   together before the authenticated client is live.
+2. Change only `redis_auth_cutover_stage` to `"enforced"` and review the plan.
+   It must swap the built-in default group member for the stable disabled
+   default user without replacing the user group or replication group.
+3. Apply. The deployment probe repeats authenticated operations and uses a
+   fresh TLS connection without credentials to prove unauthenticated commands
+   are rejected before the association succeeds.
+4. Restart once more through `octopus-secrets.service`, then repeat application
+   health and one real review. This proves success comes from reconnecting with
+   the credential rather than a connection opened during preflight.
+
+#### Rollback
+
+Before enforcement, keep `preflight` and
+`redis_authenticated_runtime_ready = false` while correcting the authenticated
+runtime path. After enforcement, change back to `preflight`, apply, and wait
+until the built-in default is restored before reverting the application or
+secret configuration. Never remove the active app user, secret, or group first;
+that would terminate working connections without a recovery path.
+
+#### Rotate the Redis password
+
+1. Add a new secret version without moving `AWSCURRENT`; record its exact
+   version ID.
+2. Set `redis_auth_secret_version_ids = [old_version_id, new_version_id]` and
+   apply so ElastiCache accepts both passwords.
+3. Move `AWSCURRENT` to the new version in Secrets Manager. The runtime timer
+   fetches it, runs the authenticated and denial probes, and only then promotes
+   the new URL and recreates web.
+4. After the service and a real review pass, set
+   `redis_auth_secret_version_ids = [new_version_id]` and apply to retire the
+   old password. To roll back, re-add the old version to ElastiCache before
+   moving `AWSCURRENT` back.
 
 Deployments created before the dedicated application identity must attach it before removing the legacy VPC-wide database/cache rule. For the first apply after upgrading, keep both paths temporarily:
 
@@ -692,6 +787,9 @@ later secret-delivery cutover.
 - Root EBS volume encrypted at rest
 - Terraform receives application secret ARNs, never application secret values
 - RDS manages and rotates its master password in Secrets Manager
+- Redis uses a dedicated runtime-only secret, exact-version CloudFormation
+  dynamic references, a least-privilege app ACL, and a staged anonymous-access
+  cutover; Terraform never reads or outputs the password
 - Runtime values are fetched with exact IAM permissions and atomically written
   to `/run/octopus/runtime.env` with mode `0600`
 - Never commit `terraform.tfvars` — it's gitignored

--- a/terraform/modules/aws/ec2-app/main.tf
+++ b/terraform/modules/aws/ec2-app/main.tf
@@ -18,23 +18,28 @@ locals {
     aws_region_base64             = base64encode(var.aws_region)
     application_secret_arn_base64 = base64encode(var.application_secret_arn)
     database_secret_arn_base64    = base64encode(var.database_secret_arn)
+    redis_secret_arn_base64       = base64encode(var.redis_secret_arn)
     public_environment_base64     = base64encode(jsonencode(var.runtime_environment))
     database_config_base64        = base64encode(jsonencode(var.database_config))
+    redis_config_base64           = base64encode(jsonencode(var.redis_config))
+    redis_probe_base64            = base64gzip(file("${path.module}/scripts/probe_redis.js"))
+    redis_auth_enforced           = var.redis_auth_cutover_stage == "enforced" ? "1" : "0"
   })
 
   runtime_installer = templatefile("${path.module}/templates/runtime-installer.sh.tpl", {
-    renderer_base64       = base64encode(file("${path.module}/scripts/render_runtime_env.py"))
-    refresh_script_base64 = base64encode(local.refresh_secrets_script)
-    docker_compose_base64 = base64encode(var.docker_compose_content)
-    nginx_conf_base64     = var.nginx_conf_content != "" ? base64encode(var.nginx_conf_content) : ""
-    proxy_params_base64   = var.proxy_params_content != "" ? base64encode(var.proxy_params_content) : ""
+    renderer_base64       = base64gzip(file("${path.module}/scripts/render_runtime_env.py"))
+    refresh_script_base64 = base64gzip(local.refresh_secrets_script)
+    docker_compose_base64 = base64gzip(var.docker_compose_content)
+    nginx_conf_base64     = var.nginx_conf_content != "" ? base64gzip(var.nginx_conf_content) : ""
+    proxy_params_base64   = var.proxy_params_content != "" ? base64gzip(var.proxy_params_content) : ""
   })
 
   runtime_secret_preflight = templatefile("${path.module}/templates/preflight-runtime-secrets.sh.tpl", {
     aws_region_base64             = base64encode(var.aws_region)
     application_secret_arn_base64 = base64encode(var.application_secret_arn)
-    renderer_base64               = base64encode(file("${path.module}/scripts/render_runtime_env.py"))
-    docker_compose_base64         = base64encode(var.docker_compose_content)
+    redis_secret_arn_base64       = base64encode(var.redis_secret_arn)
+    renderer_base64               = base64gzip(file("${path.module}/scripts/render_runtime_env.py"))
+    docker_compose_base64         = base64gzip(var.docker_compose_content)
   })
 
   runtime_secret_payload = var.runtime_secret_preflight_only ? local.runtime_secret_preflight : local.runtime_installer
@@ -44,7 +49,7 @@ locals {
       Sid      = "ReadRuntimeSecrets"
       Effect   = "Allow"
       Action   = ["secretsmanager:GetSecretValue"]
-      Resource = compact([var.application_secret_arn, var.database_secret_arn])
+      Resource = compact([var.application_secret_arn, var.database_secret_arn, var.redis_secret_arn])
     }],
     length(var.runtime_secret_kms_key_arns) > 0 ? [{
       Sid      = "DecryptRuntimeSecrets"
@@ -124,6 +129,13 @@ resource "aws_iam_role_policy" "runtime_secrets" {
     Version   = "2012-10-17"
     Statement = local.runtime_secret_policy_statements
   })
+
+  lifecycle {
+    precondition {
+      condition     = var.redis_config.enabled == (var.redis_secret_arn != "")
+      error_message = "redis_secret_arn must be set exactly when redis_config.enabled is true."
+    }
+  }
 }
 
 resource "aws_iam_instance_profile" "this" {
@@ -149,7 +161,7 @@ resource "aws_instance" "this" {
   }
 
   user_data_base64 = base64gzip(templatefile("${path.module}/templates/userdata.sh.tpl", {
-    runtime_installer_base64 = base64encode(local.runtime_installer)
+    runtime_installer_base64 = base64gzip(local.runtime_installer)
     ecr_registry_url         = var.ecr_registry_url
   }))
 
@@ -199,7 +211,7 @@ resource "aws_ssm_document" "runtime_secrets" {
           "if command -v cloud-init >/dev/null 2>&1; then cloud-init status --wait; fi",
           "installer_path=$(mktemp /run/octopus-runtime-installer.XXXXXX)",
           "trap 'rm -f -- \"$installer_path\"' EXIT",
-          "printf '%s' '${base64encode(local.runtime_secret_payload)}' | base64 --decode > \"$installer_path\"",
+          "printf '%s' '${base64gzip(local.runtime_secret_payload)}' | base64 --decode | gzip -d > \"$installer_path\"",
           "chmod 0700 \"$installer_path\"",
           "/bin/bash \"$installer_path\"",
         ]

--- a/terraform/modules/aws/ec2-app/scripts/probe_redis.js
+++ b/terraform/modules/aws/ec2-app/scripts/probe_redis.js
@@ -1,0 +1,271 @@
+"use strict";
+
+const { randomBytes } = require("node:crypto");
+const tls = require("node:tls");
+
+function redisEndpoint() {
+  const endpoint = new URL(process.env.REDIS_URL || "");
+  const username = decodeURIComponent(endpoint.username);
+  const password = decodeURIComponent(endpoint.password);
+  if (endpoint.protocol !== "rediss:" || !endpoint.hostname || !username || !password) {
+    throw new Error("invalid Redis URL");
+  }
+  return { endpoint, username, password };
+}
+
+function encodeCommand(parts) {
+  const chunks = [Buffer.from(`*${parts.length}\r\n`)];
+  for (const part of parts) {
+    const value = Buffer.from(String(part));
+    chunks.push(Buffer.from(`$${value.length}\r\n`), value, Buffer.from("\r\n"));
+  }
+  return Buffer.concat(chunks);
+}
+
+function parseReply(buffer, offset = 0) {
+  if (offset >= buffer.length) return null;
+  const prefix = String.fromCharCode(buffer[offset]);
+  const lineEnd = buffer.indexOf("\r\n", offset + 1);
+  if (lineEnd < 0) return null;
+  const line = buffer.toString("utf8", offset + 1, lineEnd);
+  const next = lineEnd + 2;
+
+  if (prefix === "+") return { value: line, offset: next };
+  if (prefix === "-") return { value: new Error(line), offset: next };
+  if (prefix === ":") return { value: Number(line), offset: next };
+  if (prefix === "$") {
+    const length = Number(line);
+    if (length === -1) return { value: null, offset: next };
+    if (!Number.isInteger(length) || length < 0 || buffer.length < next + length + 2) {
+      return null;
+    }
+    return {
+      value: buffer.toString("utf8", next, next + length),
+      offset: next + length + 2,
+    };
+  }
+  if (prefix === "*") {
+    const length = Number(line);
+    if (length === -1) return { value: null, offset: next };
+    if (!Number.isInteger(length) || length < 0) return null;
+    const values = [];
+    let cursor = next;
+    for (let index = 0; index < length; index += 1) {
+      const parsed = parseReply(buffer, cursor);
+      if (!parsed) return null;
+      values.push(parsed.value);
+      cursor = parsed.offset;
+    }
+    return { value: values, offset: cursor };
+  }
+  return { value: new Error("unsupported Redis response"), offset: next };
+}
+
+class RedisConnection {
+  constructor(options = {}) {
+    const { endpoint, username, password } = options.credentials || redisEndpoint();
+    const socketFactory = options.socketFactory || tls.connect;
+    this.username = username;
+    this.password = password;
+    this.buffer = Buffer.alloc(0);
+    this.pending = [];
+    this.onPush = null;
+    this.terminalError = null;
+    this.socket = socketFactory({
+      host: endpoint.hostname,
+      port: Number(endpoint.port || "6379"),
+      servername: endpoint.hostname,
+      rejectUnauthorized: true,
+    });
+    this.connected = new Promise((resolve, reject) => {
+      let settled = false;
+      this.resolveConnected = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      this.rejectConnected = (error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
+    });
+    this.socket.once("secureConnect", this.resolveConnected);
+    this.socket.setTimeout(5000);
+    this.socket.on("timeout", () => this.socket.destroy(new Error("timeout")));
+    this.socket.on("error", (error) => this.fail(error));
+    this.socket.on("end", () => this.fail(new Error("Redis connection ended")));
+    this.socket.on("close", () => this.fail(new Error("Redis connection closed")));
+    this.socket.on("data", (data) => {
+      this.buffer = Buffer.concat([this.buffer, data]);
+      this.drain();
+    });
+  }
+
+  async ready(authenticate = true) {
+    await this.connected;
+    if (authenticate && (await this.command("AUTH", this.username, this.password)) !== "OK") {
+      throw new Error("authentication");
+    }
+  }
+
+  command(...parts) {
+    if (this.terminalError || this.socket.destroyed) {
+      return Promise.reject(this.terminalError || new Error("Redis connection closed"));
+    }
+    return new Promise((resolve, reject) => {
+      const waiter = { resolve, reject };
+      this.pending.push(waiter);
+      try {
+        this.socket.write(encodeCommand(parts));
+      } catch (error) {
+        const index = this.pending.indexOf(waiter);
+        if (index >= 0) this.pending.splice(index, 1);
+        reject(error);
+      }
+    });
+  }
+
+  drain() {
+    while (this.buffer.length > 0) {
+      const parsed = parseReply(this.buffer);
+      if (!parsed) return;
+      this.buffer = this.buffer.subarray(parsed.offset);
+      const waiter = this.pending.shift();
+      if (waiter) {
+        if (parsed.value instanceof Error) waiter.reject(parsed.value);
+        else waiter.resolve(parsed.value);
+      } else if (this.onPush) {
+        this.onPush(parsed.value);
+      }
+    }
+  }
+
+  rejectAll(error) {
+    for (const waiter of this.pending.splice(0)) waiter.reject(error);
+  }
+
+  fail(error) {
+    if (!this.terminalError) this.terminalError = error;
+    this.rejectConnected(this.terminalError);
+    this.rejectAll(this.terminalError);
+  }
+
+  disconnect() {
+    this.socket.destroy();
+  }
+}
+
+function withDeadline(operation, timeoutMs) {
+  let timer;
+  const deadline = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error("Redis probe deadline exceeded")), timeoutMs);
+  });
+  return Promise.race([operation, deadline]).finally(() => clearTimeout(timer));
+}
+
+function isAuthenticationRequired(error) {
+  return error instanceof Error && /^NOAUTH(?:\s|$)/.test(error.message);
+}
+
+async function probe() {
+  const nonce = randomBytes(12).toString("hex");
+  const rateKey = `rl:avatar-upload:redis-probe:${nonce}`;
+  const mxKey = `mx:v1:redis-probe:${nonce}`;
+  const presenceKey = `presence:redis-probe:${nonce}`;
+  const presenceIndexKey = `presence:index:redis-probe:${nonce}`;
+  const replayKey = `gh:install:state:jti:redis-probe:${nonce}`;
+  const channel = "octopus:probe";
+  const command = new RedisConnection();
+  const publisher = new RedisConnection();
+  const subscriber = new RedisConnection();
+
+  try {
+    await Promise.all([command.ready(), publisher.ready(), subscriber.ready()]);
+    if (typeof (await command.command("INFO")) !== "string") throw new Error("info");
+
+    const received = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("timeout")), 5000);
+      subscriber.onPush = (reply) => {
+        if (Array.isArray(reply) && reply[0] === "message" && reply[1] === channel && reply[2] === nonce) {
+          clearTimeout(timer);
+          resolve();
+        }
+      };
+    });
+    await subscriber.command("SUBSCRIBE", channel);
+
+    if ((await command.command("INCR", rateKey)) !== 1) throw new Error("rate counter");
+    if ((await command.command("EXPIRE", rateKey, 30)) !== 1) throw new Error("rate expiry");
+    if ((await command.command("TTL", rateKey)) < 1) throw new Error("rate ttl");
+
+    await command.command("SET", mxKey, nonce, "EX", 30);
+    if ((await command.command("GET", mxKey)) !== nonce) throw new Error("mx cache");
+
+    await command.command("SET", presenceKey, nonce, "EX", 30);
+    if ((await command.command("ZADD", presenceIndexKey, Date.now() + 30000, presenceKey)) !== 1) {
+      throw new Error("presence index add");
+    }
+    if ((await command.command("EXPIRE", presenceIndexKey, 60)) !== 1) {
+      throw new Error("presence index expiry ttl");
+    }
+    if ((await command.command("ZREMRANGEBYSCORE", presenceIndexKey, "-inf", 0)) !== 0) {
+      throw new Error("presence index expiry");
+    }
+    const indexedKeys = await command.command("ZRANGEBYSCORE", presenceIndexKey, 0, "+inf");
+    if (!Array.isArray(indexedKeys) || !indexedKeys.includes(presenceKey)) {
+      throw new Error("presence index read");
+    }
+    const values = await command.command("MGET", presenceKey);
+    if (!Array.isArray(values) || values[0] !== nonce) throw new Error("mget");
+    if ((await command.command("DEL", presenceKey)) !== 1) throw new Error("delete");
+    if ((await command.command("ZREM", presenceIndexKey, presenceKey)) !== 1) {
+      throw new Error("presence index remove");
+    }
+
+    if ((await command.command("SET", replayKey, "1", "PX", 30000, "NX")) !== "OK") {
+      throw new Error("replay key");
+    }
+
+    if ((await publisher.command("PUBLISH", channel, nonce)) < 1) throw new Error("publish");
+    await received;
+
+    let denied = false;
+    try {
+      await command.command("SET", `foreign:redis-probe:${nonce}`, "1", "EX", 30);
+    } catch (error) {
+      denied = error instanceof Error && error.message.includes("NOPERM");
+    }
+    if (!denied) throw new Error("foreign key permission");
+
+    if (process.env.OCTOPUS_REDIS_AUTH_ENFORCED === "1") {
+      const unauthenticated = new RedisConnection();
+      let authenticationRequired = false;
+      try {
+        await unauthenticated.ready(false);
+        await unauthenticated.command("GET", mxKey);
+      } catch (error) {
+        authenticationRequired = isAuthenticationRequired(error);
+      } finally {
+        unauthenticated.disconnect();
+      }
+      if (!authenticationRequired) throw new Error("anonymous access");
+    }
+  } finally {
+    command.disconnect();
+    publisher.disconnect();
+    subscriber.disconnect();
+  }
+}
+
+module.exports = {
+  RedisConnection,
+  encodeCommand,
+  isAuthenticationRequired,
+  parseReply,
+  withDeadline,
+};
+
+if (process.env.OCTOPUS_REDIS_PROBE_RUN === "1") {
+  withDeadline(probe(), 30000).then(() => process.exit(0), () => process.exit(1));
+}

--- a/terraform/modules/aws/ec2-app/scripts/render_runtime_env.py
+++ b/terraform/modules/aws/ec2-app/scripts/render_runtime_env.py
@@ -32,6 +32,14 @@ APPLICATION_SECRET_KEYS = {
 }
 REQUIRED_APPLICATION_SECRET_KEYS = {"BETTER_AUTH_SECRET", "GITHUB_STATE_SECRET"}
 ENVIRONMENT_KEY = re.compile(r"^[A-Z][A-Z0-9_]*$")
+REDIS_AUTH_TOKEN = re.compile(r"[A-Za-z0-9!&#$^<>-]{16,128}", re.ASCII)
+REDIS_HOST = re.compile(
+    r"(?=.{1,253}\Z)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*"
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?",
+    re.ASCII,
+)
+REDIS_USERNAME = re.compile(r"[A-Za-z][A-Za-z0-9-]{0,39}", re.ASCII)
+PROTECTED_RUNTIME_KEYS = {"DATABASE_URL", "REDIS_PASSWORD", "REDIS_URL"}
 
 
 def load_json_object(path: Path, label: str) -> dict[str, Any]:
@@ -52,6 +60,15 @@ def require_string(value: Any, label: str, *, allow_empty: bool = True) -> str:
     if "\x00" in value or "\r" in value or "\n" in value:
         raise ValueError(f"{label} contains a forbidden line break or NUL")
     return value
+
+
+def require_exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    unknown = sorted(set(value) - expected)
+    if unknown:
+        raise ValueError(f"{label} contains unsupported key: {unknown[0]}")
+    missing = sorted(expected - set(value))
+    if missing:
+        raise ValueError(f"{label} is missing required key: {missing[0]}")
 
 
 def normalize_application_secrets(value: dict[str, Any]) -> dict[str, str]:
@@ -89,10 +106,62 @@ def normalize_public_environment(value: dict[str, Any]) -> dict[str, str]:
     for key, raw_value in value.items():
         if not ENVIRONMENT_KEY.fullmatch(key):
             raise ValueError(f"public environment contains invalid key: {key}")
-        if key == "DATABASE_URL" or key in APPLICATION_SECRET_KEYS:
+        if key in PROTECTED_RUNTIME_KEYS or key in APPLICATION_SECRET_KEYS:
             raise ValueError(f"public environment attempts to override protected key: {key}")
         normalized[key] = require_string(raw_value, f"public environment key {key}")
     return normalized
+
+
+def normalize_redis_secret(value: dict[str, Any]) -> str:
+    require_exact_keys(value, {"password"}, "Redis secret")
+    password = require_string(value["password"], "Redis password", allow_empty=False)
+    if not REDIS_AUTH_TOKEN.fullmatch(password):
+        raise ValueError(
+            "Redis password must be 16-128 characters using only letters, digits, and !&#$^<>-"
+        )
+    return password
+
+
+def redis_url(
+    redis_config: dict[str, Any] | None,
+    redis_secret: dict[str, Any] | None,
+) -> str | None:
+    if redis_config is None and redis_secret is None:
+        return None
+    if redis_config is None:
+        raise ValueError("Redis secret requires Redis config")
+
+    require_exact_keys(redis_config, {"enabled", "host", "port", "username"}, "Redis config")
+    enabled = redis_config["enabled"]
+    if not isinstance(enabled, bool):
+        raise ValueError("Redis config enabled must be a boolean")
+
+    host = require_string(redis_config["host"], "Redis host")
+    username = require_string(redis_config["username"], "Redis username")
+    raw_port = redis_config["port"]
+    if isinstance(raw_port, bool) or not isinstance(raw_port, int):
+        raise ValueError("Redis port must be an integer")
+
+    if not enabled:
+        if redis_secret is not None:
+            raise ValueError("Redis secret must not be supplied when Redis is disabled")
+        return None
+
+    if redis_secret is None:
+        raise ValueError("enabled Redis config requires Redis secret")
+    password = normalize_redis_secret(redis_secret)
+
+    if not REDIS_HOST.fullmatch(host):
+        raise ValueError("Redis host is not a valid DNS hostname")
+    if not REDIS_USERNAME.fullmatch(username):
+        raise ValueError("Redis username is not valid")
+    if raw_port < 1 or raw_port > 65535:
+        raise ValueError("Redis port is outside the valid range")
+
+    return (
+        f"rediss://{quote(username, safe='')}:{quote(password, safe='')}"
+        f"@{host}:{raw_port}"
+    )
 
 
 def database_url(database_secret: dict[str, Any], database_config: dict[str, Any]) -> str:
@@ -124,10 +193,16 @@ def render_environment(
     application_secret: dict[str, Any],
     database_secret: dict[str, Any],
     database_config: dict[str, Any],
+    redis_config: dict[str, Any] | None,
+    redis_secret: dict[str, Any] | None,
 ) -> str:
     values = normalize_public_environment(public_environment)
-    values.update(normalize_application_secrets(application_secret))
+    application_values = normalize_application_secrets(application_secret)
+    rendered_redis_url = redis_url(redis_config, redis_secret)
+    values.update(application_values)
     values["DATABASE_URL"] = database_url(database_secret, database_config)
+    if rendered_redis_url is not None:
+        values["REDIS_URL"] = rendered_redis_url
     return "".join(f"{key}={values[key]}\n" for key in sorted(values))
 
 
@@ -155,10 +230,13 @@ def atomic_write(path: Path, content: str) -> None:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--validate-application-secret-only", type=Path)
+    parser.add_argument("--validate-redis-secret-only", type=Path)
     parser.add_argument("--public-environment", type=Path)
     parser.add_argument("--application-secret", type=Path)
     parser.add_argument("--database-secret", type=Path)
     parser.add_argument("--database-config", type=Path)
+    parser.add_argument("--redis-config", type=Path)
+    parser.add_argument("--redis-secret", type=Path)
     parser.add_argument("--output", type=Path)
     return parser.parse_args()
 
@@ -166,9 +244,19 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     try:
+        if (
+            args.validate_application_secret_only is not None
+            and args.validate_redis_secret_only is not None
+        ):
+            raise ValueError("choose only one validate-only mode")
         if args.validate_application_secret_only is not None:
             normalize_application_secrets(
                 load_json_object(args.validate_application_secret_only, "application secret")
+            )
+            return 0
+        if args.validate_redis_secret_only is not None:
+            normalize_redis_secret(
+                load_json_object(args.validate_redis_secret_only, "Redis secret")
             )
             return 0
         if any(
@@ -187,6 +275,12 @@ def main() -> int:
             load_json_object(args.application_secret, "application secret"),
             load_json_object(args.database_secret, "database secret"),
             load_json_object(args.database_config, "database config"),
+            load_json_object(args.redis_config, "Redis config")
+            if args.redis_config is not None
+            else None,
+            load_json_object(args.redis_secret, "Redis secret")
+            if args.redis_secret is not None
+            else None,
         )
         atomic_write(args.output, content)
     except ValueError as exc:

--- a/terraform/modules/aws/ec2-app/templates/preflight-runtime-secrets.sh.tpl
+++ b/terraform/modules/aws/ec2-app/templates/preflight-runtime-secrets.sh.tpl
@@ -4,9 +4,10 @@ umask 077
 
 AWS_REGION=$(printf '%s' '${aws_region_base64}' | base64 --decode)
 APPLICATION_SECRET_ARN=$(printf '%s' '${application_secret_arn_base64}' | base64 --decode)
+REDIS_SECRET_ARN=$(printf '%s' '${redis_secret_arn_base64}' | base64 --decode)
 export AWS_PAGER=""
 
-for command_name in aws base64 docker dpkg python3; do
+for command_name in aws base64 docker dpkg gzip python3; do
   if ! command -v "$command_name" >/dev/null 2>&1; then
     echo "Octopus runtime secret preflight failed: required command is unavailable" >&2
     exit 1
@@ -26,35 +27,43 @@ cleanup() {
 }
 trap cleanup EXIT
 
-fetch_application_secret() {
+fetch_secret() {
+  local secret_arn=$1
+  local destination=$2
+  local label=$3
   local attempt=1
 
   while [ "$attempt" -le 6 ]; do
     if aws secretsmanager get-secret-value \
       --region "$AWS_REGION" \
-      --secret-id "$APPLICATION_SECRET_ARN" \
+      --secret-id "$secret_arn" \
       --query SecretString \
       --output text \
-      > "$TEMP_DIRECTORY/application.json" 2> "$TEMP_DIRECTORY/aws-error" && \
-      [ -s "$TEMP_DIRECTORY/application.json" ]; then
+      > "$destination" 2> "$TEMP_DIRECTORY/aws-error" && \
+      [ -s "$destination" ]; then
       return 0
     fi
-    : > "$TEMP_DIRECTORY/application.json"
+    : > "$destination"
     sleep "$((attempt * 2))"
     attempt=$((attempt + 1))
   done
 
-  echo "Octopus runtime secret preflight failed: application secret is unavailable" >&2
+  echo "Octopus runtime secret preflight failed: $label secret is unavailable" >&2
   cat "$TEMP_DIRECTORY/aws-error" >&2 || true
   return 1
 }
 
-printf '%s' '${renderer_base64}' | base64 --decode > "$TEMP_DIRECTORY/render_runtime_env.py"
+printf '%s' '${renderer_base64}' | base64 --decode | gzip -d > "$TEMP_DIRECTORY/render_runtime_env.py"
 chmod 0700 "$TEMP_DIRECTORY/render_runtime_env.py"
-fetch_application_secret
+fetch_secret "$APPLICATION_SECRET_ARN" "$TEMP_DIRECTORY/application.json" application
 /usr/bin/python3 "$TEMP_DIRECTORY/render_runtime_env.py" \
   --validate-application-secret-only "$TEMP_DIRECTORY/application.json"
-printf '%s' '${docker_compose_base64}' | base64 --decode > "$TEMP_DIRECTORY/docker-compose.yml"
+if [ -n "$REDIS_SECRET_ARN" ]; then
+  fetch_secret "$REDIS_SECRET_ARN" "$TEMP_DIRECTORY/redis.json" Redis
+  /usr/bin/python3 "$TEMP_DIRECTORY/render_runtime_env.py" \
+    --validate-redis-secret-only "$TEMP_DIRECTORY/redis.json"
+fi
+printf '%s' '${docker_compose_base64}' | base64 --decode | gzip -d > "$TEMP_DIRECTORY/docker-compose.yml"
 : > "$TEMP_DIRECTORY/runtime.env"
 OCTOPUS_RUNTIME_ENV_PATH="$TEMP_DIRECTORY/runtime.env" \
   docker compose -f "$TEMP_DIRECTORY/docker-compose.yml" config --quiet

--- a/terraform/modules/aws/ec2-app/templates/refresh-secrets.sh.tpl
+++ b/terraform/modules/aws/ec2-app/templates/refresh-secrets.sh.tpl
@@ -5,8 +5,12 @@ umask 077
 AWS_REGION=$(printf '%s' '${aws_region_base64}' | base64 --decode)
 APPLICATION_SECRET_ARN=$(printf '%s' '${application_secret_arn_base64}' | base64 --decode)
 DATABASE_SECRET_ARN=$(printf '%s' '${database_secret_arn_base64}' | base64 --decode)
+REDIS_SECRET_ARN=$(printf '%s' '${redis_secret_arn_base64}' | base64 --decode)
 PUBLIC_ENVIRONMENT_BASE64='${public_environment_base64}'
 DATABASE_CONFIG_BASE64='${database_config_base64}'
+REDIS_CONFIG_BASE64='${redis_config_base64}'
+REDIS_PROBE_BASE64='${redis_probe_base64}'
+REDIS_AUTH_ENFORCED='${redis_auth_enforced}'
 RUNTIME_DIRECTORY=/run/octopus
 RUNTIME_ENV=$RUNTIME_DIRECTORY/runtime.env
 RECONCILE_STAMP=$RUNTIME_DIRECTORY/reconcile-required
@@ -61,15 +65,25 @@ fetch_secret() {
 
 printf '%s' "$PUBLIC_ENVIRONMENT_BASE64" | base64 --decode > "$TEMP_DIRECTORY/public.json"
 printf '%s' "$DATABASE_CONFIG_BASE64" | base64 --decode > "$TEMP_DIRECTORY/database-config.json"
+printf '%s' "$REDIS_CONFIG_BASE64" | base64 --decode > "$TEMP_DIRECTORY/redis-config.json"
 fetch_secret "$APPLICATION_SECRET_ARN" "$TEMP_DIRECTORY/application.json"
 fetch_secret "$DATABASE_SECRET_ARN" "$TEMP_DIRECTORY/database.json"
+if [ -n "$REDIS_SECRET_ARN" ]; then
+  fetch_secret "$REDIS_SECRET_ARN" "$TEMP_DIRECTORY/redis.json"
+fi
 
-/usr/bin/python3 /usr/local/lib/octopus/render_runtime_env.py \
-  --public-environment "$TEMP_DIRECTORY/public.json" \
-  --application-secret "$TEMP_DIRECTORY/application.json" \
-  --database-secret "$TEMP_DIRECTORY/database.json" \
-  --database-config "$TEMP_DIRECTORY/database-config.json" \
+renderer_args=(
+  --public-environment "$TEMP_DIRECTORY/public.json"
+  --application-secret "$TEMP_DIRECTORY/application.json"
+  --database-secret "$TEMP_DIRECTORY/database.json"
+  --database-config "$TEMP_DIRECTORY/database-config.json"
+  --redis-config "$TEMP_DIRECTORY/redis-config.json"
   --output "$TEMP_DIRECTORY/runtime.env"
+)
+if [ -n "$REDIS_SECRET_ARN" ]; then
+  renderer_args+=(--redis-secret "$TEMP_DIRECTORY/redis.json")
+fi
+/usr/bin/python3 /usr/local/lib/octopus/render_runtime_env.py "$${renderer_args[@]}"
 
 had_runtime_env=0
 secrets_changed=1
@@ -104,6 +118,35 @@ if ! OCTOPUS_RUNTIME_ENV_PATH="$TEMP_DIRECTORY/runtime.env" \
     echo "Octopus Compose validation failed; the current database environment was retained for retry" >&2
   fi
   exit 1
+fi
+
+# The public health route intentionally excludes optional Redis. Before a
+# candidate is promoted or a stopped stack is recovered, prove the restricted
+# user can execute every command family and pub/sub path Octopus relies on.
+redis_probe_required=0
+if [ -n "$REDIS_SECRET_ARN" ] && [ "$${OCTOPUS_BOOTSTRAP:-0}" != "1" ]; then
+  if [ "$secrets_changed" -eq 1 ] || \
+    [ "$${OCTOPUS_FORCE_RECREATE:-0}" = "1" ] || \
+    [ -f "$RECONCILE_STAMP" ]; then
+    redis_probe_required=1
+  elif ! docker compose -f "$APP_DIRECTORY/docker-compose.yml" \
+    ps --status running --services 2>/dev/null | grep -qx web; then
+    redis_probe_required=1
+  fi
+fi
+
+if [ "$redis_probe_required" -eq 1 ]; then
+  if ! printf '%s' "$REDIS_PROBE_BASE64" | base64 --decode | gzip -d | \
+    OCTOPUS_RUNTIME_ENV_PATH="$TEMP_DIRECTORY/runtime.env" \
+    docker compose -f "$APP_DIRECTORY/docker-compose.yml" \
+      run --rm --no-deps -T \
+      -e OCTOPUS_REDIS_PROBE_RUN=1 \
+      -e OCTOPUS_REDIS_AUTH_ENFORCED="$REDIS_AUTH_ENFORCED" \
+      web node - \
+      > "$TEMP_DIRECTORY/redis-probe-output" 2>&1; then
+    echo "Octopus authenticated Redis probe failed" >&2
+    exit 1
+  fi
 fi
 
 if [ "$secrets_changed" -eq 1 ]; then

--- a/terraform/modules/aws/ec2-app/templates/runtime-installer.sh.tpl
+++ b/terraform/modules/aws/ec2-app/templates/runtime-installer.sh.tpl
@@ -16,7 +16,7 @@ install_base64_file() {
   local mode=$3
   local temporary_file
   temporary_file=$(mktemp "$(dirname "$destination")/.octopus-install.XXXXXX")
-  printf '%s' "$encoded_value" | base64 --decode > "$temporary_file"
+  printf '%s' "$encoded_value" | base64 --decode | gzip -d > "$temporary_file"
   chmod "$mode" "$temporary_file"
   mv -f "$temporary_file" "$destination"
 }
@@ -27,6 +27,8 @@ install_base64_file '${docker_compose_base64}' /opt/octopus/docker-compose.yml 0
 
 %{ if nginx_conf_base64 != "" ~}
 install_base64_file '${nginx_conf_base64}' /opt/octopus/nginx.conf 0644
+%{ endif ~}
+%{ if proxy_params_base64 != "" ~}
 install_base64_file '${proxy_params_base64}' /opt/octopus/proxy_params 0644
 %{ endif ~}
 

--- a/terraform/modules/aws/ec2-app/templates/userdata.sh.tpl
+++ b/terraform/modules/aws/ec2-app/templates/userdata.sh.tpl
@@ -9,7 +9,7 @@ echo "=== Octopus setup started at $(date -u) ==="
 
 # ── System update ────────────────────────────────────────────────────────────
 apt-get update -y
-apt-get install -y ca-certificates curl gnupg lsb-release git unzip awscli python3
+apt-get install -y ca-certificates curl gnupg lsb-release git gzip unzip awscli python3
 
 # ── Docker ───────────────────────────────────────────────────────────────────
 install -m 0755 -d /etc/apt/keyrings
@@ -45,7 +45,7 @@ aws ecr get-login-password --region "$AWS_REGION" \
 # values are fetched with the instance role and rendered atomically under /run.
 runtime_installer=$(mktemp /tmp/octopus-runtime-install.XXXXXX)
 trap 'rm -f "$runtime_installer"' EXIT
-printf '%s' '${runtime_installer_base64}' | base64 --decode > "$runtime_installer"
+printf '%s' '${runtime_installer_base64}' | base64 --decode | gzip -d > "$runtime_installer"
 chmod 0700 "$runtime_installer"
 OCTOPUS_BOOTSTRAP=1 "$runtime_installer"
 rm -f "$runtime_installer"

--- a/terraform/modules/aws/ec2-app/variables.tf
+++ b/terraform/modules/aws/ec2-app/variables.tf
@@ -114,6 +114,62 @@ variable "database_secret_arn" {
   }
 }
 
+variable "redis_secret_arn" {
+  description = "Exact ARN of the dedicated Redis JSON secret. Empty only when Redis is disabled."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = try(
+      var.redis_secret_arn == "" || (
+        can(regex("^arn:[^:]+:secretsmanager:[^:]+:[0-9]{12}:secret:[A-Za-z0-9/_+=.@-]+$", var.redis_secret_arn)) &&
+        split(":", var.redis_secret_arn)[3] == var.aws_region
+      ),
+      false
+    )
+    error_message = "redis_secret_arn must be empty or a complete Secrets Manager secret ARN in aws_region."
+  }
+}
+
+variable "redis_config" {
+  description = "Non-secret Redis connection metadata used to construct REDIS_URL at runtime."
+  type = object({
+    enabled  = bool
+    host     = string
+    port     = number
+    username = string
+  })
+  default = {
+    enabled  = false
+    host     = ""
+    port     = 0
+    username = ""
+  }
+
+  validation {
+    condition = var.redis_config.enabled ? (
+      var.redis_config.host != "" &&
+      var.redis_config.port >= 1 && var.redis_config.port <= 65535 &&
+      can(regex("^[A-Za-z][A-Za-z0-9-]{0,39}$", var.redis_config.username))
+      ) : (
+      var.redis_config.host == "" &&
+      var.redis_config.port == 0 &&
+      var.redis_config.username == ""
+    )
+    error_message = "redis_config must contain host, a valid port, and username when enabled, and empty values when disabled."
+  }
+}
+
+variable "redis_auth_cutover_stage" {
+  description = "Redis authentication stage used by the deployment probe to require anonymous rejection after enforcement."
+  type        = string
+
+  validation {
+    condition     = contains(["preflight", "enforced"], var.redis_auth_cutover_stage)
+    error_message = "redis_auth_cutover_stage must be either preflight or enforced."
+  }
+}
+
 variable "runtime_secret_preflight_only" {
   description = "Run read-only application-secret and Compose compatibility checks without installing runtime secret delivery."
   type        = bool

--- a/terraform/modules/aws/elasticache-redis/auth.tf
+++ b/terraform/modules/aws/elasticache-redis/auth.tf
@@ -1,0 +1,221 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+  # RBAC IDs have a 40-character limit. Derive a stable suffix so an existing
+  # valid replication-group prefix up to its 34-character limit remains usable.
+  redis_auth_id_prefix                = "oct-${substr(sha256(var.name_prefix), 0, 12)}"
+  redis_auth_app_user_id              = "${local.redis_auth_id_prefix}-app"
+  redis_auth_app_username             = "${local.redis_auth_id_prefix}-app"
+  redis_auth_app_access_string        = "on resetkeys resetchannels -@all +info (+incr +expire +ttl ~rl:invite:user:* ~rl:invite:org:* ~rl:avatar-upload:*) (+get +set ~mx:v1:*) (+set +del +expire +mget +zadd +zrem +zremrangebyscore +zrangebyscore ~presence:*) (+set ~gh:install:state:jti:*) (+publish +subscribe &octopus:cancel &octopus:probe)"
+  redis_auth_disabled_default_user_id = "${local.redis_auth_id_prefix}-disabled"
+  redis_auth_user_group_id            = "${local.redis_auth_id_prefix}-users"
+
+  redis_auth_secret_arn_parts         = split(":", var.redis_auth_secret_arn)
+  redis_auth_secret_kms_key_arn_parts = split(":", var.redis_auth_secret_kms_key_arn)
+  redis_auth_password_references = [
+    for version_id in var.redis_auth_secret_version_ids :
+    "{{resolve:secretsmanager:${var.redis_auth_secret_arn}:SecretString:password::${version_id}}}"
+  ]
+
+  # Encode each branch first so Terraform can represent CloudFormation's
+  # intentionally heterogeneous string/intrinsic-function array.
+  redis_auth_user_ids = jsondecode(var.redis_auth_cutover_stage == "preflight" ? jsonencode([
+    "default",
+    { Ref = "ApplicationUser" },
+    ]) : jsonencode([
+    { Ref = "DisabledDefaultUser" },
+    { Ref = "ApplicationUser" },
+  ]))
+
+  redis_auth_resource_tags = [
+    for key in sort(keys(merge({ Name = "${var.name_prefix}-redis-rbac" }, var.tags))) : {
+      Key   = key
+      Value = merge({ Name = "${var.name_prefix}-redis-rbac" }, var.tags)[key]
+    }
+  ]
+
+  redis_auth_user_arns = [
+    "arn:${data.aws_partition.current.partition}:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:user:${local.redis_auth_app_user_id}",
+    "arn:${data.aws_partition.current.partition}:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:user:${local.redis_auth_disabled_default_user_id}",
+  ]
+  redis_auth_builtin_default_user_arn = "arn:${data.aws_partition.current.partition}:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:user:default"
+  redis_auth_user_group_arn           = "arn:${data.aws_partition.current.partition}:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:usergroup:${local.redis_auth_user_group_id}"
+
+  redis_auth_template = {
+    AWSTemplateFormatVersion = "2010-09-09"
+    Description              = "Octopus Redis RBAC users managed without exposing passwords to Terraform"
+    Resources = {
+      ApplicationUser = {
+        Type = "AWS::ElastiCache::User"
+        Properties = {
+          AccessString = local.redis_auth_app_access_string
+          AuthenticationMode = {
+            Passwords = local.redis_auth_password_references
+            Type      = "password"
+          }
+          Engine   = "redis"
+          Tags     = local.redis_auth_resource_tags
+          UserId   = local.redis_auth_app_user_id
+          UserName = local.redis_auth_app_username
+        }
+      }
+      DisabledDefaultUser = {
+        Type = "AWS::ElastiCache::User"
+        Properties = {
+          AccessString = "off ~* -@all"
+          AuthenticationMode = {
+            Type = "no-password-required"
+          }
+          Engine   = "redis"
+          Tags     = local.redis_auth_resource_tags
+          UserId   = local.redis_auth_disabled_default_user_id
+          UserName = "default"
+        }
+      }
+      RedisUserGroup = {
+        Type = "AWS::ElastiCache::UserGroup"
+        Properties = {
+          Engine      = "redis"
+          Tags        = local.redis_auth_resource_tags
+          UserGroupId = local.redis_auth_user_group_id
+          UserIds     = local.redis_auth_user_ids
+        }
+      }
+    }
+    Outputs = {
+      AppUserName = {
+        Value = local.redis_auth_app_username
+      }
+      UserGroupId = {
+        Value = local.redis_auth_user_group_id
+      }
+    }
+  }
+}
+
+resource "aws_iam_role" "redis_auth_cloudformation" {
+  name = "${var.name_prefix}-redis-rbac-cloudformation"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "cloudformation.amazonaws.com" }
+    }]
+  })
+
+  tags = merge({ Name = "${var.name_prefix}-redis-rbac-cloudformation" }, var.tags)
+}
+
+resource "aws_iam_role_policy" "redis_auth_cloudformation" {
+  name = "${var.name_prefix}-redis-rbac"
+  role = aws_iam_role.redis_auth_cloudformation.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat([
+      {
+        Sid      = "ReadExactRedisPasswordVersions"
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = [var.redis_auth_secret_arn]
+      },
+      {
+        Sid    = "ManageExactRedisUsers"
+        Effect = "Allow"
+        Action = [
+          "elasticache:CreateUser",
+          "elasticache:DeleteUser",
+          "elasticache:DescribeUsers",
+          "elasticache:ModifyUser",
+        ]
+        Resource = local.redis_auth_user_arns
+      },
+      {
+        Sid    = "ManageExactRedisUserGroup"
+        Effect = "Allow"
+        Action = [
+          "elasticache:DeleteUserGroup",
+          "elasticache:DescribeUserGroups",
+        ]
+        Resource = [local.redis_auth_user_group_arn]
+      },
+      {
+        Sid    = "ManageExactRedisUserGroupMembership"
+        Effect = "Allow"
+        Action = [
+          "elasticache:CreateUserGroup",
+          "elasticache:ModifyUserGroup",
+        ]
+        Resource = concat(local.redis_auth_user_arns, [
+          local.redis_auth_builtin_default_user_arn,
+          local.redis_auth_user_group_arn,
+        ])
+      },
+      {
+        Sid    = "TagExactRedisAuthResources"
+        Effect = "Allow"
+        Action = [
+          "elasticache:AddTagsToResource",
+          "elasticache:ListTagsForResource",
+          "elasticache:RemoveTagsFromResource",
+        ]
+        Resource = concat(local.redis_auth_user_arns, [local.redis_auth_user_group_arn])
+      },
+      ], var.redis_auth_secret_kms_key_arn == "" ? [] : [
+      {
+        Sid      = "DecryptDedicatedRedisPasswordSecret"
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt"]
+        Resource = [var.redis_auth_secret_kms_key_arn]
+        Condition = {
+          StringEquals = {
+            "kms:CallerAccount" = data.aws_caller_identity.current.account_id
+            "kms:ViaService"    = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+          }
+        }
+      },
+    ])
+  })
+}
+
+resource "aws_cloudformation_stack" "redis_auth" {
+  name               = "${var.name_prefix}-redis-rbac"
+  iam_role_arn       = aws_iam_role.redis_auth_cloudformation.arn
+  template_body      = jsonencode(local.redis_auth_template)
+  parameters         = {}
+  on_failure         = "ROLLBACK"
+  timeout_in_minutes = 30
+
+  tags = merge({ Name = "${var.name_prefix}-redis-rbac" }, var.tags)
+
+  depends_on = [aws_iam_role_policy.redis_auth_cloudformation]
+
+  lifecycle {
+    precondition {
+      condition = (
+        local.redis_auth_secret_arn_parts[1] == data.aws_partition.current.partition &&
+        local.redis_auth_secret_arn_parts[3] == data.aws_region.current.name &&
+        local.redis_auth_secret_arn_parts[4] == data.aws_caller_identity.current.account_id
+      )
+      error_message = "redis_auth_secret_arn must belong to the same AWS partition, region, and account as the Redis cluster."
+    }
+
+    precondition {
+      condition = try(
+        var.redis_auth_secret_kms_key_arn == "" || (
+          local.redis_auth_secret_kms_key_arn_parts[1] == data.aws_partition.current.partition &&
+          local.redis_auth_secret_kms_key_arn_parts[3] == data.aws_region.current.name &&
+          local.redis_auth_secret_kms_key_arn_parts[4] == data.aws_caller_identity.current.account_id
+        ),
+        false
+      )
+      error_message = "redis_auth_secret_kms_key_arn must be empty or belong to the same AWS partition, region, and account as the Redis cluster."
+    }
+  }
+}

--- a/terraform/modules/aws/elasticache-redis/main.tf
+++ b/terraform/modules/aws/elasticache-redis/main.tf
@@ -52,19 +52,22 @@ resource "aws_elasticache_replication_group" "this" {
   replication_group_id = "${var.name_prefix}-redis"
   description          = "Octopus Redis replication group"
 
-  engine               = "redis"
-  engine_version       = var.engine_version
-  node_type            = var.node_type
-  num_cache_clusters   = var.num_cache_nodes
-  port                 = 6379
+  engine             = "redis"
+  engine_version     = var.engine_version
+  node_type          = var.node_type
+  num_cache_clusters = var.num_cache_nodes
+  port               = 6379
 
   subnet_group_name  = aws_elasticache_subnet_group.this.name
   security_group_ids = [aws_security_group.this.id]
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true
+  user_group_ids             = [local.redis_auth_user_group_id]
 
   apply_immediately = true
+
+  depends_on = [aws_cloudformation_stack.redis_auth]
 
   tags = merge({ Name = "${var.name_prefix}-redis" }, var.tags)
 }

--- a/terraform/modules/aws/elasticache-redis/outputs.tf
+++ b/terraform/modules/aws/elasticache-redis/outputs.tf
@@ -8,12 +8,17 @@ output "port" {
   value       = aws_elasticache_replication_group.this.port
 }
 
-output "connection_url" {
-  description = "Redis connection URL. Uses rediss:// (TLS) because transit_encryption_enabled = true."
-  value       = "rediss://${aws_elasticache_replication_group.this.primary_endpoint_address}:${aws_elasticache_replication_group.this.port}"
-}
-
 output "security_group_id" {
   description = "ID of the Redis security group."
   value       = aws_security_group.this.id
+}
+
+output "application_username" {
+  description = "Non-secret Redis username whose password is stored only in the dedicated Secrets Manager secret."
+  value       = local.redis_auth_app_username
+}
+
+output "user_group_id" {
+  description = "Stable ElastiCache user group ID attached in both authentication cutover stages."
+  value       = local.redis_auth_user_group_id
 }

--- a/terraform/modules/aws/elasticache-redis/tests/security.tftest.hcl
+++ b/terraform/modules/aws/elasticache-redis/tests/security.tftest.hcl
@@ -1,0 +1,308 @@
+# SEC-10 Redis RBAC regression tests.
+# Runs entirely against a mocked AWS provider — no AWS credentials required:
+#   terraform -chdir=terraform/modules/aws/elasticache-redis init -backend=false
+#   terraform -chdir=terraform/modules/aws/elasticache-redis test
+
+mock_provider "aws" {
+  override_during = plan
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:user/test"
+      id         = "123456789012"
+    }
+  }
+
+  mock_data "aws_partition" {
+    defaults = {
+      dns_suffix = "amazonaws.com"
+      partition  = "aws"
+    }
+  }
+
+  mock_data "aws_region" {
+    defaults = {
+      name = "us-east-1"
+    }
+  }
+
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn  = "arn:aws:iam::123456789012:role/octopus-redis-rbac-cloudformation"
+      id   = "octopus-redis-rbac-cloudformation"
+      name = "octopus-redis-rbac-cloudformation"
+    }
+  }
+}
+
+variables {
+  name_prefix                   = "octopus"
+  vpc_id                        = "vpc-00000000000000000"
+  subnet_ids                    = ["subnet-00000000000000001", "subnet-00000000000000002"]
+  redis_auth_secret_arn         = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/redis-auth-ABC123"
+  redis_auth_secret_version_ids = ["11111111-2222-3333-4444-555555555555"]
+  redis_auth_cutover_stage      = "preflight"
+}
+
+run "preflight_keeps_legacy_default_and_proves_password_auth" {
+  command = plan
+
+  assert {
+    condition = (
+      aws_elasticache_replication_group.this.transit_encryption_enabled &&
+      aws_elasticache_replication_group.this.at_rest_encryption_enabled &&
+      toset(aws_elasticache_replication_group.this.user_group_ids) == toset(["oct-5633c9b8af6d-users"])
+    )
+    error_message = "Preflight must attach the RBAC user group while retaining encrypted transport and storage."
+  }
+
+  assert {
+    condition = (
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Type == "AWS::ElastiCache::User" &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.UserId == "oct-5633c9b8af6d-app" &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.UserName == "oct-5633c9b8af6d-app" &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.UserName != "default" &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.AccessString == "on resetkeys resetchannels -@all +info (+incr +expire +ttl ~rl:invite:user:* ~rl:invite:org:* ~rl:avatar-upload:*) (+get +set ~mx:v1:*) (+set +del +expire +mget +zadd +zrem +zremrangebyscore +zrangebyscore ~presence:*) (+set ~gh:install:state:jti:*) (+publish +subscribe &octopus:cancel &octopus:probe)" &&
+      !strcontains(jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.AccessString, "+scan") &&
+      !strcontains(jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.AccessString, "+client") &&
+      !strcontains(jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.AccessString, "+ping") &&
+      !strcontains(jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.AccessString, "+unsubscribe") &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.AuthenticationMode.Type == "password" &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.AuthenticationMode.Passwords == [
+        "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/redis-auth-ABC123:SecretString:password::11111111-2222-3333-4444-555555555555}}",
+      ]
+    )
+    error_message = "The app user must use a non-default username and only an exact-version Secrets Manager dynamic reference for its password."
+  }
+
+  assert {
+    condition = (
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.DisabledDefaultUser.Type == "AWS::ElastiCache::User" &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.DisabledDefaultUser.Properties.UserId == "oct-5633c9b8af6d-disabled" &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.DisabledDefaultUser.Properties.UserName == "default" &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.DisabledDefaultUser.Properties.AccessString == "off ~* -@all" &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.DisabledDefaultUser.Properties.AuthenticationMode.Type == "no-password-required"
+    )
+    error_message = "The replacement default user must be permanently disabled without containing a password."
+  }
+
+  assert {
+    condition = (
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.RedisUserGroup.Type == "AWS::ElastiCache::UserGroup" &&
+      jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.RedisUserGroup.Properties.UserGroupId == "oct-5633c9b8af6d-users" &&
+      jsonencode(jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.RedisUserGroup.Properties.UserIds) == jsonencode([
+        "default",
+        { Ref = "ApplicationUser" },
+      ]) &&
+      !strcontains(jsonencode(jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.RedisUserGroup.Properties.UserIds), "DisabledDefaultUser")
+    )
+    error_message = "Preflight must keep the built-in passwordless default and add the authenticated app user for live credential proof."
+  }
+}
+
+run "enforced_disables_passwordless_default_and_supports_dual_password_rotation" {
+  command = plan
+
+  variables {
+    redis_auth_cutover_stage = "enforced"
+    redis_auth_secret_version_ids = [
+      "11111111-2222-3333-4444-555555555555",
+      "66666666-7777-8888-9999-000000000000",
+    ]
+  }
+
+  assert {
+    condition = (
+      toset(aws_elasticache_replication_group.this.user_group_ids) == toset(["oct-5633c9b8af6d-users"]) &&
+      jsonencode(jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.RedisUserGroup.Properties.UserIds) == jsonencode([
+        { Ref = "DisabledDefaultUser" },
+        { Ref = "ApplicationUser" },
+      ])
+    )
+    error_message = "Enforcement must keep the attached group, replace the built-in default with the disabled default, and retain the app user."
+  }
+
+  assert {
+    condition = jsondecode(aws_cloudformation_stack.redis_auth.template_body).Resources.ApplicationUser.Properties.AuthenticationMode.Passwords == [
+      "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/redis-auth-ABC123:SecretString:password::11111111-2222-3333-4444-555555555555}}",
+      "{{resolve:secretsmanager:arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/redis-auth-ABC123:SecretString:password::66666666-7777-8888-9999-000000000000}}",
+    ]
+    error_message = "Rotation must support exactly two explicit secret versions without resolving either password in Terraform."
+  }
+}
+
+run "cloudformation_role_is_narrow_and_secret_safe" {
+  command = plan
+
+  assert {
+    condition = (
+      jsonencode(jsondecode(aws_iam_role.redis_auth_cloudformation.assume_role_policy).Statement) == jsonencode([{
+        Action    = "sts:AssumeRole"
+        Effect    = "Allow"
+        Principal = { Service = "cloudformation.amazonaws.com" }
+      }]) &&
+      aws_cloudformation_stack.redis_auth.iam_role_arn == aws_iam_role.redis_auth_cloudformation.arn
+    )
+    error_message = "Only CloudFormation may assume the dedicated Redis RBAC service role."
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_iam_role_policy.redis_auth_cloudformation.policy).Statement : statement
+        if statement.Sid == "ReadExactRedisPasswordVersions"
+      ]).Action == ["secretsmanager:GetSecretValue"] &&
+      one([
+        for statement in jsondecode(aws_iam_role_policy.redis_auth_cloudformation.policy).Statement : statement
+        if statement.Sid == "ReadExactRedisPasswordVersions"
+      ]).Resource == ["arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/redis-auth-ABC123"] &&
+      one([
+        for statement in jsondecode(aws_iam_role_policy.redis_auth_cloudformation.policy).Statement : statement
+        if statement.Sid == "ManageExactRedisUsers"
+        ]).Resource == [
+        "arn:aws:elasticache:us-east-1:123456789012:user:oct-5633c9b8af6d-app",
+        "arn:aws:elasticache:us-east-1:123456789012:user:oct-5633c9b8af6d-disabled",
+      ] &&
+      one([
+        for statement in jsondecode(aws_iam_role_policy.redis_auth_cloudformation.policy).Statement : statement
+        if statement.Sid == "ManageExactRedisUserGroup"
+      ]).Resource == ["arn:aws:elasticache:us-east-1:123456789012:usergroup:oct-5633c9b8af6d-users"] &&
+      toset(one([
+        for statement in jsondecode(aws_iam_role_policy.redis_auth_cloudformation.policy).Statement : statement
+        if statement.Sid == "ManageExactRedisUserGroupMembership"
+        ]).Resource) == toset([
+        "arn:aws:elasticache:us-east-1:123456789012:user:default",
+        "arn:aws:elasticache:us-east-1:123456789012:user:oct-5633c9b8af6d-app",
+        "arn:aws:elasticache:us-east-1:123456789012:user:oct-5633c9b8af6d-disabled",
+        "arn:aws:elasticache:us-east-1:123456789012:usergroup:oct-5633c9b8af6d-users",
+      ]) &&
+      alltrue([
+        for statement in jsondecode(aws_iam_role_policy.redis_auth_cloudformation.policy).Statement :
+        !contains(statement.Resource, "*")
+      ])
+    )
+    error_message = "The CloudFormation role must read only the dedicated Redis secret and manage only the stable Redis users and group."
+  }
+
+  assert {
+    condition = (
+      !strcontains(aws_cloudformation_stack.redis_auth.template_body, "password-value") &&
+      !contains(keys(aws_cloudformation_stack.redis_auth.parameters), "Password") &&
+      output.application_username == "oct-5633c9b8af6d-app" &&
+      output.user_group_id == "oct-5633c9b8af6d-users"
+    )
+    error_message = "Terraform state, parameters, and outputs must contain identifiers only, never a Redis password."
+  }
+}
+
+run "customer_managed_secret_key_is_exactly_scoped" {
+  command = plan
+
+  variables {
+    redis_auth_secret_kms_key_arn = "arn:aws:kms:us-east-1:123456789012:key/11111111-2222-3333-4444-555555555555"
+  }
+
+  assert {
+    condition = (
+      one([
+        for statement in jsondecode(aws_iam_role_policy.redis_auth_cloudformation.policy).Statement : statement
+        if statement.Sid == "DecryptDedicatedRedisPasswordSecret"
+      ]).Action == ["kms:Decrypt"] &&
+      one([
+        for statement in jsondecode(aws_iam_role_policy.redis_auth_cloudformation.policy).Statement : statement
+        if statement.Sid == "DecryptDedicatedRedisPasswordSecret"
+      ]).Resource == ["arn:aws:kms:us-east-1:123456789012:key/11111111-2222-3333-4444-555555555555"] &&
+      one([
+        for statement in jsondecode(aws_iam_role_policy.redis_auth_cloudformation.policy).Statement : statement
+        if statement.Sid == "DecryptDedicatedRedisPasswordSecret"
+        ]).Condition.StringEquals == {
+        "kms:CallerAccount" = "123456789012"
+        "kms:ViaService"    = "secretsmanager.us-east-1.amazonaws.com"
+      }
+    )
+    error_message = "A customer-managed secret key must grant only kms:Decrypt on the exact key ARN."
+  }
+}
+
+run "cross_region_secret_is_rejected" {
+  command = plan
+
+  variables {
+    redis_auth_secret_arn = "arn:aws:secretsmanager:eu-west-1:123456789012:secret:octopus/redis-auth-ABC123"
+  }
+
+  expect_failures = [aws_cloudformation_stack.redis_auth]
+}
+
+run "empty_secret_versions_are_rejected" {
+  command = plan
+
+  variables {
+    redis_auth_secret_version_ids = []
+  }
+
+  expect_failures = [var.redis_auth_secret_version_ids]
+}
+
+run "more_than_two_secret_versions_are_rejected" {
+  command = plan
+
+  variables {
+    redis_auth_secret_version_ids = [
+      "11111111-2222-3333-4444-555555555555",
+      "66666666-7777-8888-9999-000000000000",
+      "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    ]
+  }
+
+  expect_failures = [var.redis_auth_secret_version_ids]
+}
+
+run "unknown_cutover_stage_is_rejected" {
+  command = plan
+
+  variables {
+    redis_auth_cutover_stage = "disabled"
+  }
+
+  expect_failures = [var.redis_auth_cutover_stage]
+}
+
+run "legacy_long_prefix_derives_bounded_stable_auth_ids" {
+  command = plan
+
+  variables {
+    name_prefix = "octopus-production-legacy-stack"
+  }
+
+  assert {
+    condition = (
+      output.application_username == "oct-${substr(sha256("octopus-production-legacy-stack"), 0, 12)}-app" &&
+      output.user_group_id == "oct-${substr(sha256("octopus-production-legacy-stack"), 0, 12)}-users" &&
+      length(output.application_username) <= 40 &&
+      length(output.user_group_id) <= 40
+    )
+    error_message = "Valid legacy prefixes must derive stable Redis RBAC IDs without exceeding AWS limits."
+  }
+}
+
+run "unsafe_name_prefix_is_rejected" {
+  command = plan
+
+  variables {
+    name_prefix = "1_invalid"
+  }
+
+  expect_failures = [var.name_prefix]
+}
+
+run "redis_six_is_rejected_without_selector_support" {
+  command = plan
+
+  variables {
+    engine_version = "6.2"
+  }
+
+  expect_failures = [var.engine_version]
+}

--- a/terraform/modules/aws/elasticache-redis/variables.tf
+++ b/terraform/modules/aws/elasticache-redis/variables.tf
@@ -2,6 +2,15 @@ variable "name_prefix" {
   description = "Prefix applied to every resource name."
   type        = string
   default     = "octopus"
+
+  validation {
+    condition = (
+      can(regex("^[a-z][a-z0-9-]{0,33}$", var.name_prefix)) &&
+      !endswith(var.name_prefix, "-") &&
+      !strcontains(var.name_prefix, "--")
+    )
+    error_message = "name_prefix must be 1-34 lowercase letters, digits, or hyphens, start with a letter, and contain no trailing or consecutive hyphen."
+  }
 }
 
 variable "vpc_id" {
@@ -36,12 +45,69 @@ variable "engine_version" {
   description = "Redis engine version."
   type        = string
   default     = "7.1"
+
+  validation {
+    condition     = try(tonumber(split(".", var.engine_version)[0]) >= 7, false)
+    error_message = "engine_version must be Redis OSS 7.0 or newer because the least-privilege RBAC policy uses ACL selectors."
+  }
 }
 
 variable "num_cache_nodes" {
   description = "Number of cache clusters in the replication group (1 = single-node, no replica)."
   type        = number
   default     = 1
+}
+
+variable "redis_auth_secret_arn" {
+  description = "ARN of the dedicated Secrets Manager secret whose SecretString contains exactly a password field for the Redis app user. Terraform never reads the secret value."
+  type        = string
+
+  validation {
+    condition     = can(regex("^arn:[^:]+:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[^:]+$", var.redis_auth_secret_arn))
+    error_message = "redis_auth_secret_arn must be a complete Secrets Manager secret ARN without a version suffix."
+  }
+}
+
+variable "redis_auth_secret_version_ids" {
+  description = "One active Secrets Manager version ID, or two exact version IDs during password rotation. Values identify versions only; passwords never enter Terraform."
+  type        = list(string)
+
+  validation {
+    condition = (
+      length(var.redis_auth_secret_version_ids) >= 1 &&
+      length(var.redis_auth_secret_version_ids) <= 2 &&
+      length(distinct(var.redis_auth_secret_version_ids)) == length(var.redis_auth_secret_version_ids) &&
+      alltrue([
+        for version_id in var.redis_auth_secret_version_ids :
+        can(regex("^[A-Za-z0-9-]{32,64}$", version_id))
+      ])
+    )
+    error_message = "redis_auth_secret_version_ids must contain one or two distinct exact Secrets Manager version IDs (32-64 letters, digits, or hyphens)."
+  }
+}
+
+variable "redis_auth_secret_kms_key_arn" {
+  description = "Optional exact customer-managed KMS key ARN used by redis_auth_secret_arn. Leave empty when the secret uses the AWS managed Secrets Manager key."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      var.redis_auth_secret_kms_key_arn == "" ||
+      can(regex("^arn:[^:]+:kms:[a-z0-9-]+:[0-9]{12}:key/[A-Za-z0-9-]+$", var.redis_auth_secret_kms_key_arn))
+    )
+    error_message = "redis_auth_secret_kms_key_arn must be empty or a complete customer-managed KMS key ARN."
+  }
+}
+
+variable "redis_auth_cutover_stage" {
+  description = "Redis authentication cutover: preflight keeps the built-in passwordless default alongside the authenticated app user; enforced replaces it with a disabled default user."
+  type        = string
+
+  validation {
+    condition     = contains(["preflight", "enforced"], var.redis_auth_cutover_stage)
+    error_message = "redis_auth_cutover_stage must be either preflight or enforced."
+  }
 }
 
 variable "tags" {

--- a/terraform/stacks/aws-ec2/main.tf
+++ b/terraform/stacks/aws-ec2/main.tf
@@ -1,5 +1,4 @@
 locals {
-  redis_url          = var.enable_redis ? module.redis[0].connection_url : ""
   origin_name_suffix = substr(sha256(var.name_prefix), 0, 12)
   origin_lb_name     = "oct-origin-${local.origin_name_suffix}"
   origin_tg_name     = "oct-app-${local.origin_name_suffix}"
@@ -96,7 +95,7 @@ locals {
     proxy_set_header X-Forwarded-Proto $forwarded_proto;
   PROXY
 
-  runtime_environment = merge({
+  runtime_environment = {
     BETTER_AUTH_URL             = "https://${var.app_domain}"
     NEXT_PUBLIC_APP_URL         = "https://${var.app_domain}"
     ADMIN_EMAILS                = var.admin_emails
@@ -113,7 +112,19 @@ locals {
     BITBUCKET_REDIRECT_URI      = "https://${var.app_domain}/api/bitbucket/callback"
     LINEAR_REDIRECT_URI         = "https://${var.app_domain}/api/linear/callback"
     SLACK_REDIRECT_URI          = "https://${var.app_domain}/api/slack/callback"
-  }, var.enable_redis ? { REDIS_URL = local.redis_url } : {})
+  }
+
+  redis_config = var.enable_redis ? {
+    enabled  = true
+    host     = module.redis[0].primary_endpoint_address
+    port     = module.redis[0].port
+    username = module.redis[0].application_username
+    } : {
+    enabled  = false
+    host     = ""
+    port     = 0
+    username = ""
+  }
 
   database_config = {
     host     = module.rds.host
@@ -335,17 +346,41 @@ module "rds" {
 }
 
 # ── ElastiCache Redis (optional) ──────────────────────────────────────────────
+resource "terraform_data" "redis_auth_cutover_guard" {
+  count = var.enable_redis ? 1 : 0
+  input = var.redis_auth_cutover_stage
+
+  lifecycle {
+    precondition {
+      condition = (
+        var.redis_auth_cutover_stage != "enforced" ||
+        (
+          var.runtime_secret_cutover_stage == "enforced" &&
+          var.redis_authenticated_runtime_ready
+        )
+      )
+      error_message = "Redis authentication cannot be enforced until runtime secret delivery was applied and its authenticated Redis probe passed; then set redis_authenticated_runtime_ready = true."
+    }
+  }
+}
+
 module "redis" {
   count  = var.enable_redis ? 1 : 0
   source = "../../modules/aws/elasticache-redis"
 
-  name_prefix                = var.name_prefix
-  vpc_id                     = module.vpc.vpc_id
-  subnet_ids                 = module.vpc.private_subnet_ids
-  allowed_security_group_ids = [aws_security_group.app_data_access.id]
-  allowed_cidr_blocks        = var.restrict_data_access_to_app ? [] : [var.vpc_cidr]
-  node_type                  = var.redis_node_type
-  tags                       = var.tags
+  name_prefix                   = var.name_prefix
+  vpc_id                        = module.vpc.vpc_id
+  subnet_ids                    = module.vpc.private_subnet_ids
+  allowed_security_group_ids    = [aws_security_group.app_data_access.id]
+  allowed_cidr_blocks           = var.restrict_data_access_to_app ? [] : [var.vpc_cidr]
+  node_type                     = var.redis_node_type
+  redis_auth_secret_arn         = var.redis_auth_secret_arn
+  redis_auth_secret_kms_key_arn = var.redis_auth_secret_kms_key_arn
+  redis_auth_secret_version_ids = var.redis_auth_secret_version_ids
+  redis_auth_cutover_stage      = var.redis_auth_cutover_stage
+  tags                          = var.tags
+
+  depends_on = [terraform_data.redis_auth_cutover_guard]
 }
 
 # ── EC2 Application ───────────────────────────────────────────────────────────
@@ -367,13 +402,17 @@ module "ec2" {
   proxy_params_content          = local.proxy_params
   application_secret_arn        = var.application_secret_arn
   database_secret_arn           = var.runtime_secret_cutover_stage == "enforced" ? module.rds.master_user_secret_arn : ""
+  redis_secret_arn              = var.enable_redis ? var.redis_auth_secret_arn : ""
+  redis_auth_cutover_stage      = var.redis_auth_cutover_stage
   runtime_secret_preflight_only = var.runtime_secret_cutover_stage == "preflight"
   runtime_secret_kms_key_arns = distinct(compact([
     var.application_secret_kms_key_arn,
     var.runtime_secret_cutover_stage == "enforced" ? var.db_secret_kms_key_arn : "",
+    var.enable_redis ? var.redis_auth_secret_kms_key_arn : "",
   ]))
   runtime_environment = local.runtime_environment
   database_config     = local.database_config
+  redis_config        = local.redis_config
 
   ingress_rules                 = local.ingress_rules
   additional_security_group_ids = [aws_security_group.app_data_access.id]

--- a/terraform/stacks/aws-ec2/outputs.tf
+++ b/terraform/stacks/aws-ec2/outputs.tf
@@ -18,9 +18,12 @@ output "database_secret_arn" {
   value       = module.rds.master_user_secret_arn
 }
 
-output "redis_url" {
-  description = "Redis connection URL (empty if Redis is disabled)."
-  value       = var.enable_redis ? module.redis[0].connection_url : ""
+output "redis_endpoint" {
+  description = "Non-secret Redis endpoint (empty if Redis is disabled). Credentials are delivered only at runtime."
+  value = var.enable_redis ? {
+    host = module.redis[0].primary_endpoint_address
+    port = module.redis[0].port
+  } : null
 }
 
 output "app_url" {

--- a/terraform/stacks/aws-ec2/terraform.tfvars.example
+++ b/terraform/stacks/aws-ec2/terraform.tfvars.example
@@ -69,6 +69,10 @@ application_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:o
 # README runtime-secret preflight before changing this value to "enforced".
 runtime_secret_cutover_stage = "enforced"
 
+# Required even when Redis is disabled so authentication cannot silently
+# downgrade if Redis is enabled or its rollout settings are edited later.
+redis_auth_cutover_stage = "preflight"
+
 # Set this only when the application secret uses a customer-managed KMS key.
 application_secret_kms_key_arn = ""
 
@@ -134,6 +138,14 @@ db_secret_kms_key_arn = ""
 # ── Redis (disabled by default) ──────────────────────────────────────────────
 enable_redis    = false
 redis_node_type = "cache.t3.micro"
+
+# When enabling Redis, first create a separate Secrets Manager JSON secret
+# containing only {"password":"..."}. Supply its exact ARN and one exact
+# version ID, then keep preflight until the authenticated probe passes.
+redis_auth_secret_arn          = ""
+redis_auth_secret_kms_key_arn  = ""
+redis_auth_secret_version_ids  = []
+redis_authenticated_runtime_ready = false
 
 # ── Google OAuth (optional) ──────────────────────────────────────────────────
 # Create at: https://console.cloud.google.com → APIs & Services → Credentials

--- a/terraform/stacks/aws-ec2/tests/network_trust.tftest.hcl
+++ b/terraform/stacks/aws-ec2/tests/network_trust.tftest.hcl
@@ -9,7 +9,30 @@
 # stack wires up in main.tf. Stack-level runs cover the root identity SG and
 # the ssh_cidr_blocks validation.
 
-mock_provider "aws" {}
+mock_provider "aws" {
+  override_during = plan
+
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "123456789012"
+      arn        = "arn:aws:iam::123456789012:user/test"
+      id         = "123456789012"
+    }
+  }
+
+  mock_data "aws_partition" {
+    defaults = {
+      dns_suffix = "amazonaws.com"
+      partition  = "aws"
+    }
+  }
+
+  mock_data "aws_region" {
+    defaults = {
+      name = "us-east-1"
+    }
+  }
+}
 
 override_data {
   target = module.vpc.data.aws_availability_zones.available
@@ -71,10 +94,13 @@ override_resource {
 }
 
 variables {
-  app_image                    = "ghcr.io/example/octopus:test"
-  app_domain                   = "octopus.example.com"
-  application_secret_arn       = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123"
-  runtime_secret_cutover_stage = "enforced"
+  app_image                     = "ghcr.io/example/octopus:test"
+  app_domain                    = "octopus.example.com"
+  application_secret_arn        = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123"
+  runtime_secret_cutover_stage  = "enforced"
+  redis_auth_secret_arn         = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/redis-auth-ABC123"
+  redis_auth_secret_version_ids = ["11111111-2222-3333-4444-555555555555"]
+  redis_auth_cutover_stage      = "preflight"
 
   origin_tls_cutover_stage   = "preflight"
   origin_tls_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
@@ -214,11 +240,13 @@ run "redis_module_restricted_to_identity_sg" {
   }
 
   variables {
-    name_prefix                = "octopus"
-    vpc_id                     = "vpc-00000000000000000"
-    subnet_ids                 = ["subnet-00000000000000001", "subnet-00000000000000002"]
-    allowed_security_group_ids = ["sg-appdata0000000001"]
-    allowed_cidr_blocks        = []
+    name_prefix                   = "octopus"
+    vpc_id                        = "vpc-00000000000000000"
+    subnet_ids                    = ["subnet-00000000000000001", "subnet-00000000000000002"]
+    allowed_security_group_ids    = ["sg-appdata0000000001"]
+    allowed_cidr_blocks           = []
+    redis_auth_secret_arn         = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/redis-auth-ABC123"
+    redis_auth_secret_version_ids = ["11111111-2222-3333-4444-555555555555"]
   }
 
   assert {
@@ -251,11 +279,13 @@ run "redis_module_compat_keeps_cidr_and_identity" {
   }
 
   variables {
-    name_prefix                = "octopus"
-    vpc_id                     = "vpc-00000000000000000"
-    subnet_ids                 = ["subnet-00000000000000001", "subnet-00000000000000002"]
-    allowed_security_group_ids = ["sg-appdata0000000001"]
-    allowed_cidr_blocks        = ["10.0.0.0/16"]
+    name_prefix                   = "octopus"
+    vpc_id                        = "vpc-00000000000000000"
+    subnet_ids                    = ["subnet-00000000000000001", "subnet-00000000000000002"]
+    allowed_security_group_ids    = ["sg-appdata0000000001"]
+    allowed_cidr_blocks           = ["10.0.0.0/16"]
+    redis_auth_secret_arn         = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/redis-auth-ABC123"
+    redis_auth_secret_version_ids = ["11111111-2222-3333-4444-555555555555"]
   }
 
   assert {
@@ -288,6 +318,7 @@ run "ec2_module_preflight_reads_only_application_secret" {
     docker_compose_content        = "services: {}"
     application_secret_arn        = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123"
     database_secret_arn           = ""
+    redis_auth_cutover_stage      = "preflight"
     runtime_secret_preflight_only = true
     runtime_environment           = { NEXT_PUBLIC_APP_URL = "https://octopus.example.com" }
     database_config               = { host = "db.internal", port = 5432, database = "octopus" }
@@ -331,6 +362,9 @@ run "ec2_module_attaches_additional_identity_sg" {
     docker_compose_content        = "services: {}"
     application_secret_arn        = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123"
     database_secret_arn           = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-ABC123"
+    redis_secret_arn              = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/redis-auth-ABC123"
+    redis_config                  = { enabled = true, host = "redis.internal", port = 6379, username = "oct-5633c9b8af6d-app" }
+    redis_auth_cutover_stage      = "enforced"
     runtime_secret_preflight_only = false
     runtime_secret_kms_key_arns   = ["arn:aws:kms:us-east-1:123456789012:key/11111111-2222-3333-4444-555555555555"]
     runtime_environment           = { NEXT_PUBLIC_APP_URL = "https://octopus.example.com" }
@@ -382,8 +416,9 @@ run "ec2_module_attaches_additional_identity_sg" {
       ]).Resource) == toset([
       "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123",
       "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-ABC123",
+      "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/redis-auth-ABC123",
     ])
-    error_message = "The instance role must restrict GetSecretValue to the exact application and database secret ARNs."
+    error_message = "The instance role must restrict GetSecretValue to the exact application, database, and Redis secret ARNs."
   }
 
   assert {
@@ -393,6 +428,31 @@ run "ec2_module_attaches_additional_identity_sg" {
     ]).Condition.StringEquals["kms:ViaService"] == "secretsmanager.us-east-1.amazonaws.com"
     error_message = "Customer-managed KMS decrypt permission must be constrained to Secrets Manager in the deployment region."
   }
+}
+
+run "redis_auth_enforcement_requires_runtime_secret_delivery" {
+  command = plan
+
+  variables {
+    enable_redis                 = true
+    redis_auth_cutover_stage     = "enforced"
+    runtime_secret_cutover_stage = "preflight"
+  }
+
+  expect_failures = [terraform_data.redis_auth_cutover_guard[0]]
+}
+
+run "redis_auth_enforcement_requires_authenticated_runtime_acknowledgement" {
+  command = plan
+
+  variables {
+    enable_redis                      = true
+    redis_auth_cutover_stage          = "enforced"
+    runtime_secret_cutover_stage      = "enforced"
+    redis_authenticated_runtime_ready = false
+  }
+
+  expect_failures = [terraform_data.redis_auth_cutover_guard[0]]
 }
 
 # ── SSH: internet-wide CIDR is rejected at validation time ────────────────────

--- a/terraform/stacks/aws-ec2/tests/origin_tls.tftest.hcl
+++ b/terraform/stacks/aws-ec2/tests/origin_tls.tftest.hcl
@@ -73,6 +73,7 @@ variables {
   app_domain                   = "octopus.example.com"
   application_secret_arn       = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123"
   runtime_secret_cutover_stage = "enforced"
+  redis_auth_cutover_stage     = "preflight"
 
   origin_tls_cutover_stage   = "preflight"
   origin_tls_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/11111111-2222-3333-4444-555555555555"
@@ -247,6 +248,7 @@ run "ec2_module_enforced_origin_is_alb_only" {
     docker_compose_content        = "services: {}"
     application_secret_arn        = "arn:aws:secretsmanager:us-east-1:123456789012:secret:octopus/application-ABC123"
     database_secret_arn           = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-ABC123"
+    redis_auth_cutover_stage      = "preflight"
     runtime_secret_preflight_only = false
     runtime_environment           = { NEXT_PUBLIC_APP_URL = "https://octopus.example.com" }
     database_config               = { host = "db.internal", port = 5432, database = "octopus" }

--- a/terraform/stacks/aws-ec2/variables.tf
+++ b/terraform/stacks/aws-ec2/variables.tf
@@ -259,6 +259,71 @@ variable "redis_node_type" {
   default     = "cache.t3.micro"
 }
 
+variable "redis_auth_secret_arn" {
+  description = "Exact ARN of the dedicated Redis JSON secret containing only a password field. Required when Redis is enabled; Terraform never reads its value."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = try(
+      var.redis_auth_secret_arn == "" || (
+        can(regex("^arn:[^:]+:secretsmanager:[^:]+:[0-9]{12}:secret:[A-Za-z0-9/_+=.@-]+$", var.redis_auth_secret_arn)) &&
+        split(":", var.redis_auth_secret_arn)[3] == var.aws_region
+      ),
+      false
+    )
+    error_message = "redis_auth_secret_arn must be empty or a complete Secrets Manager secret ARN in aws_region."
+  }
+}
+
+variable "redis_auth_secret_kms_key_arn" {
+  description = "Optional customer-managed KMS key ARN used by redis_auth_secret_arn."
+  type        = string
+  default     = ""
+
+  validation {
+    condition = (
+      var.redis_auth_secret_kms_key_arn == "" ||
+      try(
+        can(regex("^arn:[^:]+:kms:[^:]+:[0-9]{12}:key/[A-Za-z0-9-]+$", var.redis_auth_secret_kms_key_arn)) &&
+        split(":", var.redis_auth_secret_kms_key_arn)[3] == var.aws_region,
+        false
+      )
+    )
+    error_message = "redis_auth_secret_kms_key_arn must be empty or a customer-managed KMS key ARN in aws_region."
+  }
+}
+
+variable "redis_auth_secret_version_ids" {
+  description = "One or two exact Secrets Manager version IDs accepted by the Redis app user. Required when Redis is enabled and safe for Terraform state."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = length(var.redis_auth_secret_version_ids) <= 2 && alltrue([
+      for version_id in var.redis_auth_secret_version_ids :
+      can(regex("^[A-Za-z0-9-]{32,64}$", version_id))
+    ])
+    error_message = "redis_auth_secret_version_ids must contain at most two 32-64 character Secrets Manager version IDs."
+  }
+}
+
+variable "redis_auth_cutover_stage" {
+  description = "Redis authentication rollout stage. Use preflight until authenticated runtime probes pass, then enforced to disable anonymous access."
+  type        = string
+
+  validation {
+    condition     = contains(["preflight", "enforced"], var.redis_auth_cutover_stage)
+    error_message = "redis_auth_cutover_stage must be either preflight or enforced."
+  }
+}
+
+variable "redis_authenticated_runtime_ready" {
+  description = "Explicit operator acknowledgement that runtime-secret enforcement was applied and its authenticated Redis probe passed before Redis authentication enforcement."
+  type        = bool
+  default     = false
+}
+
 # ── GitHub App ────────────────────────────────────────────────────────────────
 variable "github_app_id" {
   description = "GitHub App ID."


### PR DESCRIPTION
## Intent

Implement SEC-10 for the AWS-hosted Octopus deployment: enforce Redis password authentication and least-privilege RBAC without putting secret values in Terraform state, outputs, user data, or logs. Use a dedicated Secrets Manager secret with exact version references, authenticated TLS runtime delivery, staged preflight then enforced cutover with an explicit verified-runtime acknowledgement, fail-closed probes, rollback and dual-password rotation guidance. Preserve review-engine behavior and leave the WDC/datacenter deployment unchanged. Remove global SCAN from presence through an org-scoped expiring index so the app ACL can remain key-bounded. Validate fully, push a PR for Octopus review, but do not merge or deploy.

## What Changed

- New `auth.tf` in the `elasticache-redis` module provisions a dedicated Secrets Manager secret and applies the AUTH password plus a least-privilege app ACL user via a narrowly-scoped CloudFormation stack, referencing secrets only as exact-version `{{resolve:secretsmanager:...}}` dynamic references so no secret values land in Terraform state, outputs, or logs. Cutover is staged: a preflight stage delivers credentials to the runtime first, and enforcement requires an explicit verified-runtime acknowledgement variable; `terraform/README.md` documents rollback and dual-password rotation (including the exact `--version-stages` CLI for adding a secret version without moving AWSCURRENT).
- The `ec2-app` module now renders the authenticated `rediss://` URL from Secrets Manager at boot (`render_runtime_env.py`), refreshes it via SSM (`refresh-secrets.sh.tpl`), and gates enforcement behind a fail-closed `probe_redis.js` that verifies correct credentials authenticate, wrong ones fail, and unauthenticated access gets `NOAUTH` before the association proceeds.
- `apps/web` presence tracking replaces the global Redis `SCAN` with an org-scoped expiring zset index so the app's ACL user can stay key-bounded, with matching key-pattern tightening in `cancel-bus.ts`/`redis.ts`; CI now fmt-checks the `elasticache-redis` module and runs its new `security.tftest.hcl` suite (11 tests) alongside the expanded stack tests.

## Risk Assessment

✅ Low: The only change since the last reviewed head is a documentation-only README commit that accurately implements the requested rotation CLI guidance and cutover cautions with no runtime or infrastructure behavior change.

## Testing

Ran the full changed-test surface (48 bun unit tests, 33 Terraform tests across the elasticache-redis module and aws-ec2 stack — all pass), then demonstrated the change end-to-end against a real TLS Redis 7.4 configured with the exact least-privilege RBAC access strings from auth.tf: the fail-closed probe passes authenticated and fails closed on wrong credentials, unauthenticated access gets NOAUTH, SCAN and out-of-ACL keys get NOPERM, and the real presence module completes heartbeat→roster→clear through the new org-scoped index without SCAN; transcripts saved as evidence and all transient test artifacts cleaned up.

<details>
<summary>Evidence: Redis auth e2e transcript (probe fail-closed + ACL enforcement on real TLS Redis)</summary>

<code>--- probe_redis.js: authenticated app user, OCTOPUS_REDIS_AUTH_ENFORCED=1 (expect exit 0) ---&#10;exit code: 0&#10;&#10;--- probe_redis.js: WRONG password (expect fail-closed, exit 1) ---&#10;exit code: 1&#10;&#10;--- unauthenticated client GET (default user disabled; expect NOAUTH) ---&#10;NOAUTH Authentication required.&#10;&#10;--- app user attempts SCAN (removed from presence; expect NOPERM) ---&#10;NOPERM User oct-e2e-app has no permissions to run the &#39;scan&#39; command&#10;&#10;--- app user attempts key outside ACL bounds (expect NOPERM) ---&#10;NOPERM No permissions to access a key</code>

```text
=== SEC-10 Redis auth end-to-end (real Redis 7.4, TLS, RBAC from auth.tf) ===

ACL applied (exact ElastiCache access strings from terraform/modules/aws/elasticache-redis/auth.tf):
user default off nopass sanitize-payload ~* &* -@all
user e2e-admin on sanitize-payload #3318c5bd024666d25fd949ac7a79436be47c73159e5de8298c360ae6159392d8 ~* &* +@all
user oct-e2e-app on sanitize-payload #adb97d45b08e5ebae47f4e57be906427d44bf7bf5a0ea04fefd1b109135574db resetchannels -@all +info (~rl:invite:user:* ~rl:invite:org:* ~rl:avatar-upload:* resetchannels -@all +incr +expire +ttl) (~mx:v1:* resetchannels -@all +get +set) (~presence:* resetchannels -@all +set +del +expire +mget +zadd +zrem +zremrangebyscore +zrangebyscore) (~gh:install:state:jti:* resetchannels -@all +set) (resetchannels &octopus:cancel &octopus:probe -@all +publish +subscribe)

--- probe_redis.js: authenticated app user, OCTOPUS_REDIS_AUTH_ENFORCED=1 (expect exit 0) ---
exit code: 0

--- probe_redis.js: WRONG password (expect fail-closed, exit 1) ---
exit code: 1

--- unauthenticated client GET (default user disabled; expect NOAUTH) ---
NOAUTH Authentication required.


--- app user attempts SCAN (removed from presence; expect NOPERM) ---
NOPERM User oct-e2e-app has no permissions to run the 'scan' command


--- app user attempts key outside ACL bounds (expect NOPERM) ---
NOPERM No permissions to access a key
```
</details>
<details>
<summary>Evidence: Live presence flow transcript (real presence.ts + ioredis under least-privilege ACL, no SCAN)</summary>

<code>[e2e] roster after 2 heartbeats: [ {&#34;userId&#34;: &#34;alice&#34;, &#34;currentActivity&#34;: &#34;reviewing&#34;, ...}, {&#34;userId&#34;: &#34;bob&#34;, ...} ]&#10;[e2e] roster after clearPresence(alice): [ {&#34;userId&#34;: &#34;bob&#34;, ...} ]&#10;[e2e] SCAN and out-of-bounds SET rejected with NOPERM as expected&#10;1 pass, 0 fail</code>

```text
bun test v1.3.13 (bf2e2cec)

lib/__tests__/presence.live-e2e.test.ts:
[e2e] org=e2e-org-1786296860450
[e2e] roster after 2 heartbeats: [
  {
    "userId": "alice",
    "currentActivity": "reviewing",
    "lastSeenAt": 1786296860756
  },
  {
    "userId": "bob",
    "currentActivity": null,
    "lastSeenAt": 1786296860757
  }
]
[e2e] roster after clearPresence(alice): [
  {
    "userId": "bob",
    "currentActivity": null,
    "lastSeenAt": 1786296860757
  }
]
[e2e] SCAN and out-of-bounds SET rejected with NOPERM as expected

 1 pass
 0 fail
 6 expect() calls
Ran 1 test across 1 file. [999.00ms]
```
</details>
<details>
<summary>Evidence: Terraform security tests (module + stack)</summary>

```text
terraform/modules/aws/elasticache-redis: tests/security.tftest.hcl — 11 passed, 0 failed (preflight_keeps_legacy_default_and_proves_password_auth, enforced_disables_passwordless_default_and_supports_dual_password_rotation, cloudformation_role_is_narrow_and_secret_safe, ...)
terraform/stacks/aws-ec2: network_trust + origin_tls — 22 passed, 0 failed (incl. redis_auth_enforcement_requires_runtime_secret_delivery, redis_auth_enforcement_requires_authenticated_runtime_acknowledgement)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ℹ️ `terraform/modules/aws/elasticache-redis/auth.tf:192` - First-ever apply of aws_cloudformation_stack.redis_auth can fail transiently (IAM propagation of the just-created execution role, or a bad secret version ID). Because the create fails, the stack lands in ROLLBACK_COMPLETE without being recorded in Terraform state, and a plain re-apply then fails with AlreadyExists until the operator deletes the stack in the CloudFormation console. Worth a one-line recovery note in the README&#39;s Stage 1 instructions.
- ℹ️ `terraform/README.md:431` - README rotation step 1 says &#34;Add a new secret version without moving AWSCURRENT&#34; but doesn&#39;t say how. A plain `aws secretsmanager put-secret-value` moves AWSCURRENT immediately (runtime would render the new password before ElastiCache accepts it — fail-closed but disruptive), and the correct approach needs `--version-stages` with a custom label, since versions with no staging labels are deprecated and eligible for deletion by Secrets Manager, which would break the exact-version CloudFormation reference. Suggest adding the exact CLI incantation.
- ℹ️ `terraform/modules/aws/ec2-app/scripts/probe_redis.js:168` - The enforced-stage denial probe accepts only errors matching /^NOAUTH(\s|$)/ (and the test file explicitly forbids widening to WRONGPASS/NOPERM). This matches standard Redis behavior when the default user is disabled, but if ElastiCache surfaces anonymous rejection differently (e.g. closing the connection or a different error prefix), the probe fails and blocks the SSM association — fail-closed, not a security hole, but confirm the actual rejection string during the first real Stage 2 apply.
- ℹ️ `terraform/modules/aws/elasticache-redis/variables.tf:50` - New hard validations on pre-existing module variables (name_prefix must now be lowercase/hyphen-bounded, engine_version must be Redis OSS &gt;= 7) will fail plans for any existing deployment using an uppercase prefix or Redis 6.x, forcing a rename/upgrade before this change can be applied. Deliberate fail-closed design (ACL selectors require 7.0), but operators of older stacks hit a plan-time wall with no migration note in the README.

🔧 Fix: document staged Redis secret rotation CLI and cutover cautions
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun test lib/__tests__/presence.test.ts lib/__tests__/terraform-redis-auth-security.test.ts lib/__tests__/terraform-redis-probe.test.ts lib/__tests__/terraform-runtime-env-renderer.test.ts lib/__tests__/terraform-runtime-secret-refresh.test.ts lib/__tests__/terraform-runtime-secrets-security.test.ts` — 48 pass, 0 fail</code>
- <code>`terraform test` in terraform/modules/aws/elasticache-redis — 11 pass (preflight/enforced stages, dual-password rotation, narrow CFN role, cross-region/KMS/Redis-6 rejections)</code>
- <code>`terraform test` in terraform/stacks/aws-ec2 — 22 pass (network_trust.tftest.hcl incl. redis_auth_enforcement_requires_runtime_secret_delivery and verified-runtime acknowledgement gates, origin_tls.tftest.hcl)</code>
- <code>Live e2e: Redis 7.4 in Docker with TLS, ACL users created from the exact ElastiCache access strings in auth.tf (app user + disabled passwordless default); ran `OCTOPUS_REDIS_PROBE_RUN=1 OCTOPUS_REDIS_AUTH_ENFORCED=1 node probe_redis.js` → exit 0 with correct creds, exit 1 with wrong password; unauthenticated GET → NOAUTH; app user SCAN → NOPERM; out-of-bounds SET → NOPERM</code>
- <code>Live e2e: real `presence.ts` with the real ioredis client from `@/lib/redis` (rediss:// URL, restricted ACL user) — recordPresence for two users, getOnlinePresence roster via org-scoped zset index, clearPresence removal, plus NOPERM assertions for SCAN and foreign keys (temporary bun test, removed after run)</code>
- <code>Negative-constraint checks: verified auth.tf passes passwords to CloudFormation only as {{resolve:secretsmanager:...:version}} references, and `git diff --stat` shows no changes to deploy.sh, infra/, or docker-compose (WDC deployment untouched)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `.github/workflows/ci.yml:64` - CI terraform job does not cover the elasticache-redis module: `.github/workflows/ci.yml` fmt-checks only bootstrap/aws-state, modules/aws/ec2-app, modules/aws/rds-postgres, and stacks/aws-ec2, and `terraform -chdir=terraform/stacks/aws-ec2 test` does not execute module-level test files. This change added ~300 lines of HCL (auth.tf, variables.tf) and a new tests/security.tftest.hcl to terraform/modules/aws/elasticache-redis that CI never fmt-checks or runs. Suggest adding `terraform fmt -check terraform/modules/aws/elasticache-redis` and a `terraform test` step for the module; left unapplied because extending the CI pipeline is beyond a safe mechanical lint fix.

🔧 Fix: add elasticache-redis fmt and test coverage to CI
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
