### PR TITLE
feat(billing): volume-bonus promo on credit top-ups + dashboard entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Buying credits now earns a volume bonus: a $100 top-up lands $150 in credit, and larger top-ups earn more (up to 70%). A "Buy Credits" shortcut now sits on the dashboard, and the amount you'll receive — bonus included — is shown before you pay.
+
 ## [1.0.106] - 2026-08-09
 
 ### Security

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -21,6 +21,7 @@ import { SyncReposButton } from "@/components/sync-repos-button";
 import { KpiFilters } from "@/components/dashboard/kpi-filters";
 import { ProvidersBanner } from "@/components/dashboard/providers-banner";
 import { OnboardingTips } from "@/components/dashboard/onboarding-tips";
+import { BuyCreditsButton } from "@/components/dashboard/buy-credits-button";
 
 // --- Constants ---
 
@@ -494,10 +495,15 @@ export default async function DashboardPage({
 
   return (
     <div className="mx-auto max-w-6xl p-6 md:p-10">
-      <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
-      <p className="text-muted-foreground mt-1 text-sm">
-        Overview of your repositories and integrations.
-      </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Overview of your repositories and integrations.
+          </p>
+        </div>
+        <BuyCreditsButton />
+      </div>
 
       {(!githubConnected || !bitbucketConnected || !gitlabConnected) && !bannerDismissed && (
         <ProvidersBanner

--- a/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
+++ b/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
@@ -18,7 +18,7 @@ import {
 import { purchaseCredits } from "./actions";
 import { volumeBonusUsd } from "@/lib/plans";
 
-const PRESETS = [10, 25, 50, 100];
+const PRESETS = [50, 100, 250, 500];
 
 export function PurchaseDialog({
   open,
@@ -66,25 +66,35 @@ export function PurchaseDialog({
         <DialogHeader>
           <DialogTitle>Purchase Credits</DialogTitle>
           <DialogDescription>
-            Select an amount or enter a custom value. Credits are non-refundable.
+            Buy more, get more — up to 70% bonus credits. Select an amount or
+            enter a custom value. Credits are non-refundable.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
           <div className="grid grid-cols-4 gap-2">
-            {PRESETS.map((preset) => (
-              <Button
-                key={preset}
-                variant={amount === preset ? "default" : "outline"}
-                size="sm"
-                onClick={() => {
-                  setAmount(preset);
-                  setError(null);
-                }}
-              >
-                ${preset}
-              </Button>
-            ))}
+            {PRESETS.map((preset) => {
+              const pct = Math.round((volumeBonusUsd(preset) / preset) * 100);
+              return (
+                <Button
+                  key={preset}
+                  variant={amount === preset ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => {
+                    setAmount(preset);
+                    setError(null);
+                  }}
+                  className="flex h-auto flex-col gap-0.5 py-2"
+                >
+                  <span>${preset}</span>
+                  {pct > 0 && (
+                    <span className="text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                      +{pct}%
+                    </span>
+                  )}
+                </Button>
+              );
+            })}
           </div>
 
           <div className="space-y-2">
@@ -128,7 +138,11 @@ export function PurchaseDialog({
             disabled={pending || !amount}
             className="w-full"
           >
-            {pending ? "Processing…" : `Purchase $${amount || 0} Credits`}
+            {pending
+              ? "Processing…"
+              : typeof amount === "number" && volumeBonusUsd(amount) > 0
+                ? `Pay $${amount} → get $${(amount + volumeBonusUsd(amount)).toFixed(2)} credit`
+                : `Purchase $${amount || 0} Credits`}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/components/dashboard/buy-credits-button.tsx
+++ b/apps/web/components/dashboard/buy-credits-button.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState } from "react";
+import { IconCoin } from "@tabler/icons-react";
+import { Button } from "@/components/ui/button";
+import { PurchaseDialog } from "@/app/(app)/settings/billing/purchase-dialog";
+
+// Discoverable top-up entry point for the dashboard header. Opens the same
+// purchase dialog used on the billing page (which shows the volume bonus), so
+// buying credits never requires digging into Settings → Billing.
+export function BuyCreditsButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        <IconCoin className="mr-1.5 size-4" />
+        Buy Credits
+        <span className="ml-2 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+          up to 70% bonus
+        </span>
+      </Button>
+      <PurchaseDialog open={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/apps/web/lib/__tests__/volume-bonus.test.ts
+++ b/apps/web/lib/__tests__/volume-bonus.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "bun:test";
+import { volumeBonusUsd } from "../plans";
+
+describe("volumeBonusUsd (promotional tiers)", () => {
+  it("gives 50% at $100 — the headline $150-for-$100 deal", () => {
+    expect(volumeBonusUsd(100)).toBe(50);
+    expect(100 + volumeBonusUsd(100)).toBe(150);
+  });
+
+  it("scales up: 60% at $250, 70% at $500 (highest matching tier wins)", () => {
+    expect(volumeBonusUsd(250)).toBe(150); // $250 -> $400
+    expect(volumeBonusUsd(500)).toBe(350); // $500 -> $850
+    expect(volumeBonusUsd(1000)).toBe(700); // caps at the top tier's rate
+  });
+
+  it("no bonus below the $100 floor", () => {
+    expect(volumeBonusUsd(50)).toBe(0);
+    expect(volumeBonusUsd(99)).toBe(0);
+  });
+
+  it("guards invalid input", () => {
+    expect(volumeBonusUsd(0)).toBe(0);
+    expect(volumeBonusUsd(-10)).toBe(0);
+    expect(volumeBonusUsd(NaN)).toBe(0);
+  });
+});

--- a/apps/web/lib/plans.ts
+++ b/apps/web/lib/plans.ts
@@ -18,12 +18,15 @@ export function isPaidPlanTier(tier: string): tier is PaidPlanTier {
 
 /**
  * Volume bonus on one-off credit top-ups: pay $N, get bonus credits on top.
- * Rates are kept below the subscription per-dollar bonus (10–16%) so a
- * recurring plan stays the better deal. Highest matching tier wins.
+ * Promotional rates (buy more, get more) — buying $100 lands $150 in credit.
+ * These sit ABOVE the subscription per-dollar bonus, so top-ups are the
+ * headline deal; all tiers stay margin-positive at the current PLATFORM_MARKUP.
+ * Highest matching tier wins.
  */
 export const VOLUME_BONUS_TIERS = [
-  { minUsd: 500, rate: 0.1 },
-  { minUsd: 100, rate: 0.05 },
+  { minUsd: 500, rate: 0.7 },
+  { minUsd: 250, rate: 0.6 },
+  { minUsd: 100, rate: 0.5 },
 ] as const;
 
 /** Bonus credits (USD, rounded to cents) granted for a top-up of `amountUsd`. */


### PR DESCRIPTION
## What & why

Now that `PLATFORM_MARKUP` gives margin room, turn credit top-ups into a compelling offer and make buying discoverable.

**Promo (tiered volume bonus):** raise `VOLUME_BONUS_TIERS` so a top-up earns bonus credit — $100 → **$150** (50%), $250 → **$400** (60%), $500 → **$850** (70%). Highest matching tier wins; nothing below $100. The bonus plumbing (`volumeBonusUsd` → `addFreeCredits`, keyed on the PaymentIntent so it grants once) already existed — this only changes the rates.

**Margin:** all tiers stay positive at the current markup (roughly 25% / 20% / 15% at the $100 / $250 / $500 tiers). Note this is intentionally *above* the subscription per-dollar bonus, so top-ups are the headline deal.

**Discoverability:** a "Buy Credits" button (with an "up to 70% bonus" hint) now sits in the dashboard header and opens the **existing** purchase dialog in place — no more digging into Settings → Billing. The modal presets now cover the bonus tiers and each shows its bonus %, and the confirm button shows the total credit (bonus included) before paying.

## Files
- `lib/plans.ts` — new tiers + updated doc comment.
- `settings/billing/purchase-dialog.tsx` — presets `[50,100,250,500]`, per-tile bonus %, description + confirm-button copy.
- `components/dashboard/buy-credits-button.tsx` (new) — client entry rendering `PurchaseDialog`.
- `dashboard/page.tsx` — header now holds the button.
- `lib/__tests__/volume-bonus.test.ts` (new).

## Verification
- `bun test lib/__tests__/volume-bonus.test.ts` — tiers, highest-tier-wins, $100 floor, bad input (4/4).
- `tsc --noEmit` (0 errors) + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p
