### PR TITLE
fix(reviewer): floor review score when there are no blocking findings

### DIFF
--- a/apps/web/lib/__tests__/score-normalize.test.ts
+++ b/apps/web/lib/__tests__/score-normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { normalizeScoreDenominators } from "@/lib/review-helpers";
+import { normalizeScoreDenominators, reconcileScoreTable } from "@/lib/review-helpers";
 
 const scoreSection = (rows: string) => `## 🐙 Octopus Review — PR #42
 
@@ -68,5 +68,66 @@ describe("normalizeScoreDenominators", () => {
 | Security | 4/4 | Minor nits |`;
     const result = normalizeScoreDenominators(body);
     expect(result).toContain("| Security | 4/5 |");
+  });
+});
+
+describe("reconcileScoreTable", () => {
+  const noFindings = { hasCritical: false, hasHigh: false, hasMedium: false };
+
+  it("floors sub-4 categories and Overall when there are no blocking findings (the qwen-telegram #5 case)", () => {
+    const body = scoreSection(
+      `| Security | 5/5 | Gate order preserved |
+| Code Quality | 3/5 | Trial env defaults violate org env-var policy |
+| Performance | N/A | One extra usage() fetch is trivial |
+| Error Handling | 3/5 | verify RETURNING includes column |
+| Consistency | 4/5 | Follows established patterns |
+| **Overall** | **3/5** | Lowest individual score |`,
+    );
+    const result = reconcileScoreTable(body, noFindings);
+    expect(result).toContain("| Code Quality | 4/5 |");
+    expect(result).toContain("| Error Handling | 4/5 |");
+    expect(result).toContain("| **Overall** | **4/5** |");
+    // preserved
+    expect(result).toContain("| Security | 5/5 |");
+    expect(result).toContain("| Consistency | 4/5 |");
+    expect(result).toContain("| Performance | N/A |");
+    expect(result).toContain("verify RETURNING includes column"); // notes kept
+    expect(result).not.toContain("3/5"); // no below-gate score survives
+  });
+
+  it("leaves the score untouched when a critical finding exists", () => {
+    const body = scoreSection(`| **Overall** | **2/5** | Critical issue found |`);
+    expect(reconcileScoreTable(body, { hasCritical: true, hasHigh: false, hasMedium: false })).toBe(body);
+  });
+
+  it("leaves the score untouched when only a medium finding exists (a real concern justifies a low score)", () => {
+    const body = scoreSection(
+      `| Code Quality | 3/5 | Medium concern |
+| **Overall** | **3/5** | Lowest individual score |`,
+    );
+    expect(reconcileScoreTable(body, { hasCritical: false, hasHigh: false, hasMedium: true })).toBe(body);
+  });
+
+  it("is a no-op when every category already clears the floor", () => {
+    const body = scoreSection(
+      `| Security | 5/5 | Fine |
+| **Overall** | **4/5** | Lowest individual score |`,
+    );
+    expect(reconcileScoreTable(body, noFindings)).toBe(body);
+  });
+
+  it("does not touch fractions outside the Score section", () => {
+    const body = `${scoreSection(`| **Overall** | **3/5** | Lowest individual score |`)}
+### Checklist
+- [ ] 2/5 edge cases covered
+`;
+    const result = reconcileScoreTable(body, noFindings);
+    expect(result).toContain("2/5 edge cases covered");
+    expect(result).toContain("| **Overall** | **4/5** |");
+  });
+
+  it("no-ops when there is no Score table", () => {
+    const body = "### Summary\nAll good, nothing to score.\n";
+    expect(reconcileScoreTable(body, noFindings)).toBe(body);
   });
 });

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -128,6 +128,48 @@ export function normalizeScoreDenominators(reviewBody: string): string {
   );
 }
 
