### PR TITLE
fix(billing): show saved card in purchase dialog + fix bonus-badge contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The Purchase Credits dialog now shows which saved card will be charged, and the bonus percentage on the selected amount is legible again (it was green-on-green when highlighted).
+
 ## [1.0.107] - 2026-08-09
 
 ### Added

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -22,6 +22,7 @@ import { KpiFilters } from "@/components/dashboard/kpi-filters";
 import { ProvidersBanner } from "@/components/dashboard/providers-banner";
 import { OnboardingTips } from "@/components/dashboard/onboarding-tips";
 import { BuyCreditsButton } from "@/components/dashboard/buy-credits-button";
+import { getCustomerPaymentMethods } from "@/lib/stripe";
 
 // --- Constants ---
 
@@ -127,6 +128,7 @@ export default async function DashboardPage({
         select: {
           id: true,
           githubInstallationId: true,
+          stripeCustomerId: true,
           repositories: {
             where: { isActive: true },
             select: {
@@ -174,6 +176,15 @@ export default async function DashboardPage({
   const org = member.organization;
   const repos = org.repositories;
   const totalRepos = repos.length;
+
+  // Saved card for the Buy Credits dialog. Guarded: only orgs with a Stripe
+  // customer pay the lookup, and getCustomerPaymentMethods returns [] on error.
+  const cards = org.stripeCustomerId
+    ? await getCustomerPaymentMethods(org.stripeCustomerId)
+    : [];
+  const defaultCard = cards[0]
+    ? { brand: cards[0].brand, last4: cards[0].last4 }
+    : null;
   const indexedRepos = repos.filter((r) => r.indexStatus === "indexed").length;
   const notIndexedRepos = totalRepos - indexedRepos;
   const githubConnected = org.githubInstallationId !== null;
@@ -502,7 +513,7 @@ export default async function DashboardPage({
             Overview of your repositories and integrations.
           </p>
         </div>
-        <BuyCreditsButton />
+        <BuyCreditsButton card={defaultCard} />
       </div>
 
       {(!githubConnected || !bitbucketConnected || !gitlabConnected) && !bannerDismissed && (

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -833,7 +833,11 @@ export function BillingSettings({
         </CardContent>
       </Card>
 
-      <PurchaseDialog open={purchaseOpen} onOpenChange={setPurchaseOpen} />
+      <PurchaseDialog
+        open={purchaseOpen}
+        onOpenChange={setPurchaseOpen}
+        card={paymentMethods[0] ?? null}
+      />
       <CardSetupDialog
         open={cardOpen}
         onOpenChange={setCardOpen}

--- a/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
+++ b/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
@@ -23,9 +23,12 @@ const PRESETS = [50, 100, 250, 500];
 export function PurchaseDialog({
   open,
   onOpenChange,
+  card,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Saved card to charge. `null` = none on file; omit if unknown. */
+  card?: { brand: string; last4: string } | null;
 }) {
   const router = useRouter();
   const [amount, setAmount] = useState<number | "">(25);
@@ -88,7 +91,13 @@ export function PurchaseDialog({
                 >
                   <span>${preset}</span>
                   {pct > 0 && (
-                    <span className="text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                    <span
+                      className={`text-[10px] font-medium ${
+                        amount === preset
+                          ? "text-primary-foreground/80"
+                          : "text-emerald-600 dark:text-emerald-400"
+                      }`}
+                    >
                       +{pct}%
                     </span>
                   )}
@@ -128,6 +137,19 @@ export function PurchaseDialog({
               {(amount + volumeBonusUsd(amount)).toFixed(2)} total.
             </p>
           )}
+
+          {card ? (
+            <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2 text-sm">
+              <span className="text-muted-foreground">Payment method</span>
+              <span className="font-medium capitalize">
+                {card.brand} •••• {card.last4}
+              </span>
+            </div>
+          ) : card === null ? (
+            <p className="text-xs text-muted-foreground">
+              You&apos;ll enter your card securely at checkout.
+            </p>
+          ) : null}
 
           {error && <p className="text-sm text-destructive">{error}</p>}
         </div>

--- a/apps/web/components/dashboard/buy-credits-button.tsx
+++ b/apps/web/components/dashboard/buy-credits-button.tsx
@@ -8,7 +8,11 @@ import { PurchaseDialog } from "@/app/(app)/settings/billing/purchase-dialog";
 // Discoverable top-up entry point for the dashboard header. Opens the same
 // purchase dialog used on the billing page (which shows the volume bonus), so
 // buying credits never requires digging into Settings → Billing.
-export function BuyCreditsButton() {
+export function BuyCreditsButton({
+  card,
+}: {
+  card?: { brand: string; last4: string } | null;
+}) {
   const [open, setOpen] = useState(false);
   return (
     <>
@@ -19,7 +23,7 @@ export function BuyCreditsButton() {
           up to 70% bonus
         </span>
       </Button>
-      <PurchaseDialog open={open} onOpenChange={setOpen} />
+      <PurchaseDialog open={open} onOpenChange={setOpen} card={card} />
     </>
   );
 }


### PR DESCRIPTION
Two fixes to the Purchase Credits dialog (from the recent promo work):

1. **Card details** — adds a "Payment method" row showing the saved card (brand + last4) that will be charged, like standard checkouts. Passed from `billing-settings` (already loads `paymentMethods`); on the dashboard button it's fetched via `getCustomerPaymentMethods`, **guarded** so only orgs with a `stripeCustomerId` pay the lookup (returns [] on error). When there's no card on file it shows "you'll enter your card at checkout".
2. **Badge contrast** — the per-tile bonus badge (+50/60/70%) was emerald text on the selected tile's filled green background (green-on-green). It now uses `text-primary-foreground` when selected, staying legible in both states.

Verified: `tsc --noEmit` (0) + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sw857BT1epi8Hfi11Y26p