### PR TITLE
fix(auth): enforce ban at session creation, not just page render

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -76,16 +76,25 @@ export async function POST(request: Request) {
     return new Response("Missing message or orgId", { status: 400 });
   }
 
-  // Verify org membership
+  // Verify org membership. Defense in depth: banned users can't mint sessions
+  // (session-guard.ts), but a session issued before the ban that escaped the
+  // ban-time session purge must not keep this endpoint open either.
   const membership = await prisma.organizationMember.findFirst({
     where: {
       organizationId: orgId,
       userId: session.user.id,
       deletedAt: null,
     },
+    include: {
+      user: { select: { bannedAt: true } },
+      organization: { select: { bannedAt: true } },
+    },
   });
   if (!membership) {
     return new Response("Not a member of this organization", { status: 403 });
+  }
+  if (membership.user.bannedAt || membership.organization.bannedAt) {
+    return new Response("Account suspended", { status: 403 });
   }
 
   // Get or create conversation — shared chats allow any org member

--- a/apps/web/lib/__tests__/session-guard.test.ts
+++ b/apps/web/lib/__tests__/session-guard.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Locks the ban-enforcement property: a banned user cannot mint a new session
+// (the admin ban deletes existing sessions; this guard closes the re-login
+// hole that would otherwise leave API routes like /api/chat usable).
+
+type UserRow = { email: string; bannedAt: Date | null } | null;
+
+let userRow: UserRow;
+const auditCalls: Array<Record<string, unknown>> = [];
+
+mock.module("server-only", () => ({}));
+mock.module("@octopus/db", () => ({
+  prisma: {
+    user: { findUnique: mock(() => Promise.resolve(userRow)) },
+  },
+}));
+mock.module("../audit", () => ({
+  writeAuditLog: mock((entry: Record<string, unknown>) => {
+    auditCalls.push(entry);
+    return Promise.resolve();
+  }),
+}));
+
+// Static imports are hoisted above the mock.module calls, which would evaluate
+// session-guard (and its "server-only" / prisma imports) before the mocks are
+// registered. A dynamic import after the mocks fixes the ordering.
+const { assertUserNotBanned } = await import("../session-guard");
+const { APIError } = await import("better-auth/api");
+
+describe("assertUserNotBanned", () => {
+  beforeEach(() => {
+    userRow = { email: "user@example.com", bannedAt: null };
+    auditCalls.length = 0;
+  });
+
+  it("allows a non-banned user", async () => {
+    await expect(assertUserNotBanned("u1")).resolves.toBeUndefined();
+    expect(auditCalls).toHaveLength(0);
+  });
+
+  it("throws FORBIDDEN for a banned user and audit-logs the attempt", async () => {
+    userRow = { email: "abuser@example.com", bannedAt: new Date() };
+    let thrown: unknown;
+    try {
+      await assertUserNotBanned("u2");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(APIError);
+    expect(auditCalls).toHaveLength(1);
+    expect(auditCalls[0].action).toBe("auth.login_blocked");
+  });
+
+  it("allows when the user row is missing (nothing to enforce)", async () => {
+    userRow = null;
+    await expect(assertUserNotBanned("ghost")).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -9,6 +9,7 @@ import { renderEmailTemplate } from "./email-renderer";
 import { enqueueAfter } from "./queue";
 import { reasonToMessage, validateEmailForSignup } from "./email-validator";
 import { normalizeEmail } from "./email-normalize";
+import { assertUserNotBanned } from "./session-guard";
 
 // Email/password sign-in + sign-up (and the first-boot admin seed) are a
 // self-hosted opt-in. On the multi-tenant SaaS, sign-in is OAuth + magic-link.
@@ -88,6 +89,9 @@ export const auth = betterAuth({
   databaseHooks: {
     session: {
       create: {
+        before: async (session) => {
+          await assertUserNotBanned(session.userId);
+        },
         after: async (session) => {
           const user = await prisma.user.findUnique({
             where: { id: session.userId },

--- a/apps/web/lib/session-guard.ts
+++ b/apps/web/lib/session-guard.ts
@@ -1,0 +1,35 @@
+import "server-only";
+import { APIError } from "better-auth/api";
+import { prisma } from "@octopus/db";
+import { writeAuditLog } from "./audit";
+
+/**
+ * Session-creation gate: a banned user must not be able to mint a new session.
+ *
+ * The admin ban deletes all existing sessions, but without this hook the user
+ * could simply sign back in — pages are guarded by the (app) layout redirect,
+ * while API routes (e.g. /api/chat) only require a valid session, so a fresh
+ * login would let a banned user keep consuming the API. Blocking at session
+ * creation covers every current and future route in one place.
+ */
+export async function assertUserNotBanned(userId: string): Promise<void> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { email: true, bannedAt: true },
+  });
+
+  if (!user?.bannedAt) return;
+
+  await writeAuditLog({
+    action: "auth.login_blocked",
+    category: "auth",
+    actorId: userId,
+    actorEmail: user.email,
+    targetType: "user",
+    targetId: userId,
+    metadata: { reason: "banned" },
+  });
+  throw new APIError("FORBIDDEN", {
+    message: "This account has been suspended.",
+  });
+}


### PR DESCRIPTION
## Problem

Banning a user (admin ban toggle) deletes their existing sessions, but nothing prevented them from signing straight back in. `bannedAt` was only enforced by the `(app)` layout redirect — API routes like `/api/chat` require nothing beyond a valid session, so a banned user could re-authenticate via OAuth and keep consuming the API. Observed in the wild: a user driving `/api/chat` from an external roleplay frontend (LLM-proxy abuse burning platform credits); a ban would not have stopped them.

## Fix

- **`lib/session-guard.ts` (new):** `assertUserNotBanned()` — wired into the better-auth `session.create.before` hook. A banned user cannot mint a session at all, which covers every page and API route, present and future, in one place. Attempts are audit-logged (`auth.login_blocked`) and rejected with `FORBIDDEN`.
- **`/api/chat`:** defense-in-depth `bannedAt` check on both the user and the org (folded into the existing membership query, no extra round trip) for any session that predates a ban and escaped the purge.

## Tests

`session-guard.test.ts` (bun:test, mocked `@octopus/db` per repo convention): non-banned passes, banned throws `APIError` + audit-logs, missing user row passes. Full suite green: 897 pass / 0 fail; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)