+/**
+ * Minimum category score a review may post when it surfaced NO blocking finding.
+ * Floors to a passing score, never to 5/5.
+ */
+export const MIN_SCORE_WITHOUT_BLOCKING_FINDINGS = 4;
+
+/**
+ * Reconcile the "### Score" table with the findings the review actually surfaced.
+ *
+ * Scores are holistic LLM prose and nothing else in the pipeline checks them
+ * against the findings, so a review can post e.g. Code Quality 3/5 (and therefore
+ * Overall 3/5, since Overall is the lowest category) with ZERO findings the author
+ * can act on. That is an unactionable score — it deadlocks any 4+/5 quality gate,
+ * and it is actively manufactured on re-reviews, where a hard filter strips
+ * non-critical findings from the count but leaves the score table untouched.
+ *
+ * Rule: when the review surfaced no blocking finding (no critical / high / medium),
+ * raise any category below MIN_SCORE_WITHOUT_BLOCKING_FINDINGS — and the Overall,
+ * which is their minimum — up to that floor. A critical/high/medium finding leaves
+ * the score untouched: a real, actionable concern justifies a low score.
+ *
+ * Only the Score section is edited; `N/A` and already-passing cells, bold markers,
+ * and fractions elsewhere in the body are preserved. Assumes denominators are
+ * already `/5` (normalizeScoreDenominators runs first).
+ */
+export function reconcileScoreTable(
+  reviewBody: string,
+  findings: { hasCritical: boolean; hasHigh: boolean; hasMedium: boolean },
+): string {
+  if (findings.hasCritical || findings.hasHigh || findings.hasMedium) return reviewBody;
+  const floor = MIN_SCORE_WITHOUT_BLOCKING_FINDINGS;
+  return reviewBody.replace(
+    /### Score\s*\n[\s\S]*?(?=\n### |\n## |$)/,
+    (section) =>
+      section.replace(
+        /(\*{0,2})([1-5])\/5(\*{0,2})/g,
+        (match, open: string, score: string, close: string) =>
+          parseInt(score, 10) < floor ? `${open}${floor}/5${close}` : match,
+      ),
+  );
+}
+
 // ─── Diff Parsing ───────────────────────────────────────────────────────────
 
 /**

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -78,6 +78,7 @@ import {
   generateVerificationQueries,
   resolveIndexClaimWait,
   normalizeScoreDenominators,
+  reconcileScoreTable,
   shouldFailReviewCheck,
   formatPastReviews,
   formatPrIntent,
@@ -2215,19 +2216,21 @@ Rules:
       if (filtered > 0) {
         console.log(`[reviewer] Re-review filter: removed ${filtered} non-critical findings, kept ${allParsedFindings.length}`);
 
-        // Update the main comment to reflect filtered findings.
-        // Score table is NOT touched — the LLM is instructed via prompt to score
-        // based on the current state of the PR, so its scores should already
-        // reflect resolved findings.
+        // Update the main comment to reflect filtered findings. The Score table
+        // is reconciled separately below (reconcileScoreTable), once the final
+        // findings are known — the prompt alone does not reliably re-score, so a
+        // re-review can otherwise strip every finding here yet leave a stale
+        // below-gate score table behind.
         if (reviewCommentId) {
           try {
-            let reReviewBody = mainCommentBody;
-            // Replace the Findings Summary section: from "### Findings Summary" to next heading or end
-            reReviewBody = reReviewBody.replace(
+            // Patch mainCommentBody in place (not a copy) so the score
+            // reconciliation below posts on top of the patched summary instead of
+            // reverting it.
+            mainCommentBody = mainCommentBody.replace(
               /### Findings Summary[\s\S]*?(?=\n### |\n## |$)/,
               "### Findings Summary\n\nAll previously raised findings have been addressed. No critical issues found.\n",
             );
-            await providerUpdateComment(reviewCommentId, reReviewBody);
+            await providerUpdateComment(reviewCommentId, mainCommentBody);
             console.log(`[reviewer] Updated main comment for re-review (${allParsedFindings.length} findings remain)`);
           } catch (err) {
             console.warn("[reviewer] Failed to update main comment for re-review:", err);
@@ -2287,6 +2290,26 @@ Rules:
     const hasCritical = findings.some((f) => f.severity === "🔴");
     const hasHigh = findings.some((f) => f.severity === "🟠");
     const hasMedium = findings.some((f) => f.severity === "🟡");
+
+    // Reconcile the Score table with the findings the review actually surfaced.
+    // Scores are holistic LLM prose that nothing else checks against the findings,
+    // so a review can post a below-gate score (e.g. Code Quality 3/5 -> Overall 3/5,
+    // since Overall is the lowest category) with zero findings the author can fix —
+    // an unactionable score that deadlocks a 4+/5 gate, and one the re-review filter
+    // above actively manufactures. When no blocking (critical/high/medium) finding
+    // survived, floor the sub-gate categories. See review-helpers.reconcileScoreTable.
+    if (reviewCommentId) {
+      const reconciledBody = reconcileScoreTable(mainCommentBody, { hasCritical, hasHigh, hasMedium });
+      if (reconciledBody !== mainCommentBody) {
+        mainCommentBody = reconciledBody;
+        try {
+          await providerUpdateComment(reviewCommentId, mainCommentBody);
+          console.log("[reviewer] Score table reconciled: no blocking findings — floored sub-gate categories");
+        } catch (err) {
+          console.warn("[reviewer] Failed to update comment after score reconciliation:", err);
+        }
+      }
+    }
 
     const threshold = org.checkFailureThreshold || "critical";
     const shouldRequestChanges = shouldFailReviewCheck(


### PR DESCRIPTION
## Problem
A review's score table is holistic LLM prose, and **nothing in code reconciles it with the findings**. So a review can post **Code Quality 3/5 → Overall 3/5** (Overall = lowest category) with **zero findings the author can fix** — an unactionable score that **deadlocks any 4+/5 gate** (cem-pr-loop). Re-reviews make it worse: a hard filter strips non-critical findings from the count but explicitly leaves the score table untouched, *manufacturing* "0 findings, 3/5."

Reproduced on `Art-of-Technology/qwen-telegram-service#5`: after the author fixed all 3 findings, the re-review returned **"0 findings" but still 3/5**, and only reached **5/5** after a second, evidence-heavy nudge — same commit. (Prod: `pull_requests` has no score column and `review_issues` was empty — the score is regenerated each run and never floored.)

## Fix
`reconcileScoreTable()` (`review-helpers.ts`): once the final findings are known, if the review surfaced **no blocking (critical/high/medium) finding**, floor any sub-4 category — and the Overall — to **4/5** (passing, never 5/5). A real blocking finding leaves the score untouched. Only the `### Score` section is edited; `N/A`, passing cells, bold markers, and fractions elsewhere are preserved.

Wired into `processReview` right after the final severities are computed; the re-review filter block now patches the comment body in place so the reconciliation posts on top of it (not a stale copy).

## Verification
- 6 new unit tests incl. the exact qwen #5 table (3/5 → 4/5), "critical/medium finding → untouched," "no bleed outside the Score section," "no table → no-op". **13/13 pass.**
- `tsc` clean.

## Follow-ups (not in this PR)
- Re-review jobs are silently dropped when one is in flight + fresh, and the webhook 3-min reset can double-review and let an older run's comment write land last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)