### PR TITLE
fix(models): retire Opus 4.6/4.7 and order the model catalog newest-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Retired the older Opus 4.6 and 4.7 models from the review-model list and re-ordered the Settings model dropdown newest-first. Organizations and repositories still set to a retired model are moved to Opus 4.8.
+
 ## [1.0.112] - 2026-08-13
 
 ### Security

--- a/packages/db/prisma/migrations/20260813200000_retire_opus_4647_reorder_models/migration.sql
+++ b/packages/db/prisma/migrations/20260813200000_retire_opus_4647_reorder_models/migration.sql
@@ -1,0 +1,32 @@
+-- Retire Opus 4.6 / 4.7 and give the LLM catalog a clean, newest-first order.
+-- Prod had drifted from the seed: it still carried claude-opus-4-6 and
+-- claude-opus-4-7 (dropped from the seed but never removed) and most rows had
+-- sortOrder = 0, so the model dropdown looked jumbled.
+
+-- 1. Reassign every org/repo still pointed at the retired models to Opus 4.8
+--    (proven-live). MUST run before the DELETE so nothing references a removed
+--    model. No-ops on installs that never had them.
+UPDATE "organizations" SET "defaultModelId" = 'claude-opus-4-8'
+  WHERE "defaultModelId" IN ('claude-opus-4-6', 'claude-opus-4-7');
+UPDATE "repositories" SET "reviewModelId" = 'claude-opus-4-8'
+  WHERE "reviewModelId" IN ('claude-opus-4-6', 'claude-opus-4-7');
+
+-- 2. Remove the retired catalog rows.
+DELETE FROM "available_models"
+  WHERE "modelId" IN ('claude-opus-4-6', 'claude-opus-4-7');
+
+-- 3. Newest-first, grouped by provider (Anthropic, then Google, OpenAI, local).
+--    UPDATEs are keyed on modelId, so models an install doesn't have are no-ops.
+UPDATE "available_models" SET "sortOrder" = 0  WHERE "modelId" = 'claude-opus-5';
+UPDATE "available_models" SET "sortOrder" = 1  WHERE "modelId" = 'claude-opus-4-8';
+UPDATE "available_models" SET "sortOrder" = 2  WHERE "modelId" IN ('claude-sonnet-4-6', 'claude-sonnet-4-6-20250619');
+UPDATE "available_models" SET "sortOrder" = 3  WHERE "modelId" = 'claude-haiku-4-5-20251001';
+UPDATE "available_models" SET "sortOrder" = 4  WHERE "modelId" = 'claude-fable-5';
+UPDATE "available_models" SET "sortOrder" = 5  WHERE "modelId" = 'claude-sonnet-4-20250514';
+UPDATE "available_models" SET "sortOrder" = 6  WHERE "modelId" = 'claude-opus-4-20250514';
+UPDATE "available_models" SET "sortOrder" = 10 WHERE "modelId" = 'gemini-2.5-pro';
+UPDATE "available_models" SET "sortOrder" = 11 WHERE "modelId" = 'gemini-2.5-flash';
+UPDATE "available_models" SET "sortOrder" = 12 WHERE "modelId" = 'gpt-5.3-codex';
+UPDATE "available_models" SET "sortOrder" = 20 WHERE "modelId" = 'claude-code:sonnet';
+UPDATE "available_models" SET "sortOrder" = 30 WHERE "modelId" = 'ollama:qwen2.5-coder:14b';
+UPDATE "available_models" SET "sortOrder" = 31 WHERE "modelId" = 'ollama:qwen2.5-coder:7b';


### PR DESCRIPTION
## What

The Settings → Models dropdown still showed **Opus 4.6** and **Opus 4.7** (dropped from the seed long ago but never removed from prod), and most `available_models` rows shared `sortOrder = 0`, so the list rendered in a jumbled order.

This is a **data-only** migration (`20260813200000_retire_opus_4647_reorder_models`):

1. **Reassign** every org (`defaultModelId`) and repo (`reviewModelId`) still pointed at `claude-opus-4-6` / `claude-opus-4-7` → `claude-opus-4-8` (proven-live), **before** the delete so nothing dangles.
2. **Delete** the two retired catalog rows.
3. **Re-number** `sortOrder` newest-first, grouped by provider (Anthropic → Google → OpenAI → local).

## Prod impact (measured read-only before writing)

- Opus 4.7: 4 orgs + 16 repos
- Opus 4.6: 5 orgs + 18 repos

All 9 orgs + 34 repos get reassigned to Opus 4.8.

## Safety

- Every statement is keyed on `modelId`, so installs that never had these models no-op (safe for fresh/self-host DBs).
- No schema change → passes the expand-only `migrate-check` gate (DML only, no DDL).
- No UI change needed: the dropdown already orders by `[category, sortOrder]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)