### PR TITLE
fix(billing): spend gate honors the repo-level model pin

### DIFF
--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -172,7 +172,10 @@ function orgOwnsKeyForProvider(
   }
 }
 
-export async function getOrgSpendLimitStatus(orgId: string): Promise<SpendLimitResult> {
+export async function getOrgSpendLimitStatus(
+  orgId: string,
+  repoId?: string,
+): Promise<SpendLimitResult> {
   const org = await prisma.organization.findUnique({
     where: { id: orgId },
     select: {
@@ -207,7 +210,11 @@ export async function getOrgSpendLimitStatus(orgId: string): Promise<SpendLimitR
       import("@/lib/ai-client"),
       import("@/lib/ai-router"),
     ]);
-    const provider = await getProviderForModel(await getReviewModel(orgId));
+    // Resolve the provider of the model this review will ACTUALLY use — a
+    // repo-level pin overrides the org default. Without repoId, a BYOK-Anthropic
+    // org whose default is Anthropic would be exempted even when a repo is pinned
+    // to a platform provider (e.g. Grok), letting that usage skip the credit gate.
+    const provider = await getProviderForModel(await getReviewModel(orgId, repoId));
     if (orgOwnsKeyForProvider(org, provider)) return { blocked: false };
   } catch (err) {
     console.error("[cost] spend-gate provider resolution failed; using strict BYOK check:", err);
@@ -229,8 +236,8 @@ export async function getOrgSpendLimitStatus(orgId: string): Promise<SpendLimitR
   return { blocked: false };
 }
 
-export async function isOrgOverSpendLimit(orgId: string): Promise<boolean> {
-  const status = await getOrgSpendLimitStatus(orgId);
+export async function isOrgOverSpendLimit(orgId: string, repoId?: string): Promise<boolean> {
+  const status = await getOrgSpendLimitStatus(orgId, repoId);
   return status.blocked;
 }
 

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1126,7 +1126,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
     // brand-new org that never got credit must not be told it "exceeded a
     // monthly limit", and the two reasons must be separable in the reviews
     // table (both used to write the same errorMessage — see credit-health).
-    const spendStatus = await getOrgSpendLimitStatus(org.id);
+    const spendStatus = await getOrgSpendLimitStatus(org.id, repo.id);
     if (spendStatus.blocked) {
       const outOfCredits = spendStatus.reason === "no_credits";
       console.warn(`[reviewer] Org ${org.id} blocked (${spendStatus.reason}) — skipping review`);

--- a/apps/web/lib/summarizer.ts
+++ b/apps/web/lib/summarizer.ts
@@ -10,7 +10,7 @@ export async function summarizeRepository(
   fullName: string,
   organizationId?: string,
 ): Promise<{ summary: string; purpose: string }> {
-  if (organizationId && await isOrgOverSpendLimit(organizationId)) {
+  if (organizationId && await isOrgOverSpendLimit(organizationId, repoId)) {
     console.warn(`[summarizer] Org ${organizationId} over spend limit — skipping summarize`);
     return { summary: "Skipped: monthly AI usage limit reached.", purpose: "Unknown" };
   }


### PR DESCRIPTION
## What

Closes a revenue leak found while adding platform Grok/OpenRouter models. `getOrgSpendLimitStatus` resolved the BYOK exemption from the **org-default** model (`getReviewModel(orgId)`), but a review honors a **repo-level** `reviewModelId` pin. So a BYOK-Anthropic org (exempt on its Anthropic default) with a repo pinned to a **platform** provider like Grok skipped the credit gate — usage was still deducted, so the balance could go unboundedly negative.

## Fix

Thread `repoId` through so the exemption is evaluated against the provider the review will actually use:
- `getOrgSpendLimitStatus(orgId, repoId?)` and `isOrgOverSpendLimit(orgId, repoId?)` → `getReviewModel(orgId, repoId)`
- `reviewer.ts` passes `repo.id`; `summarizeRepository` passes its `repoId`
- Genuinely org-level paths (daily digest, chat, bare local review) stay org-scoped

No schema change. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)