### PR TITLE
fix(chat): route chat + issue export through the provider abstraction

### DIFF
--- a/apps/web/app/(app)/settings/integrations/issue-content-action.ts
+++ b/apps/web/app/(app)/settings/integrations/issue-content-action.ts
@@ -4,10 +4,10 @@ import { headers, cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
-import Anthropic from "@anthropic-ai/sdk";
 import { logAiUsage } from "@/lib/ai-usage";
 import { isOrgOverSpendLimit } from "@/lib/cost";
 import { getReviewModel } from "@/lib/ai-client";
+import { createAiMessage } from "@/lib/ai-router";
 
 // ── Helpers ──
 
@@ -30,13 +30,6 @@ async function getSessionAndOrg(): Promise<{ orgId: string } | { error: string }
   return { orgId };
 }
 
-let anthropicClient: Anthropic | null = null;
-function getAnthropicClient(): Anthropic {
-  if (!anthropicClient) {
-    anthropicClient = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
-  }
-  return anthropicClient;
-}
 
 // ── Generate issue content ──
 
@@ -70,9 +63,9 @@ export async function generateIssueContent(
   const model = await getReviewModel(orgId);
 
   try {
-    const response = await getAnthropicClient().messages.create({
+    const response = await createAiMessage({
       model,
-      max_tokens: 1024,
+      maxTokens: 1024,
       messages: [
         {
           role: "user",
@@ -107,20 +100,20 @@ Write everything in English. Be professional and concise. Do NOT use markdown co
 Respond ONLY with valid JSON: {"title": "...", "description": "..."}`,
         },
       ],
-    });
+    }, orgId);
 
     logAiUsage({
-      provider: model.startsWith("gpt") || model.startsWith("o1") || model.startsWith("o3") ? "openai" : "anthropic",
+      provider: response.provider,
       model,
       operation: "generate-issue-content",
-      inputTokens: response.usage.input_tokens,
-      outputTokens: response.usage.output_tokens,
-      cacheReadTokens: response.usage.cache_read_input_tokens ?? 0,
-      cacheWriteTokens: response.usage.cache_creation_input_tokens ?? 0,
+      inputTokens: response.usage.inputTokens,
+      outputTokens: response.usage.outputTokens,
+      cacheReadTokens: response.usage.cacheReadTokens,
+      cacheWriteTokens: response.usage.cacheWriteTokens,
       organizationId: orgId,
     }).catch(console.warn);
 
-    let text = response.content[0].type === "text" ? response.content[0].text : "";
+    let text = response.text;
 
     // Strip markdown code fences if present
     const fenceMatch = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?\s*```/);

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -21,6 +21,7 @@ import { getOrgSpendLimitStatus } from "@/lib/cost";
 import { generateSparseVector } from "@/lib/sparse-vector";
 import { requestAgentSearch, findClaudeAgent, requestAgentAnswer } from "@/lib/agent-search";
 import { getReviewModel } from "@/lib/ai-client";
+import { streamChat } from "@/lib/chat-stream";
 import {
   chatScopeGuardEnabled,
   checkChatScope,
@@ -692,7 +693,6 @@ ${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent run
           } catch {}
         }
 
-        const client = getAnthropicClient();
         let fullResponse = "";
         let deltaBatch = "";
         let lastBroadcast = Date.now();
@@ -707,69 +707,50 @@ ${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent run
         }
         const chatModel = await getReviewModel(orgId, chatRepoId);
 
-        const anthropicStream = client.messages.stream({
-          model: chatModel,
-          max_tokens: 4096,
-          system: [
-            {
-              type: "text" as const,
-              text: systemInstructions,
-              cache_control: { type: "ephemeral" as const },
-            },
-            {
-              type: "text" as const,
-              text: finalSystemContext,
-            },
-          ],
-          messages: historyMessages,
-        });
+        const flushDelta = async () => {
+          if (chatChannel && deltaBatch) {
+            try {
+              await pubby.trigger(chatChannel, "chat-stream-delta", { text: deltaBatch });
+            } catch {}
+          }
+          deltaBatch = "";
+          lastBroadcast = Date.now();
+        };
 
-        for await (const event of anthropicStream) {
-          if (
-            event.type === "content_block_delta" &&
-            event.delta.type === "text_delta"
-          ) {
-            const text = event.delta.text;
+        const result = await streamChat({
+          orgId,
+          model: chatModel,
+          systemCacheable: systemInstructions,
+          system: finalSystemContext,
+          messages: historyMessages,
+          maxTokens: 4096,
+          onDelta: async (text) => {
             fullResponse += text;
             controller.enqueue(
-              encoder.encode(
-                `data: ${JSON.stringify({ type: "delta", text })}\n\n`,
-              ),
+              encoder.encode(`data: ${JSON.stringify({ type: "delta", text })}\n\n`),
             );
-
-            // Broadcast deltas for shared chats (batched)
+            // Broadcast deltas for shared chats (batched).
             if (chatChannel) {
               deltaBatch += text;
               if (deltaBatch.length >= 200 || Date.now() - lastBroadcast >= 500) {
-                try {
-                  await pubby.trigger(chatChannel, "chat-stream-delta", { text: deltaBatch });
-                } catch {}
-                deltaBatch = "";
-                lastBroadcast = Date.now();
+                await flushDelta();
               }
             }
-          }
-        }
+          },
+        });
+        await flushDelta();
 
-        // Flush remaining delta batch
-        if (chatChannel && deltaBatch) {
-          try {
-            await pubby.trigger(chatChannel, "chat-stream-delta", { text: deltaBatch });
-          } catch {}
-        }
-
-        // Log streaming chat usage
-        const finalMessage = await anthropicStream.finalMessage();
-        const inputTokens = finalMessage.usage.input_tokens;
-        const outputTokens = finalMessage.usage.output_tokens;
-        const cacheRead = finalMessage.usage.cache_read_input_tokens ?? 0;
-        const cacheWrite = finalMessage.usage.cache_creation_input_tokens ?? 0;
+        // Log streaming chat usage against the provider that served it.
+        const inputTokens = result.usage.inputTokens;
+        const outputTokens = result.usage.outputTokens;
+        const cacheRead = result.usage.cacheReadTokens;
+        const cacheWrite = result.usage.cacheWriteTokens;
         const totalTokens = inputTokens + outputTokens;
         const maxTokens = 200_000;
         const remainingTokens = maxTokens - inputTokens;
 
         await logAiUsage({
-          provider: "anthropic",
+          provider: result.provider,
           model: chatModel,
           operation: "chat",
           inputTokens,
@@ -864,7 +845,7 @@ ${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent run
         // Auto-generate title on first message
         if (isFirstMessage && fullResponse) {
           try {
-            const titleResponse = await client.messages.create({
+            const titleResponse = await getAnthropicClient().messages.create({
               model: "claude-haiku-4-5-20251001",
               max_tokens: 50,
               messages: [

--- a/apps/web/app/api/cli/chat/route.ts
+++ b/apps/web/app/api/cli/chat/route.ts
@@ -11,6 +11,7 @@ import { rerankDocuments } from "@/lib/reranker";
 import Anthropic from "@anthropic-ai/sdk";
 import { requestAgentSearch } from "@/lib/agent-search";
 import { getReviewModel } from "@/lib/ai-client";
+import { streamChat } from "@/lib/chat-stream";
 import { getOrgSpendLimitStatus } from "@/lib/cost";
 import {
   chatScopeGuardEnabled,
@@ -213,37 +214,32 @@ ${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent ("$
           encoder.encode(`data: ${JSON.stringify({ type: "conversation_id", id: conversation.id })}\n\n`),
         );
 
-        const client = getAnthropicClient();
         let fullResponse = "";
 
         const chatModel = await getReviewModel(orgId, repoId);
 
-        const anthropicStream = client.messages.stream({
+        const result = await streamChat({
+          orgId,
           model: chatModel,
-          max_tokens: 4096,
           system: systemPrompt,
           messages: historyMessages,
-        });
-
-        for await (const event of anthropicStream) {
-          if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
-            const text = event.delta.text;
+          maxTokens: 4096,
+          onDelta: (text) => {
             fullResponse += text;
             controller.enqueue(
               encoder.encode(`data: ${JSON.stringify({ type: "delta", text })}\n\n`),
             );
-          }
-        }
+          },
+        });
 
-        const finalMessage = await anthropicStream.finalMessage();
         await logAiUsage({
-          provider: "anthropic",
+          provider: result.provider,
           model: chatModel,
           operation: "chat",
-          inputTokens: finalMessage.usage.input_tokens,
-          outputTokens: finalMessage.usage.output_tokens,
-          cacheReadTokens: finalMessage.usage.cache_read_input_tokens ?? 0,
-          cacheWriteTokens: finalMessage.usage.cache_creation_input_tokens ?? 0,
+          inputTokens: result.usage.inputTokens,
+          outputTokens: result.usage.outputTokens,
+          cacheReadTokens: result.usage.cacheReadTokens,
+          cacheWriteTokens: result.usage.cacheWriteTokens,
           organizationId: orgId,
         });
 
@@ -258,7 +254,7 @@ ${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent ("$
         // Auto-generate title on first message
         if (conversation.messages.length === 0 && fullResponse) {
           try {
-            const titleResponse = await client.messages.create({
+            const titleResponse = await getAnthropicClient().messages.create({
               model: "claude-haiku-4-5-20251001",
               max_tokens: 50,
               messages: [

--- a/apps/web/lib/chat-queue-processor.ts
+++ b/apps/web/lib/chat-queue-processor.ts
@@ -1,4 +1,3 @@
-import Anthropic from "@anthropic-ai/sdk";
 import { buildIndexWarning } from "@/lib/review-helpers";
 import { prisma } from "@octopus/db";
 import { pubby } from "@/lib/pubby";
@@ -14,17 +13,9 @@ import {
 } from "@/lib/qdrant";
 import { logAiUsage } from "@/lib/ai-usage";
 import { getReviewModel } from "@/lib/ai-client";
+import { streamChat } from "@/lib/chat-stream";
 import { isOrgOverSpendLimit } from "@/lib/cost";
 import { generateSparseVector } from "@/lib/sparse-vector";
-
-let anthropicClient: Anthropic | null = null;
-
-function getAnthropicClient(): Anthropic {
-  if (!anthropicClient) {
-    anthropicClient = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
-  }
-  return anthropicClient;
-}
 
 const STALE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -265,53 +256,44 @@ ${chatHistoryContext || "No relevant previous conversations found."}
 
     const chatModel = await getReviewModel(orgId);
 
-    const client = getAnthropicClient();
-    let fullResponse = "";
     let deltaBatch = "";
     let lastBroadcast = Date.now();
-
-    const anthropicStream = client.messages.stream({
-      model: chatModel,
-      max_tokens: 4096,
-      system: [
-        { type: "text" as const, text: systemInstructions, cache_control: { type: "ephemeral" as const } },
-        { type: "text" as const, text: systemContext },
-      ],
-      messages: historyMessages,
-    });
-
-    for await (const event of anthropicStream) {
-      if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
-        const text = event.delta.text;
-        fullResponse += text;
-        deltaBatch += text;
-
-        // Broadcast delta batches (~200 chars or ~500ms)
-        if (deltaBatch.length >= 200 || Date.now() - lastBroadcast >= 500) {
-          try {
-            await pubby.trigger(channel, "chat-stream-delta", { text: deltaBatch });
-          } catch {}
-          deltaBatch = "";
-          lastBroadcast = Date.now();
-        }
-      }
-    }
-
-    // Flush remaining delta
-    if (deltaBatch) {
+    const flushDelta = async () => {
+      if (!deltaBatch) return;
       try {
         await pubby.trigger(channel, "chat-stream-delta", { text: deltaBatch });
       } catch {}
-    }
+      deltaBatch = "";
+      lastBroadcast = Date.now();
+    };
 
-    // Log usage
-    const finalMessage = await anthropicStream.finalMessage();
+    const result = await streamChat({
+      orgId,
+      model: chatModel,
+      systemCacheable: systemInstructions,
+      system: systemContext,
+      messages: historyMessages,
+      maxTokens: 4096,
+      onDelta: async (text) => {
+        deltaBatch += text;
+        // Broadcast delta batches (~200 chars or ~500ms).
+        if (deltaBatch.length >= 200 || Date.now() - lastBroadcast >= 500) {
+          await flushDelta();
+        }
+      },
+    });
+    await flushDelta();
+    const fullResponse = result.text;
+
+    // Log usage against the provider that actually served the response.
     await logAiUsage({
-      provider: "anthropic",
+      provider: result.provider,
       model: chatModel,
       operation: "chat",
-      inputTokens: finalMessage.usage.input_tokens,
-      outputTokens: finalMessage.usage.output_tokens,
+      inputTokens: result.usage.inputTokens,
+      outputTokens: result.usage.outputTokens,
+      cacheReadTokens: result.usage.cacheReadTokens,
+      cacheWriteTokens: result.usage.cacheWriteTokens,
       organizationId: orgId,
     });
 

--- a/apps/web/lib/chat-stream.ts
+++ b/apps/web/lib/chat-stream.ts
@@ -1,0 +1,111 @@
+import "server-only";
+import Anthropic from "@anthropic-ai/sdk";
+import { createAiMessage, resolveProvider } from "@/lib/ai-router";
+import type { AiMessage, AiProvider } from "@/lib/providers";
+
+/**
+ * Shared chat text generation that RESOLVES THE PROVIDER from the model instead
+ * of hard-coding the Anthropic client. Chat/export used to build a raw Anthropic
+ * client and send the org's (possibly non-Anthropic) review model verbatim — so
+ * an org pinned to Grok/OpenRouter/Google got Anthropic 404s. This routes every
+ * provider correctly.
+ *
+ * Anthropic keeps true token streaming (the common path, unchanged). Other
+ * providers have no streaming method in the provider abstraction, so we get the
+ * full response through the shared router (correct provider + BYOK/platform key)
+ * and emit it as a single delta — the response arrives in one chunk rather than
+ * token-by-token, but it works and bills correctly. Callers still do their own
+ * logAiUsage with the returned provider + usage.
+ */
+
+export interface StreamChatParams {
+  orgId: string;
+  model: string;
+  /** Cacheable system prefix (Anthropic prompt cache); stable across turns. */
+  systemCacheable?: string;
+  /** Dynamic system context appended after the cacheable prefix. */
+  system?: string;
+  messages: AiMessage[];
+  maxTokens?: number;
+  /** Called for each text delta (one call total for non-Anthropic providers). */
+  onDelta: (text: string) => void | Promise<void>;
+}
+
+export interface StreamChatResult {
+  text: string;
+  provider: AiProvider;
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+  };
+}
+
+let platformAnthropic: Anthropic | null = null;
+function anthropicClient(): Anthropic {
+  if (!platformAnthropic) {
+    platformAnthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+  }
+  return platformAnthropic;
+}
+
+export async function streamChat(params: StreamChatParams): Promise<StreamChatResult> {
+  const { orgId, model, systemCacheable, system, messages, onDelta } = params;
+  const maxTokens = params.maxTokens ?? 4096;
+  const provider = await resolveProvider(model);
+
+  if (provider === "anthropic") {
+    const systemBlocks = systemCacheable
+      ? [
+          {
+            type: "text" as const,
+            text: systemCacheable,
+            cache_control: { type: "ephemeral" as const },
+          },
+          ...(system ? [{ type: "text" as const, text: system }] : []),
+        ]
+      : system;
+
+    const stream = anthropicClient().messages.stream({
+      model,
+      max_tokens: maxTokens,
+      ...(systemBlocks ? { system: systemBlocks } : {}),
+      messages,
+    });
+
+    let text = "";
+    for await (const event of stream) {
+      if (event.type === "content_block_delta" && event.delta.type === "text_delta") {
+        text += event.delta.text;
+        await onDelta(event.delta.text);
+      }
+    }
+
+    const final = await stream.finalMessage();
+    return {
+      text,
+      provider,
+      usage: {
+        inputTokens: final.usage.input_tokens,
+        outputTokens: final.usage.output_tokens,
+        cacheReadTokens: final.usage.cache_read_input_tokens ?? 0,
+        cacheWriteTokens: final.usage.cache_creation_input_tokens ?? 0,
+      },
+    };
+  }
+
+  // Non-Anthropic: single-shot through the router (no provider streaming API).
+  const combinedSystem = [systemCacheable, system].filter(Boolean).join("\n\n");
+  const res = await createAiMessage(
+    {
+      model,
+      maxTokens,
+      messages,
+      ...(combinedSystem ? { system: combinedSystem, cacheSystem: Boolean(systemCacheable) } : {}),
+    },
+    orgId,
+  );
+  if (res.text) await onDelta(res.text);
+  return { text: res.text, provider: res.provider, usage: res.usage };
+}


### PR DESCRIPTION
## What

Chat (dashboard queue + SSE + CLI) and the issue-content export built a **raw Anthropic client** and passed the org's review model verbatim — so an org pinned to a non-Anthropic model (Grok, OpenRouter/Kimi, Google) got Anthropic **404s**. This is the "chat breaks" caveat from the cloud-models work; it blocked selling those models as anything but review-only.

## Fix

New `lib/chat-stream.ts#streamChat` resolves the provider from the model:
- **Anthropic** keeps true token streaming (the common path, unchanged).
- **Other providers** have no streaming method in the `Provider` abstraction, so the response comes through the shared router (`createAiMessage` — correct provider + BYOK/platform key) and is emitted as a **single delta**. Not token-by-token, but it works and bills correctly.

Billing stays correct: each site logs usage against the **returned provider** (not a hardcoded `"anthropic"`) with the returned token counts.

- Three streaming sites (`chat-queue-processor`, `app/api/chat`, `app/api/cli/chat`) call `streamChat` with their own `onDelta` transport (pubby / SSE).
- Issue export (non-streaming) calls `createAiMessage` directly — also fixes its previously-wrong prefix-guess provider attribution in `logAiUsage`.
- Title-generation sub-calls remain on hardcoded Haiku.
- Removed the now-dead per-file Anthropic clients where they became unused; kept them where still used (chat-scope guard, title-gen).

## Notes

- Pairs with #750 (repo-pin spend-gate fix); together they close both cloud-model follow-ups.
- No schema change. `tsc --noEmit` clean. Non-Anthropic chat is single-chunk (no provider streaming API yet) — a reasonable v1; true cross-provider streaming can come later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)