### PR TITLE
feat(onboarding): connect-first + GitHub reconnect prompts + funnel tracking

### DIFF
--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -202,6 +202,31 @@ export default async function DashboardPage({
   const gitlabConnected = !!gitlabIntegration;
   const bannerDismissed = cookieStore.get("providers_banner_dismissed")?.value === "1";
 
+  // Connect-first empty state: an org with no provider and no repos gets one
+  // clear action instead of an all-zero analytics grid. Not dismissible —
+  // there is nothing else to show until code is connected. Also skips the
+  // chart queries below, which would all be empty for this cohort.
+  if (!githubConnected && !bitbucketConnected && !gitlabConnected && totalRepos === 0) {
+    return (
+      <div className="mx-auto max-w-6xl p-6 md:p-10">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Overview of your repositories and integrations.
+          </p>
+        </div>
+        <ProvidersBanner
+          hero
+          githubConnected={githubConnected}
+          bitbucketConnected={bitbucketConnected}
+          gitlabConnected={gitlabConnected}
+          githubAppSlug={githubAppSlug}
+          gitlabRedirectUri={process.env.GITLAB_REDIRECT_URI ?? null}
+        />
+      </div>
+    );
+  }
+
   const hasIndexedRepo = repos.some((r) => r.indexStatus === "indexed");
   const hasAnalyzedRepo = repos.some((r) => r.analysisStatus === "analyzed" || r.analysisStatus === "completed");
   const hasAutoReviewRepo = repos.some((r) => r.autoReview === true);

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -188,6 +188,11 @@ export default async function DashboardPage({
   const indexedRepos = repos.filter((r) => r.indexStatus === "indexed").length;
   const notIndexedRepos = totalRepos - indexedRepos;
   const githubConnected = org.githubInstallationId !== null;
+  // Dropped-install detection: the GitHub App was uninstalled (installationId
+  // nulled) but active GitHub repos remain, so PR webhooks are silently dropped
+  // and the org gets no reviews while still looking "connected". Prompt a
+  // reconnect. (~9 real orgs in prod — see the credit-health / onboarding scan.)
+  const githubReconnectNeeded = !githubConnected && repos.some((r) => r.provider === "github");
   const githubAppSlug = (await getGithubAppConfig())?.slug ?? undefined;
 
   const bitbucketIntegration = await prisma.bitbucketIntegration.findUnique({
@@ -541,7 +546,26 @@ export default async function DashboardPage({
         <BuyCreditsButton card={defaultCard} />
       </div>
 
-      {(!githubConnected || !bitbucketConnected || !gitlabConnected) && !bannerDismissed && (
+      {githubReconnectNeeded && (
+        <div className="mt-6 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4">
+          <p className="font-medium text-amber-700 dark:text-amber-400">
+            GitHub connection removed — reviews are paused
+          </p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Octopus no longer has access to your GitHub repositories, so new pull
+            requests aren&apos;t being reviewed. This usually happens when the GitHub
+            App is uninstalled. Reconnect to resume automatic reviews.
+          </p>
+          <a
+            href="/api/github/install?returnTo=/dashboard"
+            className="bg-primary text-primary-foreground hover:bg-primary/90 mt-3 inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium"
+          >
+            Reconnect GitHub
+          </a>
+        </div>
+      )}
+
+      {!githubReconnectNeeded && (!githubConnected || !bitbucketConnected || !gitlabConnected) && !bannerDismissed && (
         <ProvidersBanner
           githubConnected={githubConnected}
           bitbucketConnected={bitbucketConnected}

--- a/apps/web/app/(app)/repositories/repositories-content.tsx
+++ b/apps/web/app/(app)/repositories/repositories-content.tsx
@@ -2089,6 +2089,24 @@ export function RepositoriesContent({
               <p className="text-sm text-muted-foreground">
                 {currentSearch ? "No repositories match your search" : "No repositories yet"}
               </p>
+              {!currentSearch && (
+                <div className="mt-4 flex flex-col items-center gap-2">
+                  {githubAppSlug && (
+                    <Button size="sm" variant="cta" asChild>
+                      <a href="/api/github/install?returnTo=/repositories">
+                        <IconBrandGithub className="mr-1 size-3.5" />
+                        Connect GitHub
+                      </a>
+                    </Button>
+                  )}
+                  <a
+                    href="/settings/integrations"
+                    className="text-xs text-muted-foreground underline hover:text-foreground transition-colors"
+                  >
+                    Connect GitLab or Bitbucket
+                  </a>
+                </div>
+              )}
             </div>
           ) : (
             <>

--- a/apps/web/app/api/github/callback/route.ts
+++ b/apps/web/app/api/github/callback/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/github";
 import { getGithubAppConfig } from "@/lib/github-app-config";
 import { getRedis } from "@/lib/redis";
+import { writeAuditLog } from "@/lib/audit";
 import {
   GITHUB_INSTALL_STATE_COOKIE,
   GITHUB_INSTALL_STATE_TTL_MS,
@@ -26,7 +27,15 @@ import {
 const baseUrl = process.env.BETTER_AUTH_URL || "http://localhost:3000";
 const callbackUrl = new URL("/api/github/callback", baseUrl).toString();
 
-function errorRedirect(reason: string) {
+async function errorRedirect(reason: string) {
+  // Funnel: every failed connect attempt is recorded with its reason.
+  // Actor/org are unknown on some paths (e.g. invalid state), so only the
+  // reason goes in — writeAuditLog swallows its own errors.
+  await writeAuditLog({
+    action: "integration.install_failed",
+    category: "system",
+    metadata: { provider: "github", reason },
+  });
   const url = new URL("/settings/integrations", baseUrl);
   url.searchParams.set("error", reason);
   const response = NextResponse.redirect(url);
@@ -281,6 +290,20 @@ async function finishVerification(request: NextRequest, stateParam: string) {
     caller.organizationId,
   );
   if (!binding.ok) return errorRedirect(binding.reason);
+
+  // Funnel: install completed and bound to the org.
+  await writeAuditLog({
+    action: "integration.connected",
+    category: "system",
+    actorId: verified.payload.uid,
+    organizationId: caller.organizationId,
+    targetType: "Organization",
+    targetId: caller.organizationId,
+    metadata: {
+      provider: "github",
+      installationId: verified.payload.installationId,
+    },
+  });
 
   revalidatePath("/", "layout");
   revalidatePath("/");

--- a/apps/web/app/api/github/install/route.ts
+++ b/apps/web/app/api/github/install/route.ts
@@ -10,6 +10,7 @@ import {
   signInstallState,
 } from "@/lib/github-install-state";
 import { getGithubAppConfig } from "@/lib/github-app-config";
+import { writeAuditLog } from "@/lib/audit";
 
 const baseUrl = process.env.BETTER_AUTH_URL || "http://localhost:3000";
 
@@ -47,6 +48,16 @@ export async function GET(request: NextRequest) {
   }
 
   const returnTo = safeReturnPath(request.nextUrl.searchParams.get("returnTo"));
+
+  // Funnel: signup → install started → connected (see /api/github/callback).
+  await writeAuditLog({
+    action: "integration.install_started",
+    category: "system",
+    actorId: session.user.id,
+    actorEmail: session.user.email,
+    organizationId: membership.organizationId,
+    metadata: { provider: "github", returnTo },
+  });
 
   const nonce = crypto.randomBytes(16).toString("base64url");
   const state = signInstallState({

--- a/apps/web/app/api/github/install/route.ts
+++ b/apps/web/app/api/github/install/route.ts
@@ -50,14 +50,16 @@ export async function GET(request: NextRequest) {
   const returnTo = safeReturnPath(request.nextUrl.searchParams.get("returnTo"));
 
   // Funnel: signup → install started → connected (see /api/github/callback).
-  await writeAuditLog({
+  // Fire-and-forget: telemetry must never block or fail the onboarding redirect
+  // (Octopus review #762) — a transient audit-log error can't strand the user.
+  void writeAuditLog({
     action: "integration.install_started",
     category: "system",
     actorId: session.user.id,
     actorEmail: session.user.email,
     organizationId: membership.organizationId,
     metadata: { provider: "github", returnTo },
-  });
+  }).catch(() => {});
 
   const nonce = crypto.randomBytes(16).toString("base64url");
   const state = signInstallState({

--- a/apps/web/components/dashboard/providers-banner.tsx
+++ b/apps/web/components/dashboard/providers-banner.tsx
@@ -26,6 +26,7 @@ import {
   IconCheck,
 } from "@tabler/icons-react";
 import { startGitlabOAuth } from "@/app/(app)/settings/integrations/actions";
+import { trackEvent } from "@/lib/analytics";
 
 const DEFAULT_GITLAB_HOST = "https://gitlab.com";
 const GITLAB_REQUIRED_SCOPES =
@@ -47,12 +48,15 @@ export function ProvidersBanner({
   gitlabConnected,
   githubAppSlug,
   gitlabRedirectUri,
+  hero = false,
 }: {
   githubConnected: boolean;
   bitbucketConnected: boolean;
   gitlabConnected: boolean;
   githubAppSlug: string | undefined;
   gitlabRedirectUri: string | null;
+  /** Connect-first empty state: bigger headline, not dismissible. */
+  hero?: boolean;
 }) {
   const [dismissed, setDismissed] = useState(false);
   const [bbDialogOpen, setBbDialogOpen] = useState(false);
@@ -90,24 +94,28 @@ export function ProvidersBanner({
 
   return (
     <>
-      <Card className="mt-6 px-5 py-5">
+      <Card className={hero ? "mt-6 px-5 py-6 sm:px-6" : "mt-6 px-5 py-5"}>
         <div className="flex items-start justify-between">
           <div>
-            <p className="text-sm font-semibold">Connect your code providers</p>
-            <p className="text-muted-foreground mt-0.5 text-xs">
+            <p className={hero ? "text-lg font-semibold tracking-tight" : "text-sm font-semibold"}>
+              {hero ? "Connect your code to start reviewing" : "Connect your code providers"}
+            </p>
+            <p className={hero ? "text-muted-foreground mt-1 text-sm" : "text-muted-foreground mt-0.5 text-xs"}>
               Link your repositories to get AI-powered code reviews on every pull request.
             </p>
           </div>
-          <button
-            onClick={() => {
-              setCookie("providers_banner_dismissed", "1", 365);
-              setDismissed(true);
-            }}
-            className="text-muted-foreground hover:text-foreground transition-colors rounded-sm p-0.5 shrink-0"
-            aria-label="Dismiss"
-          >
-            <IconX className="size-4" />
-          </button>
+          {!hero && (
+            <button
+              onClick={() => {
+                setCookie("providers_banner_dismissed", "1", 365);
+                setDismissed(true);
+              }}
+              className="text-muted-foreground hover:text-foreground transition-colors rounded-sm p-0.5 shrink-0"
+              aria-label="Dismiss"
+            >
+              <IconX className="size-4" />
+            </button>
+          )}
         </div>
 
         <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -151,7 +159,15 @@ export function ProvidersBanner({
               ) : (
                 githubInstallUrl && (
                   <Button size="sm" variant="cta" className="h-8 w-full text-xs" asChild>
-                    <a href={githubInstallUrl}>
+                    <a
+                      href={githubInstallUrl}
+                      onClick={() =>
+                        trackEvent("cta_click", {
+                          location: hero ? "dashboard_connect_hero" : "dashboard_providers_banner",
+                          label: "connect_github",
+                        })
+                      }
+                    >
                       Connect GitHub &rarr;
                     </a>
                   </Button>


### PR DESCRIPTION
## Why

Of 326 orgs that registered but never ran a review, 269 (82%) never connected a GitHub App or any repo. They land on the analytics dashboard after signup, see an all-zero grid whose only connect prompt is a dismissible banner, and bounce. This PR makes connecting a repo the obvious first action and instruments the funnel so the drop-off becomes measurable. Provider-agnostic on purpose — no redirect that assumes GitHub.

## What

1. **Connect-first dashboard state** — `apps/web/app/(app)/dashboard/page.tsx`: when the org has no provider connected AND zero repos, render a prominent, non-dismissible "Connect your code to start reviewing" hero (GitHub / GitLab / Bitbucket, with the existing connect flows) instead of the empty analytics grid. Implemented as a `hero` prop on the existing `ProvidersBanner`, so the provider cards, Bitbucket workspace dialog, and GitLab OAuth dialog are reused verbatim. The early return also skips the chart queries, which are all empty for this cohort. Orgs with any repo or provider see the dashboard unchanged.
2. **Repositories empty state** — `repositories-content.tsx`: "No repositories yet" now has a primary **Connect GitHub** button (same `/api/github/install?returnTo=/repositories` action as the toolbar's Manage GitHub) plus a link to connect GitLab or Bitbucket via Settings → Integrations. Shown only when not filtering by search.
3. **Funnel instrumentation (purely additive)** —
   - `integration.install_started` audit log in `/api/github/install` (actor, org, returnTo)
   - `integration.connected` audit log on successful bind in `/api/github/callback`
   - `integration.install_failed` audit log with the reason on every error redirect in `/api/github/callback` (single hook in `errorRedirect`, so all ~20 failure reasons are captured)
   - `trackEvent("cta_click", ...)` on the hero and ProvidersBanner Connect GitHub clicks, distinguished by `location` (`dashboard_connect_hero` vs `dashboard_providers_banner`), following the settings/integrations pattern

Deliberately unchanged: the post-signup redirect in `complete-profile/actions.ts` — the provider-agnostic hero handles that cohort without assuming GitHub.

## Verification

`bunx tsc --noEmit` in `apps/web`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)