### PR TITLE
fix(landing): make /editor a public route

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -12,6 +12,7 @@ const publicPrefixes = [
   "/status",
   "/not-a-rabbit",
   "/compare",
+  "/editor",
   "/vs-",
   "/api/auth",
   "/api/github",


### PR DESCRIPTION
## Why
The `/editor` marketing page (v1.0.120) was live but **redirected anonymous visitors to `/login`** (307) — it was missing from the middleware `publicPrefixes` allowlist, so it was treated as an authenticated route.

## Fix
Add `"/editor"` to `apps/web/middleware.ts` `publicPrefixes`, next to the other marketing routes (`/compare`, `/bug-bounty`, `/vs-`, …). One line; restores public access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)