### PR TITLE
fix(billing): move settings card above usage summary

### DIFF
--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -657,7 +657,7 @@ export function BillingSettings({
         </CardContent>
       </Card>
 
-      {/* Card 3: Payment Methods */}
+      {/* Payment Methods */}
       <Card>
         <CardHeader>
           <CardTitle>Payment Methods</CardTitle>
@@ -722,7 +722,7 @@ export function BillingSettings({
         </CardContent>
       </Card>
 
-      {/* Card 4: Transaction History */}
+      {/* Transaction History */}
       <Card>
         <CardHeader>
           <CardTitle>Transaction History</CardTitle>

--- a/apps/web/app/(app)/settings/billing/billing-settings.tsx
+++ b/apps/web/app/(app)/settings/billing/billing-settings.tsx
@@ -247,6 +247,167 @@ export function BillingSettings({
 
   return (
     <div className="space-y-6">
+      {/* Billing Settings */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Billing Settings</CardTitle>
+          <CardDescription>
+            Configure auto-reload and billing contact.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {autoReloadPaused && (
+            <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+              Auto-reload was paused during the billing safety upgrade. Review
+              the amounts and save to re-enable it.
+            </div>
+          )}
+          {/* Auto-reload */}
+          <form
+            id="auto-reload-settings"
+            action={autoReloadAction}
+            className="scroll-mt-6 space-y-4"
+          >
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <Label>Auto-Reload</Label>
+                <p className="text-xs text-muted-foreground">
+                  Automatically purchase credits when balance is low.
+                </p>
+              </div>
+              <Switch
+                checked={autoReloadEnabled}
+                onCheckedChange={(checked) => setAutoReloadEnabled(checked)}
+                disabled={!canManageBilling}
+                aria-label="Enable auto-reload"
+              />
+            </div>
+            <input type="hidden" name="enabled" value={String(autoReloadEnabled)} />
+            {!autoReloadEnabled && (
+              <>
+                <input
+                  type="hidden"
+                  name="thresholdAmount"
+                  value={autoReloadConfig?.thresholdAmount ?? 10}
+                />
+                <input
+                  type="hidden"
+                  name="reloadAmount"
+                  value={autoReloadConfig?.reloadAmount ?? 50}
+                />
+              </>
+            )}
+
+            {autoReloadEnabled && (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="thresholdAmount">
+                    When balance falls below
+                  </Label>
+                  <div className="relative">
+                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                      $
+                    </span>
+                    <Input
+                      id="thresholdAmount"
+                      name="thresholdAmount"
+                      type="number"
+                      min={1}
+                      max={1000}
+                      step={1}
+                      defaultValue={autoReloadConfig?.thresholdAmount ?? 10}
+                      disabled={!canManageBilling}
+                      className="pl-7"
+                    />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="reloadAmount">Reload amount</Label>
+                  <div className="relative">
+                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+                      $
+                    </span>
+                    <Input
+                      id="reloadAmount"
+                      name="reloadAmount"
+                      type="number"
+                      min={5}
+                      max={1000}
+                      step={1}
+                      defaultValue={autoReloadConfig?.reloadAmount ?? 50}
+                      disabled={!canManageBilling}
+                      className="pl-7"
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {autoReloadState.error && (
+              <p className="text-sm text-destructive">
+                {autoReloadState.error}
+              </p>
+            )}
+            {autoReloadState.success && (
+              <p className="text-sm text-green-600">Auto-reload updated.</p>
+            )}
+
+            {canManageBilling && (
+              <Button
+                type="submit"
+                size="sm"
+                disabled={autoReloadPending}
+              >
+                {autoReloadPending
+                  ? "Saving..."
+                  : !autoReloadEnabled && autoReloadConfig?.enabled
+                    ? "Turn Off Auto-Reload"
+                    : "Save Auto-Reload"}
+              </Button>
+            )}
+          </form>
+
+          <Separator />
+
+          {/* Billing Email */}
+          <form action={emailAction} className="space-y-3">
+            <div className="space-y-2">
+              <Label htmlFor="billingEmail">Billing Email</Label>
+              <Input
+                id="billingEmail"
+                name="billingEmail"
+                type="email"
+                defaultValue={billingEmail ?? ""}
+                disabled={!canManageBilling}
+                placeholder="billing@company.com"
+              />
+              <p className="text-xs text-muted-foreground">
+                Receipts and billing notifications will be sent to this email.
+              </p>
+            </div>
+            {emailState.error && (
+              <p className="text-sm text-destructive">{emailState.error}</p>
+            )}
+            {emailState.success && (
+              <p className="text-sm text-green-600">Billing email updated.</p>
+            )}
+            <Button
+              type="submit"
+              size="sm"
+              disabled={emailPending || !canManageBilling}
+            >
+              {emailPending ? "Saving..." : "Update Email"}
+            </Button>
+          </form>
+
+          {!canManageBilling && (
+            <p className="text-muted-foreground text-center text-xs">
+              Only owners and admins can manage billing settings.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
       <div className="space-y-1">
         <h2
           id="usage-spend-limits-heading"
@@ -784,167 +945,6 @@ export function BillingSettings({
           {transactions.length === 0 && (
             <p className="text-sm text-muted-foreground text-center py-8">
               No transactions yet.
-            </p>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Card 5: Billing Settings */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Billing Settings</CardTitle>
-          <CardDescription>
-            Configure auto-reload and billing contact.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          {autoReloadPaused && (
-            <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
-              Auto-reload was paused during the billing safety upgrade. Review
-              the amounts and save to re-enable it.
-            </div>
-          )}
-          {/* Auto-reload */}
-          <form
-            id="auto-reload-settings"
-            action={autoReloadAction}
-            className="scroll-mt-6 space-y-4"
-          >
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <Label>Auto-Reload</Label>
-                <p className="text-xs text-muted-foreground">
-                  Automatically purchase credits when balance is low.
-                </p>
-              </div>
-              <Switch
-                checked={autoReloadEnabled}
-                onCheckedChange={(checked) => setAutoReloadEnabled(checked)}
-                disabled={!canManageBilling}
-                aria-label="Enable auto-reload"
-              />
-            </div>
-            <input type="hidden" name="enabled" value={String(autoReloadEnabled)} />
-            {!autoReloadEnabled && (
-              <>
-                <input
-                  type="hidden"
-                  name="thresholdAmount"
-                  value={autoReloadConfig?.thresholdAmount ?? 10}
-                />
-                <input
-                  type="hidden"
-                  name="reloadAmount"
-                  value={autoReloadConfig?.reloadAmount ?? 50}
-                />
-              </>
-            )}
-
-            {autoReloadEnabled && (
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="thresholdAmount">
-                    When balance falls below
-                  </Label>
-                  <div className="relative">
-                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
-                      $
-                    </span>
-                    <Input
-                      id="thresholdAmount"
-                      name="thresholdAmount"
-                      type="number"
-                      min={1}
-                      max={1000}
-                      step={1}
-                      defaultValue={autoReloadConfig?.thresholdAmount ?? 10}
-                      disabled={!canManageBilling}
-                      className="pl-7"
-                    />
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="reloadAmount">Reload amount</Label>
-                  <div className="relative">
-                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
-                      $
-                    </span>
-                    <Input
-                      id="reloadAmount"
-                      name="reloadAmount"
-                      type="number"
-                      min={5}
-                      max={1000}
-                      step={1}
-                      defaultValue={autoReloadConfig?.reloadAmount ?? 50}
-                      disabled={!canManageBilling}
-                      className="pl-7"
-                    />
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {autoReloadState.error && (
-              <p className="text-sm text-destructive">
-                {autoReloadState.error}
-              </p>
-            )}
-            {autoReloadState.success && (
-              <p className="text-sm text-green-600">Auto-reload updated.</p>
-            )}
-
-            {canManageBilling && (
-              <Button
-                type="submit"
-                size="sm"
-                disabled={autoReloadPending}
-              >
-                {autoReloadPending
-                  ? "Saving..."
-                  : !autoReloadEnabled && autoReloadConfig?.enabled
-                    ? "Turn Off Auto-Reload"
-                    : "Save Auto-Reload"}
-              </Button>
-            )}
-          </form>
-
-          <Separator />
-
-          {/* Billing Email */}
-          <form action={emailAction} className="space-y-3">
-            <div className="space-y-2">
-              <Label htmlFor="billingEmail">Billing Email</Label>
-              <Input
-                id="billingEmail"
-                name="billingEmail"
-                type="email"
-                defaultValue={billingEmail ?? ""}
-                disabled={!canManageBilling}
-                placeholder="billing@company.com"
-              />
-              <p className="text-xs text-muted-foreground">
-                Receipts and billing notifications will be sent to this email.
-              </p>
-            </div>
-            {emailState.error && (
-              <p className="text-sm text-destructive">{emailState.error}</p>
-            )}
-            {emailState.success && (
-              <p className="text-sm text-green-600">Billing email updated.</p>
-            )}
-            <Button
-              type="submit"
-              size="sm"
-              disabled={emailPending || !canManageBilling}
-            >
-              {emailPending ? "Saving..." : "Update Email"}
-            </Button>
-          </form>
-
-          {!canManageBilling && (
-            <p className="text-muted-foreground text-center text-xs">
-              Only owners and admins can manage billing settings.
             </p>
           )}
         </CardContent>


### PR DESCRIPTION
## Intent

Move the existing Billing Settings card above the Usage and spend limits summary on the Billing page. Preserve all auto-reload and billing-email behavior, fields, permissions, and accessibility; this is a layout-only DOM reorder with no billing logic or styling changes.

## What Changed

- Reordered the Billing page in `apps/web/app/(app)/settings/billing/billing-settings.tsx` so the existing Billing Settings card (auto-reload and billing email) now renders above the "Usage and spend limits" summary. This is a pure block move — the pipeline's test stage confirmed via line-set diff comparison and a render harness that only the card order changed, with all fields, permissions, and accessibility (labeled inputs, aria-labeled switch, `#auto-reload-settings` anchor) intact.
- Dropped the now-stale "Card N" positional numbering from the section comments after the reorder.

## Risk Assessment

✅ Low: The change is a verified byte-identical relocation of one JSX card block within a single file (only a section comment differs), fully matching the stated layout-only intent, with the in-page #auto-reload-settings anchor and all behavior, permissions, and accessibility attributes preserved.

## Testing

Confirmed via diff analysis that the change is a pure DOM reorder (only a comment differs), ran the 93 passing billing unit tests as a baseline, then rendered both base and new versions of the BillingSettings component with the app's compiled Tailwind CSS and screenshotted them in headless Chrome — the after-shot shows the Billing Settings card above the usage summary with identical card contents and intact accessibility attributes.

- Evidence: Billing page AFTER (this change) — Billing Settings card above usage summary (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZPBA1DYA5BWJSDP60301GVY/billing-after.png</code>)
- Evidence: Billing page BEFORE (base commit) — Billing Settings card at bottom (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZPBA1DYA5BWJSDP60301GVY/billing-before.png</code>)
<details>
<summary>Evidence: Rendered AFTER page (HTML with app Tailwind CSS)</summary>

```text
<!doctype html>
<html lang="en">
<head>
<meta charset="utf-8" />
<meta name="viewport" content="width=device-width, initial-scale=1" />
<title>Billing page — AFTER — 035c719 (this change)</title>
<link rel="stylesheet" href="billing.css" />
</head>
<body class="bg-background text-foreground antialiased">
<div style="max-width:56rem;margin:0 auto;padding:2rem 1.5rem">
<div style="margin-bottom:1rem;font:600 13px ui-sans-serif;color:#fff;background:#0f172a;display:inline-block;padding:4px 10px;border-radius:6px">AFTER — 035c719 (this change)</div>
<div class="space-y-6"><div data-slot="card" data-size="default" class="ring-foreground/10 bg-card text-card-foreground gap-6 overflow-hidden rounded-xl py-6 text-sm shadow-xs ring-1 has-[&gt;img:first-child]:pt-0 data-[size=sm]:gap-4 data-[size=sm]:py-4 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col"><div data-slot="card-header" class="gap-1 rounded-t-xl px-6 group-data-[size=sm]/card:px-4 [.border-b]:pb-6 group-data-[size=sm]/card:[.border-b]:pb-4 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]"><div data-slot="card-title" class="text-base leading-normal font-medium group-data-[size=sm]/card:text-sm">Billing Settings</div><div data-slot="card-description" class="text-muted-foreground text-sm">Configure auto-reload and billing contact.</div></div><div data-slot="card-content" class="px-6 group-data-[size=sm]/card:px-4 space-y-6"><form id="auto-reload-settings" class="scroll-mt-6 space-y-4" action="javascript:throw new Error(&#x27;React form unexpectedly submitted.&#x27;)"><div class="flex items-center justify-between gap-4"><div><label data-slot="label" class="gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed">Auto-Reload</label><p class="text-xs text-muted-foreground">Automatically purchase credits when balance is low.</p></div><button type="button" role="switch" aria-checked="true" data-state="checked" value="on" data-slot="switch" data-size="default" class="data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent shadow-xs focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50" aria-label="Enable auto-reload"><span data-state="checked" data-slot="switch-thumb" class="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform"></span></button><input type="checkbox" aria-hidden="true" style="transform:translateX(-100%);position:absolute;pointer-events:none;opacity:0;margin:0" tabindex="-1" checked="" value="on"/></div><input type="hidden" name="enabled" value="true"/><div class="grid grid-cols-1 gap-4 sm:grid-cols-2"><div class="space-y-2"><label data-slot="label" class="gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed" for="thresholdAmount">When balance falls below</label><div class="relative"><span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">$</span><input type="number" data-slot="input" class="dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 pl-7" id="thresholdAmount" min="1" max="1000" step="1" name="thresholdAmount" value="10"/></div></div><div class="space-y-2"><label data-slot="label" class="gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed" for="reloadAmount">Reload amount</label><div class="relative"><span class="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">$</span><input type="number" data-slot="input" class="dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 pl-7" id="reloadAmount" min="5" max="1000" step="1" name="reloadAmount" value="50"/></div></div></div><button data-slot="button" data-variant="default" data-size="sm" class="focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 aria-invalid:ring-3 [&amp;_svg:not([class*=&#x27;size-&#x27;])]:size-4 inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&amp;_svg]:pointer-events-none shrink-0 [&amp;_svg]:shrink-0 outline-none group/button select-none bg-primary text-primary-foreground hover:bg-primary/80 h-8 gap-1 rounded-[min(var(--radius-md),10px)] px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5" type="submit">Save Auto-Reload</button></form><div data-orientation="horizontal" role="none" data-slot="separator" class="bg-border shrink-0 data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch"></div><form class="space-y-3" action="javascript:throw new Error(&#x27;React form unexpectedly submitted.&#x27;)"><div class="space-y-2"><label data-slot="label" class="gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed" for="billingEmail">Billing Email</label><input type="email" data-slot="input" class="dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-9 rounded-md border bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-3 aria-inv

... [18585 bytes truncated] ...

mary text-primary-foreground [a]:hover:bg-primary/80 cursor-pointer text-[11px]">All</span><span data-slot="badge" data-variant="outline" class="h-5 gap-1 rounded-full border px-2 py-0.5 font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&amp;&gt;svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&amp;&gt;svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground cursor-pointer text-[11px]">purchase</span><span data-slot="badge" data-variant="outline" class="h-5 gap-1 rounded-full border px-2 py-0.5 font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&amp;&gt;svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&amp;&gt;svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground cursor-pointer text-[11px]">usage</span></div><div class="hidden sm:block"><div class="border rounded-md overflow-hidden"><table class="w-full text-sm"><thead><tr class="border-b bg-muted/30"><th class="text-left px-3 py-2 font-medium">Date</th><th class="text-left px-3 py-2 font-medium">Type</th><th class="text-left px-3 py-2 font-medium">Description</th><th class="text-right px-3 py-2 font-medium">Amount</th><th class="text-right px-3 py-2 font-medium">Balance</th><th class="text-center px-3 py-2 font-medium w-16"></th></tr></thead><tbody><tr class="border-b last:border-b-0"><td class="px-3 py-2 whitespace-nowrap text-muted-foreground">2026-08-01</td><td class="px-3 py-2"><span data-slot="badge" data-variant="default" class="h-5 gap-1 rounded-full border px-2 py-0.5 transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&amp;&gt;svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&amp;&gt;svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge [a]:hover:bg-primary/80 text-[10px] font-normal bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 border-green-200 dark:border-green-800">purchase</span></td><td class="px-3 py-2 text-muted-foreground truncate max-w-[200px]">Credit purchase</td><td class="px-3 py-2 text-right font-mono whitespace-nowrap text-green-600">+$50.00</td><td class="px-3 py-2 text-right font-mono whitespace-nowrap">$47.50</td><td class="px-3 py-2 text-center"><div class="inline-flex items-center gap-2"><a href="/api/billing/invoice/txn_1" class="inline-flex items-center text-muted-foreground hover:text-foreground transition-colors" title="Download invoice PDF"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="tabler-icon tabler-icon-file-invoice size-4"><path d="M14 3v4a1 1 0 0 0 1 1h4"></path><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2"></path><path d="M9 7l1 0"></path><path d="M9 13l6 0"></path><path d="M13 17l2 0"></path></svg></a></div></td></tr><tr class="border-b last:border-b-0"><td class="px-3 py-2 whitespace-nowrap text-muted-foreground">2026-08-05</td><td class="px-3 py-2"><span data-slot="badge" data-variant="secondary" class="h-5 gap-1 rounded-full border border-transparent px-2 py-0.5 transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&amp;&gt;svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&amp;&gt;svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 text-[10px] font-normal">usage</span></td><td class="px-3 py-2 text-muted-foreground truncate max-w-[200px]">AI review usage</td><td class="px-3 py-2 text-right font-mono whitespace-nowrap text-muted-foreground">$2.50</td><td class="px-3 py-2 text-right font-mono whitespace-nowrap">$45.00</td><td class="px-3 py-2 text-center"><div class="inline-flex items-center gap-2"></div></td></tr></tbody></table></div></div><div class="sm:hidden space-y-2"><div class="rounded-md border p-3 space-y-1"><div class="flex items-center justify-between"><span data-slot="badge" data-variant="default" class="h-5 gap-1 rounded-full border px-2 py-0.5 transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&amp;&gt;svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&amp;&gt;svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge [a]:hover:bg-primary/80 text-[10px] font-normal bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 border-green-200 dark:border-green-800">purchase</span><span class="text-sm font-mono text-green-600">+$50.00</span></div><p class="text-xs text-muted-foreground truncate">Credit purchase</p><div class="flex items-center justify-between text-xs text-muted-foreground"><span>2026-08-01</span><div class="flex items-center gap-2"><a href="/api/billing/invoice/txn_1" class="hover:text-foreground transition-colors" title="Download invoice PDF"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="tabler-icon tabler-icon-file-invoice size-3.5"><path d="M14 3v4a1 1 0 0 0 1 1h4"></path><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2"></path><path d="M9 7l1 0"></path><path d="M9 13l6 0"></path><path d="M13 17l2 0"></path></svg></a><span>Balance: $47.50</span></div></div></div><div class="rounded-md border p-3 space-y-1"><div class="flex items-center justify-between"><span data-slot="badge" data-variant="secondary" class="h-5 gap-1 rounded-full border border-transparent px-2 py-0.5 transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&amp;&gt;svg]:size-3! inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&amp;&gt;svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80 text-[10px] font-normal">usage</span><span class="text-sm font-mono text-muted-foreground">$2.50</span></div><p class="text-xs text-muted-foreground truncate">AI review usage</p><div class="flex items-center justify-between text-xs text-muted-foreground"><span>2026-08-05</span><div class="flex items-center gap-2"><span>Balance: $45.00</span></div></div></div></div></div></div></div><script>addEventListener("submit",function(a){if(!a.defaultPrevented){var c=a.target,d=a.submitter,e=c.action,b=d;if(d){var f=d.getAttribute("formAction");null!=f&&(e=f,b=null)}"javascript:throw new Error('React form unexpectedly submitted.')"===e&&(a.preventDefault(),b?(a=document.createElement("input"),a.name=b.name,a.value=b.value,b.parentNode.insertBefore(a,b),b=new FormData(c),a.parentNode.removeChild(a)):b=new FormData(c),a=c.ownerDocument||c,(a.$$reactFormReplay=a.$$reactFormReplay||[]).push(c,d,b))}});</script>
</div>
</body>
</html>
```
</details>
- Evidence: Rendered BEFORE page (HTML with app Tailwind CSS) (local file: <code>/var/folders/yz/_qq8km3x433d7wkcql1rzpvw0000gn/T/no-mistakes-evidence/01KZPBA1DYA5BWJSDP60301GVY/billing-before.html</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `apps/web/app/(app)/settings/billing/billing-settings.tsx:660` - Section comments &#39;{/* Card 3: Payment Methods */}&#39; (line 660) and &#39;{/* Card 4: Transaction History */}&#39; (line 725) retain stale positional numbering now that the former &#39;Card 5&#39; (Billing Settings) was moved to the top and renamed to a non-numbered comment. Comment-only; no functional impact.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff b657cef..035c719` line-set comparison proving a pure block move (only comment text differs)</code>
- <code>`bun test lib/__tests__/billing.test.ts lib/__tests__/billing-period.test.ts` — 93 pass, 0 fail</code>
- <code>Temporary render harness `bun test app/(app)/settings/billing/__render-evidence.test.tsx` rendering base and new BillingSettings with mock props; asserted Billing Settings card precedes the &#39;Usage and spend limits&#39; heading in the new version and follows it in the base (deleted after run)</code>
- `Headless Chrome (chrome-devtools-axi) accessibility snapshot confirming the moved card keeps its aria-labeled switch, labeled inputs, and the #auto-reload-settings anchor target`
- `Captured styled before/after screenshots of the rendered Billing page`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `packages/db/src/index.ts:1` - Repo-wide `tsc --noEmit` fails with 221 pre-existing errors in files untouched by this change, caused by the Prisma client not being generated in this worktree (`db:generate` requires DATABASE_URL, unavailable here). Not introduced by this diff and not resolvable in this environment; ESLint on the changed file is clean.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
