### PR TITLE
feat(billing): add usage and spend limits dashboard with production-safe auto-reload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
     env:
       DATABASE_URL: "postgresql://octopus:octopus@localhost:5432/octopus_agent_task_test"
       RUN_AGENT_TASK_DB_TESTS: "1"
+      RUN_BILLING_DB_TESTS: "1"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -126,4 +127,8 @@ jobs:
 
       - name: Test agent task ownership against PostgreSQL
         run: bun test lib/__tests__/agent-task-security.db.test.ts
+        working-directory: apps/web
+
+      - name: Test billing auto-reload invariants against PostgreSQL
+        run: bun test lib/__tests__/billing.db.test.ts
         working-directory: apps/web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Billing now shows monthly AI usage, the configured spend limit, remaining allowance, reset date, current credit balance, and auto-reload status in one responsive overview.
+
+### Fixed
+- Auto-reload can now be turned off reliably, ignores refund deductions, prevents concurrent duplicate charges, and recovers interrupted charges through Stripe webhooks and scheduled reconciliation.
+- Existing auto-reload settings are paused once during the durable-payment upgrade; owners must review and re-enable them from Billing after deployment.
+
 ## [1.0.109] - 2026-08-10
 
 ## [1.0.108] - 2026-08-10

--- a/apps/web/app/(app)/settings/billing/actions.ts
+++ b/apps/web/app/(app)/settings/billing/actions.ts
@@ -293,16 +293,30 @@ export async function updateAutoReload(
     }
   }
 
-  const savedThreshold = Number.isFinite(thresholdAmount)
+  const thresholdValid = Number.isFinite(thresholdAmount)
     && thresholdAmount >= 1
-    && thresholdAmount <= 1000
-    ? thresholdAmount
-    : 10;
-  const savedReload = Number.isFinite(reloadAmount)
+    && thresholdAmount <= 1000;
+  const reloadValid = Number.isFinite(reloadAmount)
     && reloadAmount >= 5
