### PR TITLE
fix(credits): link the out-of-credits PR comment straight to checkout

### DIFF
--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1130,9 +1130,13 @@ export async function processReview(pullRequestId: string): Promise<void> {
     if (spendStatus.blocked) {
       const outOfCredits = spendStatus.reason === "no_credits";
       console.warn(`[reviewer] Org ${org.id} blocked (${spendStatus.reason}) — skipping review`);
+      // Link the CTA straight to checkout: blocked users see this comment a lot
+      // (top live failure reason) but never convert — the old copy said "in
+      // Settings" with no clickable path. See credit-health diagnosis.
+      const appUrl = process.env.BETTER_AUTH_URL || process.env.NEXT_PUBLIC_APP_URL || "https://octopus-review.ai";
       const limitMsg = outOfCredits
-        ? "> 🐙 **Octopus Review** — Your organization is **out of credits**. Add credits (or your own API keys) in Settings to start receiving reviews."
-        : "> 🐙 **Octopus Review** — Your organization has reached its monthly AI usage limit.\n>\n> Please add your own API keys in Settings to continue receiving reviews.";
+        ? `> 🐙 **Octopus Review** — Your organization is **out of credits**. [**Add credits**](${appUrl}/settings/billing) or add your own [API keys](${appUrl}/settings/api-keys) to start receiving reviews again.`
+        : `> 🐙 **Octopus Review** — Your organization has reached its monthly AI usage limit.\n>\n> [Raise your limit](${appUrl}/settings/billing) or add your own [API keys](${appUrl}/settings/api-keys) to continue receiving reviews.`;
       if (reviewCommentId) {
         await providerUpdateComment(reviewCommentId, limitMsg);
       } else {


### PR DESCRIPTION
## Why
The out-of-credits block is the **single top live review-failure reason** — `errorMessage="Out of credits"` fired **1,072 times in the last 14 days** (verified read-only on prod). But the PR comment only told users to add credits *"in Settings"* with **no clickable link**, and the affected high-usage orgs never convert: the 9 most-active non-paying orgs have **zero Stripe customers / zero payment attempts** — they hit the wall hundreds of times and were never routed to checkout.

This is a pure conversion leak: the wording fix (B1, #727) shipped and is firing, but there's no path from the block to a purchase.

## What
`apps/web/lib/reviewer.ts` — the credit-block comment now links the CTA directly:
- **Out of credits** → `[Add credits](…/settings/billing)` or `[API keys](…/settings/api-keys)`
- **Monthly limit** → `[Raise your limit](…/settings/billing)` or `[API keys](…/settings/api-keys)`

Absolute links use the existing `BETTER_AUTH_URL || NEXT_PUBLIC_APP_URL` base (same pattern as invitation emails). No behaviour change beyond the comment copy/links.

## Follow-ups (not in this PR)
- Onboarding is the bigger leak: 269 of 326 never-activated orgs never connected a repo (separate PR, needs a UX-approach call).
- ~9 orgs have indexed repos but a dropped GitHub installation → PR events silently discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)