### PR TITLE
feat(admin): model discovery endpoint (pull latest from provider)

### DIFF
--- a/apps/web/app/api/admin/models/discover/route.ts
+++ b/apps/web/app/api/admin/models/discover/route.ts
@@ -1,0 +1,142 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import OpenAI from "openai";
+import { isAdminApiAuthorized } from "@/lib/admin-auth";
+import { prisma } from "@octopus/db";
+
+// Vendor admin "pull latest from provider": ask each provider's own API which
+// models exist, and diff against the available_models catalog. Lets the admin
+// see NEW upstream models to add and catalog rows the provider no longer lists
+// (candidates to retire) — so the catalog is driven by provider truth instead
+// of a hand-maintained list. Guarded by the shared ADMIN_API_SECRET bearer;
+// read-only (no writes). octopus-admin renders the result and the admin picks
+// what to add via the existing createAvailableModel action.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface DiscoveredModel {
+  id: string;
+  displayName: string;
+}
+interface ProviderResult {
+  keyConfigured: boolean;
+  newUpstream: DiscoveredModel[]; // exist at provider, not in catalog
+  inCatalogNotUpstream: string[]; // in catalog, provider no longer lists them
+  error?: string;
+}
+
+function titleCase(id: string): string {
+  return id
+    .replace(/[-_:]/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
+}
+
+async function discoverAnthropic(catalog: Set<string>): Promise<ProviderResult> {
+  const key = process.env.ANTHROPIC_API_KEY;
+  if (!key) return { keyConfigured: false, newUpstream: [], inCatalogNotUpstream: [] };
+  const client = new Anthropic({ apiKey: key });
+  const upstream: DiscoveredModel[] = [];
+  const upstreamIds = new Set<string>();
+  // Auto-paginates; Anthropic's catalog is small.
+  for await (const m of client.models.list({ limit: 100 })) {
+    upstreamIds.add(m.id);
+    upstream.push({ id: m.id, displayName: m.display_name || titleCase(m.id) });
+  }
+  return {
+    keyConfigured: true,
+    newUpstream: upstream.filter((m) => !catalog.has(m.id)),
+    inCatalogNotUpstream: [...catalog].filter((id) => !upstreamIds.has(id)),
+  };
+}
+
+async function discoverOpenAI(catalog: Set<string>): Promise<ProviderResult> {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) return { keyConfigured: false, newUpstream: [], inCatalogNotUpstream: [] };
+  const client = new OpenAI({ apiKey: key });
+  const list = await client.models.list();
+  // OpenAI's list returns every id (embeddings, audio, snapshots). Keep only
+  // chat-capable families and drop non-text + dated snapshots.
+  const isChat = (id: string) =>
+    /^(gpt-|o\d)/i.test(id) &&
+    !/(embedding|whisper|tts|audio|realtime|image|dall|moderation|transcribe|search|instruct)/i.test(id) &&
+    !/-\d{4}-\d{2}-\d{2}$/.test(id) &&
+    !/-\d{4}$/.test(id);
+  const upstreamIds = new Set<string>();
+  const upstream: DiscoveredModel[] = [];
+  for (const m of list.data) {
+    if (!isChat(m.id)) continue;
+    upstreamIds.add(m.id);
+    upstream.push({ id: m.id, displayName: titleCase(m.id) });
+  }
+  return {
+    keyConfigured: true,
+    newUpstream: upstream.filter((m) => !catalog.has(m.id)),
+    // Only flag catalog rows within the families we can see, so filtered-out
+    // ids don't get falsely reported as retired.
+    inCatalogNotUpstream: [...catalog].filter(
+      (id) => /^(gpt-|o\d)/i.test(id) && !upstreamIds.has(id),
+    ),
+  };
+}
+
+async function discoverGoogle(catalog: Set<string>): Promise<ProviderResult> {
+  const key = process.env.GOOGLE_API_KEY;
+  if (!key) return { keyConfigured: false, newUpstream: [], inCatalogNotUpstream: [] };
+  // @google/generative-ai has no list API — hit the REST endpoint directly.
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models?pageSize=200&key=${encodeURIComponent(key)}`,
+    { cache: "no-store" },
+  );
+  if (!res.ok) throw new Error(`Google models API ${res.status}`);
+  const body = (await res.json()) as {
+    models?: { name: string; displayName?: string; supportedGenerationMethods?: string[] }[];
+  };
+  const upstreamIds = new Set<string>();
+  const upstream: DiscoveredModel[] = [];
+  for (const m of body.models ?? []) {
+    if (!m.supportedGenerationMethods?.includes("generateContent")) continue;
+    const id = m.name.replace(/^models\//, "");
+    upstreamIds.add(id);
+    upstream.push({ id, displayName: m.displayName || titleCase(id) });
+  }
+  return {
+    keyConfigured: true,
+    newUpstream: upstream.filter((m) => !catalog.has(m.id)),
+    inCatalogNotUpstream: [...catalog].filter((id) => !upstreamIds.has(id)),
+  };
+}
+
+export async function GET(request: NextRequest) {
+  if (!isAdminApiAuthorized(request)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const rows = await prisma.availableModel.findMany({
+    select: { modelId: true, provider: true },
+  });
+  const byProvider = (p: string) =>
+    new Set(rows.filter((r) => r.provider === p).map((r) => r.modelId));
+
+  // Each provider isolated: one failing (bad key, outage) must not sink the rest.
+  const settle = async (fn: () => Promise<ProviderResult>): Promise<ProviderResult> => {
+    try {
+      return await fn();
+    } catch (e) {
+      return {
+        keyConfigured: true,
+        newUpstream: [],
+        inCatalogNotUpstream: [],
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  };
+
+  const [anthropic, openai, google] = await Promise.all([
+    settle(() => discoverAnthropic(byProvider("anthropic"))),
+    settle(() => discoverOpenAI(byProvider("openai"))),
+    settle(() => discoverGoogle(byProvider("google"))),
+  ]);
+
+  return NextResponse.json({ ok: true, providers: { anthropic, openai, google } });
+}


### PR DESCRIPTION
## What

`GET /api/admin/models/discover` — the server side of a "Pull latest from provider" button for the vendor model catalog. Guarded by the shared `ADMIN_API_SECRET` bearer (inert on self-host), read-only.

Asks each provider's own API which models exist and diffs against `available_models`:
- **Anthropic** — `client.models.list()` (auto-paginated)
- **OpenAI** — `client.models.list()` filtered to chat families (drops embeddings/audio/dated snapshots)
- **Google** — `v1beta/models` REST (the SDK has no list API), `generateContent`-capable only

## Why

The catalog was hand-maintained and drifted — stale entries lingered and real new models (e.g. Sonnet 5) were missing. This makes **the provider API the source of truth**: `newUpstream` = models to add, `inCatalogNotUpstream` = catalog rows the provider no longer lists (retire candidates).

## Shape

```
{ ok, providers: { anthropic: { keyConfigured, newUpstream:[{id,displayName}], inCatalogNotUpstream:[id], error? }, openai:{…}, google:{…} } }
```

Each provider is isolated (`Promise.all` over per-provider try/catch), so one bad key/outage can't sink the response. octopus-admin renders this and the admin adds picks via the existing `createAvailableModel` action (pricing stays manual — no list API returns prices).

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)