### PR TITLE
chore(sentry): ignore network-layer fetch failures (client noise)

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -41,6 +41,14 @@ Sentry.init({
     "Failed to execute 'insertBefore' on 'Node'",
     "The node to be removed is not a child of this node",
     "The node before which the new node is to be inserted is not a child of this node",
+    // Network-layer fetch failures: a dropped/offline connection, a navigation
+    // that aborts an in-flight request, or a bot/monitor that never completes
+    // the request. These are unactionable client noise and differ per browser.
+    // A genuine backend outage still surfaces server-side (5xx + logs), so
+    // filtering these does not blind us to real problems.
+    "Failed to fetch", // Chromium
+    "Load failed", // Safari
+    "NetworkError when attempting to fetch resource", // Firefox
   ],
   beforeSend: (event) => scrubEvent(event),
 });


### PR DESCRIPTION
## What

Adds the cross-browser network-failure messages to the client Sentry `ignoreErrors`:
- `Failed to fetch` (Chromium)
- `Load failed` (Safari)
- `NetworkError when attempting to fetch resource` (Firefox)

## Why

Triggered by issue `OCTOPUS-REVIEW-G` — a single `TypeError: Failed to fetch` on `/login` (1 occurrence in 7 days, **0 users impacted**, an `onunhandledrejection` from a client whose fetch failed at the network layer). These messages mean a dropped/offline connection, a navigation that aborts an in-flight request, or a bot that never completes the request — unactionable client noise, not app bugs.

A genuine backend outage still surfaces server-side (5xx + logs), so this doesn't blind us to real problems. Matches the existing pattern (browser-translation DOM errors are already filtered here).

Takes effect on the next hosted build (client DSN + config are build-time inlined). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)