-    && reloadAmount <= 1000
-    ? reloadAmount
-    : 50;
+    && reloadAmount <= 1000;
+  let savedThreshold = thresholdValid ? thresholdAmount : 10;
+  let savedReload = reloadValid ? reloadAmount : 50;
+  if (!thresholdValid || !reloadValid) {
+    const existing = await prisma.autoReloadConfig.findUnique({
+      where: { organizationId: result.orgId },
+      select: { thresholdAmount: true, reloadAmount: true },
+    });
+    if (existing) {
+      const storedThreshold = Number(existing.thresholdAmount);
+      const storedReload = Number(existing.reloadAmount);
+      if (!thresholdValid && Number.isFinite(storedThreshold)) {
+        savedThreshold = Math.min(Math.max(storedThreshold, 1), 1000);
+      }
+      if (!reloadValid && Number.isFinite(storedReload)) {
+        savedReload = Math.min(Math.max(storedReload, 5), 1000);
+      }
+    }
+  }
   try {
     await updateAutoReloadConfigDurably(
       result.orgId,

--- a/apps/web/app/(app)/settings/billing/actions.ts
+++ b/apps/web/app/(app)/settings/billing/actions.ts
@@ -8,11 +8,16 @@ import { prisma } from "@octopus/db";
 import {
   createCheckoutSession,
   createSubscriptionCheckoutSession,
+  getOffSessionPaymentMethodId,
   getOrCreateStripeCustomer,
   getStripe,
 } from "@/lib/stripe";
 import { SUBSCRIPTION_PLANS, isPaidPlanTier } from "@/lib/plans";
-import { chargeCreditsOffSession } from "@/lib/credits";
+import {
+  chargeCreditsOffSession,
+  rearmAutoReloadAfterPaymentMethodChange,
+  updateAutoReloadConfigDurably,
+} from "@/lib/credits";
 import { chargeSubscription, grantSubscriptionPeriod, addOneMonth } from "@/lib/subscription";
 
 async function getOwnerOrgId(): Promise<{ orgId: string } | { error: string }> {
@@ -42,7 +47,7 @@ async function getOwnerOrgId(): Promise<{ orgId: string } | { error: string }> {
 export async function purchaseCredits(
   amount: number,
 ): Promise<{ url?: string; success?: boolean; error?: string }> {
-  if (typeof amount !== "number" || amount < 5 || amount > 1000) {
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount < 5 || amount > 1000) {
     return { error: "Amount must be between $5 and $1,000." };
   }
 
@@ -167,6 +172,15 @@ export async function finalizeCardSetup(
       console.error("[billing] finalizeCardSetup: detaching old cards failed (non-fatal):", err);
     }
 
+    try {
+      await rearmAutoReloadAfterPaymentMethodChange(result.orgId);
+    } catch (err) {
+      console.error("[billing] finalizeCardSetup: auto-reload rearm failed:", err);
+      return {
+        error: "Card saved, but auto-reload could not restart. Please save it again.",
+      };
+    }
+
     revalidatePath("/settings/billing");
     return { success: true };
   } catch (err) {
@@ -252,28 +266,54 @@ export async function updateAutoReload(
   const thresholdAmount = Number(formData.get("thresholdAmount"));
   const reloadAmount = Number(formData.get("reloadAmount"));
 
-  if (enabled && (isNaN(thresholdAmount) || thresholdAmount < 1)) {
-    return { error: "Threshold must be at least $1." };
+  if (enabled && (!Number.isFinite(thresholdAmount) || thresholdAmount < 1 || thresholdAmount > 1000)) {
+    return { error: "Threshold must be between $1 and $1,000." };
   }
 
-  if (enabled && (isNaN(reloadAmount) || reloadAmount < 5)) {
-    return { error: "Reload amount must be at least $5." };
+  if (enabled && (!Number.isFinite(reloadAmount) || reloadAmount < 5 || reloadAmount > 1000)) {
+    return { error: "Reload amount must be between $5 and $1,000." };
   }
 
-  await prisma.autoReloadConfig.upsert({
-    where: { organizationId: result.orgId },
-    create: {
-      organizationId: result.orgId,
+  if (enabled) {
+    const org = await prisma.organization.findUnique({
+      where: { id: result.orgId },
+      select: { stripeCustomerId: true },
+    });
+    if (!org?.stripeCustomerId) {
+      return { error: "Add a payment method before enabling auto-reload." };
+    }
+
+    try {
+      if (!(await getOffSessionPaymentMethodId(org.stripeCustomerId))) {
+        return { error: "Add a payment method before enabling auto-reload." };
+      }
+    } catch (err) {
+      console.error("[billing] could not verify auto-reload payment method:", err);
+      return { error: "Could not verify your payment method. Please try again." };
+    }
+  }
+
+  const savedThreshold = Number.isFinite(thresholdAmount)
+    && thresholdAmount >= 1
+    && thresholdAmount <= 1000
+    ? thresholdAmount
+    : 10;
+  const savedReload = Number.isFinite(reloadAmount)
+    && reloadAmount >= 5
+    && reloadAmount <= 1000
+    ? reloadAmount
+    : 50;
+  try {
+    await updateAutoReloadConfigDurably(
+      result.orgId,
       enabled,
-      thresholdAmount: thresholdAmount || 10,
-      reloadAmount: reloadAmount || 50,
-    },
-    update: {
-      enabled,
-      thresholdAmount: thresholdAmount || 10,
-      reloadAmount: reloadAmount || 50,
-    },
-  });
+      savedThreshold,
+      savedReload,
+    );
+  } catch (err) {
+    console.error("[billing] durable auto-reload update failed:", err);
+    return { error: "Could not update auto-reload. Please try again." };
+  }
 
   revalidatePath("/settings/billing");
   return { success: true };
@@ -319,7 +359,10 @@ export async function updateSpendLimit(
   const raw = formData.get("monthlySpendLimitUsd") as string;
   const monthlySpendLimitUsd = raw ? Number(raw) : null;
 
-  if (monthlySpendLimitUsd !== null && (isNaN(monthlySpendLimitUsd) || monthlySpendLimitUsd < 0)) {
+  if (
+    monthlySpendLimitUsd !== null &&
+    (!Number.isFinite(monthlySpendLimitUsd) || monthlySpendLimitUsd < 0)
+  ) {
     return { error: "Invalid spend limit." };
   }
 

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -15,6 +15,14 @@ import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   IconPlus,
   IconExternalLink,
   IconLoader2,
@@ -27,6 +35,7 @@ import {
 import { useRouter } from "next/navigation";
 import { PurchaseDialog } from "./purchase-dialog";
 import { CardSetupDialog } from "./card-setup-dialog";
+import { summarizeMonthlySpend } from "@/lib/billing-period";
 import { SUBSCRIPTION_PLANS, INVOICEABLE_TXN_TYPES } from "@/lib/plans";
 import {
   updateAutoReload,
@@ -48,7 +57,7 @@ type PaymentMethod = {
 };
 
 type Props = {
-  isOwner: boolean;
+  canManageBilling: boolean;
   orgId: string;
   creditBalance: number;
   freeCreditBalance: number;
@@ -64,18 +73,25 @@ type Props = {
   planCancelAtPeriodEnd: boolean;
   autoReloadConfig: {
     enabled: boolean;
+    pausedForDurableUpgrade: boolean;
     thresholdAmount: number;
     reloadAmount: number;
   } | null;
   initialTransactions: Transaction[];
   totalTransactions: number;
   monthlySpend: number;
+  monthlyResetLabel: string;
   paymentMethods: PaymentMethod[];
 };
 
 function formatUsd(n: number): string {
   if (Math.abs(n) < 0.01 && n !== 0) return `$${n.toFixed(4)}`;
   return `$${n.toFixed(2)}`;
+}
+
+function formatPercent(n: number): string {
+  if (n > 0 && n < 1) return "<1%";
+  return `${Math.round(n)}%`;
 }
 
 function typeBadgeVariant(type: string) {
@@ -115,7 +131,7 @@ function typeBadgeClass(type: string) {
 }
 
 export function BillingSettings({
-  isOwner,
+  canManageBilling,
   orgId,
   creditBalance,
   freeCreditBalance,
@@ -130,10 +146,12 @@ export function BillingSettings({
   initialTransactions,
   totalTransactions,
   monthlySpend,
+  monthlyResetLabel,
   paymentMethods,
 }: Props) {
   const router = useRouter();
   const [purchaseOpen, setPurchaseOpen] = useState(false);
+  const [spendLimitOpen, setSpendLimitOpen] = useState(false);
   const [cardOpen, setCardOpen] = useState(false);
   const [transactions, setTransactions] = useState(initialTransactions);
   const [hasMore, setHasMore] = useState(initialTransactions.length < totalTransactions);
@@ -153,6 +171,8 @@ export function BillingSettings({
   const [autoReloadEnabled, setAutoReloadEnabled] = useState(
     autoReloadConfig?.enabled ?? false,
   );
+  const autoReloadActive = autoReloadConfig?.enabled ?? false;
+  const autoReloadPaused = autoReloadConfig?.pausedForDurableUpgrade ?? false;
 
   const [planPending, startPlanTransition] = useTransition();
   const [planError, setPlanError] = useState<string | null>(null);
@@ -183,6 +203,10 @@ export function BillingSettings({
   };
 
   const total = creditBalance + freeCreditBalance;
+  const spendSummary = summarizeMonthlySpend(
+    monthlySpend,
+    monthlySpendLimitUsd,
+  );
 
   const handleLoadMore = async (): Promise<boolean> => {
     setLoadingMore(true);
@@ -216,37 +240,143 @@ export function BillingSettings({
 
   return (
     <div className="space-y-6">
-      {/* Card 1: Credit Balance */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Credit Balance</CardTitle>
-          <CardDescription>
-            Your organization&apos;s available credits for AI features.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 gap-4 mb-4">
-            <div className="rounded-lg border bg-muted/20 p-4">
-              <p className="text-xs text-muted-foreground mb-1">Free Credits</p>
-              <p className="text-2xl font-semibold">{formatUsd(freeCreditBalance)}</p>
+      <div className="space-y-1">
+        <h2
+          id="usage-spend-limits-heading"
+          className="text-xl font-semibold tracking-tight sm:text-2xl"
+        >
+          Usage and spend limits
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Manage your organization&apos;s AI usage charges and available credits.
+        </p>
+      </div>
+
+      <Card
+        className="gap-0 py-0"
+        role="region"
+        aria-labelledby="usage-spend-limits-heading"
+      >
+        <CardContent className="p-0">
+          <div className="space-y-4 p-4 sm:p-6">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-3xl font-semibold tracking-tight">
+                  {formatUsd(spendSummary.spendUsd)}
+                </p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Spent this month
+                  <span className="px-1.5" aria-hidden="true">
+                    ·
+                  </span>
+                  Resets {monthlyResetLabel}
+                </p>
+              </div>
+              {spendSummary.percentUsed != null ? (
+                <p
+                  className={`text-sm font-medium ${
+                    spendSummary.limitReached ? "text-destructive" : ""
+                  }`}
+                >
+                  {formatPercent(spendSummary.percentUsed)} used
+                </p>
+              ) : (
+                <Badge variant="secondary">Unlimited</Badge>
+              )}
             </div>
-            <div className="rounded-lg border bg-muted/20 p-4">
-              <p className="text-xs text-muted-foreground mb-1">
-                Purchased Credits
-              </p>
-              <p className="text-2xl font-semibold">{formatUsd(creditBalance)}</p>
-            </div>
+
+            {spendSummary.limitUsd != null &&
+              spendSummary.progressPercent != null && (
+                <div
+                  className="h-2 overflow-hidden rounded-full bg-muted"
+                  role="progressbar"
+                  aria-label="Monthly spend used"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={Math.round(spendSummary.progressPercent)}
+                  aria-valuetext={`${formatUsd(spendSummary.spendUsd)} of ${formatUsd(spendSummary.limitUsd)} used`}
+                >
+                  <div
+                    className={`h-full rounded-full ${
+                      spendSummary.limitReached
+                        ? "bg-destructive"
+                        : "bg-primary"
+                    }`}
+                    style={{ width: `${spendSummary.progressPercent}%` }}
+                  />
+                </div>
+              )}
           </div>
-          <div className="flex items-center justify-between">
+
+          <Separator />
+
+          <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between sm:p-6">
             <div>
-              <span className="text-sm text-muted-foreground">Total Balance: </span>
-              <span className="text-sm font-semibold">{formatUsd(total)}</span>
+              <p className="font-medium">
+                {spendSummary.limitUsd != null
+                  ? `${formatUsd(spendSummary.limitUsd)} monthly spend limit`
+                  : "No monthly spend limit"}
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {spendSummary.remainingUsd != null
+                  ? `${formatUsd(spendSummary.remainingUsd)} remaining this month`
+                  : "AI usage is not capped for this organization."}
+              </p>
             </div>
-            {isOwner && (
-              <Button size="sm" onClick={() => setPurchaseOpen(true)}>
-                <IconPlus className="size-4 mr-1" />
-                Purchase Credits
+            {canManageBilling && (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full sm:w-auto"
+                onClick={() => setSpendLimitOpen(true)}
+              >
+                Adjust limit
               </Button>
+            )}
+          </div>
+
+          <Separator />
+
+          <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between sm:p-6">
+            <div>
+              <p className="text-2xl font-semibold tracking-tight">
+                {formatUsd(total)}
+              </p>
+              <div className="mt-1 flex flex-wrap items-center gap-1.5 text-sm text-muted-foreground">
+                <span>Current balance</span>
+                <span aria-hidden="true">·</span>
+                <a
+                  href="#auto-reload-settings"
+                  className="font-medium text-foreground underline-offset-4 hover:underline"
+                >
+                  Auto-reload
+                </a>
+                <Badge
+                  variant={autoReloadActive ? "default" : "secondary"}
+                  className="ml-0.5"
+                >
+                  {autoReloadActive ? "On" : autoReloadPaused ? "Paused" : "Off"}
+                </Badge>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Free {formatUsd(freeCreditBalance)} · Purchased{" "}
+                {formatUsd(creditBalance)}
+              </p>
+            </div>
+            {canManageBilling && (
+              <div className="flex w-full flex-col gap-1 sm:w-auto sm:items-end">
+                <Button
+                  type="button"
+                  className="w-full sm:w-auto"
+                  onClick={() => setPurchaseOpen(true)}
+                >
+                  <IconPlus className="size-4" />
+                  Buy usage credits
+                </Button>
+                <p className="text-center text-xs text-muted-foreground sm:text-right">
+                  Up to 70% bonus credits
+                </p>
+              </div>
             )}
           </div>
         </CardContent>
@@ -284,7 +414,7 @@ export function BillingSettings({
                       {Math.round(((plan.creditsUsd - plan.priceUsd) / plan.priceUsd) * 100)}%
                       bonus over topping up).
                     </p>
-                    {isOwner && !isCurrent && (
+                    {canManageBilling && !isCurrent && (
                       <Button
                         size="sm"
                         disabled={planPending}
@@ -311,7 +441,7 @@ export function BillingSettings({
             )}
           </div>
           {planError && <p className="text-sm text-destructive mt-3">{planError}</p>}
-          {isOwner && stripeCustomerId && (
+          {canManageBilling && stripeCustomerId && (
             <div className="mt-4">
               <Button
                 variant="outline"
@@ -328,7 +458,7 @@ export function BillingSettings({
               </Button>
             </div>
           )}
-          {isOwner && planTier !== "free" && (
+          {canManageBilling && planTier !== "free" && (
             <div className="mt-4">
               {planCancelAtPeriodEnd ? (
                 <Button
@@ -352,65 +482,6 @@ export function BillingSettings({
               )}
             </div>
           )}
-        </CardContent>
-      </Card>
-
-      {/* Card 2: Usage Summary */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Usage Summary</CardTitle>
-          <CardDescription>Current month AI usage and spend limit.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-muted-foreground">
-                This month&apos;s usage
-              </span>
-              <span className="text-sm font-medium">{formatUsd(monthlySpend)}</span>
-            </div>
-            <Separator />
-            {isOwner ? (
-              <form action={spendAction} className="space-y-3">
-                <div className="space-y-2">
-                  <Label htmlFor="monthlySpendLimitUsd">
-                    Monthly Spend Limit (USD)
-                  </Label>
-                  <Input
-                    id="monthlySpendLimitUsd"
-                    name="monthlySpendLimitUsd"
-                    type="number"
-                    min={0}
-                    step={1}
-                    defaultValue={monthlySpendLimitUsd ?? ""}
-                    placeholder="No limit"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Leave empty for no limit. AI features will be paused when
-                    the limit is reached.
-                  </p>
-                </div>
-                {spendState.error && (
-                  <p className="text-sm text-destructive">{spendState.error}</p>
-                )}
-                {spendState.success && (
-                  <p className="text-sm text-green-600">Spend limit updated.</p>
-                )}
-                <Button type="submit" size="sm" disabled={spendPending}>
-                  {spendPending ? "Saving..." : "Update Limit"}
-                </Button>
-              </form>
-            ) : (
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">Spend limit</span>
-                <span className="text-sm font-medium">
-                  {monthlySpendLimitUsd != null
-                    ? formatUsd(monthlySpendLimitUsd)
-                    : "No limit"}
-                </span>
-              </div>
-            )}
-          </div>
         </CardContent>
       </Card>
 
@@ -451,7 +522,7 @@ export function BillingSettings({
                 No saved payment methods.
               </p>
             )}
-            {isOwner && (
+            {canManageBilling && (
               <div className="flex flex-wrap gap-2">
                 <Button variant="outline" size="sm" onClick={() => setCardOpen(true)}>
                   <IconCreditCard className="size-4 mr-1" />
@@ -716,9 +787,19 @@ export function BillingSettings({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
+          {autoReloadPaused && (
+            <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+              Auto-reload was paused during the billing safety upgrade. Review
+              the amounts and save to re-enable it.
+            </div>
+          )}
           {/* Auto-reload */}
-          <form action={autoReloadAction} className="space-y-4">
-            <div className="flex items-center justify-between">
+          <form
+            id="auto-reload-settings"
+            action={autoReloadAction}
+            className="scroll-mt-6 space-y-4"
+          >
+            <div className="flex items-center justify-between gap-4">
               <div>
                 <Label>Auto-Reload</Label>
                 <p className="text-xs text-muted-foreground">
@@ -728,13 +809,28 @@ export function BillingSettings({
               <Switch
                 checked={autoReloadEnabled}
                 onCheckedChange={(checked) => setAutoReloadEnabled(checked)}
-                disabled={!isOwner}
+                disabled={!canManageBilling}
+                aria-label="Enable auto-reload"
               />
             </div>
             <input type="hidden" name="enabled" value={String(autoReloadEnabled)} />
+            {!autoReloadEnabled && (
+              <>
+                <input
+                  type="hidden"
+                  name="thresholdAmount"
+                  value={autoReloadConfig?.thresholdAmount ?? 10}
+                />
+                <input
+                  type="hidden"
+                  name="reloadAmount"
+                  value={autoReloadConfig?.reloadAmount ?? 50}
+                />
+              </>
+            )}
 
             {autoReloadEnabled && (
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
                   <Label htmlFor="thresholdAmount">
                     When balance falls below
@@ -748,9 +844,10 @@ export function BillingSettings({
                       name="thresholdAmount"
                       type="number"
                       min={1}
+                      max={1000}
                       step={1}
                       defaultValue={autoReloadConfig?.thresholdAmount ?? 10}
-                      disabled={!isOwner}
+                      disabled={!canManageBilling}
                       className="pl-7"
                     />
                   </div>
@@ -766,9 +863,10 @@ export function BillingSettings({
                       name="reloadAmount"
                       type="number"
                       min={5}
+                      max={1000}
                       step={1}
                       defaultValue={autoReloadConfig?.reloadAmount ?? 50}
-                      disabled={!isOwner}
+                      disabled={!canManageBilling}
                       className="pl-7"
                     />
                   </div>
@@ -785,13 +883,17 @@ export function BillingSettings({
               <p className="text-sm text-green-600">Auto-reload updated.</p>
             )}
 
-            {autoReloadEnabled && (
+            {canManageBilling && (
               <Button
                 type="submit"
                 size="sm"
-                disabled={autoReloadPending || !isOwner}
+                disabled={autoReloadPending}
               >
-                {autoReloadPending ? "Saving..." : "Save Auto-Reload"}
+                {autoReloadPending
+                  ? "Saving..."
+                  : !autoReloadEnabled && autoReloadConfig?.enabled
+                    ? "Turn Off Auto-Reload"
+                    : "Save Auto-Reload"}
               </Button>
             )}
           </form>
@@ -807,7 +909,7 @@ export function BillingSettings({
                 name="billingEmail"
                 type="email"
                 defaultValue={billingEmail ?? ""}
-                disabled={!isOwner}
+                disabled={!canManageBilling}
                 placeholder="billing@company.com"
               />
               <p className="text-xs text-muted-foreground">
@@ -820,18 +922,76 @@ export function BillingSettings({
             {emailState.success && (
               <p className="text-sm text-green-600">Billing email updated.</p>
             )}
-            <Button type="submit" size="sm" disabled={emailPending || !isOwner}>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={emailPending || !canManageBilling}
+            >
               {emailPending ? "Saving..." : "Update Email"}
             </Button>
           </form>
 
-          {!isOwner && (
+          {!canManageBilling && (
             <p className="text-muted-foreground text-center text-xs">
               Only owners and admins can manage billing settings.
             </p>
           )}
         </CardContent>
       </Card>
+
+      <Dialog open={spendLimitOpen} onOpenChange={setSpendLimitOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Adjust monthly spend limit</DialogTitle>
+            <DialogDescription>
+              Set the maximum monthly platform-billed AI usage. Leave the field
+              empty for no limit.
+            </DialogDescription>
+          </DialogHeader>
+          <form action={spendAction} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="monthlySpendLimitUsd">
+                Monthly Spend Limit (USD)
+              </Label>
+              <Input
+                id="monthlySpendLimitUsd"
+                name="monthlySpendLimitUsd"
+                type="number"
+                min={0}
+                step={1}
+                defaultValue={monthlySpendLimitUsd ?? ""}
+                placeholder="No limit"
+              />
+              <p className="text-xs text-muted-foreground">
+                AI features using platform credits pause when this limit is
+                reached.
+              </p>
+            </div>
+            {spendState.error && (
+              <p className="text-sm text-destructive" role="alert">
+                {spendState.error}
+              </p>
+            )}
+            {spendState.success && (
+              <p className="text-sm text-green-600" aria-live="polite">
+                Spend limit updated.
+              </p>
+            )}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setSpendLimitOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={spendPending}>
+                {spendPending ? "Saving..." : "Save limit"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
 
       <PurchaseDialog
         open={purchaseOpen}

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -35,7 +35,10 @@ import {
 import { useRouter } from "next/navigation";
 import { PurchaseDialog } from "./purchase-dialog";
 import { CardSetupDialog } from "./card-setup-dialog";
-import { summarizeMonthlySpend } from "@/lib/billing-period";
+import {
+  getAutoReloadDisplayStatus,
+  summarizeMonthlySpend,
+} from "@/lib/billing-period";
 import { SUBSCRIPTION_PLANS, INVOICEABLE_TXN_TYPES } from "@/lib/plans";
 import {
   updateAutoReload,
@@ -173,6 +176,10 @@ export function BillingSettings({
   );
   const autoReloadActive = autoReloadConfig?.enabled ?? false;
   const autoReloadPaused = autoReloadConfig?.pausedForDurableUpgrade ?? false;
+  const autoReloadStatus = getAutoReloadDisplayStatus(
+    autoReloadActive,
+    autoReloadPaused,
+  );
 
   const [planPending, startPlanTransition] = useTransition();
   const [planError, setPlanError] = useState<string | null>(null);
@@ -352,10 +359,14 @@ export function BillingSettings({
                   Auto-reload
                 </a>
                 <Badge
-                  variant={autoReloadActive ? "default" : "secondary"}
+                  variant={autoReloadStatus === "on" ? "default" : "secondary"}
                   className="ml-0.5"
                 >
-                  {autoReloadActive ? "On" : autoReloadPaused ? "Paused" : "Off"}
+                  {autoReloadStatus === "on"
+                    ? "On"
+                    : autoReloadStatus === "paused"
+                      ? "Paused"
+                      : "Off"}
                 </Badge>
               </div>
               <p className="mt-1 text-xs text-muted-foreground">

--- a/apps/web/app/(app)/settings/billing/card-setup-dialog.tsx
+++ b/apps/web/app/(app)/settings/billing/card-setup-dialog.tsx
@@ -121,8 +121,10 @@ export function CardSetupDialog({
         <DialogHeader>
           <DialogTitle>Add card</DialogTitle>
           <DialogDescription>
-            Saved for subscriptions, top-ups, and auto-reload. Card details go
-            directly to Stripe — they never touch our servers.
+            Saved for subscriptions and top-ups. If you enable auto-reload,
+            you authorize Octopus to charge the configured reload amount each
+            time your balance reaches your threshold. You can turn it off at
+            any time. Card details go directly to Stripe.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/web/app/(app)/settings/billing/page.tsx
+++ b/apps/web/app/(app)/settings/billing/page.tsx
@@ -3,6 +3,10 @@ import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { getOrgMonthlySpend } from "@/lib/cost";
+import {
+  formatBillingResetLabel,
+  getUtcMonthBounds,
+} from "@/lib/billing-period";
 import { getCustomerPaymentMethods } from "@/lib/stripe";
 import { BillingSettings } from "./billing-settings";
 
@@ -42,7 +46,7 @@ export default async function BillingPage() {
   if (!member) redirect("/dashboard");
 
   const org = member.organization;
-  const isOwner = member.role === "owner" || member.role === "admin";
+  const canManageBilling = member.role === "owner" || member.role === "admin";
 
   // Bracket notation on purpose: Next inlines `process.env.NEXT_PUBLIC_*`
   // dot-access at BUILD time (client and server), and the CI image is built
@@ -68,11 +72,12 @@ export default async function BillingPage() {
       ? getCustomerPaymentMethods(org.stripeCustomerId)
       : Promise.resolve([]),
   ]);
+  const { end: monthlyPeriodEnd } = getUtcMonthBounds();
 
   return (
     <BillingSettings
       key={org.id}
-      isOwner={isOwner}
+      canManageBilling={canManageBilling}
       orgId={org.id}
       creditBalance={Number(org.creditBalance)}
       freeCreditBalance={Number(org.freeCreditBalance)}
@@ -87,6 +92,7 @@ export default async function BillingPage() {
         autoReloadConfig
           ? {
               enabled: autoReloadConfig.enabled,
+              pausedForDurableUpgrade: autoReloadConfig.pausedForDurableUpgrade,
               thresholdAmount: Number(autoReloadConfig.thresholdAmount),
               reloadAmount: Number(autoReloadConfig.reloadAmount),
             }
@@ -103,6 +109,7 @@ export default async function BillingPage() {
       }))}
       totalTransactions={totalTransactions}
       monthlySpend={monthlySpend}
+      monthlyResetLabel={formatBillingResetLabel(monthlyPeriodEnd)}
       paymentMethods={paymentMethods}
     />
   );

--- a/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
+++ b/apps/web/app/(app)/settings/billing/purchase-dialog.tsx
@@ -75,7 +75,7 @@ export function PurchaseDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="grid grid-cols-4 gap-2">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
             {PRESETS.map((preset) => {
               const pct = Math.round((volumeBonusUsd(preset) / preset) * 100);
               return (

--- a/apps/web/app/api/cli/usage/route.ts
+++ b/apps/web/app/api/cli/usage/route.ts
@@ -1,6 +1,7 @@
 import { authenticateApiToken } from "@/lib/api-auth";
 import { prisma } from "@octopus/db";
 import { getModelPricing, calcCost, getOrgMonthlySpend } from "@/lib/cost";
+import { getUtcMonthBounds } from "@/lib/billing-period";
 
 export async function GET(request: Request) {
   const result = await authenticateApiToken(request);
@@ -8,15 +9,18 @@ export async function GET(request: Request) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const now = new Date();
-  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  // Same UTC calendar month getOrgMonthlySpend uses, so `period`, `totalSpend`,
+  // and `breakdown` all describe one window. totalSpend is exact (committed
+  // credit ledger); breakdown is priced from AiUsage rows at current rates, so
+  // it can differ slightly from totalSpend.
+  const { start, end } = getUtcMonthBounds();
 
   const [usages, pricing, monthlySpend, org] = await Promise.all([
     prisma.aiUsage.groupBy({
       by: ["model", "operation"],
       where: {
         organizationId: result.org.id,
-        createdAt: { gte: monthStart },
+        createdAt: { gte: start, lt: end },
       },
       _sum: {
         inputTokens: true,
@@ -58,8 +62,8 @@ export async function GET(request: Request) {
 
   return Response.json({
     period: {
-      start: monthStart.toISOString(),
-      end: now.toISOString(),
+      start: start.toISOString(),
+      end: end.toISOString(),
     },
     totalSpend: monthlySpend,
     spendLimit: org?.monthlySpendLimitUsd ?? null,

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -11,20 +11,12 @@ import {
   getOrgBalance,
   grantAutoReloadFromPaymentIntent,
   grantPurchaseFromPaymentIntent,
+  stripeObjectId,
 } from "@/lib/credits";
 import { grantSubscriptionPeriod, addOneMonth } from "@/lib/subscription";
 import { isPaidPlanTier, volumeBonusUsd } from "@/lib/plans";
 import { prisma } from "@octopus/db";
 import type Stripe from "stripe";
-
-function stripeObjectId(value: unknown): string | null {
-  if (typeof value === "string") return value;
-  if (value && typeof value === "object" && "id" in value) {
-    const id = (value as { id?: unknown }).id;
-    return typeof id === "string" ? id : null;
-  }
-  return null;
-}
 
 async function getMatchingAutoReloadAttempt(
   intent: Stripe.PaymentIntent,
@@ -59,7 +51,9 @@ async function getMatchingAutoReloadAttempt(
 }
 
 const LEGACY_AUTO_RELOAD_MIN_CENTS = 500;
-const LEGACY_AUTO_RELOAD_MAX_CENTS = 100_000;
+// The pre-migration config only enforced reloadAmount >= 5 into a
+// Decimal(12,4) column, so the upper bound is Stripe's own USD ceiling.
+const LEGACY_AUTO_RELOAD_MAX_CENTS = 99_999_999;
 
 /**
  * Recover a succeeded PI created by an old replica during a rolling deploy.
@@ -82,7 +76,7 @@ async function grantValidatedLegacyAutoReload(intent: Stripe.PaymentIntent): Pro
     || intent.status !== "succeeded"
     || intent.currency !== "usd"
     || typeof rawMetadataAmount !== "string"
-    || !/^\d{1,4}(?:\.\d{1,2})?$/.test(rawMetadataAmount)
+    || !/^\d{1,6}(?:\.\d{1,4})?$/.test(rawMetadataAmount)
     || !Number.isFinite(metadataAmount)
     || metadataAmount <= 0
     || intent.amount !== metadataAmountCents

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -1,9 +1,113 @@
+import "server-only";
+
 import { NextRequest, NextResponse } from "next/server";
 import { constructWebhookEvent, getStripe } from "@/lib/stripe";
-import { addCredits, addFreeCredits, deductCredits, grantPurchaseFromPaymentIntent } from "@/lib/credits";
+import {
+  addCredits,
+  addFreeCredits,
+  applyAutoReloadPaymentIntent,
+  autoReloadPaymentIntentMatches,
+  deductCredits,
+  getOrgBalance,
+  grantAutoReloadFromPaymentIntent,
+  grantPurchaseFromPaymentIntent,
+} from "@/lib/credits";
 import { grantSubscriptionPeriod, addOneMonth } from "@/lib/subscription";
 import { isPaidPlanTier, volumeBonusUsd } from "@/lib/plans";
 import { prisma } from "@octopus/db";
+import type Stripe from "stripe";
+
+function stripeObjectId(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "id" in value) {
+    const id = (value as { id?: unknown }).id;
+    return typeof id === "string" ? id : null;
+  }
+  return null;
+}
+
+async function getMatchingAutoReloadAttempt(
+  intent: Stripe.PaymentIntent,
+  requireReceivedAmount: boolean,
+) {
+  const orgId = intent.metadata?.orgId;
+  const attemptId = intent.metadata?.autoReloadAttemptId;
+  const idempotencyKey = intent.metadata?.autoReloadKey;
+  // Both durable fields absent means an old replica created this PI during the
+  // rolling deploy. Partial durable metadata is never accepted as legacy.
+  if (!attemptId && !idempotencyKey) return null;
+  if (!orgId || !attemptId || !idempotencyKey) {
+    throw new Error("Auto-reload PaymentIntent has incomplete durable metadata");
+  }
+
+  const attempt = await prisma.autoReloadAttempt.findFirst({
+    where: {
+      id: attemptId,
+      organizationId: orgId,
+      idempotencyKey,
+    },
+  });
+  if (!attempt) {
+    throw new Error("Auto-reload PaymentIntent has no matching durable attempt");
+  }
+
+  if (!autoReloadPaymentIntentMatches(intent, orgId, attempt, requireReceivedAmount)) {
+    throw new Error("Auto-reload PaymentIntent does not match its durable attempt");
+  }
+
+  return { attempt, orgId, attemptId, idempotencyKey };
+}
+
+const LEGACY_AUTO_RELOAD_MIN_CENTS = 500;
+const LEGACY_AUTO_RELOAD_MAX_CENTS = 100_000;
+
+/**
+ * Recover a succeeded PI created by an old replica during a rolling deploy.
+ * This deliberately accepts only the exact legacy shape, and the PI id remains
+ * the unique credit-ledger key. Newly formatted PIs always take the strict
+ * durable-attempt path above.
+ */
+async function grantValidatedLegacyAutoReload(intent: Stripe.PaymentIntent): Promise<void> {
+  const metadata = intent.metadata;
+  const orgId = metadata?.orgId;
+  const rawMetadataAmount = metadata?.amountUsd;
+  const metadataAmount = Number(rawMetadataAmount);
+  const metadataAmountCents = Math.round(metadataAmount * 100);
+
+  if (
+    !orgId
+    || metadata?.type !== "auto_reload"
+    || metadata?.autoReloadAttemptId
+    || metadata?.autoReloadKey
+    || intent.status !== "succeeded"
+    || intent.currency !== "usd"
+    || typeof rawMetadataAmount !== "string"
+    || !/^\d{1,4}(?:\.\d{1,2})?$/.test(rawMetadataAmount)
+    || !Number.isFinite(metadataAmount)
+    || metadataAmount <= 0
+    || intent.amount !== metadataAmountCents
+    || intent.amount_received !== intent.amount
+    || intent.amount < LEGACY_AUTO_RELOAD_MIN_CENTS
+    || intent.amount > LEGACY_AUTO_RELOAD_MAX_CENTS
+  ) {
+    throw new Error("Legacy auto-reload PaymentIntent failed validation");
+  }
+
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: { stripeCustomerId: true },
+  });
+  if (!org?.stripeCustomerId || stripeObjectId(intent.customer) !== org.stripeCustomerId) {
+    throw new Error("Legacy auto-reload PaymentIntent customer does not match its organization");
+  }
+
+  await grantAutoReloadFromPaymentIntent(
+    orgId,
+    metadataAmount,
+    intent.id,
+    intent.latest_charge,
+  );
+}
 
 async function getReceiptUrl(paymentIntentId: string | null): Promise<string | null> {
   if (!paymentIntentId) return null;
@@ -172,25 +276,54 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    // Authoritative grant for off-session direct credit purchases. The server
-    // action grants inline for instant feedback, but if that process dies
-    // between charge and grant the customer would be charged with no credits —
-    // this webhook is the guarantee. Keyed on the PI id, so the inline grant
-    // and this one collapse to exactly one (P2002-idempotent). Only OUR direct
-    // off-session PIs carry metadata.type="credit_purchase"; Checkout PIs don't
-    // (their grant runs on checkout.session.completed), so no double-grant.
+    // Authoritative grant for our off-session PaymentIntents. Inline grants
+    // provide instant feedback, while this webhook recovers a process/DB
+    // failure after Stripe has charged the card. Both paths key the ledger on
+    // the PI id, so they collapse to exactly one grant (P2002-idempotent).
     if (event.type === "payment_intent.succeeded") {
       const intent = event.data.object;
       const orgId = intent.metadata?.orgId;
       const amountUsd = Number(intent.metadata?.amountUsd || 0);
       if (intent.metadata?.type === "credit_purchase" && orgId && amountUsd > 0) {
         await grantPurchaseFromPaymentIntent(orgId, amountUsd, intent.id, intent.latest_charge);
+      } else if (intent.metadata?.type === "auto_reload") {
+        const matched = await getMatchingAutoReloadAttempt(intent, true);
+        if (matched) {
+          const balance = await getOrgBalance(matched.orgId);
+          await applyAutoReloadPaymentIntent(
+            matched.orgId,
+            balance.total,
+            intent,
+            matched.attempt,
+          );
+        } else {
+          await grantValidatedLegacyAutoReload(intent);
+        }
       }
     }
 
     if (event.type === "payment_intent.payment_failed") {
       const intent = event.data.object;
       console.error("[stripe-webhook] Payment failed:", intent.id, intent.last_payment_error?.message);
+      if (intent.metadata?.type === "auto_reload") {
+        const matched = await getMatchingAutoReloadAttempt(intent, false);
+        if (matched) {
+          // Event delivery is unordered. Re-read Stripe's current PI before
+          // changing durable state so an older failure snapshot cannot demote
+          // a PI that has since succeeded (or emit a false owner alert).
+          const currentIntent = await getStripe().paymentIntents.retrieve(intent.id);
+          if (!autoReloadPaymentIntentMatches(currentIntent, matched.orgId, matched.attempt, false)) {
+            throw new Error("Current auto-reload PaymentIntent does not match its durable attempt");
+          }
+          const balance = await getOrgBalance(matched.orgId);
+          await applyAutoReloadPaymentIntent(
+            matched.orgId,
+            balance.total,
+            currentIntent,
+            matched.attempt,
+          );
+        }
+      }
     }
   } catch (err) {
     console.error("[stripe-webhook] Processing failed — returning 500 so Stripe retries:", err);

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -83,6 +83,11 @@ export async function register() {
       // daily inside a grace window (see lib/subscription.ts).
       if (process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED !== "true") {
         await boss.schedule("subscription-renewals", "0 6 * * *");
+
+        // Reclaim durable auto-reload attempts without waiting for another
+        // deduction or page visit. pg-boss deduplicates this schedule across
+        // review-engine replicas; self-hosted installs have no billing path.
+        await boss.schedule("reconcile-auto-reloads", "* * * * *");
       }
     }
 

--- a/apps/web/lib/__tests__/billing-period.test.ts
+++ b/apps/web/lib/__tests__/billing-period.test.ts
@@ -1,9 +1,21 @@
 import { describe, expect, it } from "bun:test";
 import {
   formatBillingResetLabel,
+  getAutoReloadDisplayStatus,
   getUtcMonthBounds,
   summarizeMonthlySpend,
 } from "@/lib/billing-period";
+
+describe("auto-reload display status", () => {
+  it("prioritizes a rollout pause over the saved enabled flag", () => {
+    expect(getAutoReloadDisplayStatus(true, true)).toBe("paused");
+  });
+
+  it("shows active and inactive persisted states", () => {
+    expect(getAutoReloadDisplayStatus(true, false)).toBe("on");
+    expect(getAutoReloadDisplayStatus(false, false)).toBe("off");
+  });
+});
 
 describe("billing period", () => {
   it("returns UTC month boundaries across a year boundary", () => {

--- a/apps/web/lib/__tests__/billing-period.test.ts
+++ b/apps/web/lib/__tests__/billing-period.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatBillingResetLabel,
+  getUtcMonthBounds,
+  summarizeMonthlySpend,
+} from "@/lib/billing-period";
+
+describe("billing period", () => {
+  it("returns UTC month boundaries across a year boundary", () => {
+    const { start, end } = getUtcMonthBounds(
+      new Date("2026-12-31T23:59:59.999Z"),
+    );
+
+    expect(start.toISOString()).toBe("2026-12-01T00:00:00.000Z");
+    expect(end.toISOString()).toBe("2027-01-01T00:00:00.000Z");
+    expect(formatBillingResetLabel(end)).toBe("Jan 1");
+  });
+});
+
+describe("monthly spend summary", () => {
+  it("represents an unlimited month without progress or remaining values", () => {
+    expect(summarizeMonthlySpend(12.5, null)).toEqual({
+      spendUsd: 12.5,
+      limitUsd: null,
+      remainingUsd: null,
+      percentUsed: null,
+      progressPercent: null,
+      limitReached: false,
+    });
+  });
+
+  it("calculates remaining spend and progress below the limit", () => {
+    expect(summarizeMonthlySpend(25, 100)).toEqual({
+      spendUsd: 25,
+      limitUsd: 100,
+      remainingUsd: 75,
+      percentUsed: 25,
+      progressPercent: 25,
+      limitReached: false,
+    });
+  });
+
+  it("caps visual progress while preserving the true over-limit percentage", () => {
+    expect(summarizeMonthlySpend(125, 100)).toEqual({
+      spendUsd: 125,
+      limitUsd: 100,
+      remainingUsd: 0,
+      percentUsed: 125,
+      progressPercent: 100,
+      limitReached: true,
+    });
+  });
+
+  it("treats a zero limit as reached even before usage", () => {
+    expect(summarizeMonthlySpend(0, 0)).toEqual({
+      spendUsd: 0,
+      limitUsd: 0,
+      remainingUsd: 0,
+      percentUsed: 100,
+      progressPercent: 100,
+      limitReached: true,
+    });
+  });
+});

--- a/apps/web/lib/__tests__/billing.db.test.ts
+++ b/apps/web/lib/__tests__/billing.db.test.ts
@@ -1,0 +1,319 @@
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+
+const RUN_DB_TESTS = process.env.RUN_BILLING_DB_TESTS === "1";
+
+function assertDedicatedTestDatabase(): void {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error(
+      "RUN_BILLING_DB_TESTS=1 requires DATABASE_URL for a dedicated test database",
+    );
+  }
+
+  let databaseName: string;
+  try {
+    databaseName = decodeURIComponent(new URL(databaseUrl).pathname.slice(1));
+  } catch {
+    throw new Error("DATABASE_URL must be a valid PostgreSQL URL");
+  }
+
+  if (!/(^|[-_])test($|[-_])/.test(databaseName.toLowerCase())) {
+    throw new Error(
+      `Refusing to run billing DB tests against non-test database "${databaseName}"`,
+    );
+  }
+}
+
+if (RUN_DB_TESTS) {
+  assertDedicatedTestDatabase();
+  mock.module("server-only", () => ({}));
+  mock.module("@/lib/stripe", () => ({
+    getStripe: () => {
+      throw new Error("Stripe must not be called by the billing DB test");
+    },
+    getOffSessionPaymentMethodId: () => Promise.resolve(null),
+  }));
+  mock.module("@/lib/events/bus", () => ({
+    eventBus: {
+      emit: () => {},
+      on: () => {},
+      off: () => {},
+    },
+  }));
+}
+
+type DbModule = typeof import("@octopus/db");
+type CreditsModule = typeof import("@/lib/credits");
+
+let prisma: DbModule["prisma"];
+let grantAutoReloadFromPaymentIntent: CreditsModule["grantAutoReloadFromPaymentIntent"];
+
+if (RUN_DB_TESTS) {
+  ({ prisma } = await import("@octopus/db"));
+  ({ grantAutoReloadFromPaymentIntent } = await import("@/lib/credits"));
+}
+
+const describeDb = RUN_DB_TESTS ? describe : describe.skip;
+const fixtureId = randomUUID().replaceAll("-", "");
+const organizationId = `billing_db_org_${fixtureId}`;
+const migrationSchema = `billing_migration_${fixtureId}`;
+const migrationUrl = new URL(
+  "../../../../packages/db/prisma/migrations/20260810120000_add_auto_reload_attempts/migration.sql",
+  import.meta.url,
+);
+
+function quotedIdentifier(identifier: string): string {
+  if (!/^[a-z0-9_]+$/.test(identifier)) {
+    throw new Error(`Unsafe PostgreSQL identifier: ${identifier}`);
+  }
+  return `"${identifier}"`;
+}
+
+function migrationStatements(sql: string): string[] {
+  return sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+}
+
+function attemptData(label: string, activeOrganizationId: string | null) {
+  const now = Date.now();
+  return {
+    id: `billing_db_attempt_${label}_${fixtureId}`,
+    status: "pending",
+    idempotencyKey: `billing-db-${label}-${fixtureId}`,
+    amountCents: 5_000,
+    stripeCustomerId: `cus_billing_db_${fixtureId}`,
+    stripePaymentMethodId: `pm_billing_db_${fixtureId}`,
+    leaseExpiresAt: new Date(now + 5 * 60 * 1_000),
+    retryUntil: new Date(now + 23 * 60 * 60 * 1_000),
+    organizationId,
+    activeOrganizationId,
+  };
+}
+
+describeDb("billing auto-reload invariants with PostgreSQL", () => {
+  beforeAll(async () => {
+    await prisma.organization.create({
+      data: {
+        id: organizationId,
+        name: "Billing DB Test",
+        slug: `billing-db-${fixtureId}`,
+      },
+    });
+  });
+
+  afterAll(async () => {
+    try {
+      await prisma.organization.deleteMany({ where: { id: organizationId } });
+    } finally {
+      await prisma.$disconnect();
+    }
+  });
+
+  it("enforces one active claim and completes duplicate grants exactly once", async () => {
+    const claims = await Promise.allSettled([
+      prisma.autoReloadAttempt.create({
+        data: attemptData("claim-a", organizationId),
+      }),
+      prisma.autoReloadAttempt.create({
+        data: attemptData("claim-b", organizationId),
+      }),
+    ]);
+
+    const winner = claims.find((claim) => claim.status === "fulfilled");
+    const loser = claims.find((claim) => claim.status === "rejected");
+    expect(claims.filter((claim) => claim.status === "fulfilled")).toHaveLength(1);
+    expect(claims.filter((claim) => claim.status === "rejected")).toHaveLength(1);
+    if (!winner || winner.status !== "fulfilled") {
+      throw new Error("Expected one auto-reload claim to succeed");
+    }
+    if (!loser || loser.status !== "rejected") {
+      throw new Error("Expected one auto-reload claim to lose the unique slot");
+    }
+    expect(loser.reason).toMatchObject({ code: "P2002" });
+
+    const paymentIntentId = `pi_billing_db_${fixtureId}`;
+    const attemptIdentity = {
+      id: winner.value.id,
+      idempotencyKey: winner.value.idempotencyKey,
+    };
+
+    await Promise.all([
+      grantAutoReloadFromPaymentIntent(
+        organizationId,
+        50,
+        paymentIntentId,
+        null,
+        attemptIdentity,
+      ),
+      grantAutoReloadFromPaymentIntent(
+        organizationId,
+        50,
+        paymentIntentId,
+        null,
+        attemptIdentity,
+      ),
+    ]);
+
+    const [organization, transactions, completedAttempt] = await Promise.all([
+      prisma.organization.findUniqueOrThrow({
+        where: { id: organizationId },
+        select: { creditBalance: true, freeCreditBalance: true },
+      }),
+      prisma.creditTransaction.findMany({
+        where: { organizationId, stripeSessionId: paymentIntentId },
+      }),
+      prisma.autoReloadAttempt.findUniqueOrThrow({
+        where: { id: winner.value.id },
+      }),
+    ]);
+
+    expect(Number(organization.creditBalance)).toBe(50);
+    expect(Number(organization.freeCreditBalance)).toBe(0);
+    expect(transactions).toHaveLength(1);
+    expect(Number(transactions[0]?.amount)).toBe(50);
+    expect(transactions[0]?.type).toBe("auto_reload");
+    expect(completedAttempt.status).toBe("completed");
+    expect(completedAttempt.activeOrganizationId).toBeNull();
+    expect(completedAttempt.stripePaymentIntentId).toBe(paymentIntentId);
+    expect(completedAttempt.completedAt).toBeInstanceOf(Date);
+
+    const replacement = await prisma.autoReloadAttempt.create({
+      data: attemptData("replacement", organizationId),
+    });
+    const retainedHistory = await prisma.autoReloadAttempt.create({
+      data: {
+        ...attemptData("history", null),
+        status: "completed",
+        completedAt: new Date(),
+      },
+    });
+
+    expect(replacement.activeOrganizationId).toBe(organizationId);
+    expect(retainedHistory.activeOrganizationId).toBeNull();
+    expect(
+      await prisma.autoReloadAttempt.count({
+        where: { organizationId, activeOrganizationId: null },
+      }),
+    ).toBe(2);
+  });
+
+  it("applies the durable-attempt migration safely to legacy auto-reload rows", async () => {
+    const schema = quotedIdentifier(migrationSchema);
+    const migrationSql = await readFile(migrationUrl, "utf8");
+
+    try {
+      await prisma.$transaction(async (tx) => {
+        await tx.$executeRawUnsafe(`CREATE SCHEMA ${schema}`);
+        await tx.$executeRawUnsafe(`SET LOCAL search_path TO ${schema}`);
+        await tx.$executeRawUnsafe(`
+          CREATE TABLE "organizations" (
+            "id" TEXT NOT NULL PRIMARY KEY
+          )
+        `);
+        await tx.$executeRawUnsafe(`
+          CREATE TABLE "auto_reload_configs" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "enabled" BOOLEAN NOT NULL DEFAULT false,
+            "thresholdAmount" NUMERIC(12, 4) NOT NULL DEFAULT 10,
+            "reloadAmount" NUMERIC(12, 4) NOT NULL DEFAULT 50,
+            "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            "updatedAt" TIMESTAMP(3) NOT NULL,
+            "organizationId" TEXT NOT NULL UNIQUE,
+            CONSTRAINT "auto_reload_configs_organizationId_fkey"
+              FOREIGN KEY ("organizationId") REFERENCES "organizations"("id")
+              ON DELETE CASCADE ON UPDATE CASCADE
+          )
+        `);
+        await tx.$executeRawUnsafe(`
+          INSERT INTO "organizations" ("id")
+          VALUES ('org-enabled'), ('org-disabled')
+        `);
+        await tx.$executeRawUnsafe(`
+          INSERT INTO "auto_reload_configs" (
+            "id",
+            "enabled",
+            "thresholdAmount",
+            "reloadAmount",
+            "updatedAt",
+            "organizationId"
+          ) VALUES
+            ('config-enabled', true, 12.5000, 73.2500, CURRENT_TIMESTAMP, 'org-enabled'),
+            ('config-disabled', false, 8.7500, 41.5000, CURRENT_TIMESTAMP, 'org-disabled')
+        `);
+
+        for (const statement of migrationStatements(migrationSql)) {
+          await tx.$executeRawUnsafe(statement);
+        }
+
+        const configs = await tx.$queryRawUnsafe<
+          Array<{
+            id: string;
+            enabled: boolean;
+            paused: boolean;
+            threshold: string;
+            reload: string;
+          }>
+        >(`
+          SELECT
+            "id",
+            "enabled",
+            "pausedForDurableUpgrade" AS "paused",
+            "thresholdAmount"::text AS "threshold",
+            "reloadAmount"::text AS "reload"
+          FROM "auto_reload_configs"
+          ORDER BY "id"
+        `);
+        expect(configs).toEqual([
+          {
+            id: "config-disabled",
+            enabled: false,
+            paused: false,
+            threshold: "8.7500",
+            reload: "41.5000",
+          },
+          {
+            id: "config-enabled",
+            enabled: false,
+            paused: true,
+            threshold: "12.5000",
+            reload: "73.2500",
+          },
+        ]);
+
+        const attemptTable = await tx.$queryRawUnsafe<Array<{ exists: boolean }>>(`
+          SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = '${migrationSchema}'
+              AND table_name = 'auto_reload_attempts'
+          ) AS "exists"
+        `);
+        expect(attemptTable).toEqual([{ exists: true }]);
+
+        const paymentMethodColumn = await tx.$queryRawUnsafe<
+          Array<{ isNullable: string }>
+        >(`
+          SELECT is_nullable AS "isNullable"
+          FROM information_schema.columns
+          WHERE table_schema = '${migrationSchema}'
+            AND table_name = 'auto_reload_attempts'
+            AND column_name = 'stripePaymentMethodId'
+        `);
+        expect(paymentMethodColumn).toEqual([{ isNullable: "YES" }]);
+      });
+    } finally {
+      await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS ${schema} CASCADE`);
+    }
+  });
+});

--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -66,6 +66,7 @@ let mockAutoReloadAttemptCreate = mock(({ data }: { data: Record<string, unknown
   Promise.resolve({ stripePaymentIntentId: null, ...data }),
 );
 let mockAutoReloadAttemptUpdateMany = mock(() => Promise.resolve({ count: 1 }));
+let mockAutoReloadAttemptCount = mock(() => Promise.resolve(1));
 
 async function mockAutoReloadAttemptCreateMany(
   args: { data: Record<string, unknown>; skipDuplicates?: boolean },
@@ -157,6 +158,7 @@ mock.module("@octopus/db", () => ({
       create: (...args: unknown[]) => mockAutoReloadAttemptCreate(...args),
       createMany: (...args: unknown[]) => mockAutoReloadAttemptCreateMany(...args as never),
       updateMany: (...args: unknown[]) => mockAutoReloadAttemptUpdateMany(...args),
+      count: (...args: unknown[]) => mockAutoReloadAttemptCount(...args),
     },
     aiUsage: {
       create: ({ data }: { data: { usedOwnKey: boolean } }) => {
@@ -194,6 +196,7 @@ mock.module("@octopus/db", () => ({
             create: (...args: unknown[]) => mockAutoReloadAttemptCreate(...args),
             createMany: (...args: unknown[]) => mockAutoReloadAttemptCreateMany(...args as never),
             updateMany: (...args: unknown[]) => mockAutoReloadAttemptUpdateMany(...args),
+            count: (...args: unknown[]) => mockAutoReloadAttemptCount(...args),
           },
         });
       } catch (err) {
@@ -325,6 +328,7 @@ function resetBillingMocks() {
     Promise.resolve({ stripePaymentIntentId: null, ...data }),
   );
   mockAutoReloadAttemptUpdateMany = mock(() => Promise.resolve({ count: 1 }));
+  mockAutoReloadAttemptCount = mock(() => Promise.resolve(1));
   mockOrganizationFindUnique = mock(() => Promise.resolve(null));
   organizationUpdates = [];
   createdAiUsage = [];

--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -56,6 +56,30 @@ let mockCreditAggregate = mock(() =>
 let mockCreditTransactionFindFirst = mock(() => Promise.resolve(null));
 let mockCreditTransactionUpdate = mock(() => Promise.resolve());
 let mockAutoReloadConfigFindUnique = mock(() => Promise.resolve(null));
+let mockAutoReloadConfigUpsert = mock(({ create }: { create: unknown }) =>
+  Promise.resolve(create),
+);
+let mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(null));
+let mockAutoReloadAttemptFindFirst = mock(() => Promise.resolve(null));
+let mockAutoReloadAttemptFindMany = mock(() => Promise.resolve([] as unknown[]));
+let mockAutoReloadAttemptCreate = mock(({ data }: { data: Record<string, unknown> }) =>
+  Promise.resolve({ stripePaymentIntentId: null, ...data }),
+);
+let mockAutoReloadAttemptUpdateMany = mock(() => Promise.resolve({ count: 1 }));
+
+async function mockAutoReloadAttemptCreateMany(
+  args: { data: Record<string, unknown>; skipDuplicates?: boolean },
+) {
+  try {
+    await mockAutoReloadAttemptCreate({ data: args.data });
+    return { count: 1 };
+  } catch (err) {
+    if (args.skipDuplicates && (err as { code?: unknown } | null)?.code === "P2002") {
+      return { count: 0 };
+    }
+    throw err;
+  }
+}
 let mockOrganizationFindUnique = mock(() => Promise.resolve(null));
 let mockOrganizationFindMany = mock(() => Promise.resolve([] as unknown[]));
 let createdAiUsage: Array<{ id: string; usedOwnKey: boolean; chargedCostUsd: number | null }>;
@@ -80,6 +104,12 @@ let mockCheckoutSessionsList = mock(() =>
 let mockPaymentIntentsCreate = mock(() =>
   Promise.resolve({ status: "succeeded", latest_charge: null }),
 );
+let mockPaymentIntentsRetrieve = mock(() =>
+  Promise.resolve({ status: "succeeded", latest_charge: null }),
+);
+let mockPaymentIntentsCancel = mock(() =>
+  Promise.resolve({ status: "canceled", latest_charge: null }),
+);
 let mockChargesRetrieve = mock(() => Promise.resolve({ receipt_url: null }));
 
 type StubRefund = { id: string; amount: number; status: string };
@@ -93,6 +123,15 @@ function asyncRefundList(items: StubRefund[]) {
   };
 }
 let mockRefundsList = mock(() => asyncRefundList([]));
+
+function asyncPaymentIntentList(items: unknown[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const item of items) yield item;
+    },
+  };
+}
+let mockPaymentIntentsList = mock(() => asyncPaymentIntentList([]));
 
 mock.module("@octopus/db", () => ({
   prisma: {
@@ -109,6 +148,15 @@ mock.module("@octopus/db", () => ({
     },
     autoReloadConfig: {
       findUnique: (...args: unknown[]) => mockAutoReloadConfigFindUnique(...args),
+      upsert: (...args: unknown[]) => mockAutoReloadConfigUpsert(...args as never),
+    },
+    autoReloadAttempt: {
+      findUnique: (...args: unknown[]) => mockAutoReloadAttemptFindUnique(...args),
+      findFirst: (...args: unknown[]) => mockAutoReloadAttemptFindFirst(...args),
+      findMany: (...args: unknown[]) => mockAutoReloadAttemptFindMany(...args),
+      create: (...args: unknown[]) => mockAutoReloadAttemptCreate(...args),
+      createMany: (...args: unknown[]) => mockAutoReloadAttemptCreateMany(...args as never),
+      updateMany: (...args: unknown[]) => mockAutoReloadAttemptUpdateMany(...args),
     },
     aiUsage: {
       create: ({ data }: { data: { usedOwnKey: boolean } }) => {
@@ -131,10 +179,21 @@ mock.module("@octopus/db", () => ({
         return await callback({
           $queryRaw: (...args: unknown[]) => mockTxQueryRaw(...args),
           organization: {
+            findUnique: (...args: unknown[]) => mockOrganizationFindUnique(...args),
             update: (...args: unknown[]) => mockTxOrganizationUpdate(...args),
           },
           creditTransaction: {
             create: (...args: unknown[]) => mockTxCreditTransactionCreate(...args),
+          },
+          autoReloadConfig: {
+            findUnique: (...args: unknown[]) => mockAutoReloadConfigFindUnique(...args),
+            upsert: (...args: unknown[]) => mockAutoReloadConfigUpsert(...args as never),
+          },
+          autoReloadAttempt: {
+            findUnique: (...args: unknown[]) => mockAutoReloadAttemptFindUnique(...args),
+            create: (...args: unknown[]) => mockAutoReloadAttemptCreate(...args),
+            createMany: (...args: unknown[]) => mockAutoReloadAttemptCreateMany(...args as never),
+            updateMany: (...args: unknown[]) => mockAutoReloadAttemptUpdateMany(...args),
           },
         });
       } catch (err) {
@@ -178,9 +237,14 @@ mock.module("@/lib/stripe", () => ({
     },
     paymentIntents: {
       create: (...args: unknown[]) => mockPaymentIntentsCreate(...args),
+      retrieve: (...args: unknown[]) => mockPaymentIntentsRetrieve(...args),
+      cancel: (...args: unknown[]) => mockPaymentIntentsCancel(...args),
+      list: (...args: unknown[]) => mockPaymentIntentsList(...args),
     },
   }),
 }));
+
+mock.module("server-only", () => ({}));
 
 const {
   addCredits,
@@ -188,6 +252,10 @@ const {
   deductCredits,
   getOrgBalance,
   chargeCreditsOffSession,
+  rearmAutoReloadAfterPaymentMethodChange,
+  reconcileAutoReloadAttempts,
+  triggerAutoReloadIfNeeded,
+  updateAutoReloadConfigDurably,
 } = await import("@/lib/credits");
 const { POST } = await import("@/app/api/stripe/webhook/route");
 const { addOneMonth, renewDueSubscriptions } = await import("@/lib/subscription");
@@ -247,6 +315,16 @@ function resetBillingMocks() {
   mockCreditTransactionFindFirst = mock(() => Promise.resolve(null));
   mockCreditTransactionUpdate = mock(() => Promise.resolve());
   mockAutoReloadConfigFindUnique = mock(() => Promise.resolve(null));
+  mockAutoReloadConfigUpsert = mock(({ create }: { create: unknown }) =>
+    Promise.resolve(create),
+  );
+  mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(null));
+  mockAutoReloadAttemptFindFirst = mock(() => Promise.resolve(null));
+  mockAutoReloadAttemptFindMany = mock(() => Promise.resolve([] as unknown[]));
+  mockAutoReloadAttemptCreate = mock(({ data }: { data: Record<string, unknown> }) =>
+    Promise.resolve({ stripePaymentIntentId: null, ...data }),
+  );
+  mockAutoReloadAttemptUpdateMany = mock(() => Promise.resolve({ count: 1 }));
   mockOrganizationFindUnique = mock(() => Promise.resolve(null));
   organizationUpdates = [];
   createdAiUsage = [];
@@ -277,6 +355,13 @@ function resetBillingMocks() {
   mockPaymentIntentsCreate = mock(() =>
     Promise.resolve({ status: "succeeded", latest_charge: null }),
   );
+  mockPaymentIntentsRetrieve = mock(() =>
+    Promise.resolve({ status: "succeeded", latest_charge: null }),
+  );
+  mockPaymentIntentsCancel = mock(() =>
+    Promise.resolve({ status: "canceled", latest_charge: null }),
+  );
+  mockPaymentIntentsList = mock(() => asyncPaymentIntentList([]));
   mockChargesRetrieve = mock(() => Promise.resolve({ receipt_url: null }));
   mockRefundsList = mock(() => asyncRefundList([]));
 }
@@ -287,6 +372,19 @@ function stripeRequest(body = "{}") {
     headers: { "stripe-signature": "sig_test" },
     body,
   });
+}
+
+function succeededIntentFromCreateParams(
+  params: Record<string, unknown>,
+  id: string,
+) {
+  return {
+    ...params,
+    id,
+    status: "succeeded",
+    amount_received: params.amount,
+    latest_charge: null,
+  };
 }
 
 beforeEach(() => {
@@ -379,15 +477,26 @@ describe("credits ledger", () => {
 describe("auto-reload failure notification", () => {
   it("emits auto-reload-failed when the reload charge is declined", async () => {
     mockAutoReloadConfigFindUnique = mock(() =>
-      Promise.resolve({ enabled: true, thresholdAmount: 25, reloadAmount: 50 } as never),
+      Promise.resolve({
+        enabled: true,
+        thresholdAmount: 25,
+        reloadAmount: 50,
+      } as never),
     );
     mockOrganizationFindUnique = mock(() =>
-      Promise.resolve({ stripeCustomerId: "cus_1" } as never),
+      Promise.resolve({
+        stripeCustomerId: "cus_1",
+        creditBalance: orgState.creditBalance,
+        freeCreditBalance: orgState.freeCreditBalance,
+      } as never),
     );
-    mockCreditTransactionFindFirst = mock(() => Promise.resolve(null)); // no recent reload
     mockOffSessionPaymentMethodId = mock(() => Promise.resolve("pm_1"));
-    const declined = new Error("Your card was declined.") as Error & { code: string };
+    const declined = new Error("Your card was declined.") as Error & {
+      code: string;
+      type: string;
+    };
     declined.code = "card_declined";
+    declined.type = "StripeCardError";
     mockPaymentIntentsCreate = mock(() => Promise.reject(declined));
 
     // Deduct into the auto-reload threshold; the fire-and-forget reload runs.
@@ -403,6 +512,1261 @@ describe("auto-reload failure notification", () => {
       reloadAmount: 50,
       reason: "card_declined",
     });
+  });
+
+  it("persists the exact Stripe parameters and reuses the stored idempotency key", async () => {
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({
+        enabled: true,
+        thresholdAmount: 25,
+        reloadAmount: 50,
+      } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({
+        stripeCustomerId: "cus_1",
+        creditBalance: orgState.creditBalance,
+        freeCreditBalance: orgState.freeCreditBalance,
+      } as never),
+    );
+    mockOffSessionPaymentMethodId = mock(() => Promise.resolve("pm_1"));
+    let persisted: Record<string, unknown> | undefined;
+    mockAutoReloadAttemptCreate = mock(({ data }: { data: Record<string, unknown> }) => {
+      persisted = data;
+      return Promise.resolve({ stripePaymentIntentId: null, ...data });
+    });
+    let seenParams: Record<string, unknown> | undefined;
+    let seenOpts: { idempotencyKey?: string } | undefined;
+    mockPaymentIntentsCreate = mock((params: unknown, opts: unknown) => {
+      seenParams = params as Record<string, unknown>;
+      seenOpts = opts as { idempotencyKey?: string };
+      return Promise.resolve(
+        succeededIntentFromCreateParams(params as Record<string, unknown>, "pi_auto_1") as never,
+      );
+    });
+
+    await deductCredits("org_1", 6, "Review run");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(persisted).toMatchObject({
+      organizationId: "org_1",
+      activeOrganizationId: "org_1",
+      status: "initializing",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: null,
+      leaseExpiresAt: expect.any(Date),
+      retryUntil: expect.any(Date),
+    });
+    expect(persisted?.idempotencyKey).toMatch(/^auto-reload-[0-9a-f-]+$/);
+    expect(seenOpts?.idempotencyKey).toBe(persisted?.idempotencyKey);
+    expect(seenParams).toMatchObject({
+      amount: 5000,
+      customer: "cus_1",
+      payment_method: "pm_1",
+      metadata: {
+        autoReloadAttemptId: persisted?.id,
+        autoReloadKey: persisted?.idempotencyKey,
+      },
+    });
+    expect(
+      createdTransactions.filter((row) => (row as { type: string }).type === "auto_reload"),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    ["non-finite threshold", Number.NaN, 50],
+    ["threshold below minimum", 0, 50],
+    ["threshold above maximum", 1001, 1000],
+    ["non-finite reload", 10, Number.POSITIVE_INFINITY],
+    ["reload below minimum", 10, 4],
+    ["reload above maximum", 10, 1001],
+  ] as const)(
+    "refuses to create an attempt for a legacy config with %s",
+    async (_case, thresholdAmount, reloadAmount) => {
+      mockAutoReloadConfigFindUnique = mock(() =>
+        Promise.resolve({ enabled: true, thresholdAmount, reloadAmount } as never),
+      );
+
+      await triggerAutoReloadIfNeeded("org_1", 0);
+
+      expect(mockOrganizationFindUnique).not.toHaveBeenCalled();
+      expect(mockAutoReloadAttemptCreate).not.toHaveBeenCalled();
+      expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    },
+  );
+
+  it("accepts a reload amount below the threshold", async () => {
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: true, thresholdAmount: 100, reloadAmount: 50 } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1", creditBalance: 0, freeCreditBalance: 0 } as never),
+    );
+    mockPaymentIntentsCreate = mock((params: unknown) =>
+      Promise.resolve(
+        succeededIntentFromCreateParams(params as Record<string, unknown>, "pi_threshold") as never,
+      ),
+    );
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows only one concurrent worker to create the reload PaymentIntent", async () => {
+    const config = { enabled: true, thresholdAmount: 30, reloadAmount: 50 };
+    mockAutoReloadConfigFindUnique = mock(() => Promise.resolve(config as never));
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({
+        stripeCustomerId: "cus_1",
+        creditBalance: orgState.creditBalance,
+        freeCreditBalance: orgState.freeCreditBalance,
+      } as never),
+    );
+    let releaseFirst: (() => void) | undefined;
+    mockAutoReloadAttemptCreate = mock(({ data }: { data: Record<string, unknown> }) => {
+      if (!releaseFirst) {
+        return new Promise((resolve) => {
+          releaseFirst = () => resolve({ stripePaymentIntentId: null, ...data });
+        });
+      }
+      releaseFirst();
+      return Promise.reject(Object.assign(new Error("active attempt exists"), { code: "P2002" }));
+    });
+    mockPaymentIntentsCreate = mock((params: unknown) =>
+      Promise.resolve(
+        succeededIntentFromCreateParams(params as Record<string, unknown>, "pi_auto_once") as never,
+      ),
+    );
+
+    await Promise.all([
+      triggerAutoReloadIfNeeded("org_1", 0),
+      triggerAutoReloadIfNeeded("org_1", 0),
+    ]);
+
+    expect(mockAutoReloadAttemptCreate).toHaveBeenCalledTimes(2);
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries an unknown Stripe outcome with the persisted parameters after config changes", async () => {
+    mockAutoReloadConfigFindUnique = mock(() =>
+      // A bad config edit must not change or discard an already-persisted
+      // attempt; retrying its stable Stripe request remains safe.
+      Promise.resolve({ enabled: true, thresholdAmount: 0, reloadAmount: 5000 } as never),
+    );
+    const attempt = {
+      id: "attempt_1",
+      organizationId: "org_1",
+      status: "pending",
+      idempotencyKey: "auto-reload-stable-key",
+      amountCents: 5000,
+      stripeCustomerId: "cus_original",
+      stripePaymentMethodId: "pm_original",
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(Date.now() + 60_000),
+      lastSubmittedAt: null,
+      createdAt: new Date(),
+      failureReason: null,
+    };
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    let seenParams: Record<string, unknown> | undefined;
+    let seenOpts: Record<string, unknown> | undefined;
+    const unknown = Object.assign(new Error("socket closed"), {
+      type: "StripeConnectionError",
+    });
+    mockPaymentIntentsCreate = mock((params: unknown, opts: unknown) => {
+      seenParams = params as Record<string, unknown>;
+      seenOpts = opts as Record<string, unknown>;
+      return Promise.reject(unknown);
+    });
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(seenParams).toMatchObject({
+      amount: 5000,
+      customer: "cus_original",
+      payment_method: "pm_original",
+      metadata: {
+        autoReloadAttemptId: "attempt_1",
+        autoReloadKey: "auto-reload-stable-key",
+      },
+    });
+    expect(seenOpts).toEqual({ idempotencyKey: "auto-reload-stable-key" });
+    expect(mockOrganizationFindUnique).not.toHaveBeenCalled();
+    expect(mockOffSessionPaymentMethodId).not.toHaveBeenCalled();
+    expect(mockAutoReloadAttemptUpdateMany).toHaveBeenLastCalledWith({
+      where: {
+        id: "attempt_1",
+        activeOrganizationId: "org_1",
+        idempotencyKey: "auto-reload-stable-key",
+        status: "submitting",
+      },
+      data: {
+        status: "uncertain",
+        leaseExpiresAt: expect.any(Date),
+        failureReason: "payment_status_unknown",
+      },
+    });
+  });
+
+  it("keeps an idempotency conflict uncertain and active without a false failure notice", async () => {
+    const attempt = {
+      id: "attempt_idempotency",
+      organizationId: "org_1",
+      status: "pending",
+      idempotencyKey: "auto-reload-idempotency",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(Date.now() + 60_000),
+      lastSubmittedAt: null,
+      createdAt: new Date(),
+      failureReason: null,
+    };
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    mockPaymentIntentsCreate = mock(() =>
+      Promise.reject(Object.assign(new Error("key is currently in use"), {
+        type: "StripeInvalidRequestError",
+        code: "idempotency_key_in_use",
+      })),
+    );
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(mockAutoReloadAttemptUpdateMany).toHaveBeenLastCalledWith({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: "org_1",
+        idempotencyKey: attempt.idempotencyKey,
+        status: "submitting",
+      },
+      data: {
+        status: "uncertain",
+        leaseExpiresAt: expect.any(Date),
+        failureReason: "payment_status_unknown",
+      },
+    });
+    expect(emittedEvents.some((event) => event.type === "auto-reload-failed")).toBe(false);
+  });
+
+  it("persists a processing PaymentIntent as active instead of failing it", async () => {
+    const attempt = {
+      id: "attempt_processing",
+      organizationId: "org_1",
+      status: "pending",
+      idempotencyKey: "auto-reload-processing",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(Date.now() + 60_000),
+      lastSubmittedAt: null,
+      createdAt: new Date(),
+      failureReason: null,
+    };
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    mockPaymentIntentsCreate = mock((params: unknown) =>
+      Promise.resolve({
+        ...(params as Record<string, unknown>),
+        id: "pi_processing",
+        status: "processing",
+        amount_received: 0,
+        latest_charge: null,
+      } as never),
+    );
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(mockAutoReloadAttemptUpdateMany).toHaveBeenLastCalledWith({
+      where: {
+        id: attempt.id,
+        organizationId: "org_1",
+        idempotencyKey: attempt.idempotencyKey,
+        activeOrganizationId: "org_1",
+        status: { in: ["submitting", "processing", "uncertain"] },
+        OR: [
+          { stripePaymentIntentId: null },
+          { stripePaymentIntentId: "pi_processing" },
+        ],
+      },
+      data: {
+        status: "processing",
+        stripePaymentIntentId: "pi_processing",
+        failureReason: null,
+        leaseExpiresAt: expect.any(Date),
+      },
+    });
+    expect(createdTransactions.some((row) => (row as { type: string }).type === "auto_reload")).toBe(false);
+    expect(emittedEvents.some((event) => event.type === "auto-reload-failed")).toBe(false);
+  });
+
+  it("retrieves a persisted processing PI and grants only after Stripe reports success", async () => {
+    const attempt = {
+      id: "attempt_processing_reconcile",
+      organizationId: "org_1",
+      status: "processing",
+      idempotencyKey: "auto-reload-processing-reconcile",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: "pi_processing_reconcile",
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(Date.now() + 60_000),
+      failureReason: null,
+    };
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    mockPaymentIntentsRetrieve = mock(() =>
+      Promise.resolve({
+        id: attempt.stripePaymentIntentId,
+        status: "succeeded",
+        currency: "usd",
+        amount: 5000,
+        amount_received: 5000,
+        customer: "cus_1",
+        payment_method: "pm_1",
+        latest_charge: null,
+        metadata: {
+          orgId: "org_1",
+          type: "auto_reload",
+          autoReloadAttemptId: attempt.id,
+          autoReloadKey: attempt.idempotencyKey,
+        },
+      } as never),
+    );
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(mockPaymentIntentsRetrieve).toHaveBeenCalledWith("pi_processing_reconcile");
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    expect(createdTransactions.some((row) => (row as { type: string }).type === "auto_reload")).toBe(true);
+  });
+
+  it("cancels a blocked nonterminal PI before marking the attempt failed", async () => {
+    const attempt = {
+      id: "attempt_requires_action",
+      organizationId: "org_1",
+      status: "processing",
+      idempotencyKey: "auto-reload-requires-action",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: "pi_requires_action",
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(Date.now() + 60_000),
+      failureReason: null,
+    };
+    const intent = {
+      id: attempt.stripePaymentIntentId,
+      status: "requires_action",
+      currency: "usd",
+      amount: 5000,
+      amount_received: 0,
+      customer: "cus_1",
+      payment_method: "pm_1",
+      latest_charge: null,
+      metadata: {
+        orgId: "org_1",
+        type: "auto_reload",
+        autoReloadAttemptId: attempt.id,
+        autoReloadKey: attempt.idempotencyKey,
+      },
+    };
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    mockPaymentIntentsRetrieve = mock(() => Promise.resolve(intent as never));
+    mockPaymentIntentsCancel = mock(() =>
+      Promise.resolve({ ...intent, status: "canceled" } as never),
+    );
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(mockPaymentIntentsCancel).toHaveBeenCalledWith("pi_requires_action");
+    expect(emittedEvents).toContainEqual({
+      type: "auto-reload-failed",
+      orgId: "org_1",
+      reloadAmount: 50,
+      remainingBalance: 0,
+      reason: "canceled",
+    });
+  });
+
+  it("lists Stripe customer intents before retrying an uncertain attempt", async () => {
+    const submittedAt = new Date(Date.now() - 60_000);
+    const attempt = {
+      id: "attempt_uncertain",
+      organizationId: "org_1",
+      status: "uncertain",
+      idempotencyKey: "auto-reload-uncertain",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(Date.now() + 60_000),
+      lastSubmittedAt: submittedAt,
+      createdAt: new Date(submittedAt.getTime() - 60_000),
+      failureReason: "payment_status_unknown",
+    };
+    const order: string[] = [];
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    mockPaymentIntentsList = mock(() => {
+      order.push("list");
+      return asyncPaymentIntentList([]);
+    });
+    mockPaymentIntentsCreate = mock((params: unknown) => {
+      order.push("create");
+      return Promise.resolve(
+        succeededIntentFromCreateParams(params as Record<string, unknown>, "pi_after_list") as never,
+      );
+    });
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(order).toEqual(["list", "create"]);
+    expect(mockPaymentIntentsList).toHaveBeenCalledWith({
+      customer: "cus_1",
+      created: { gte: expect.any(Number) },
+      limit: 100,
+    });
+  });
+
+  it("lists Stripe customer intents before releasing a settled uncertain attempt", async () => {
+    const submittedAt = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    const attempt = {
+      id: "attempt_expired_uncertain",
+      organizationId: "org_1",
+      status: "uncertain",
+      idempotencyKey: "auto-reload-expired-uncertain",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(0),
+      lastSubmittedAt: submittedAt,
+      createdAt: new Date(submittedAt.getTime() - 60_000),
+      failureReason: "payment_status_unknown",
+    };
+    let reads = 0;
+    mockAutoReloadAttemptFindUnique = mock(() =>
+      Promise.resolve((reads++ === 0 ? attempt : null) as never),
+    );
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: false, thresholdAmount: 25, reloadAmount: 50 } as never),
+    );
+    const order: string[] = [];
+    mockPaymentIntentsList = mock(() => {
+      order.push("list");
+      return asyncPaymentIntentList([]);
+    });
+    mockAutoReloadAttemptUpdateMany = mock((args: unknown) => {
+      if ((args as { data?: { activeOrganizationId?: unknown } }).data?.activeOrganizationId === null) {
+        order.push("release");
+      }
+      return Promise.resolve({ count: 1 });
+    });
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(order).toEqual(["list", "release"]);
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+  });
+
+  it("does not release a recently submitted uncertain attempt when Stripe lists no PI yet", async () => {
+    const submittedAt = new Date(Date.now() - 10 * 60 * 1000);
+    const attempt = {
+      id: "attempt_recent_uncertain",
+      organizationId: "org_1",
+      status: "uncertain",
+      idempotencyKey: "auto-reload-recent-uncertain",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(0),
+      lastSubmittedAt: submittedAt,
+      createdAt: new Date(submittedAt.getTime() - 60_000),
+      failureReason: "payment_status_unknown",
+    };
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    mockPaymentIntentsList = mock(() => asyncPaymentIntentList([]));
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    expect(mockAutoReloadAttemptUpdateMany).toHaveBeenLastCalledWith({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: "org_1",
+        idempotencyKey: attempt.idempotencyKey,
+        status: { in: ["submitting", "processing", "uncertain"] },
+        stripePaymentIntentId: null,
+      },
+      data: {
+        status: "uncertain",
+        failureReason: "awaiting_stripe_settlement",
+        leaseExpiresAt: expect.any(Date),
+      },
+    });
+    expect(
+      mockAutoReloadAttemptUpdateMany.mock.calls.some(
+        ([args]) => (args as { data?: { activeOrganizationId?: unknown } }).data
+          ?.activeOrganizationId === null,
+      ),
+    ).toBe(false);
+  });
+
+  it("commits the durable claim before deduction returns and does not await Stripe I/O", async () => {
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: true, thresholdAmount: 25, reloadAmount: 50 } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({
+        stripeCustomerId: "cus_1",
+        creditBalance: orgState.creditBalance,
+        freeCreditBalance: orgState.freeCreditBalance,
+      } as never),
+    );
+
+    let persistedData: Record<string, unknown> | undefined;
+    let resolveClaim!: (value: unknown) => void;
+    mockAutoReloadAttemptCreate = mock(({ data }: { data: Record<string, unknown> }) => {
+      persistedData = data;
+      return new Promise((resolve) => {
+        resolveClaim = resolve;
+      });
+    });
+    let resolvePaymentMethod!: (value: string | null) => void;
+    mockOffSessionPaymentMethodId = mock(() =>
+      new Promise((resolve) => {
+        resolvePaymentMethod = resolve;
+      }),
+    );
+
+    let settled = false;
+    const deduction = deductCredits("org_1", 6, "Review run").then(() => {
+      settled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockAutoReloadAttemptCreate).toHaveBeenCalledTimes(1);
+    expect(mockOffSessionPaymentMethodId).not.toHaveBeenCalled();
+    expect(settled).toBe(false);
+
+    resolveClaim({ stripePaymentIntentId: null, ...persistedData });
+    await deduction;
+
+    expect(settled).toBe(true);
+    expect(mockOffSessionPaymentMethodId).toHaveBeenCalledTimes(1);
+    resolvePaymentMethod(null);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  it("does not create durable or Stripe work for a disabled configuration", async () => {
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: false, thresholdAmount: 25, reloadAmount: 50 } as never),
+    );
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(mockAutoReloadAttemptCreate).not.toHaveBeenCalled();
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+  });
+
+  it("atomically saves enable-at-zero with its first durable attempt", async () => {
+    orgState = { creditBalance: 0, freeCreditBalance: 0 };
+    const order: string[] = [];
+    let enabled = false;
+    mockAutoReloadConfigUpsert = mock(({ create }: { create: { enabled: boolean } }) => {
+      enabled = create.enabled;
+      order.push("config");
+      return Promise.resolve(create);
+    });
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve(
+        enabled
+          ? { enabled: true, thresholdAmount: 10, reloadAmount: 50 }
+          : null,
+      ) as never,
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({
+        stripeCustomerId: "cus_1",
+        creditBalance: 0,
+        freeCreditBalance: 0,
+      } as never),
+    );
+    mockAutoReloadAttemptCreate = mock(({ data }: { data: Record<string, unknown> }) => {
+      order.push("claim");
+      return Promise.resolve({ stripePaymentIntentId: null, ...data });
+    });
+    mockOffSessionPaymentMethodId = mock(() => Promise.resolve(null));
+
+    await updateAutoReloadConfigDurably("org_1", true, 10, 50);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(order.slice(0, 2)).toEqual(["config", "claim"]);
+    expect(mockAutoReloadConfigUpsert).toHaveBeenCalledWith({
+      where: { organizationId: "org_1" },
+      create: {
+        organizationId: "org_1",
+        enabled: true,
+        pausedForDurableUpgrade: false,
+        thresholdAmount: 10,
+        reloadAmount: 50,
+      },
+      update: {
+        enabled: true,
+        pausedForDurableUpgrade: false,
+        thresholdAmount: 10,
+        reloadAmount: 50,
+      },
+    });
+    expect(mockAutoReloadAttemptCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("explicit re-enable rearms a safe failed attempt even during its cooldown", async () => {
+    orgState = { creditBalance: 0, freeCreditBalance: 0 };
+    const failedAttempt = {
+      id: "attempt_enable_retry",
+      organizationId: "org_1",
+      status: "failed",
+      idempotencyKey: "auto-reload-enable-retry",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: null,
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(Date.now() + 5 * 60 * 1000),
+      retryUntil: new Date(0),
+      lastSubmittedAt: null,
+      createdAt: new Date(),
+      failureReason: "no_payment_method",
+    };
+    let active: Record<string, unknown> | null = failedAttempt;
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(active as never));
+    mockAutoReloadAttemptUpdateMany = mock((args: unknown) => {
+      const input = args as { data: { activeOrganizationId?: string | null } };
+      if (input.data.activeOrganizationId === null) active = null;
+      return Promise.resolve({ count: 1 });
+    });
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: true, thresholdAmount: 10, reloadAmount: 50 } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1", creditBalance: 0, freeCreditBalance: 0 } as never),
+    );
+    mockAutoReloadAttemptCreate = mock(({ data }: { data: Record<string, unknown> }) => {
+      active = { stripePaymentIntentId: null, failureReason: null, ...data };
+      return Promise.resolve(active);
+    });
+    mockOffSessionPaymentMethodId = mock(() => Promise.resolve(null));
+
+    await updateAutoReloadConfigDurably("org_1", true, 10, 50);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockAutoReloadAttemptUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: failedAttempt.id,
+        activeOrganizationId: "org_1",
+        status: "failed",
+      },
+      data: {
+        status: "disabled",
+        activeOrganizationId: null,
+        failureReason: "owner_retry_requested",
+        completedAt: expect.any(Date),
+      },
+    });
+    expect(mockAutoReloadAttemptCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("disabling retires only attempts proven never submitted", async () => {
+    await updateAutoReloadConfigDurably("org_1", false, 10, 50);
+
+    expect(mockAutoReloadAttemptUpdateMany).toHaveBeenCalledWith({
+      where: {
+        activeOrganizationId: "org_1",
+        status: { in: ["initializing", "pending"] },
+        stripePaymentIntentId: null,
+        lastSubmittedAt: null,
+      },
+      data: {
+        status: "disabled",
+        activeOrganizationId: null,
+        failureReason: "auto_reload_disabled",
+        completedAt: expect.any(Date),
+      },
+    });
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+  });
+
+  it("does not charge when disable wins after a worker leases a pending attempt", async () => {
+    const attempt = {
+      id: "attempt_disable_race",
+      organizationId: "org_1",
+      status: "pending",
+      idempotencyKey: "auto-reload-disable-race",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(0),
+      lastSubmittedAt: null,
+      createdAt: new Date(),
+      failureReason: null,
+    };
+    let state = "pending";
+    let signalLeaseStarted!: () => void;
+    const leaseStarted = new Promise<void>((resolve) => {
+      signalLeaseStarted = resolve;
+    });
+    let releaseLease!: () => void;
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    mockAutoReloadAttemptUpdateMany = mock((args: unknown) => {
+      const input = args as {
+        where: { status?: unknown };
+        data: { status?: string; leaseExpiresAt?: Date };
+      };
+      if (input.data.status === "disabled") {
+        const won = state === "pending";
+        if (won) state = "disabled";
+        return Promise.resolve({ count: won ? 1 : 0 });
+      }
+      if (input.where.status === "pending" && !input.data.status) {
+        signalLeaseStarted();
+        return new Promise((resolve) => {
+          releaseLease = () => resolve({ count: 1 });
+        });
+      }
+      if (input.data.status === "submitting") {
+        const won = state === "pending";
+        if (won) state = "submitting";
+        return Promise.resolve({ count: won ? 1 : 0 });
+      }
+      return Promise.resolve({ count: 1 });
+    });
+
+    const worker = triggerAutoReloadIfNeeded("org_1", 0);
+    await leaseStarted;
+    await updateAutoReloadConfigDurably("org_1", false, 10, 50);
+    releaseLease();
+    await worker;
+
+    expect(state).toBe("disabled");
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+  });
+
+  it("does not charge when disable wins during initializing card lookup", async () => {
+    const attempt = {
+      id: "attempt_disable_lookup",
+      organizationId: "org_1",
+      status: "initializing",
+      idempotencyKey: "auto-reload-disable-lookup",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: null,
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(0),
+      lastSubmittedAt: null,
+      createdAt: new Date(),
+      failureReason: null,
+    };
+    let state = "initializing";
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: true, thresholdAmount: 10, reloadAmount: 50 } as never),
+    );
+    let signalLookupStarted!: () => void;
+    const lookupStarted = new Promise<void>((resolve) => {
+      signalLookupStarted = resolve;
+    });
+    let resolvePaymentMethod!: (value: string | null) => void;
+    mockOffSessionPaymentMethodId = mock(() => {
+      signalLookupStarted();
+      return new Promise((resolve) => {
+        resolvePaymentMethod = resolve;
+      });
+    });
+    mockAutoReloadAttemptUpdateMany = mock((args: unknown) => {
+      const input = args as { where: { status?: unknown }; data: { status?: string } };
+      if (input.data.status === "disabled") {
+        const won = state === "initializing";
+        if (won) state = "disabled";
+        return Promise.resolve({ count: won ? 1 : 0 });
+      }
+      if (input.data.status === "pending") {
+        const won = state === "initializing";
+        if (won) state = "pending";
+        return Promise.resolve({ count: won ? 1 : 0 });
+      }
+      return Promise.resolve({ count: state === "initializing" ? 1 : 0 });
+    });
+
+    const worker = triggerAutoReloadIfNeeded("org_1", 0);
+    await lookupStarted;
+    await updateAutoReloadConfigDurably("org_1", false, 10, 50);
+    resolvePaymentMethod("pm_new");
+    await worker;
+
+    expect(state).toBe("disabled");
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+  });
+
+  it("starts the idempotency retry window at the first Stripe submission", async () => {
+    const attempt = {
+      id: "attempt_late_submission",
+      organizationId: "org_1",
+      status: "pending",
+      idempotencyKey: "auto-reload-late-submission",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(0),
+      lastSubmittedAt: null,
+      createdAt: new Date(Date.now() - 48 * 60 * 60 * 1000),
+      failureReason: null,
+    };
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    mockPaymentIntentsCreate = mock((params: unknown) =>
+      Promise.resolve({
+        ...(params as Record<string, unknown>),
+        id: "pi_late_submission",
+        status: "processing",
+        amount_received: 0,
+        latest_charge: null,
+      } as never),
+    );
+
+    const before = Date.now();
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    const submittingCall = mockAutoReloadAttemptUpdateMany.mock.calls.find(
+      ([args]) => (args as { data?: { status?: string } }).data?.status === "submitting",
+    );
+    const submittingData = (submittingCall?.[0] as {
+      data: { lastSubmittedAt: Date; retryUntil: Date };
+    }).data;
+    expect(submittingData.lastSubmittedAt.getTime()).toBeGreaterThanOrEqual(before);
+    expect(submittingData.retryUntil.getTime()).toBeGreaterThan(
+      before + 22 * 60 * 60 * 1000,
+    );
+  });
+
+  it("rearms a no-card failure after the owner saves a payment method", async () => {
+    const failedAttempt = {
+      id: "attempt_no_card",
+      organizationId: "org_1",
+      status: "failed",
+      idempotencyKey: "auto-reload-no-card",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: null,
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      retryUntil: new Date(0),
+      lastSubmittedAt: null,
+      createdAt: new Date(),
+      failureReason: "no_payment_method",
+    };
+    let active: Record<string, unknown> | null = failedAttempt;
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(active as never));
+    mockAutoReloadAttemptUpdateMany = mock((args: unknown) => {
+      const input = args as { data: { activeOrganizationId?: string | null } };
+      if (input.data.activeOrganizationId === null) active = null;
+      return Promise.resolve({ count: 1 });
+    });
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: true, thresholdAmount: 30, reloadAmount: 50 } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1", creditBalance: 0, freeCreditBalance: 0 } as never),
+    );
+    mockAutoReloadAttemptCreate = mock(({ data }: { data: Record<string, unknown> }) => {
+      active = { stripePaymentIntentId: null, failureReason: null, ...data };
+      return Promise.resolve(active);
+    });
+    mockOffSessionPaymentMethodId = mock(() => Promise.resolve(null));
+
+    await rearmAutoReloadAfterPaymentMethodChange("org_1");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockPaymentIntentsList).not.toHaveBeenCalled();
+    expect(mockAutoReloadAttemptCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles a submitted failed PI with Stripe before card replacement rearms it", async () => {
+    const submittedAt = new Date(Date.now() - 10 * 60 * 1000);
+    const failedAttempt = {
+      id: "attempt_declined_card",
+      organizationId: "org_1",
+      status: "failed",
+      idempotencyKey: "auto-reload-declined-card",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_old",
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      retryUntil: new Date(Date.now() + 60_000),
+      lastSubmittedAt: submittedAt,
+      createdAt: new Date(submittedAt.getTime() - 60_000),
+      failureReason: "card_declined",
+    };
+    const oldIntent = {
+      id: "pi_declined_card",
+      status: "requires_payment_method",
+      currency: "usd",
+      amount: 5000,
+      amount_received: 0,
+      customer: "cus_1",
+      payment_method: "pm_old",
+      latest_charge: null,
+      metadata: {
+        orgId: "org_1",
+        type: "auto_reload",
+        autoReloadAttemptId: failedAttempt.id,
+        autoReloadKey: failedAttempt.idempotencyKey,
+      },
+      last_payment_error: { code: "card_declined" },
+    };
+    let active: Record<string, unknown> | null = failedAttempt;
+    const order: string[] = [];
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(active as never));
+    mockAutoReloadAttemptFindFirst = mock(() => Promise.resolve(active as never));
+    mockPaymentIntentsList = mock(() => {
+      order.push("list");
+      return asyncPaymentIntentList([oldIntent]);
+    });
+    mockPaymentIntentsCancel = mock(() => {
+      order.push("cancel");
+      return Promise.resolve({ ...oldIntent, status: "canceled" } as never);
+    });
+    mockAutoReloadAttemptUpdateMany = mock((args: unknown) => {
+      const input = args as {
+        where: { status?: unknown };
+        data: { status?: string; activeOrganizationId?: string | null; stripePaymentIntentId?: string };
+      };
+      if (input.data.status === "disabled") {
+        order.push("release");
+        active = null;
+        return Promise.resolve({ count: 1 });
+      }
+      if (input.data.stripePaymentIntentId && !input.data.status && active) {
+        active = { ...active, stripePaymentIntentId: input.data.stripePaymentIntentId };
+        return Promise.resolve({ count: 1 });
+      }
+      if (input.data.status === "failed") {
+        if (input.where.status === "initializing" && active?.status === "initializing") {
+          active = { ...active, status: "failed" };
+          return Promise.resolve({ count: 1 });
+        }
+        return Promise.resolve({ count: 0 });
+      }
+      return Promise.resolve({ count: 1 });
+    });
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: true, thresholdAmount: 30, reloadAmount: 50 } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1", creditBalance: 0, freeCreditBalance: 0 } as never),
+    );
+    mockAutoReloadAttemptCreate = mock(({ data }: { data: Record<string, unknown> }) => {
+      order.push("claim");
+      active = { stripePaymentIntentId: null, failureReason: null, ...data };
+      return Promise.resolve(active);
+    });
+    mockOffSessionPaymentMethodId = mock(() => Promise.resolve(null));
+
+    await rearmAutoReloadAfterPaymentMethodChange("org_1");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(order.slice(0, 4)).toEqual(["list", "cancel", "release", "claim"]);
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+  });
+
+  it("scheduled reconciliation replays an expired pending attempt with its exact persisted request", async () => {
+    const attempt = {
+      id: "attempt_sweep_pending",
+      organizationId: "org_1",
+      status: "pending",
+      idempotencyKey: "auto-reload-sweep-stable",
+      amountCents: 5000,
+      stripeCustomerId: "cus_original",
+      stripePaymentMethodId: "pm_original",
+      stripePaymentIntentId: null,
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(Date.now() + 60_000),
+      failureReason: null,
+    };
+    mockAutoReloadAttemptFindMany = mock(() =>
+      Promise.resolve([{ id: attempt.id, organizationId: "org_1" }] as never),
+    );
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+    // An already-authorized attempt must finish even if auto-reload was disabled
+    // after its original request became indeterminate.
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: false, thresholdAmount: 10, reloadAmount: 50 } as never),
+    );
+    let seenParams: Record<string, unknown> | undefined;
+    let seenOpts: Record<string, unknown> | undefined;
+    mockPaymentIntentsCreate = mock((params: unknown, opts: unknown) => {
+      seenParams = params as Record<string, unknown>;
+      seenOpts = opts as Record<string, unknown>;
+      return Promise.resolve(
+        succeededIntentFromCreateParams(params as Record<string, unknown>, "pi_sweep_pending") as never,
+      );
+    });
+
+    await expect(reconcileAutoReloadAttempts()).resolves.toEqual({
+      scanned: 1,
+      attempted: 1,
+      failed: 0,
+    });
+
+    expect(seenParams).toMatchObject({
+      amount: 5000,
+      currency: "usd",
+      customer: "cus_original",
+      payment_method: "pm_original",
+      off_session: true,
+      confirm: true,
+      metadata: {
+        orgId: "org_1",
+        type: "auto_reload",
+        amountUsd: "50",
+        autoReloadAttemptId: attempt.id,
+        autoReloadKey: attempt.idempotencyKey,
+      },
+    });
+    expect(seenOpts).toEqual({ idempotencyKey: attempt.idempotencyKey });
+    expect(mockAutoReloadConfigFindUnique).not.toHaveBeenCalled();
+    expect(
+      createdTransactions.filter((row) => (row as { type: string }).type === "auto_reload"),
+    ).toHaveLength(1);
+  });
+
+  it("scheduled reconciliation grants a charged attempt without creating another PaymentIntent", async () => {
+    const attempt = {
+      id: "attempt_sweep_charged",
+      organizationId: "org_1",
+      status: "charged",
+      idempotencyKey: "auto-reload-charged-stable",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: "pi_already_charged",
+      leaseExpiresAt: new Date(0),
+      retryUntil: new Date(Date.now() + 60_000),
+      failureReason: null,
+    };
+    mockAutoReloadAttemptFindMany = mock(() =>
+      Promise.resolve([{ id: attempt.id, organizationId: "org_1" }] as never),
+    );
+    mockAutoReloadAttemptFindUnique = mock(() => Promise.resolve(attempt as never));
+
+    await expect(reconcileAutoReloadAttempts()).resolves.toEqual({
+      scanned: 1,
+      attempted: 1,
+      failed: 0,
+    });
+
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    expect(createdTransactions).toContainEqual({
+      amount: 50,
+      type: "auto_reload",
+      description: "Auto-reload — $50",
+      stripeSessionId: "pi_already_charged",
+      balanceAfter: 78,
+      organizationId: "org_1",
+    });
+    expect(mockAutoReloadAttemptUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: attempt.id,
+        organizationId: "org_1",
+        idempotencyKey: attempt.idempotencyKey,
+        status: { in: ["initializing", "pending", "submitting", "processing", "charged", "failed", "uncertain"] },
+      },
+      data: {
+        status: "completed",
+        activeOrganizationId: null,
+        stripePaymentIntentId: "pi_already_charged",
+        failureReason: null,
+        completedAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("bounds scheduled reconciliation to expired pending and charged attempts", async () => {
+    await expect(reconcileAutoReloadAttempts()).resolves.toEqual({
+      scanned: 0,
+      attempted: 0,
+      failed: 0,
+    });
+
+    expect(mockAutoReloadAttemptFindMany).toHaveBeenCalledWith({
+      where: {
+        activeOrganizationId: { not: null },
+        status: { in: ["initializing", "pending", "submitting", "processing", "charged", "uncertain"] },
+        leaseExpiresAt: { lte: expect.any(Date) },
+      },
+      select: { id: true, organizationId: true },
+      orderBy: { leaseExpiresAt: "asc" },
+      take: 100,
+    });
+  });
+
+  it("isolates a failed candidate and continues the reconciliation batch", async () => {
+    mockAutoReloadAttemptFindMany = mock(() =>
+      Promise.resolve([
+        { id: "attempt_bad", organizationId: "org_bad" },
+        { id: "attempt_good", organizationId: "org_good" },
+      ] as never),
+    );
+    let balanceReads = 0;
+    mockFindUniqueOrThrow = mock(async () => {
+      balanceReads += 1;
+      if (balanceReads === 1) throw new Error("org balance unavailable");
+      return { creditBalance: orgState.creditBalance, freeCreditBalance: orgState.freeCreditBalance };
+    });
+    mockAutoReloadAttemptFindUnique = mock(() =>
+      Promise.resolve({
+        id: "attempt_good",
+        organizationId: "org_good",
+        status: "pending",
+        idempotencyKey: "auto-reload-good",
+        amountCents: 5000,
+        stripeCustomerId: "cus_good",
+        stripePaymentMethodId: "pm_good",
+        stripePaymentIntentId: null,
+        leaseExpiresAt: new Date(0),
+        retryUntil: new Date(Date.now() + 60_000),
+        failureReason: null,
+      } as never),
+    );
+    mockPaymentIntentsCreate = mock((params: unknown) =>
+      Promise.resolve(
+        succeededIntentFromCreateParams(params as Record<string, unknown>, "pi_good") as never,
+      ),
+    );
+
+    await expect(reconcileAutoReloadAttempts()).resolves.toEqual({
+      scanned: 2,
+      attempted: 1,
+      failed: 1,
+    });
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+    expect(
+      createdTransactions.filter((row) => (row as { type: string }).type === "auto_reload"),
+    ).toHaveLength(1);
+  });
+
+  it("suppresses a decline notice when a raced webhook already completed the attempt", async () => {
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: true, thresholdAmount: 25, reloadAmount: 50 } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({
+        stripeCustomerId: "cus_1",
+        creditBalance: orgState.creditBalance,
+        freeCreditBalance: orgState.freeCreditBalance,
+      } as never),
+    );
+    mockAutoReloadAttemptUpdateMany = mock(() => Promise.resolve({ count: 0 }));
+    mockPaymentIntentsCreate = mock(() =>
+      Promise.reject(Object.assign(new Error("declined"), {
+        type: "StripeCardError",
+        code: "card_declined",
+      })),
+    );
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(emittedEvents.some((event) => event.type === "auto-reload-failed")).toBe(false);
+  });
+
+  it("suppresses a non-succeeded notice when a raced webhook already completed the attempt", async () => {
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: true, thresholdAmount: 25, reloadAmount: 50 } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({
+        stripeCustomerId: "cus_1",
+        creditBalance: orgState.creditBalance,
+        freeCreditBalance: orgState.freeCreditBalance,
+      } as never),
+    );
+    mockAutoReloadAttemptUpdateMany = mock(() => Promise.resolve({ count: 0 }));
+    mockPaymentIntentsCreate = mock(() =>
+      Promise.resolve({ id: "pi_action", status: "requires_action", latest_charge: null } as never),
+    );
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(emittedEvents.some((event) => event.type === "auto-reload-failed")).toBe(false);
+  });
+
+  it("can trigger immediately at zero balance without waiting for a deduction", async () => {
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({ enabled: true, thresholdAmount: 10, reloadAmount: 50 } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_1", creditBalance: 0, freeCreditBalance: 0 } as never),
+    );
+    mockPaymentIntentsCreate = mock((params: unknown) =>
+      Promise.resolve(
+        succeededIntentFromCreateParams(params as Record<string, unknown>, "pi_zero") as never,
+      ),
+    );
+
+    await triggerAutoReloadIfNeeded("org_1", 0);
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report a successful charge as failed when only the credit grant fails", async () => {
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({
+        enabled: true,
+        thresholdAmount: 25,
+        reloadAmount: 50,
+      } as never),
+    );
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({
+        stripeCustomerId: "cus_1",
+        creditBalance: orgState.creditBalance,
+        freeCreditBalance: orgState.freeCreditBalance,
+      } as never),
+    );
+    mockPaymentIntentsCreate = mock((params: unknown) =>
+      Promise.resolve(
+        succeededIntentFromCreateParams(params as Record<string, unknown>, "pi_auto_recover") as never,
+      ),
+    );
+    mockTxCreditTransactionCreate = mock(({ data }: { data: unknown }) => {
+      if ((data as { type: string }).type === "auto_reload") {
+        return Promise.reject(new Error("database unavailable"));
+      }
+      createdTransactions.push(data);
+      return Promise.resolve(data);
+    });
+
+    await deductCredits("org_1", 6, "Review run");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+    expect(emittedEvents.some((event) => event.type === "auto-reload-failed")).toBe(false);
+    expect(
+      createdTransactions.filter((row) => (row as { type: string }).type === "auto_reload"),
+    ).toHaveLength(0);
   });
 });
 
@@ -495,6 +1859,17 @@ describe("Stripe webhook route", () => {
   });
 
   it("deducts credits when Stripe reports a refund and maps the payment intent back to the org", async () => {
+    // Even with auto-reload enabled and the resulting balance below threshold,
+    // a refund must never charge the customer again.
+    mockAutoReloadConfigFindUnique = mock(() =>
+      Promise.resolve({
+        id: "arc_refund",
+        enabled: true,
+        thresholdAmount: 25,
+        reloadAmount: 50,
+        updatedAt: new Date(0),
+      } as never),
+    );
     currentEvent = {
       type: "charge.refunded",
       data: {
@@ -530,6 +1905,8 @@ describe("Stripe webhook route", () => {
         organizationId: "org_1",
       },
     ]);
+    expect(mockAutoReloadConfigFindUnique).not.toHaveBeenCalled();
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
   });
 
   it("deducts each partial refund by its own amount, not the cumulative charge total", async () => {
@@ -867,13 +2244,13 @@ describe("off-session payment method resolution", () => {
 
 
 describe("volume purchase bonus", () => {
-  it("computes tiered bonus (0 below $100, 5% at $100+, 10% at $500+)", () => {
+  it("computes tiered bonus (50% at $100, 60% at $250, 70% at $500+)", () => {
     expect(volumeBonusUsd(25)).toBe(0);
     expect(volumeBonusUsd(99)).toBe(0);
-    expect(volumeBonusUsd(100)).toBe(5);
-    expect(volumeBonusUsd(250)).toBe(12.5);
-    expect(volumeBonusUsd(500)).toBe(50);
-    expect(volumeBonusUsd(1000)).toBe(100);
+    expect(volumeBonusUsd(100)).toBe(50);
+    expect(volumeBonusUsd(250)).toBe(150);
+    expect(volumeBonusUsd(500)).toBe(350);
+    expect(volumeBonusUsd(1000)).toBe(700);
     expect(volumeBonusUsd(0)).toBe(0);
     expect(volumeBonusUsd(-5)).toBe(0);
   });
@@ -894,15 +2271,15 @@ describe("volume purchase bonus", () => {
     const response = await POST(stripeRequest() as never);
 
     expect(response.status).toBe(200);
-    // free 8 + purchased 20, then +100 purchased, +5 free bonus.
-    expect(orgState).toEqual({ creditBalance: 120, freeCreditBalance: 13 });
+    // free 8 + purchased 20, then +100 purchased, +50 free bonus.
+    expect(orgState).toEqual({ creditBalance: 120, freeCreditBalance: 58 });
     const types = createdTransactions.map((t) => (t as { type: string }).type);
     expect(types).toContain("purchase");
     expect(types).toContain("free_credit");
     const bonus = createdTransactions.find(
       (t) => (t as { type: string }).type === "free_credit",
     ) as { amount: number };
-    expect(bonus.amount).toBe(5); // NOT part of the purchase/revenue row
+    expect(bonus.amount).toBe(50); // NOT part of the purchase/revenue row
   });
 
   it("grants no bonus row for a sub-$100 top-up", async () => {
@@ -966,8 +2343,8 @@ describe("off-session credit purchase", () => {
     const res = await chargeCreditsOffSession("org_1", 100, "idem-test");
 
     expect(res).toEqual({ status: "succeeded", paymentIntentId: "pi_buy" });
-    // free 8 + purchased 20, then +100 purchased and +5 free bonus.
-    expect(orgState).toEqual({ creditBalance: 120, freeCreditBalance: 13 });
+    // free 8 + purchased 20, then +100 purchased and +50 free bonus.
+    expect(orgState).toEqual({ creditBalance: 120, freeCreditBalance: 58 });
     const purchase = createdTransactions.find((t) => (t as { type: string }).type === "purchase") as {
       stripeSessionId: string;
       amount: number;
@@ -977,7 +2354,7 @@ describe("off-session credit purchase", () => {
     const bonus = createdTransactions.find((t) => (t as { type: string }).type === "free_credit") as {
       amount: number;
     };
-    expect(bonus.amount).toBe(5);
+    expect(bonus.amount).toBe(50);
   });
 
   it("failed with cardError=true when the saved card is genuinely declined", async () => {
@@ -1027,8 +2404,8 @@ describe("payment_intent.succeeded backfill (charge-without-grant recovery)", ()
     const response = await POST(stripeRequest() as never);
 
     expect(response.status).toBe(200);
-    // +100 purchased, +5 bonus.
-    expect(orgState).toEqual({ creditBalance: 120, freeCreditBalance: 13 });
+    // +100 purchased, +50 bonus.
+    expect(orgState).toEqual({ creditBalance: 120, freeCreditBalance: 58 });
     const purchase = createdTransactions.find((t) => (t as { type: string }).type === "purchase") as {
       stripeSessionId: string;
     };
@@ -1057,6 +2434,410 @@ describe("payment_intent.succeeded backfill (charge-without-grant recovery)", ()
 
     expect(response.status).toBe(200);
     expect(orgState).toEqual({ creditBalance: 20, freeCreditBalance: 8 }); // unchanged, no double-grant
+  });
+
+  it("recovers an auto-reload charge by granting credits keyed on the PI id", async () => {
+    mockAutoReloadAttemptFindFirst = mock(() =>
+      Promise.resolve({
+        id: "attempt_recover",
+        organizationId: "org_1",
+        idempotencyKey: "auto-reload-recover",
+        amountCents: 5000,
+        stripeCustomerId: "cus_1",
+        stripePaymentMethodId: "pm_1",
+        stripePaymentIntentId: null,
+      } as never),
+    );
+    currentEvent = {
+      type: "payment_intent.succeeded",
+      data: {
+        object: {
+          id: "pi_auto_recover",
+          status: "succeeded",
+          currency: "usd",
+          amount: 5000,
+          amount_received: 5000,
+          customer: "cus_1",
+          payment_method: "pm_1",
+          latest_charge: null,
+          metadata: {
+            orgId: "org_1",
+            type: "auto_reload",
+            amountUsd: "999",
+            autoReloadAttemptId: "attempt_recover",
+            autoReloadKey: "auto-reload-recover",
+          },
+        },
+      },
+    };
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(orgState).toEqual({ creditBalance: 70, freeCreditBalance: 8 });
+    expect(createdTransactions).toContainEqual({
+      amount: 50,
+      type: "auto_reload",
+      description: "Auto-reload — $50",
+      stripeSessionId: "pi_auto_recover",
+      balanceAfter: 78,
+      organizationId: "org_1",
+    });
+    expect(mockAutoReloadAttemptUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: "attempt_recover",
+        organizationId: "org_1",
+        idempotencyKey: "auto-reload-recover",
+        status: { in: ["initializing", "pending", "submitting", "processing", "charged", "failed", "uncertain"] },
+      },
+      data: {
+        status: "completed",
+        activeOrganizationId: null,
+        stripePaymentIntentId: "pi_auto_recover",
+        failureReason: null,
+        completedAt: expect.any(Date),
+      },
+    });
+  });
+
+  it("acknowledges an already-granted auto-reload PI without double-crediting", async () => {
+    mockTxCreditTransactionCreate = mock(() =>
+      Promise.reject(Object.assign(new Error("duplicate"), { code: "P2002" })),
+    );
+    mockAutoReloadAttemptFindFirst = mock(() =>
+      Promise.resolve({
+        id: "attempt_duplicate",
+        organizationId: "org_1",
+        idempotencyKey: "auto-reload-duplicate",
+        amountCents: 5000,
+        stripeCustomerId: "cus_1",
+        stripePaymentMethodId: "pm_1",
+        stripePaymentIntentId: "pi_auto_duplicate",
+      } as never),
+    );
+    currentEvent = {
+      type: "payment_intent.succeeded",
+      data: {
+        object: {
+          id: "pi_auto_duplicate",
+          status: "succeeded",
+          currency: "usd",
+          amount: 5000,
+          amount_received: 5000,
+          customer: "cus_1",
+          payment_method: "pm_1",
+          latest_charge: null,
+          metadata: {
+            orgId: "org_1",
+            type: "auto_reload",
+            amountUsd: "50",
+            autoReloadAttemptId: "attempt_duplicate",
+            autoReloadKey: "auto-reload-duplicate",
+          },
+        },
+      },
+    };
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(orgState).toEqual({ creditBalance: 20, freeCreditBalance: 8 });
+  });
+
+  it("recovers a tightly validated legacy auto-reload PI during a rolling deploy", async () => {
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_legacy" } as never),
+    );
+    currentEvent = {
+      type: "payment_intent.succeeded",
+      data: {
+        object: {
+          id: "pi_legacy_auto_reload",
+          status: "succeeded",
+          currency: "usd",
+          amount: 5000,
+          amount_received: 5000,
+          customer: "cus_legacy",
+          payment_method: "pm_legacy",
+          latest_charge: null,
+          metadata: {
+            orgId: "org_1",
+            type: "auto_reload",
+            amountUsd: "50",
+          },
+        },
+      },
+    };
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(createdTransactions).toContainEqual({
+      amount: 50,
+      type: "auto_reload",
+      description: "Auto-reload — $50",
+      stripeSessionId: "pi_legacy_auto_reload",
+      balanceAfter: 78,
+      organizationId: "org_1",
+    });
+    expect(mockAutoReloadAttemptFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects a legacy auto-reload PI whose Stripe customer does not match the org", async () => {
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({ stripeCustomerId: "cus_expected" } as never),
+    );
+    currentEvent = {
+      type: "payment_intent.succeeded",
+      data: {
+        object: {
+          id: "pi_legacy_wrong_customer",
+          status: "succeeded",
+          currency: "usd",
+          amount: 5000,
+          amount_received: 5000,
+          customer: "cus_other",
+          payment_method: "pm_legacy",
+          latest_charge: null,
+          metadata: {
+            orgId: "org_1",
+            type: "auto_reload",
+            amountUsd: "50",
+          },
+        },
+      },
+    };
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(500);
+    expect(createdTransactions).toEqual([]);
+  });
+
+  it("returns 500 so Stripe retries a transient auto-reload grant failure", async () => {
+    mockTxCreditTransactionCreate = mock(() =>
+      Promise.reject(new Error("database unavailable")),
+    );
+    mockAutoReloadAttemptFindFirst = mock(() =>
+      Promise.resolve({
+        id: "attempt_retry",
+        organizationId: "org_1",
+        idempotencyKey: "auto-reload-retry",
+        amountCents: 5000,
+        stripeCustomerId: "cus_1",
+        stripePaymentMethodId: "pm_1",
+        stripePaymentIntentId: null,
+      } as never),
+    );
+    currentEvent = {
+      type: "payment_intent.succeeded",
+      data: {
+        object: {
+          id: "pi_auto_retry",
+          status: "succeeded",
+          currency: "usd",
+          amount: 5000,
+          amount_received: 5000,
+          customer: "cus_1",
+          payment_method: "pm_1",
+          latest_charge: null,
+          metadata: {
+            orgId: "org_1",
+            type: "auto_reload",
+            amountUsd: "50",
+            autoReloadAttemptId: "attempt_retry",
+            autoReloadKey: "auto-reload-retry",
+          },
+        },
+      },
+    };
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "processing failed" });
+    expect(orgState).toEqual({ creditBalance: 20, freeCreditBalance: 8 });
+  });
+
+  it("does not trust auto-reload metadata when the paid amount mismatches the persisted attempt", async () => {
+    mockAutoReloadAttemptFindFirst = mock(() =>
+      Promise.resolve({
+        id: "attempt_mismatch",
+        organizationId: "org_1",
+        idempotencyKey: "auto-reload-mismatch",
+        amountCents: 5000,
+        stripeCustomerId: "cus_1",
+        stripePaymentMethodId: "pm_1",
+        stripePaymentIntentId: null,
+      } as never),
+    );
+    currentEvent = {
+      type: "payment_intent.succeeded",
+      data: {
+        object: {
+          id: "pi_auto_mismatch",
+          status: "succeeded",
+          currency: "usd",
+          amount: 5000,
+          amount_received: 4000,
+          customer: "cus_1",
+          payment_method: "pm_1",
+          latest_charge: null,
+          metadata: {
+            orgId: "org_1",
+            type: "auto_reload",
+            amountUsd: "5000",
+            autoReloadAttemptId: "attempt_mismatch",
+            autoReloadKey: "auto-reload-mismatch",
+          },
+        },
+      },
+    };
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(500);
+    expect(createdTransactions).toEqual([]);
+    expect(orgState).toEqual({ creditBalance: 20, freeCreditBalance: 8 });
+    expect(mockAutoReloadAttemptUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it("finalizes only the matching durable attempt on payment_intent.payment_failed", async () => {
+    mockAutoReloadAttemptFindFirst = mock(() =>
+      Promise.resolve({
+        id: "attempt_failed",
+        organizationId: "org_1",
+        idempotencyKey: "auto-reload-failed",
+        amountCents: 5000,
+        stripeCustomerId: "cus_1",
+        stripePaymentMethodId: "pm_1",
+        stripePaymentIntentId: null,
+      } as never),
+    );
+    let finalized = false;
+    mockAutoReloadAttemptUpdateMany = mock(() => {
+      if (finalized) return Promise.resolve({ count: 0 });
+      finalized = true;
+      return Promise.resolve({ count: 1 });
+    });
+    currentEvent = {
+      type: "payment_intent.payment_failed",
+      data: {
+        object: {
+          id: "pi_auto_failed",
+          status: "requires_payment_method",
+          currency: "usd",
+          amount: 5000,
+          amount_received: 0,
+          customer: "cus_1",
+          payment_method: "pm_1",
+          metadata: {
+            orgId: "org_1",
+            type: "auto_reload",
+            autoReloadAttemptId: "attempt_failed",
+            autoReloadKey: "auto-reload-failed",
+          },
+          last_payment_error: { code: "card_declined", message: "declined" },
+        },
+      },
+    };
+    mockPaymentIntentsRetrieve = mock(() =>
+      Promise.resolve({
+        ...(currentEvent as { data: { object: Record<string, unknown> } }).data.object,
+        status: "canceled",
+      } as never),
+    );
+
+    const response = await POST(stripeRequest() as never);
+    const duplicateResponse = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(duplicateResponse.status).toBe(200);
+    expect(mockAutoReloadAttemptUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: "attempt_failed",
+        organizationId: "org_1",
+        idempotencyKey: "auto-reload-failed",
+        activeOrganizationId: "org_1",
+        status: { in: ["submitting", "processing", "uncertain"] },
+      },
+      data: {
+        status: "failed",
+        stripePaymentIntentId: "pi_auto_failed",
+        failureReason: "card_declined",
+        leaseExpiresAt: expect.any(Date),
+        completedAt: expect.any(Date),
+      },
+    });
+    expect(
+      emittedEvents.filter((event) => event.type === "auto-reload-failed"),
+    ).toEqual([
+      {
+        type: "auto-reload-failed",
+        orgId: "org_1",
+        reloadAmount: 50,
+        remainingBalance: 28,
+        reason: "card_declined",
+      },
+    ]);
+  });
+
+  it("uses current Stripe state so an older failed event cannot demote a succeeded PI", async () => {
+    const attempt = {
+      id: "attempt_out_of_order",
+      organizationId: "org_1",
+      idempotencyKey: "auto-reload-out-of-order",
+      amountCents: 5000,
+      stripeCustomerId: "cus_1",
+      stripePaymentMethodId: "pm_1",
+      stripePaymentIntentId: "pi_out_of_order",
+    };
+    mockAutoReloadAttemptFindFirst = mock(() => Promise.resolve(attempt as never));
+    currentEvent = {
+      type: "payment_intent.payment_failed",
+      data: {
+        object: {
+          id: "pi_out_of_order",
+          status: "requires_payment_method",
+          currency: "usd",
+          amount: 5000,
+          amount_received: 0,
+          customer: "cus_1",
+          payment_method: "pm_1",
+          metadata: {
+            orgId: "org_1",
+            type: "auto_reload",
+            autoReloadAttemptId: attempt.id,
+            autoReloadKey: attempt.idempotencyKey,
+          },
+          last_payment_error: { code: "card_declined", message: "declined" },
+        },
+      },
+    };
+    mockPaymentIntentsRetrieve = mock(() =>
+      Promise.resolve({
+        id: "pi_out_of_order",
+        status: "succeeded",
+        currency: "usd",
+        amount: 5000,
+        amount_received: 5000,
+        customer: "cus_1",
+        payment_method: "pm_1",
+        latest_charge: null,
+        metadata: {
+          orgId: "org_1",
+          type: "auto_reload",
+          autoReloadAttemptId: attempt.id,
+          autoReloadKey: attempt.idempotencyKey,
+        },
+      } as never),
+    );
+
+    const response = await POST(stripeRequest() as never);
+
+    expect(response.status).toBe(200);
+    expect(createdTransactions.some((row) => (row as { type: string }).type === "auto_reload")).toBe(true);
+    expect(emittedEvents.some((event) => event.type === "auto-reload-failed")).toBe(false);
   });
 
   it("ignores a Checkout PI (no metadata.type) so it can't double-grant a checkout purchase", async () => {

--- a/apps/web/lib/__tests__/concurrency-guard.test.ts
+++ b/apps/web/lib/__tests__/concurrency-guard.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "bun:test";
-import { concurrencyGuardApplies } from "@/lib/cost";
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const { concurrencyGuardApplies } = await import("@/lib/cost");
 
 describe("concurrencyGuardApplies (#506 low-balance guard)", () => {
   it("never guards a fully-BYOK org (no platform spend)", () => {

--- a/apps/web/lib/__tests__/cost.test.ts
+++ b/apps/web/lib/__tests__/cost.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, mock } from "bun:test";
 
+mock.module("server-only", () => ({}));
+
 // Mock the db module before importing cost.ts (which imports prisma at top level).
 // Bun's module mocks are file-scoped and automatically cleaned up — no manual restore needed.
 mock.module("@octopus/db", () => ({
   prisma: {},
 }));
 
-import { calcCost, formatUsd, formatNumber } from "@/lib/cost";
+const { calcCost, formatUsd, formatNumber } = await import("@/lib/cost");
 
 // The cache-write premium tracks PROMPT_CACHE_TTL (1.25x for 5m, 2x for 1h).
 // Pin 5m so the formula assertions below stay deterministic; a dedicated test

--- a/apps/web/lib/__tests__/review-routing.test.ts
+++ b/apps/web/lib/__tests__/review-routing.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "bun:test";
-import { classifyDiff, extractChangedPaths, MECHANICAL_MODEL } from "@/lib/review-routing";
+import { describe, it, expect, mock } from "bun:test";
+
+mock.module("server-only", () => ({}));
+
+const { classifyDiff, extractChangedPaths, MECHANICAL_MODEL } = await import(
+  "@/lib/review-routing"
+);
 
 function diffFor(path: string, added = 3): string {
   const plus = Array.from({ length: added }, (_, i) => `+line ${i}`).join("\n");

--- a/apps/web/lib/__tests__/spend-limit.test.ts
+++ b/apps/web/lib/__tests__/spend-limit.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 
+mock.module("server-only", () => ({}));
+
 // getOrgSpendLimitStatus reaches prisma + the review-model/provider resolvers.
 // Mock those before importing cost.ts. Mock fns close over these mutable vars so
-// each test can set the org, the effective review provider, and monthly usage.
+// each test can set the org, the effective review provider, and monthly spend.
 type OrgRow = {
   type: number;
   anthropicApiKey: string | null;
@@ -21,7 +23,10 @@ type OrgRow = {
 let org: OrgRow;
 let provider = "anthropic";
 let providerThrows = false;
-let usageRows: Array<{ model: string; _sum: Record<string, number> }> = [];
+let usageDebitTotal: number | null = null;
+const creditTransactionAggregate = mock(async (_args: unknown) => ({
+  _sum: { amount: usageDebitTotal },
+}));
 
 function baseOrg(overrides: Partial<OrgRow> = {}): OrgRow {
   return {
@@ -44,7 +49,7 @@ function baseOrg(overrides: Partial<OrgRow> = {}): OrgRow {
 mock.module("@octopus/db", () => ({
   prisma: {
     organization: { findUnique: mock(async () => org) },
-    aiUsage: { groupBy: mock(async () => usageRows) },
+    creditTransaction: { aggregate: creditTransactionAggregate },
     // getModelPricing falls back to FALLBACK_PRICING when the DB list is empty.
     availableModel: { findMany: mock(async () => []), findFirst: mock(async () => null) },
   },
@@ -59,13 +64,14 @@ mock.module("@/lib/ai-router", () => ({
   }),
 }));
 
-import { getOrgSpendLimitStatus } from "@/lib/cost";
+const { getOrgMonthlySpend, getOrgSpendLimitStatus } = await import("@/lib/cost");
 
 beforeEach(() => {
   org = baseOrg();
   provider = "anthropic";
   providerThrows = false;
-  usageRows = [];
+  usageDebitTotal = null;
+  creditTransactionAggregate.mockClear();
 });
 
 describe("getOrgSpendLimitStatus — BYOK admission (B4)", () => {
@@ -113,18 +119,59 @@ describe("getOrgSpendLimitStatus — credit vs cap discrimination (B1 source of 
 
   it("returns reason=spend_limit when a positive-balance org exceeds its monthly cap", async () => {
     org = baseOrg({ creditBalance: 100, freeCreditBalance: 0, monthlySpendLimitUsd: 1 });
-    // ~$30 of platform-billed usage this month (1M output tokens on opus-4-8
-    // fallback pricing $25/M × 1.2 markup) blows the $1 cap.
-    usageRows = [
-      { model: "claude-opus-4-8", _sum: { inputTokens: 0, outputTokens: 1_000_000, cacheReadTokens: 0, cacheWriteTokens: 0 } },
-    ];
+    usageDebitTotal = -30;
     const res = await getOrgSpendLimitStatus("o");
     expect(res.blocked).toBe(true);
     expect(res).toMatchObject({ reason: "spend_limit" });
   });
 
+  it("uses committed usage debits for current-month spend", async () => {
+    org = baseOrg({ creditBalance: 100, freeCreditBalance: 0, monthlySpendLimitUsd: 4 });
+    usageDebitTotal = -4.25;
+
+    expect(await getOrgSpendLimitStatus("o")).toEqual({
+      blocked: true,
+      reason: "spend_limit",
+      limitUsd: 4,
+    });
+  });
+
   it("exempts community orgs from the credit gate entirely", async () => {
     org = baseOrg({ type: 2, creditBalance: 0, freeCreditBalance: 0 });
     expect(await getOrgSpendLimitStatus("o")).toEqual({ blocked: false });
+  });
+});
+
+describe("getOrgMonthlySpend — committed ledger source", () => {
+  it("sums only non-refund usage debits inside the current UTC month", async () => {
+    usageDebitTotal = -12.3456;
+
+    expect(await getOrgMonthlySpend("org_1")).toBe(12.3456);
+
+    const query = creditTransactionAggregate.mock.calls[0]?.[0] as {
+      where: {
+        organizationId: string;
+        type: string;
+        stripeRefundId: null;
+        amount: { lt: number };
+        createdAt: { gte: Date; lt: Date };
+      };
+    };
+    expect(query.where).toMatchObject({
+      organizationId: "org_1",
+      type: "usage",
+      stripeRefundId: null,
+      amount: { lt: 0 },
+    });
+    expect(query.where.createdAt.gte.getUTCDate()).toBe(1);
+    expect(query.where.createdAt.gte.getUTCHours()).toBe(0);
+    expect(query.where.createdAt.lt.getUTCDate()).toBe(1);
+    expect(query.where.createdAt.lt.getTime()).toBeGreaterThan(
+      query.where.createdAt.gte.getTime(),
+    );
+  });
+
+  it("returns zero when no committed usage debit exists", async () => {
+    expect(await getOrgMonthlySpend("org_1")).toBe(0);
   });
 });

--- a/apps/web/lib/__tests__/stripe-payment-method.test.ts
+++ b/apps/web/lib/__tests__/stripe-payment-method.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+let mockCustomerRetrieve = mock(() => Promise.resolve({ deleted: false } as never));
+let mockPaymentMethodRetrieve = mock(() => Promise.resolve({} as never));
+let mockPaymentMethodList = mock(() => Promise.resolve({ data: [] } as never));
+
+const stripeClient = {
+  customers: {
+    retrieve: (...args: unknown[]) => mockCustomerRetrieve(...args),
+  },
+  paymentMethods: {
+    retrieve: (...args: unknown[]) => mockPaymentMethodRetrieve(...args),
+    list: (...args: unknown[]) => mockPaymentMethodList(...args),
+  },
+};
+
+mock.module("server-only", () => ({}));
+
+const { resolveOffSessionCardPaymentMethodId } = await import("@/lib/stripe-payment-method");
+
+function resolveCard(customerId: string) {
+  return resolveOffSessionCardPaymentMethodId(stripeClient as never, customerId);
+}
+
+beforeEach(() => {
+  mockCustomerRetrieve = mock(() => Promise.resolve({ deleted: false } as never));
+  mockPaymentMethodRetrieve = mock(() => Promise.resolve({} as never));
+  mockPaymentMethodList = mock(() => Promise.resolve({ data: [] } as never));
+});
+
+describe("off-session card resolution", () => {
+  it("retrieves a string default and accepts it only when it is this customer's card", async () => {
+    mockCustomerRetrieve = mock(() =>
+      Promise.resolve({
+        deleted: false,
+        invoice_settings: { default_payment_method: "pm_default" },
+      } as never),
+    );
+    mockPaymentMethodRetrieve = mock(() =>
+      Promise.resolve({ id: "pm_default", type: "card", customer: "cus_1" } as never),
+    );
+
+    await expect(resolveCard("cus_1")).resolves.toBe("pm_default");
+
+    expect(mockPaymentMethodRetrieve).toHaveBeenCalledWith("pm_default");
+    expect(mockPaymentMethodList).not.toHaveBeenCalled();
+  });
+
+  it("falls back to one attached card when the default is non-card or belongs elsewhere", async () => {
+    mockCustomerRetrieve = mock(() =>
+      Promise.resolve({
+        deleted: false,
+        invoice_settings: { default_payment_method: "pm_bank" },
+      } as never),
+    );
+    mockPaymentMethodRetrieve = mock(() =>
+      Promise.resolve({ id: "pm_bank", type: "us_bank_account", customer: "cus_1" } as never),
+    );
+    mockPaymentMethodList = mock(() =>
+      Promise.resolve({ data: [{ id: "pm_card", type: "card", customer: "cus_1" }] } as never),
+    );
+
+    await expect(resolveCard("cus_1")).resolves.toBe("pm_card");
+
+    expect(mockPaymentMethodList).toHaveBeenCalledWith({
+      customer: "cus_1",
+      type: "card",
+      limit: 1,
+    });
+  });
+
+  it("propagates a Stripe outage instead of misreporting it as no saved card", async () => {
+    mockCustomerRetrieve = mock(() =>
+      Promise.resolve({
+        deleted: false,
+        invoice_settings: { default_payment_method: "pm_default" },
+      } as never),
+    );
+    mockPaymentMethodRetrieve = mock(() => Promise.reject(new Error("stripe unavailable")));
+
+    await expect(resolveCard("cus_1")).rejects.toThrow("stripe unavailable");
+    expect(mockPaymentMethodList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/billing-period.ts
+++ b/apps/web/lib/billing-period.ts
@@ -1,0 +1,72 @@
+export type MonthlySpendSummary = {
+  spendUsd: number;
+  limitUsd: number | null;
+  remainingUsd: number | null;
+  percentUsed: number | null;
+  progressPercent: number | null;
+  limitReached: boolean;
+};
+
+export function getUtcMonthBounds(now = new Date()): { start: Date; end: Date } {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+
+  return {
+    start: new Date(Date.UTC(year, month, 1)),
+    end: new Date(Date.UTC(year, month + 1, 1)),
+  };
+}
+
+export function formatBillingResetLabel(periodEnd: Date): string {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(periodEnd);
+}
+
+export function summarizeMonthlySpend(
+  monthlySpendUsd: number,
+  monthlySpendLimitUsd: number | null,
+): MonthlySpendSummary {
+  const spendUsd = Number.isFinite(monthlySpendUsd)
+    ? Math.max(0, monthlySpendUsd)
+    : 0;
+  const limitUsd =
+    monthlySpendLimitUsd != null && Number.isFinite(monthlySpendLimitUsd)
+      ? Math.max(0, monthlySpendLimitUsd)
+      : null;
+
+  if (limitUsd == null) {
+    return {
+      spendUsd,
+      limitUsd: null,
+      remainingUsd: null,
+      percentUsed: null,
+      progressPercent: null,
+      limitReached: false,
+    };
+  }
+
+  if (limitUsd === 0) {
+    return {
+      spendUsd,
+      limitUsd,
+      remainingUsd: 0,
+      percentUsed: 100,
+      progressPercent: 100,
+      limitReached: true,
+    };
+  }
+
+  const percentUsed = (spendUsd / limitUsd) * 100;
+
+  return {
+    spendUsd,
+    limitUsd,
+    remainingUsd: Math.max(0, limitUsd - spendUsd),
+    percentUsed,
+    progressPercent: Math.min(100, percentUsed),
+    limitReached: spendUsd >= limitUsd,
+  };
+}

--- a/apps/web/lib/billing-period.ts
+++ b/apps/web/lib/billing-period.ts
@@ -7,6 +7,16 @@ export type MonthlySpendSummary = {
   limitReached: boolean;
 };
 
+export type AutoReloadDisplayStatus = "on" | "paused" | "off";
+
+export function getAutoReloadDisplayStatus(
+  enabled: boolean,
+  pausedForDurableUpgrade: boolean,
+): AutoReloadDisplayStatus {
+  if (pausedForDurableUpgrade) return "paused";
+  return enabled ? "on" : "off";
+}
+
 export function getUtcMonthBounds(now = new Date()): { start: Date; end: Date } {
   const year = now.getUTCFullYear();
   const month = now.getUTCMonth();

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -1,10 +1,10 @@
+import "server-only";
+
 import { prisma } from "@octopus/db";
 import { ORG_TYPE } from "@/lib/org-types";
-// NOTE: the review-model/provider resolvers are imported LAZILY inside
-// getOrgSpendLimitStatus (not at the top level). cost.ts also exports
-// client-safe formatters (formatUsd/formatNumber), and `@/lib/ai-router` pulls
-// in `server-only`; a top-level import would poison cost.ts for any client
-// importer and break unit tests that import the formatters.
+import { getUtcMonthBounds } from "@/lib/billing-period";
+// Keep the review-model/provider resolvers lazy so pure pricing helpers do not
+// initialize the provider stack and its configuration during module startup.
 
 type ModelPricing = { input: number; output: number };
 
@@ -110,39 +110,23 @@ export function calcCost(
 }
 
 export async function getOrgMonthlySpend(orgId: string): Promise<number> {
-  const now = new Date();
-  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const { start, end } = getUtcMonthBounds();
 
-  const usages = await prisma.aiUsage.groupBy({
-    by: ["model"],
+  // The credit ledger is the source of truth for spend: a usage row exists
+  // only after the balance deduction commits. Refund deductions share the
+  // legacy `usage` type, so exclude rows carrying a Stripe refund id.
+  const debits = await prisma.creditTransaction.aggregate({
     where: {
       organizationId: orgId,
-      createdAt: { gte: monthStart },
-      usedOwnKey: false,
+      type: "usage",
+      stripeRefundId: null,
+      amount: { lt: 0 },
+      createdAt: { gte: start, lt: end },
     },
-    _sum: {
-      inputTokens: true,
-      outputTokens: true,
-      cacheReadTokens: true,
-      cacheWriteTokens: true,
-    },
+    _sum: { amount: true },
   });
 
-  const pricing = await getModelPricing();
-  let total = 0;
-
-  for (const row of usages) {
-    total += calcCost(
-      pricing,
-      row.model,
-      row._sum?.inputTokens ?? 0,
-      row._sum?.outputTokens ?? 0,
-      row._sum?.cacheReadTokens ?? 0,
-      row._sum?.cacheWriteTokens ?? 0,
-    );
-  }
-
-  return total;
+  return Math.max(0, -Number(debits._sum.amount ?? 0));
 }
 
 export type SpendLimitResult =

--- a/apps/web/lib/credits.ts
+++ b/apps/web/lib/credits.ts
@@ -457,6 +457,11 @@ const BURN_QUERY_CEILING = 100; // dollars
 // An unresolved attempt owns this short worker lease. If a process disappears,
 // another worker can retry with the exact persisted Stripe parameters and key.
 const AUTO_RELOAD_LEASE_MS = 5 * 60 * 1000;
+// Conclusive failures back off exponentially per recent failure, so a
+// permanently declining card settles at a few attempts per day instead of one
+// new PaymentIntent per lease. An explicit owner retry bypasses the cooldown.
+const AUTO_RELOAD_FAILURE_BACKOFF_WINDOW_MS = 24 * 60 * 60 * 1000;
+const AUTO_RELOAD_FAILURE_MAX_BACKOFF_MS = 6 * 60 * 60 * 1000;
 // Stripe retains idempotency results for at least 24 hours. Stop automatic
 // retries just before that boundary rather than risk reusing a pruned key.
 const AUTO_RELOAD_RETRY_WINDOW_MS = 23 * 60 * 60 * 1000;
@@ -485,6 +490,7 @@ type AutoReloadAttemptState = AutoReloadAttemptIdentity & {
   retryUntil: Date;
   lastSubmittedAt: Date | null;
   createdAt: Date;
+  completedAt: Date | null;
   failureReason: string | null;
 };
 
@@ -648,6 +654,7 @@ async function createDurableAutoReloadAttempt(
   return {
     ...data,
     stripePaymentIntentId: null,
+    completedAt: null,
     failureReason: null,
   };
 }
@@ -670,8 +677,27 @@ async function ensureDurableAutoReloadAttempt(
       };
     }
 
-    // A conclusive failure cools down for one lease. Fresh customer activity
-    // can release it afterward and claim a new durable attempt.
+    // A conclusive failure cools down before fresh customer activity can
+    // release it. The cooldown doubles with every recent failure so ongoing
+    // usage against a dead card cannot arm hundreds of new charges per day.
+    const failedAt = existing.completedAt ?? existing.leaseExpiresAt;
+    const recentFailures = await store.autoReloadAttempt.count({
+      where: {
+        organizationId: orgId,
+        status: "failed",
+        completedAt: {
+          gte: new Date(failedAt.getTime() - AUTO_RELOAD_FAILURE_BACKOFF_WINDOW_MS),
+        },
+      },
+    });
+    const backoffMs = Math.min(
+      AUTO_RELOAD_LEASE_MS * 2 ** Math.max(recentFailures - 1, 0),
+      AUTO_RELOAD_FAILURE_MAX_BACKOFF_MS,
+    );
+    if (new Date(failedAt.getTime() + backoffMs) > now) {
+      return { attempt: existing, readyToProcess: false };
+    }
+
     const released = await store.autoReloadAttempt.updateMany({
       where: {
         id: existing.id,
@@ -1174,11 +1200,18 @@ async function processDurableAutoReloadAttempt(
       });
       return;
     }
+    let latestCharge: string | null = null;
+    try {
+      const intent = await getStripe().paymentIntents.retrieve(attempt.stripePaymentIntentId);
+      latestCharge = stripeObjectId(intent.latest_charge);
+    } catch {
+      /* non-critical — receipt backfill only */
+    }
     await grantAutoReloadFromPaymentIntent(
       orgId,
       attempt.amountCents / 100,
       attempt.stripePaymentIntentId,
-      null,
+      latestCharge,
       { id: attempt.id, idempotencyKey: attempt.idempotencyKey },
     );
     return;

--- a/apps/web/lib/credits.ts
+++ b/apps/web/lib/credits.ts
@@ -189,7 +189,7 @@ export async function failAutoReloadAttemptFromPaymentIntent(
       id: attempt.id,
       organizationId: orgId,
       idempotencyKey: attempt.idempotencyKey,
-      status: { in: ["charged", "completed", "failed"] },
+      status: { in: ["charged", "completed", "failed", "disabled"] },
     },
     select: { id: true, status: true, stripePaymentIntentId: true },
   });
@@ -197,7 +197,7 @@ export async function failAutoReloadAttemptFromPaymentIntent(
     throw new Error("Failed auto-reload PaymentIntent lost its durable attempt claim");
   }
 
-  if (terminal.status === "charged" || terminal.status === "completed") return false;
+  if (terminal.status !== "failed") return false;
 
   // The synchronous Stripe error may have conclusively marked the attempt
   // failed before exposing a PI id. Backfill it from the signed webhook without
@@ -545,7 +545,7 @@ function isValidAutoReloadConfig(threshold: number, reloadAmount: number): boole
     && reloadAmount <= 1000;
 }
 
-function stripeObjectId(value: unknown): string | null {
+export function stripeObjectId(value: unknown): string | null {
   if (typeof value === "string") return value;
   if (value && typeof value === "object" && "id" in value) {
     const id = (value as { id?: unknown }).id;
@@ -939,7 +939,7 @@ export async function applyAutoReloadPaymentIntent(
         id: attempt.id,
         organizationId: orgId,
         idempotencyKey: attempt.idempotencyKey,
-        status: { in: ["initializing", "pending", "submitting", "processing", "failed", "uncertain"] },
+        status: { in: ["initializing", "pending", "submitting", "processing", "failed", "uncertain", "disabled"] },
         OR: [
           { stripePaymentIntentId: null },
           { stripePaymentIntentId: intent.id },

--- a/apps/web/lib/credits.ts
+++ b/apps/web/lib/credits.ts
@@ -1,4 +1,8 @@
-import { prisma } from "@octopus/db";
+import "server-only";
+
+import { prisma, type Prisma } from "@octopus/db";
+import { randomUUID } from "node:crypto";
+import type Stripe from "stripe";
 import { getStripe, getOffSessionPaymentMethodId } from "./stripe";
 import { eventBus } from "./events/bus";
 import { volumeBonusUsd } from "./plans";
@@ -65,11 +69,160 @@ export async function grantPurchaseFromPaymentIntent(
 }
 
 /**
+ * Grant credits for a succeeded auto-reload PaymentIntent. The PI id is the
+ * durable ledger key, so the inline fast-path and Stripe webhook recovery can
+ * both call this without double-granting.
+ */
+export async function grantAutoReloadFromPaymentIntent(
+  orgId: string,
+  amountUsd: number,
+  paymentIntentId: string,
+  latestCharge: string | { id: string } | null,
+  attempt?: { id: string; idempotencyKey: string },
+): Promise<void> {
+  let duplicateGrant = false;
+  try {
+    await addCredits(
+      orgId,
+      amountUsd,
+      "auto_reload",
+      `Auto-reload — $${amountUsd}`,
+      paymentIntentId,
+    );
+  } catch (err) {
+    if (isDuplicateLedgerError(err)) {
+      duplicateGrant = true;
+    } else {
+      throw err;
+    }
+  }
+
+  // Keep the durable attempt active until the value-bearing ledger grant has
+  // committed. A webhook racing the inline path may observe a duplicate ledger
+  // row, but it must still be allowed to close the same attempt.
+  if (attempt) {
+    const completion = await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        organizationId: orgId,
+        idempotencyKey: attempt.idempotencyKey,
+        status: { in: ["initializing", "pending", "submitting", "processing", "charged", "failed", "uncertain"] },
+      },
+      data: {
+        status: "completed",
+        activeOrganizationId: null,
+        stripePaymentIntentId: paymentIntentId,
+        failureReason: null,
+        completedAt: new Date(),
+      },
+    });
+
+    if (completion.count !== 1) {
+      const completed = await prisma.autoReloadAttempt.findFirst({
+        where: {
+          id: attempt.id,
+          organizationId: orgId,
+          idempotencyKey: attempt.idempotencyKey,
+          stripePaymentIntentId: paymentIntentId,
+          status: "completed",
+        },
+        select: { id: true },
+      });
+      if (!completed) {
+        throw new Error("Auto-reload grant committed but its durable attempt could not be completed");
+      }
+    }
+  }
+
+  if (duplicateGrant) {
+    return;
+  }
+
+  // Best-effort receipt backfill — credits already committed.
+  const chargeId = typeof latestCharge === "string" ? latestCharge : latestCharge?.id;
+  if (chargeId) {
+    try {
+      const chargeObj = await getStripe().charges.retrieve(chargeId);
+      if (chargeObj.receipt_url) {
+        await prisma.creditTransaction.update({
+          where: { stripeSessionId: paymentIntentId },
+          data: { receiptUrl: chargeObj.receipt_url },
+        });
+      }
+    } catch {
+      /* non-critical */
+    }
+  }
+}
+
+/** Finalize a matching durable attempt after Stripe reports PI failure. */
+export async function failAutoReloadAttemptFromPaymentIntent(
+  orgId: string,
+  paymentIntentId: string,
+  attempt: { id: string; idempotencyKey: string },
+  reason?: string,
+): Promise<boolean> {
+  const now = new Date();
+  const failure = await prisma.autoReloadAttempt.updateMany({
+    where: {
+      id: attempt.id,
+      organizationId: orgId,
+      idempotencyKey: attempt.idempotencyKey,
+      activeOrganizationId: orgId,
+      // State transitions are monotonic: a failure snapshot may arrive after a
+      // succeeded event, so it must never demote a charged/completed attempt.
+      status: { in: ["submitting", "processing", "uncertain"] },
+    },
+    data: {
+      status: "failed",
+      stripePaymentIntentId: paymentIntentId,
+      failureReason: reason ?? "payment_failed",
+      leaseExpiresAt: new Date(now.getTime() + AUTO_RELOAD_LEASE_MS),
+      completedAt: now,
+    },
+  });
+
+  if (failure.count === 1) return true;
+
+  const terminal = await prisma.autoReloadAttempt.findFirst({
+    where: {
+      id: attempt.id,
+      organizationId: orgId,
+      idempotencyKey: attempt.idempotencyKey,
+      status: { in: ["charged", "completed", "failed"] },
+    },
+    select: { id: true, status: true, stripePaymentIntentId: true },
+  });
+  if (!terminal || (terminal.stripePaymentIntentId && terminal.stripePaymentIntentId !== paymentIntentId)) {
+    throw new Error("Failed auto-reload PaymentIntent lost its durable attempt claim");
+  }
+
+  if (terminal.status === "charged" || terminal.status === "completed") return false;
+
+  // The synchronous Stripe error may have conclusively marked the attempt
+  // failed before exposing a PI id. Backfill it from the signed webhook without
+  // treating the duplicate failure as a new owner-notification transition.
+  if (!terminal.stripePaymentIntentId) {
+    await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        organizationId: orgId,
+        idempotencyKey: attempt.idempotencyKey,
+        stripePaymentIntentId: null,
+        status: "failed",
+      },
+      data: { stripePaymentIntentId: paymentIntentId },
+    });
+  }
+  return false;
+}
+
+/**
  * Charge the org's saved card off-session for a one-off credit top-up and
  * grant the credits inline — no Stripe Checkout redirect. Mirrors the
- * auto-reload/subscription off-session charge. There is no
- * payment_intent.succeeded webhook, so the grant MUST happen here; it is
- * keyed on the PaymentIntent id (unique stripeSessionId) so it can't
+ * auto-reload/subscription off-session charge. The inline grant provides
+ * immediate feedback and payment_intent.succeeded is the recovery path; both
+ * are keyed on the PaymentIntent id (unique stripeSessionId), so they cannot
  * double-grant. Returns "no_card" when there's nothing saved (caller falls
  * back to Checkout), "failed" on decline/Stripe error.
  */
@@ -220,15 +373,16 @@ export async function deductCredits(
 ): Promise<void> {
   if (amount <= 0) return;
 
-  let totalAfter = 0;
-
-  await prisma.$transaction(async (tx) => {
+  const deduction = await prisma.$transaction(async (tx): Promise<{
+    totalAfter: number;
+    durableClaim: DurableAutoReloadClaim | null;
+  }> => {
     // Lock the row to prevent race conditions
     const rows = await tx.$queryRaw<
       Array<{ creditBalance: number; freeCreditBalance: number }>
     >`SELECT "creditBalance"::float, "freeCreditBalance"::float FROM organizations WHERE id = ${orgId} FOR UPDATE`;
 
-    if (rows.length === 0) return;
+    if (rows.length === 0) return { totalAfter: 0, durableClaim: null };
 
     const free = rows[0].freeCreditBalance;
     const purchased = rows[0].creditBalance;
@@ -245,7 +399,7 @@ export async function deductCredits(
       newPurchased = purchased - remainder;
     }
 
-    totalAfter = newFree + newPurchased;
+    const totalAfter = newFree + newPurchased;
 
     await tx.organization.update({
       where: { id: orgId },
@@ -265,14 +419,30 @@ export async function deductCredits(
         organizationId: orgId,
       },
     });
+
+    // Make the value deduction and its reload work claim one atomic commit.
+    // A process crash can now leave either both rows or neither row, never a
+    // low-balance ledger entry with no durable recovery work.
+    const durableClaim = !stripeRefundId
+      ? await ensureDurableAutoReloadAttempt(orgId, totalAfter, tx)
+      : null;
+    return { totalAfter, durableClaim };
   });
 
-  await maybeNotifyCreditLow(orgId, totalAfter);
+  await maybeNotifyCreditLow(orgId, deduction.totalAfter);
 
-  // Check auto-reload after deduction (fire-and-forget)
-  triggerAutoReloadIfNeeded(orgId, totalAfter).catch((err) =>
-    console.error("[credits] Auto-reload failed:", err),
-  );
+  // External Stripe I/O remains off the deduction hot path. At this point the
+  // attempt is durable; if this best-effort kick is interrupted, pg-boss safely
+  // reclaims its expired lease.
+  if (deduction.durableClaim?.readyToProcess) {
+    void processDurableAutoReloadAttempt(
+      orgId,
+      deduction.totalAfter,
+      deduction.durableClaim.attempt,
+    ).catch((err) =>
+      console.error("[credits] Auto-reload processing failed:", err),
+    );
+  }
 }
 
 // Minimum low-credit threshold for slow/steady usage; preserves the original
@@ -284,6 +454,49 @@ const BURN_LOOKBACK_MS = 60 * 60 * 1000; // 1 hour
 // deduction hot path cheap. Orgs above this balance never need a warning;
 // the next deduction that drops them below it will re-evaluate.
 const BURN_QUERY_CEILING = 100; // dollars
+// An unresolved attempt owns this short worker lease. If a process disappears,
+// another worker can retry with the exact persisted Stripe parameters and key.
+const AUTO_RELOAD_LEASE_MS = 5 * 60 * 1000;
+// Stripe retains idempotency results for at least 24 hours. Stop automatic
+// retries just before that boundary rather than risk reusing a pruned key.
+const AUTO_RELOAD_RETRY_WINDOW_MS = 23 * 60 * 60 * 1000;
+// An empty Stripe list is checked again only after every submission has had a
+// full hour to settle. This separates "not found" from a request whose response
+// was lost while Stripe may still be completing it.
+const AUTO_RELOAD_SUBMISSION_SETTLE_MS = 60 * 60 * 1000;
+// Keep each scheduled reconciliation run bounded. Expired leases are ordered
+// oldest-first, and every claimed row moves its lease forward so later batches
+// cannot be starved by one repeatedly failing attempt.
+const AUTO_RELOAD_RECONCILE_BATCH_SIZE = 100;
+
+export type AutoReloadAttemptIdentity = {
+  id: string;
+  idempotencyKey: string;
+  amountCents: number;
+  stripeCustomerId: string;
+  stripePaymentMethodId: string | null;
+  stripePaymentIntentId: string | null;
+};
+
+type AutoReloadAttemptState = AutoReloadAttemptIdentity & {
+  organizationId: string;
+  status: string;
+  leaseExpiresAt: Date;
+  retryUntil: Date;
+  lastSubmittedAt: Date | null;
+  createdAt: Date;
+  failureReason: string | null;
+};
+
+type DurableAutoReloadClaim = {
+  attempt: AutoReloadAttemptState;
+  readyToProcess: boolean;
+};
+
+type AutoReloadStore = Pick<
+  Prisma.TransactionClient,
+  "autoReloadConfig" | "organization" | "autoReloadAttempt"
+>;
 
 /**
  * Emit a `credit-low` event when the balance can no longer cover the org's
@@ -323,102 +536,964 @@ async function maybeNotifyCreditLow(
   });
 }
 
-async function triggerAutoReloadIfNeeded(
+function isValidAutoReloadConfig(threshold: number, reloadAmount: number): boolean {
+  return Number.isFinite(threshold)
+    && threshold >= 1
+    && threshold <= 1000
+    && Number.isFinite(reloadAmount)
+    && reloadAmount >= 5
+    && reloadAmount <= 1000;
+}
+
+function stripeObjectId(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && "id" in value) {
+    const id = (value as { id?: unknown }).id;
+    return typeof id === "string" ? id : null;
+  }
+  return null;
+}
+
+export function autoReloadPaymentIntentMatches(
+  intent: Stripe.PaymentIntent,
+  orgId: string,
+  attempt: AutoReloadAttemptIdentity,
+  requireReceivedAmount: boolean,
+): boolean {
+  const paymentMethodId = stripeObjectId(intent.payment_method)
+    ?? stripeObjectId(intent.last_payment_error?.payment_method);
+  return intent.metadata?.orgId === orgId
+    && intent.metadata?.type === "auto_reload"
+    && intent.metadata?.autoReloadAttemptId === attempt.id
+    && intent.metadata?.autoReloadKey === attempt.idempotencyKey
+    && intent.currency === "usd"
+    && intent.amount === attempt.amountCents
+    && (!requireReceivedAmount || intent.amount_received === attempt.amountCents)
+    && stripeObjectId(intent.customer) === attempt.stripeCustomerId
+    && Boolean(attempt.stripePaymentMethodId)
+    && paymentMethodId === attempt.stripePaymentMethodId
+    && (!attempt.stripePaymentIntentId || attempt.stripePaymentIntentId === intent.id);
+}
+
+export function isTerminalAutoReloadPaymentIntentStatus(status: string): boolean {
+  return status === "canceled";
+}
+
+function shouldCancelUnresolvedAutoReloadPaymentIntent(
+  intent: Stripe.PaymentIntent,
+  attempt: AutoReloadAttemptState,
+): boolean {
+  return intent.status === "requires_payment_method"
+    || intent.status === "requires_action"
+    || attempt.retryUntil <= new Date();
+}
+
+async function createDurableAutoReloadAttempt(
   orgId: string,
   currentBalance: number,
-): Promise<void> {
-  const config = await prisma.autoReloadConfig.findUnique({
+  now: Date,
+  store: AutoReloadStore,
+): Promise<AutoReloadAttemptState | null> {
+  const config = await store.autoReloadConfig.findUnique({
     where: { organizationId: orgId },
   });
-
-  if (!config || !config.enabled) return;
+  if (!config?.enabled) return null;
 
   const threshold = Number(config.thresholdAmount);
   const reloadAmount = Number(config.reloadAmount);
+  if (!isValidAutoReloadConfig(threshold, reloadAmount)) {
+    console.error("[credits] Refusing auto-reload with invalid persisted configuration", { orgId });
+    return null;
+  }
+  if (currentBalance > threshold) return null;
 
-  if (currentBalance > threshold) return;
-
-  // Need a Stripe customer with a payment method on file
-  const org = await prisma.organization.findUnique({
+  const org = await store.organization.findUnique({
     where: { id: orgId },
-    select: { stripeCustomerId: true },
-  });
-
-  if (!org?.stripeCustomerId) return;
-
-  // Prevent duplicate auto-reloads: check if one happened in the last 5 minutes
-  const recentReload = await prisma.creditTransaction.findFirst({
-    where: {
-      organizationId: orgId,
-      type: "auto_reload",
-      createdAt: { gte: new Date(Date.now() - 5 * 60 * 1000) },
+    select: {
+      stripeCustomerId: true,
+      creditBalance: true,
+      freeCreditBalance: true,
     },
   });
+  if (!org?.stripeCustomerId) return null;
 
-  if (recentReload) return;
+  const liveBalance = Number(org.creditBalance) + Number(org.freeCreditBalance);
+  if (liveBalance > threshold) return null;
 
-  try {
-    // Cards saved via Checkout are attached but not the customer default, and
-    // an off-session confirm does not fall back to attached cards — resolve
-    // the payment method explicitly or the reload silently no-ops.
-    const paymentMethod = await getOffSessionPaymentMethodId(org.stripeCustomerId);
-    if (!paymentMethod) return;
+  const attemptId = randomUUID();
+  const idempotencyKey = `auto-reload-${attemptId}`;
+  const data = {
+    id: attemptId,
+    organizationId: orgId,
+    activeOrganizationId: orgId,
+    status: "initializing",
+    idempotencyKey,
+    amountCents: Math.round(reloadAmount * 100),
+    stripeCustomerId: org.stripeCustomerId,
+    stripePaymentMethodId: null,
+    // Immediately claimable by the local kick or the next scheduled sweep.
+    leaseExpiresAt: now,
+    // Armed from the first actual Stripe submission, not claim creation.
+    retryUntil: now,
+    lastSubmittedAt: null,
+    createdAt: now,
+  };
+  // ON CONFLICT DO NOTHING is safe inside the usage-ledger transaction. A
+  // caught unique violation would leave PostgreSQL's transaction aborted.
+  const inserted = await store.autoReloadAttempt.createMany({
+    data,
+    skipDuplicates: true,
+  });
+  if (inserted.count !== 1) return null;
+  return {
+    ...data,
+    stripePaymentIntentId: null,
+    failureReason: null,
+  };
+}
 
-    const paymentIntent = await getStripe().paymentIntents.create({
-      amount: Math.round(reloadAmount * 100),
-      currency: "usd",
-      customer: org.stripeCustomerId,
-      payment_method: paymentMethod,
-      off_session: true,
-      confirm: true,
-      metadata: {
-        orgId,
-        type: "auto_reload",
-        amountUsd: String(reloadAmount),
+async function ensureDurableAutoReloadAttempt(
+  orgId: string,
+  currentBalance: number,
+  store: AutoReloadStore = prisma,
+): Promise<DurableAutoReloadClaim | null> {
+  const now = new Date();
+  const existing = await store.autoReloadAttempt.findUnique({
+    where: { activeOrganizationId: orgId },
+  }) as AutoReloadAttemptState | null;
+
+  if (existing) {
+    if (existing.status !== "failed" || existing.leaseExpiresAt > now) {
+      return {
+        attempt: existing,
+        readyToProcess: existing.status !== "failed" && existing.leaseExpiresAt <= now,
+      };
+    }
+
+    // A conclusive failure cools down for one lease. Fresh customer activity
+    // can release it afterward and claim a new durable attempt.
+    const released = await store.autoReloadAttempt.updateMany({
+      where: {
+        id: existing.id,
+        activeOrganizationId: orgId,
+        status: "failed",
+        leaseExpiresAt: { lte: now },
+      },
+      data: { activeOrganizationId: null },
+    });
+    if (released.count !== 1) return null;
+  }
+
+  const created = await createDurableAutoReloadAttempt(orgId, currentBalance, now, store);
+  return created ? { attempt: created, readyToProcess: true } : null;
+}
+
+async function lockAutoReloadOrganization(
+  tx: Prisma.TransactionClient,
+  orgId: string,
+): Promise<number> {
+  const rows = await tx.$queryRaw<
+    Array<{ creditBalance: number; freeCreditBalance: number }>
+  >`SELECT "creditBalance"::float, "freeCreditBalance"::float FROM organizations WHERE id = ${orgId} FOR UPDATE`;
+  if (rows.length !== 1) {
+    throw new Error("Organization not found while updating auto-reload");
+  }
+  return Number(rows[0].creditBalance) + Number(rows[0].freeCreditBalance);
+}
+
+function kickDurableAutoReloadClaim(
+  orgId: string,
+  currentBalance: number,
+  claim: DurableAutoReloadClaim | null,
+): void {
+  if (!claim?.readyToProcess) return;
+  void processDurableAutoReloadAttempt(orgId, currentBalance, claim.attempt).catch((err) =>
+    console.error("[credits] Auto-reload processing failed:", err),
+  );
+}
+
+/**
+ * Persist the owner setting and its first low-balance work claim atomically.
+ * Disabling cancels only rows that the pre-I/O state boundary proves have never
+ * reached Stripe. In-flight/unknown/value-bearing attempts remain recoverable.
+ */
+export async function updateAutoReloadConfigDurably(
+  orgId: string,
+  enabled: boolean,
+  thresholdAmount: number,
+  reloadAmount: number,
+): Promise<void> {
+  if (!isValidAutoReloadConfig(thresholdAmount, reloadAmount)) {
+    throw new Error("Invalid auto-reload configuration");
+  }
+
+  const failedSettlement = enabled
+    ? await settleFailedAutoReloadForOwnerRetry(orgId)
+    : { safeFailedAttemptId: null, completed: false };
+  let currentBalance = 0;
+  const claim = await prisma.$transaction(async (tx) => {
+    currentBalance = await lockAutoReloadOrganization(tx, orgId);
+    await tx.autoReloadConfig.upsert({
+      where: { organizationId: orgId },
+      create: {
+        organizationId: orgId,
+        enabled,
+        pausedForDurableUpgrade: false,
+        thresholdAmount,
+        reloadAmount,
+      },
+      update: {
+        enabled,
+        pausedForDurableUpgrade: false,
+        thresholdAmount,
+        reloadAmount,
       },
     });
 
-    if (paymentIntent.status === "succeeded") {
-      await addCredits(
-        orgId,
-        reloadAmount,
-        "auto_reload",
-        `Auto-reload — $${reloadAmount}`,
-        paymentIntent.id,
-      );
-
-      // Store receipt URL
-      const charge = paymentIntent.latest_charge;
-      if (charge && typeof charge === "string") {
-        try {
-          const chargeObj = await getStripe().charges.retrieve(charge);
-          if (chargeObj.receipt_url) {
-            await prisma.creditTransaction.update({
-              where: { stripeSessionId: paymentIntent.id },
-              data: { receiptUrl: chargeObj.receipt_url },
-            });
-          }
-        } catch { /* non-critical */ }
-      }
-
-      console.log(`[credits] Auto-reload $${reloadAmount} for org ${orgId}`);
+    if (!enabled) {
+      await tx.autoReloadAttempt.updateMany({
+        where: {
+          activeOrganizationId: orgId,
+          status: { in: ["initializing", "pending"] },
+          stripePaymentIntentId: null,
+          lastSubmittedAt: null,
+        },
+        data: {
+          status: "disabled",
+          activeOrganizationId: null,
+          failureReason: "auto_reload_disabled",
+          completedAt: new Date(),
+        },
+      });
+      return null;
     }
+
+    if (failedSettlement.safeFailedAttemptId) {
+      await tx.autoReloadAttempt.updateMany({
+        where: {
+          id: failedSettlement.safeFailedAttemptId,
+          activeOrganizationId: orgId,
+          status: "failed",
+        },
+        data: {
+          status: "disabled",
+          activeOrganizationId: null,
+          failureReason: "owner_retry_requested",
+          completedAt: new Date(),
+        },
+      });
+    }
+
+    if (failedSettlement.completed) return null;
+    return ensureDurableAutoReloadAttempt(orgId, currentBalance, tx);
+  });
+
+  // The transaction above is the durability guarantee. This local kick only
+  // reduces latency; an interrupted process is recovered by the lease sweep.
+  kickDurableAutoReloadClaim(orgId, currentBalance, claim);
+}
+
+async function findPersistedAutoReloadPaymentIntent(
+  attempt: AutoReloadAttemptState,
+): Promise<Stripe.PaymentIntent | null> {
+  if (!attempt.stripePaymentMethodId) return null;
+
+  if (attempt.stripePaymentIntentId) {
+    const intent = await getStripe().paymentIntents.retrieve(attempt.stripePaymentIntentId);
+    if (!autoReloadPaymentIntentMatches(intent, attempt.organizationId, attempt, false)) {
+      throw new Error("Persisted auto-reload PaymentIntent no longer matches its durable attempt");
+    }
+    return intent;
+  }
+
+  // Stripe Search is eventually consistent, so an empty result cannot prove
+  // that an in-flight create did not land. The normal customer-scoped list API
+  // is the recovery source; paginate the bounded attempt window and validate
+  // every financial field locally.
+  const createdGte = Math.max(
+    0,
+    Math.floor((attempt.createdAt.getTime() - 5 * 60 * 1000) / 1000),
+  );
+  const matches: Stripe.PaymentIntent[] = [];
+  let examined = 0;
+  for await (const intent of getStripe().paymentIntents.list({
+    customer: attempt.stripeCustomerId,
+    // Deliberately omit `lte`: a host clock that trails Stripe must not hide a
+    // just-created PI and incorrectly authorize a replacement charge.
+    created: { gte: createdGte },
+    limit: 100,
+  })) {
+    examined += 1;
+    if (examined > 10_000) {
+      throw new Error("Stripe auto-reload recovery window exceeded its safety bound");
+    }
+    if (autoReloadPaymentIntentMatches(intent, attempt.organizationId, attempt, false)) {
+      matches.push(intent);
+    }
+  }
+  if (matches.length > 1) {
+    throw new Error("Stripe listed multiple matching auto-reload PaymentIntents");
+  }
+  return matches[0] ?? null;
+}
+
+async function settleFailedAutoReloadForOwnerRetry(orgId: string): Promise<{
+  safeFailedAttemptId: string | null;
+  completed: boolean;
+}> {
+  const observed = await prisma.autoReloadAttempt.findUnique({
+    where: { activeOrganizationId: orgId },
+  }) as AutoReloadAttemptState | null;
+  if (observed?.status !== "failed") {
+    return { safeFailedAttemptId: null, completed: false };
+  }
+  if (!observed.lastSubmittedAt) {
+    return { safeFailedAttemptId: observed.id, completed: false };
+  }
+  if (!observed.stripePaymentMethodId) {
+    throw new Error("Submitted failed auto-reload attempt has no payment method");
+  }
+
+  let intent = await findPersistedAutoReloadPaymentIntent(observed);
+  if (intent && intent.status !== "succeeded" && intent.status !== "canceled") {
+    try {
+      intent = await getStripe().paymentIntents.cancel(intent.id);
+    } catch {
+      // Cancellation can race completion. Only an explicit terminal reread
+      // permits the old attempt to be retired or considered granted.
+      intent = await getStripe().paymentIntents.retrieve(intent.id);
+      if (intent.status !== "succeeded" && intent.status !== "canceled") {
+        throw new Error("Previous auto-reload PaymentIntent is still active");
+      }
+    }
+  }
+  if (!intent) return { safeFailedAttemptId: observed.id, completed: false };
+
+  const balance = await getOrgBalance(orgId);
+  const outcome = await applyAutoReloadPaymentIntent(
+    orgId,
+    balance.total,
+    intent,
+    observed,
+  );
+  return outcome === "completed"
+    ? { safeFailedAttemptId: null, completed: true }
+    : { safeFailedAttemptId: observed.id, completed: false };
+}
+
+/**
+ * A newly saved card is an explicit owner retry. Retire only an attempt whose
+ * state is proven pre-submission, or a failed attempt after Stripe confirms the
+ * old request is terminal/absent; then atomically arm a replacement if needed.
+ */
+export async function rearmAutoReloadAfterPaymentMethodChange(orgId: string): Promise<void> {
+  const failedSettlement = await settleFailedAutoReloadForOwnerRetry(orgId);
+  if (failedSettlement.completed) return;
+  let currentBalance = 0;
+  const claim = await prisma.$transaction(async (tx) => {
+    currentBalance = await lockAutoReloadOrganization(tx, orgId);
+    await tx.autoReloadAttempt.updateMany({
+      where: {
+        activeOrganizationId: orgId,
+        OR: [
+          {
+            status: { in: ["initializing", "pending"] },
+            stripePaymentIntentId: null,
+            lastSubmittedAt: null,
+          },
+          ...(failedSettlement.safeFailedAttemptId
+            ? [{ id: failedSettlement.safeFailedAttemptId, status: "failed" }]
+            : []),
+        ],
+      },
+      data: {
+        status: "disabled",
+        activeOrganizationId: null,
+        failureReason: "payment_method_replaced",
+        completedAt: new Date(),
+      },
+    });
+    return ensureDurableAutoReloadAttempt(orgId, currentBalance, tx);
+  });
+
+  kickDurableAutoReloadClaim(orgId, currentBalance, claim);
+}
+
+export async function applyAutoReloadPaymentIntent(
+  orgId: string,
+  currentBalance: number,
+  intent: Stripe.PaymentIntent,
+  attempt: AutoReloadAttemptIdentity,
+): Promise<"active" | "completed" | "failed"> {
+  if (!autoReloadPaymentIntentMatches(intent, orgId, attempt, false)) {
+    throw new Error("Auto-reload PaymentIntent does not match its durable attempt");
+  }
+
+  if (intent.status === "succeeded") {
+    if (intent.amount_received !== attempt.amountCents) {
+      throw new Error("Succeeded auto-reload PaymentIntent has an unexpected received amount");
+    }
+
+    const charged = await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        organizationId: orgId,
+        idempotencyKey: attempt.idempotencyKey,
+        status: { in: ["initializing", "pending", "submitting", "processing", "failed", "uncertain"] },
+        OR: [
+          { stripePaymentIntentId: null },
+          { stripePaymentIntentId: intent.id },
+        ],
+      },
+      data: {
+        status: "charged",
+        stripePaymentIntentId: intent.id,
+        failureReason: null,
+      },
+    });
+
+    if (charged.count !== 1) {
+      const terminal = await prisma.autoReloadAttempt.findFirst({
+        where: {
+          id: attempt.id,
+          organizationId: orgId,
+          idempotencyKey: attempt.idempotencyKey,
+          stripePaymentIntentId: intent.id,
+          status: { in: ["charged", "completed"] },
+        },
+        select: { status: true },
+      });
+      if (!terminal) {
+        throw new Error("Succeeded auto-reload PaymentIntent lost its durable attempt claim");
+      }
+      if (terminal.status === "completed") return "completed";
+    }
+
+    await grantAutoReloadFromPaymentIntent(
+      orgId,
+      attempt.amountCents / 100,
+      intent.id,
+      intent.latest_charge,
+      { id: attempt.id, idempotencyKey: attempt.idempotencyKey },
+    );
+    return "completed";
+  }
+
+  if (isTerminalAutoReloadPaymentIntentStatus(intent.status)) {
+    const transitioned = await failAutoReloadAttemptFromPaymentIntent(
+      orgId,
+      intent.id,
+      { id: attempt.id, idempotencyKey: attempt.idempotencyKey },
+      intent.last_payment_error?.code ?? intent.status,
+    );
+    if (transitioned) {
+      eventBus.emit({
+        type: "auto-reload-failed",
+        orgId,
+        reloadAmount: attempt.amountCents / 100,
+        remainingBalance: currentBalance,
+        reason: intent.last_payment_error?.code ?? intent.status,
+      });
+    }
+    return "failed";
+  }
+
+  // `processing`, `requires_confirmation`, and `requires_capture` are active
+  // states. Persist the PI and wait for an authoritative webhook/retrieval;
+  // never release the org slot and create a second charge.
+  await prisma.autoReloadAttempt.updateMany({
+    where: {
+      id: attempt.id,
+      organizationId: orgId,
+      idempotencyKey: attempt.idempotencyKey,
+      activeOrganizationId: orgId,
+      status: { in: ["submitting", "processing", "uncertain"] },
+      OR: [
+        { stripePaymentIntentId: null },
+        { stripePaymentIntentId: intent.id },
+      ],
+    },
+    data: {
+      status: "processing",
+      stripePaymentIntentId: intent.id,
+      failureReason: null,
+      leaseExpiresAt: new Date(Date.now() + AUTO_RELOAD_LEASE_MS),
+    },
+  });
+  return "active";
+}
+
+async function reconcilePersistedAutoReloadAttempt(
+  orgId: string,
+  currentBalance: number,
+  attempt: AutoReloadAttemptState,
+): Promise<void> {
+  const intent = await findPersistedAutoReloadPaymentIntent(attempt);
+  if (intent) {
+    if (
+      intent.status !== "succeeded"
+      && intent.status !== "canceled"
+      && shouldCancelUnresolvedAutoReloadPaymentIntent(intent, attempt)
+    ) {
+      // Nonterminal PIs can still succeed later. Cancel them authoritatively
+      // before releasing the org slot; a race that already succeeded makes
+      // Stripe reject cancellation and the next retrieval grants the credits.
+      const canceled = await getStripe().paymentIntents.cancel(intent.id);
+      await applyAutoReloadPaymentIntent(orgId, currentBalance, canceled, attempt);
+    } else {
+      await applyAutoReloadPaymentIntent(orgId, currentBalance, intent, attempt);
+    }
+    return;
+  }
+
+  const now = new Date();
+  if (attempt.status === "charged") {
+    // `charged` is value-bearing state. A missing PI id/object is corruption,
+    // not proof that Stripe did not charge, so never release the org slot or
+    // create a replacement charge. The recurring error keeps this visible to
+    // operators until the original PI can be recovered.
+    await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: orgId,
+        idempotencyKey: attempt.idempotencyKey,
+        status: "charged",
+      },
+      data: {
+        failureReason: "charged_payment_intent_missing",
+        leaseExpiresAt: new Date(now.getTime() + AUTO_RELOAD_LEASE_MS),
+      },
+    });
+    throw new Error("Charged auto-reload attempt has no recoverable PaymentIntent");
+  }
+
+  if (!attempt.lastSubmittedAt) {
+    // Only `pending` is proven pre-submission. Any other state without a
+    // submission timestamp predates/infringes the durable boundary and cannot
+    // safely be retried or released based on database state alone.
+    if (attempt.status === "pending") {
+      await executeAutoReloadAttempt(orgId, currentBalance, attempt);
+      return;
+    }
+    await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: orgId,
+        idempotencyKey: attempt.idempotencyKey,
+        status: { in: ["submitting", "processing", "uncertain"] },
+        stripePaymentIntentId: null,
+      },
+      data: {
+        status: "uncertain",
+        failureReason: "submission_timestamp_missing",
+        leaseExpiresAt: new Date(now.getTime() + AUTO_RELOAD_LEASE_MS),
+      },
+    });
+    throw new Error("Uncertain auto-reload attempt has no submission timestamp");
+  }
+
+  if (attempt.retryUntil > now) {
+    // Retry the exact persisted request/key directly from its in-flight state.
+    // Never transiently label a previously submitted request `pending`, because
+    // settings changes are allowed to cancel only never-submitted rows.
+    await executeAutoReloadAttempt(orgId, currentBalance, attempt);
+    return;
+  }
+
+  const settleUntil = new Date(Math.max(
+    attempt.lastSubmittedAt.getTime() + AUTO_RELOAD_SUBMISSION_SETTLE_MS,
+    attempt.retryUntil.getTime() + AUTO_RELOAD_SUBMISSION_SETTLE_MS,
+  ));
+  if (settleUntil > now) {
+    await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: orgId,
+        idempotencyKey: attempt.idempotencyKey,
+        status: { in: ["submitting", "processing", "uncertain"] },
+        stripePaymentIntentId: null,
+      },
+      data: {
+        status: "uncertain",
+        failureReason: "awaiting_stripe_settlement",
+        leaseExpiresAt: new Date(now.getTime() + AUTO_RELOAD_LEASE_MS),
+      },
+    });
+    return;
+  }
+
+  // The retry window has closed and every submission has had a conservative
+  // settlement interval. Only the fresh, customer-scoped Stripe list above,
+  // with exact local validation and no match, now permits a replacement claim.
+  const released = await prisma.autoReloadAttempt.updateMany({
+    where: {
+      id: attempt.id,
+      activeOrganizationId: orgId,
+      idempotencyKey: attempt.idempotencyKey,
+      status: { in: ["submitting", "processing", "uncertain"] },
+      stripePaymentIntentId: null,
+    },
+    data: {
+      status: "failed",
+      activeOrganizationId: null,
+      failureReason: "payment_intent_not_found",
+      completedAt: now,
+    },
+  });
+  if (released.count === 1) {
+    // The prior logical request is now proven absent; create a fresh durable
+    // attempt if the owner still has auto-reload enabled and remains below the
+    // threshold. This prevents a permanent `uncertain` dead-end.
+    await triggerAutoReloadIfNeeded(orgId, currentBalance);
+  }
+}
+
+async function processDurableAutoReloadAttempt(
+  orgId: string,
+  currentBalance: number,
+  attempt: AutoReloadAttemptState,
+): Promise<void> {
+  const now = new Date();
+  const leaseExpiresAt = new Date(now.getTime() + AUTO_RELOAD_LEASE_MS);
+
+  if (attempt.status === "charged") {
+    const claimed = await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: orgId,
+        status: "charged",
+        leaseExpiresAt: { lte: now },
+      },
+      data: { leaseExpiresAt },
+    });
+    if (claimed.count !== 1) return;
+    if (!attempt.stripePaymentIntentId) {
+      await reconcilePersistedAutoReloadAttempt(orgId, currentBalance, {
+        ...attempt,
+        leaseExpiresAt,
+      });
+      return;
+    }
+    await grantAutoReloadFromPaymentIntent(
+      orgId,
+      attempt.amountCents / 100,
+      attempt.stripePaymentIntentId,
+      null,
+      { id: attempt.id, idempotencyKey: attempt.idempotencyKey },
+    );
+    return;
+  }
+
+  if (attempt.status === "initializing") {
+    const claimed = await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: orgId,
+        status: "initializing",
+        leaseExpiresAt: { lte: now },
+      },
+      data: { leaseExpiresAt },
+    });
+    if (claimed.count !== 1) return;
+
+    const config = await prisma.autoReloadConfig.findUnique({
+      where: { organizationId: orgId },
+      select: { enabled: true },
+    });
+    if (!config?.enabled) {
+      await prisma.autoReloadAttempt.updateMany({
+        where: {
+          id: attempt.id,
+          activeOrganizationId: orgId,
+          status: "initializing",
+          stripePaymentIntentId: null,
+        },
+        data: {
+          status: "disabled",
+          activeOrganizationId: null,
+          failureReason: "auto_reload_disabled",
+          completedAt: now,
+        },
+      });
+      return;
+    }
+
+    const paymentMethod = await getOffSessionPaymentMethodId(attempt.stripeCustomerId);
+    if (!paymentMethod) {
+      const failed = await prisma.autoReloadAttempt.updateMany({
+        where: {
+          id: attempt.id,
+          activeOrganizationId: orgId,
+          status: "initializing",
+        },
+        data: {
+          status: "failed",
+          failureReason: "no_payment_method",
+          leaseExpiresAt,
+          completedAt: now,
+        },
+      });
+      if (failed.count === 1) {
+        eventBus.emit({
+          type: "auto-reload-failed",
+          orgId,
+          reloadAmount: attempt.amountCents / 100,
+          remainingBalance: currentBalance,
+          reason: "no_payment_method",
+        });
+      }
+      return;
+    }
+
+    const initialized = await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: orgId,
+        status: "initializing",
+      },
+      data: {
+        status: "pending",
+        stripePaymentMethodId: paymentMethod,
+      },
+    });
+    if (initialized.count !== 1) return;
+    await executeAutoReloadAttempt(orgId, currentBalance, {
+      ...attempt,
+      status: "pending",
+      stripePaymentMethodId: paymentMethod,
+      leaseExpiresAt,
+    });
+    return;
+  }
+
+  if (attempt.status === "pending") {
+    const claimed = await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: orgId,
+        status: "pending",
+        leaseExpiresAt: { lte: now },
+      },
+      data: { leaseExpiresAt },
+    });
+    if (claimed.count !== 1) return;
+    const claimedAttempt = { ...attempt, leaseExpiresAt };
+    if (attempt.stripePaymentIntentId) {
+      await reconcilePersistedAutoReloadAttempt(orgId, currentBalance, claimedAttempt);
+    } else {
+      await executeAutoReloadAttempt(orgId, currentBalance, claimedAttempt);
+    }
+    return;
+  }
+
+  if (
+    attempt.status === "submitting"
+    || attempt.status === "processing"
+    || attempt.status === "uncertain"
+  ) {
+    const claimed = await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: orgId,
+        status: attempt.status,
+        leaseExpiresAt: { lte: now },
+      },
+      data: { leaseExpiresAt },
+    });
+    if (claimed.count === 1) {
+      await reconcilePersistedAutoReloadAttempt(orgId, currentBalance, {
+        ...attempt,
+        leaseExpiresAt,
+      });
+    }
+  }
+}
+
+export async function triggerAutoReloadIfNeeded(
+  orgId: string,
+  currentBalance: number,
+): Promise<void> {
+  const claim = await prisma.$transaction(async (tx) => {
+    await lockAutoReloadOrganization(tx, orgId);
+    return ensureDurableAutoReloadAttempt(orgId, currentBalance, tx);
+  });
+  if (!claim?.readyToProcess) return;
+  await processDurableAutoReloadAttempt(orgId, currentBalance, claim.attempt);
+}
+
+/** Recover every expired active state; each row is protected by a DB lease. */
+export async function reconcileAutoReloadAttempts(): Promise<{
+  scanned: number;
+  attempted: number;
+  failed: number;
+}> {
+  const now = new Date();
+  const candidates = await prisma.autoReloadAttempt.findMany({
+    where: {
+      activeOrganizationId: { not: null },
+      status: { in: ["initializing", "pending", "submitting", "processing", "charged", "uncertain"] },
+      leaseExpiresAt: { lte: now },
+    },
+    select: { id: true, organizationId: true },
+    orderBy: { leaseExpiresAt: "asc" },
+    take: AUTO_RELOAD_RECONCILE_BATCH_SIZE,
+  });
+
+  let attempted = 0;
+  let failed = 0;
+  for (const candidate of candidates) {
+    try {
+      const balance = await getOrgBalance(candidate.organizationId);
+      await triggerAutoReloadIfNeeded(candidate.organizationId, balance.total);
+      attempted += 1;
+    } catch (err) {
+      failed += 1;
+      console.error("[credits] Auto-reload reconciliation failed:", {
+        attemptId: candidate.id,
+        organizationId: candidate.organizationId,
+        err,
+      });
+    }
+  }
+
+  return { scanned: candidates.length, attempted, failed };
+}
+
+function isIndeterminateStripeError(err: unknown): boolean {
+  const stripeError = err as { type?: unknown; rawType?: unknown; code?: unknown } | null;
+  const type = typeof stripeError?.type === "string"
+    ? stripeError.type
+    : typeof stripeError?.rawType === "string"
+      ? stripeError.rawType
+      : undefined;
+  if (
+    type === "StripeIdempotencyError"
+    || type === "idempotency_error"
+    || stripeError?.code === "idempotency_key_in_use"
+  ) {
+    return true;
+  }
+
+  // Idempotency conflicts are deliberately indeterminate: another same-key
+  // request may still be executing, so the attempt remains active for Stripe
+  // reconciliation instead of becoming a retryable failure.
+  return !new Set([
+    "StripeCardError",
+    "card_error",
+    "StripeInvalidRequestError",
+    "invalid_request_error",
+    "StripeAuthenticationError",
+    "authentication_error",
+    "StripePermissionError",
+  ]).has(type ?? "");
+}
+
+async function executeAutoReloadAttempt(
+  orgId: string,
+  currentBalance: number,
+  attempt: AutoReloadAttemptState,
+): Promise<void> {
+  if (!attempt.stripePaymentMethodId) {
+    throw new Error("Cannot execute an auto-reload before its card is persisted");
+  }
+  if (!["pending", "submitting", "processing", "uncertain"].includes(attempt.status)) {
+    throw new Error(`Cannot submit an auto-reload from state ${attempt.status}`);
+  }
+
+  const submittedAt = new Date();
+  const retryUntil = attempt.lastSubmittedAt
+    ? attempt.retryUntil
+    : new Date(submittedAt.getTime() + AUTO_RELOAD_RETRY_WINDOW_MS);
+  // This CAS is the exact pre-I/O boundary. Disabling/replacing a card may
+  // cancel a `pending` row; if that transaction wins, no Stripe request runs.
+  // If this CAS wins first, the request is durably marked in-flight and later
+  // settings changes preserve it for reconciliation.
+  const submitted = await prisma.autoReloadAttempt.updateMany({
+    where: {
+      id: attempt.id,
+      activeOrganizationId: orgId,
+      idempotencyKey: attempt.idempotencyKey,
+      status: attempt.status,
+      stripePaymentIntentId: null,
+    },
+    data: {
+      status: "submitting",
+      lastSubmittedAt: submittedAt,
+      retryUntil,
+      failureReason: null,
+      leaseExpiresAt: new Date(submittedAt.getTime() + AUTO_RELOAD_LEASE_MS),
+    },
+  });
+  if (submitted.count !== 1) return;
+
+  const submittedAttempt: AutoReloadAttemptState = {
+    ...attempt,
+    status: "submitting",
+    lastSubmittedAt: submittedAt,
+    retryUntil,
+    failureReason: null,
+    leaseExpiresAt: new Date(submittedAt.getTime() + AUTO_RELOAD_LEASE_MS),
+  };
+  const reloadAmount = attempt.amountCents / 100;
+  let paymentIntent: Stripe.PaymentIntent;
+  try {
+    paymentIntent = await getStripe().paymentIntents.create(
+      {
+        amount: attempt.amountCents,
+        currency: "usd",
+        customer: attempt.stripeCustomerId,
+        payment_method: attempt.stripePaymentMethodId,
+        off_session: true,
+        confirm: true,
+        metadata: {
+          orgId,
+          type: "auto_reload",
+          amountUsd: String(reloadAmount),
+          autoReloadAttemptId: attempt.id,
+          autoReloadKey: attempt.idempotencyKey,
+        },
+      },
+      { idempotencyKey: attempt.idempotencyKey },
+    );
   } catch (err) {
-    // Payment failed (card declined, expired, etc.). Post-paid metering means
-    // the in-flight review already spent the tokens; the actionable signal is
-    // to the owner — their card failed and reviews will stop once the balance
-    // is exhausted. A silent console.error left them blind (#506).
-    console.error("[credits] Auto-reload payment failed:", err);
+    console.error("[credits] Auto-reload payment request failed:", err);
     const code = (err as { code?: unknown } | null)?.code;
     const reason = typeof code === "string" ? code : undefined;
-    eventBus.emit({
-      type: "auto-reload-failed",
-      orgId,
-      reloadAmount,
-      remainingBalance: currentBalance,
-      reason,
+    const indeterminate = isIndeterminateStripeError(err);
+    const transitioned = await prisma.autoReloadAttempt.updateMany({
+      where: {
+        id: attempt.id,
+        activeOrganizationId: orgId,
+        idempotencyKey: attempt.idempotencyKey,
+        status: "submitting",
+      },
+      data: indeterminate
+        ? {
+            status: "uncertain",
+            leaseExpiresAt: new Date(Date.now() + AUTO_RELOAD_LEASE_MS),
+            failureReason: "payment_status_unknown",
+          }
+        : {
+            status: "failed",
+            failureReason: reason ?? "payment_failed",
+            leaseExpiresAt: new Date(Date.now() + AUTO_RELOAD_LEASE_MS),
+            completedAt: new Date(),
+          },
     });
+
+    if (!indeterminate && transitioned.count === 1) {
+      eventBus.emit({
+        type: "auto-reload-failed",
+        orgId,
+        reloadAmount,
+        remainingBalance: currentBalance,
+        reason,
+      });
+    }
+    return;
   }
+
+  await applyAutoReloadPaymentIntent(orgId, currentBalance, paymentIntent, submittedAttempt);
 }
 
 export async function hasEnoughCredits(

--- a/apps/web/lib/queue-workers.ts
+++ b/apps/web/lib/queue-workers.ts
@@ -10,6 +10,7 @@ import { enforceAuditLogRetention, enforceActivityEventRetention } from "./audit
 import { enforceWebhookDeliveryRetention } from "./webhook-tenant";
 import { refreshReleaseCache } from "./releases";
 import { renewDueSubscriptions } from "./subscription";
+import { reconcileAutoReloadAttempts } from "./credits";
 import { runOllamaPull } from "./ollama-admin";
 import { reapStuckReviews } from "./reap-stuck-reviews";
 import type { QueueConfig } from "./queue";
@@ -113,6 +114,24 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     }
   });
 
+  // Hosted auto-reload reconciliation — scheduled every minute. The durable
+  // attempt lease and PI-keyed credit ledger make repeated runs race-safe.
+  await boss.work("reconcile-auto-reloads", async (jobs) => {
+    for (const job of jobs) {
+      try {
+        const result = await reconcileAutoReloadAttempts();
+        if (result.scanned || result.failed) {
+          console.log(
+            `[queue] reconcile-auto-reloads ${job.id}: scanned=${result.scanned} attempted=${result.attempted} failed=${result.failed}`,
+          );
+        }
+      } catch (err) {
+        console.error(`[queue] reconcile-auto-reloads failed (job ${job.id}):`, err);
+        throw err;
+      }
+    }
+  });
+
   // Daily ActivityEvent retention job — scheduled in instrumentation.ts via
   // boss.schedule(); idempotent deleteMany makes concurrent instances harmless.
   await boss.work("enforce-activity-retention", async (jobs) => {
@@ -193,5 +212,5 @@ export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promis
     }
   });
 
-  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review, enforce-audit-retention, enforce-activity-retention, refresh-release-cache, reap-stuck-reviews, pull-ollama-model");
+  console.log("[queue] Workers registered: welcome-email, process-review, post-large-review-result, community-review, enforce-audit-retention, enforce-activity-retention, refresh-release-cache, reap-stuck-reviews, subscription-renewals, reconcile-auto-reloads, pull-ollama-model");
 }

--- a/apps/web/lib/queue.ts
+++ b/apps/web/lib/queue.ts
@@ -147,6 +147,15 @@ export async function startQueue(): Promise<PgBoss> {
     expireInSeconds: 1800, // 30 min — one off-session charge per due org
   }).catch(() => {});
 
+  // Hosted auto-reload reconciliation (scheduled every minute in
+  // instrumentation.ts). The worker reclaims expired durable attempt leases;
+  // retrying the job itself once covers a transient sweep-level DB failure.
+  await boss.createQueue("reconcile-auto-reloads", {
+    retryLimit: 1,
+    retryDelay: 30,
+    expireInSeconds: 300,
+  }).catch(() => {});
+
   // Admin-triggered Ollama model downloads (self-hosted). Long expiry — a
   // large model is many GB. No auto-retry: runOllamaPull records failures in
   // the OllamaModelPull row itself and re-pulls are admin-driven from the UI.

--- a/apps/web/lib/stripe-payment-method.ts
+++ b/apps/web/lib/stripe-payment-method.ts
@@ -1,0 +1,64 @@
+import "server-only";
+
+import type Stripe from "stripe";
+
+/** Resolve a usable off-session card without ever returning another PM type. */
+export async function resolveOffSessionCardPaymentMethodId(
+  stripe: Pick<Stripe, "customers" | "paymentMethods">,
+  stripeCustomerId: string,
+): Promise<string | null> {
+  const customer = await stripe.customers.retrieve(stripeCustomerId);
+  if (customer.deleted) return null;
+
+  const defaultMethod = customer.invoice_settings?.default_payment_method;
+  if (
+    defaultMethod
+    && typeof defaultMethod === "object"
+    && defaultMethod.type === "card"
+    && (
+      defaultMethod.customer === stripeCustomerId
+      || (
+        typeof defaultMethod.customer === "object"
+        && defaultMethod.customer?.id === stripeCustomerId
+      )
+    )
+  ) {
+    return defaultMethod.id;
+  }
+
+  // A string default does not carry its type or attachment. Resolve it before
+  // use, and only accept a card attached to this exact customer.
+  if (typeof defaultMethod === "string") {
+    try {
+      const resolvedDefault = await stripe.paymentMethods.retrieve(defaultMethod);
+      const attachedCustomer = resolvedDefault.customer;
+      if (
+        resolvedDefault.type === "card"
+        && (
+          attachedCustomer === stripeCustomerId
+          || (
+            typeof attachedCustomer === "object"
+            && attachedCustomer?.id === stripeCustomerId
+          )
+        )
+      ) {
+        return resolvedDefault.id;
+      }
+    } catch (err) {
+      // A stale deleted default is equivalent to no usable default; a real
+      // Stripe/API outage must still propagate rather than look like no card.
+      if ((err as { code?: unknown } | null)?.code !== "resource_missing") {
+        throw err;
+      }
+    }
+  }
+
+  // Fall back to the first attached card. Stripe filters this server-side, so
+  // there is no pagination gap and a non-card default can never leak through.
+  const methods = await stripe.paymentMethods.list({
+    customer: stripeCustomerId,
+    type: "card",
+    limit: 1,
+  });
+  return methods.data[0]?.id ?? null;
+}

--- a/apps/web/lib/stripe.ts
+++ b/apps/web/lib/stripe.ts
@@ -1,5 +1,8 @@
+import "server-only";
+
 import Stripe from "stripe";
 import { prisma } from "@octopus/db";
+import { resolveOffSessionCardPaymentMethodId } from "./stripe-payment-method";
 
 let _stripe: Stripe | null = null;
 export function getStripe(): Stripe {
@@ -181,18 +184,7 @@ export async function createSubscriptionCheckoutSession(
 export async function getOffSessionPaymentMethodId(
   stripeCustomerId: string,
 ): Promise<string | null> {
-  const customer = await getStripe().customers.retrieve(stripeCustomerId);
-  if (!customer.deleted) {
-    const def = customer.invoice_settings?.default_payment_method;
-    if (typeof def === "string") return def;
-    if (def && typeof def === "object") return def.id;
-  }
-  const methods = await getStripe().paymentMethods.list({
-    customer: stripeCustomerId,
-    type: "card",
-    limit: 1,
-  });
-  return methods.data[0]?.id ?? null;
+  return resolveOffSessionCardPaymentMethodId(getStripe(), stripeCustomerId);
 }
 
 export async function createPortalSession(

--- a/apps/web/lib/subscription.ts
+++ b/apps/web/lib/subscription.ts
@@ -5,8 +5,9 @@ import { SUBSCRIPTION_PLANS, type PaidPlanTier } from "@/lib/plans";
 
 /**
  * Monthly subscriptions WITHOUT Stripe Billing: each period we charge the
- * org's saved card with an off-session PaymentIntent (exactly like
- * auto-reload in credits.ts) and grant the plan's credits into the unified
+ * org's saved card with an off-session PaymentIntent (auto-reload in
+ * credits.ts uses the same saved-card charge, wrapped in durable
+ * AutoReloadAttempt rows) and grant the plan's credits into the unified
  * balance. The daily `subscription-renewals` cron (instrumentation.ts →
  * queue-workers.ts) picks up orgs whose planRenewsAt has passed.
  *

--- a/packages/db/prisma/migrations/20260810120000_add_auto_reload_attempts/migration.sql
+++ b/packages/db/prisma/migrations/20260810120000_add_auto_reload_attempts/migration.sql
@@ -1,0 +1,54 @@
+-- CreateTable
+CREATE TABLE "auto_reload_attempts" (
+    "id" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'initializing',
+    "idempotencyKey" TEXT NOT NULL,
+    "amountCents" INTEGER NOT NULL,
+    "stripeCustomerId" TEXT NOT NULL,
+    "stripePaymentMethodId" TEXT,
+    "stripePaymentIntentId" TEXT,
+    "leaseExpiresAt" TIMESTAMP(3) NOT NULL,
+    "retryUntil" TIMESTAMP(3) NOT NULL,
+    "lastSubmittedAt" TIMESTAMP(3),
+    "failureReason" TEXT,
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "activeOrganizationId" TEXT,
+
+    CONSTRAINT "auto_reload_attempts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "auto_reload_attempts_idempotencyKey_key" ON "auto_reload_attempts"("idempotencyKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "auto_reload_attempts_stripePaymentIntentId_key" ON "auto_reload_attempts"("stripePaymentIntentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "auto_reload_attempts_activeOrganizationId_key" ON "auto_reload_attempts"("activeOrganizationId");
+
+-- CreateIndex
+CREATE INDEX "auto_reload_attempts_organizationId_createdAt_idx" ON "auto_reload_attempts"("organizationId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "auto_reload_attempts_status_leaseExpiresAt_idx" ON "auto_reload_attempts"("status", "leaseExpiresAt");
+
+-- AddForeignKey
+ALTER TABLE "auto_reload_attempts" ADD CONSTRAINT "auto_reload_attempts_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Quiesce every legacy auto-reload before a rolling deploy. Old replicas do
+-- not participate in the durable-attempt claim and could otherwise charge in
+-- parallel with a new replica. Preserve the amounts and mark the pause so the
+-- UI can ask the owner to review and explicitly re-enable once the rollout is
+-- complete.
+ALTER TABLE "auto_reload_configs"
+ADD COLUMN "pausedForDurableUpgrade" BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE "auto_reload_configs"
+SET
+    "enabled" = false,
+    "pausedForDurableUpgrade" = true,
+    "updatedAt" = CURRENT_TIMESTAMP
+WHERE "enabled" = true;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -197,6 +197,7 @@ model Organization {
   daySummaries       DaySummary[]
   creditTransactions CreditTransaction[]
   autoReloadConfig   AutoReloadConfig?
+  autoReloadAttempts AutoReloadAttempt[]
   apiTokens          OrgApiToken[]
   localAgents        LocalAgent[]
   agentSearchTasks   AgentSearchTask[]
@@ -808,6 +809,10 @@ model CreditTransaction {
 model AutoReloadConfig {
   id              String   @id @default(cuid())
   enabled         Boolean  @default(false)
+  // One-time rollout marker: the durable-attempt migration pauses every
+  // previously enabled config so old and new replicas cannot charge in
+  // parallel. Cleared when an owner explicitly saves the setting again.
+  pausedForDurableUpgrade Boolean @default(false)
   thresholdAmount Decimal  @db.Decimal(12, 4) @default(10)
   reloadAmount    Decimal  @db.Decimal(12, 4) @default(50)
   createdAt       DateTime @default(now())
@@ -816,6 +821,36 @@ model AutoReloadConfig {
   organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@map("auto_reload_configs")
+}
+
+// Durable state for an automatic credit reload. Stripe retries must reuse the
+// exact customer, payment method, amount, and idempotency key from this row.
+// activeOrganizationId is populated only while an attempt is unresolved; its
+// unique constraint makes the database the concurrency boundary per org while
+// retaining completed/failed attempts for audit and webhook reconciliation.
+model AutoReloadAttempt {
+  id                    String   @id @default(cuid())
+  status                String   @default("initializing") // initializing | pending | submitting | processing | charged | completed | failed | uncertain | disabled
+  idempotencyKey        String   @unique
+  amountCents           Int
+  stripeCustomerId      String
+  stripePaymentMethodId String?
+  stripePaymentIntentId String?  @unique
+  leaseExpiresAt        DateTime
+  retryUntil            DateTime
+  lastSubmittedAt       DateTime?
+  failureReason         String?
+  completedAt           DateTime?
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  organizationId       String
+  organization         Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  activeOrganizationId String?      @unique
+
+  @@index([organizationId, createdAt])
+  @@index([status, leaseExpiresAt])
+  @@map("auto_reload_attempts")
 }
 
 model OrgApiToken {


### PR DESCRIPTION
## Intent

Add a Claude-style Usage and spend limits experience to Billing: show monthly usage, configured maximum, remaining allowance, UTC reset date, current balance and auto-reload status, while keeping existing purchases, subscriptions and transaction history. Make auto-reload production-safe with durable idempotent attempts, refund suppression, webhook and scheduled recovery, safe rollout migration, validation, disable support, saved-card consent, and exact committed-ledger spend. Keep per-seat limits and team credit requests out of scope.

## What Changed

- Billing settings now shows a usage and spend limits dashboard: monthly usage from the committed credit ledger (UTC month via new `billing-period.ts`), configured spend limit with an adjust dialog, remaining allowance, reset date, balance with free/purchased split, and auto-reload status (including a paused state and re-consent banner) alongside existing purchases, subscriptions, and transaction history.
- Auto-reload is rebuilt around a durable `AutoReloadAttempt` table (new Prisma migration) with idempotent charge attempts, failure backoff, refund suppression, Stripe webhook and scheduled-queue recovery, receipt backfill, saved-card consent validation, and a rollout migration that pauses legacy configs for review; the CLI usage route was aligned to the same UTC ledger-month semantics.
- Adds extensive coverage: unit suites for billing, billing periods, spend limits, and Stripe payment methods (143 passing), plus opt-in Postgres tests for exactly-once grant under concurrency and legacy config migration, wired into CI.

## Risk Assessment

✅ Low: The round delta cleanly and correctly implements the three requested fixes (verified backoff math, owner-retry bypass, receipt backfill, and config preservation) with test coverage updated, leaving no outstanding findings beyond items the user explicitly dispositioned.

## Testing

Ran all changed unit test suites (143 pass) and the new Postgres-backed billing invariant tests (idempotent duplicate grants, legacy config pause), verified the rollout migration applies cleanly onto the base-commit schema, then drove the real app end-to-end — signup, login, and the Billing page against seeded data — capturing screenshots of the usage/spend-limit card (exact committed-ledger spend, limit, remaining, UTC reset), balance with auto-reload On/Paused states, the spend-limit dialog persisting to Postgres, the no-saved-card consent guard, and the migration-paused banner; everything passed with no product issues found.

- Evidence: Billing page — usage &amp; spend limits card ($37.65 spent, resets Sep 1, $100 limit, $62.35 remaining, balance $47.35, auto-reload On) (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZP557NTS73MXA2Q2CQBYSA0/billing-usage-spend-limits-top.png</code>)
- Evidence: Transaction history (purchase, usage, auto-reload rows with receipts) + auto-reload settings (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZP557NTS73MXA2Q2CQBYSA0/billing-transactions-autoreload-settings.png</code>)
- Evidence: Adjust monthly spend limit dialog (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZP557NTS73MXA2Q2CQBYSA0/billing-adjust-limit-dialog.png</code>)
- Evidence: Spend limit updated to $150 (confirmed persisted in Postgres, card shows 25% used) (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZP557NTS73MXA2Q2CQBYSA0/billing-spend-limit-updated.png</code>)
- Evidence: Saved-card consent guard: auto-reload save rejected without a payment method (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZP557NTS73MXA2Q2CQBYSA0/billing-autoreload-no-card-guard.png</code>)
- Evidence: Migration-paused rollout state: &#39;Paused&#39; auto-reload badge on balance card (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZP557NTS73MXA2Q2CQBYSA0/billing-autoreload-paused-badge.png</code>)
- Evidence: Migration-paused rollout state: re-consent banner in billing settings (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZP557NTS73MXA2Q2CQBYSA0/billing-autoreload-paused-banner.png</code>)
<details>
<summary>Evidence: Postgres persistence check after saving spend limit via UI</summary>

```text
$ docker exec octopus-billing-test-pg psql -U octopus -d octopus_ui_test -tc 'SELECT "monthlySpendLimitUsd" FROM organizations'
150
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed ✅</summary>

- ⚠️ `apps/web/lib/credits.ts:673` - Unbounded retry cadence against a permanently declining card: a conclusively failed attempt only cools down for one AUTO_RELOAD_LEASE_MS (5 min) before ensureDurableAutoReloadAttempt releases the slot and the next usage deduction arms a brand-new attempt/PaymentIntent. An org with ongoing usage below threshold and a dead card can generate ~288 charge attempts/day indefinitely, risking card-network excessive-reattempt rules and Stripe retry flags. (Improvement over the old per-deduction retry, but consider escalating backoff or a consecutive-failure cap.)
- ℹ️ `apps/web/app/api/stripe/webhook/route.ts:43` - Poison webhook events 500-loop for days: if the org is deleted (cascade removes the AutoReloadAttempt) or a legacy auto-reload PI fails grantValidatedLegacyAutoReload validation, getMatchingAutoReloadAttempt throws on every redelivery, so Stripe retries the same event with 500s for ~3 days. Consistent with the deliberate &#34;500 = retry&#34; contract; produces log/alert noise but no incorrect state.
- ℹ️ `apps/web/lib/credits.ts:1181` - Auto-reload grants recovered via the charged-attempt reconciliation path pass latestCharge=null to grantAutoReloadFromPaymentIntent, so those ledger rows never get a receiptUrl backfilled — unlike inline and webhook grants. Retrieving the PI (or its latest_charge) here would restore the receipt link in transaction history.
- ℹ️ `apps/web/app/(app)/settings/billing/actions.ts:296` - Saving the auto-reload form with the switch off silently clamps out-of-range legacy threshold/reload values to the 10/50 defaults (savedThreshold/savedReload fallbacks), rewriting an owner&#39;s stored amounts without any message. Low impact since the migration already pauses legacy configs and requires review, but the rewrite is invisible.
- ℹ️ `apps/web/lib/credits.ts:52` - Simplification opportunity: the compare-and-swap updateMany followed by a verify-findFirst-or-throw fallback recurs ~6 times across grantAutoReloadFromPaymentIntent, failAutoReloadAttemptFromPaymentIntent, applyAutoReloadPaymentIntent, and processDurableAutoReloadAttempt. Extracting a shared guarded-transition helper would materially shrink credits.ts, though refactoring this money path is best done with the existing test suite as a gate.

🔧 Fix: add auto-reload failure backoff, receipt backfill, preserve config
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun test lib/__tests__/billing.test.ts lib/__tests__/billing-period.test.ts lib/__tests__/spend-limit.test.ts lib/__tests__/stripe-payment-method.test.ts lib/__tests__/cost.test.ts lib/__tests__/concurrency-guard.test.ts lib/__tests__/review-routing.test.ts` — 143 pass, 0 fail</code>
- <code>`RUN_BILLING_DB_TESTS=1 bun test lib/__tests__/billing.db.test.ts` against a disposable Postgres 17 (docker) — 2 pass: exactly-once duplicate grant under concurrency, safe durable-attempt migration of legacy auto-reload rows</code>
- <code>Applied `20260810120000_add_auto_reload_attempts/migration.sql` onto a database created from the base commit&#39;s Prisma schema — applies cleanly (table, unique idempotency/payment-intent/active-org constraints, config backfill)</code>
- <code>Manual E2E: booted `next dev` against seeded Postgres, signed up + logged in via the real auth flow, loaded /settings/billing — verified $37.65 monthly usage computed from seeded committed-ledger usage debits, $100 limit, $62.35 remaining, UTC reset label &#39;Resets Sep 1&#39;, $47.35 balance with free/purchased split, Auto-reload &#39;On&#39; badge, purchases/subscriptions/transaction history intact</code>
- <code>Manual E2E: Adjust limit dialog $100 → $150 — UI confirms &#39;Spend limit updated.&#39;, Postgres `organizations.monthlySpendLimitUsd` = 150, card re-renders 25% used / $112.35 remaining</code>
- `Manual E2E: Save Auto-Reload with no saved card — rejected with 'Add a payment method before enabling auto-reload.'`
- <code>Manual E2E: set `pausedForDurableUpgrade=true` in DB — page shows &#39;Paused&#39; badge and the billing-safety-upgrade re-consent banner</code>
- `Scope check: diff contains no per-seat limit or team credit request behavior`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `apps/web/app/api/cli/usage/route.ts:12` - apps/web/app/api/cli/usage/route.ts: the response&#39;s `period` field still advertises a server-local month window and the per-model `breakdown` is priced from AiUsage rows, but `totalSpend` now comes from getOrgMonthlySpend&#39;s UTC-month committed credit ledger. The response&#39;s implied contract (totalSpend ≈ sum of breakdown over `period`) is now inaccurate. Aligning the route to UTC bounds / ledger semantics is a behavior change, so it was left for a follow-up.

🔧 Fix: align CLI usage route to UTC ledger month
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
