### PR TITLE
feat(models): list Claude Fable 5.1 in pricing docs + fallback pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Claude Fable 5.1 (`claude-fable-5-1`) is available as an opt-in review model at $10/$50 per 1M tokens, the same price as Fable 5. The platform default is unchanged (Opus 4.8). Listed on the pricing page and in the docs; fallback pricing added so usage never bills at $0.
+
 ## [1.0.122] - 2026-08-30
 
 ### Fixed

--- a/apps/web/app/(landing)/docs/pricing/page.tsx
+++ b/apps/web/app/(landing)/docs/pricing/page.tsx
@@ -115,6 +115,7 @@ export default function PricingPage() {
               </tr>
             </thead>
             <tbody className="text-[#888]">
+              <ModelRow model="Claude Fable 5.1" input="$10" output="$50" />
               <ModelRow model="Claude Fable 5" input="$10" output="$50" />
               <ModelRow model="Claude Opus 5" input="$5" output="$25" />
               <ModelRow model="Claude Opus 4.8" input="$5" output="$25" />

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -18,6 +18,8 @@ const FALLBACK_PRICING: Record<string, ModelPricing> = {
   // Claude Fable 5 is the Claude 5 frontier model; offered as the top "max"
   // review tier (2x Opus 5).
   "claude-fable-5": { input: 10, output: 50 },
+  // Fable 5.1 succeeds Fable 5 at the same price; opt-in, never the default.
+  "claude-fable-5-1": { input: 10, output: 50 },
   // Anthropic's published API id for Opus 5 is undated (no dated canonical id
   // was released); the key must match the id used in calls for exact-key lookup.
   "claude-opus-5": { input: 5, output: 25 },

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -208,6 +208,7 @@ This is ideal for teams that already have API agreements with AI providers or wa
       {
         heading: "Model Pricing",
         text: `Octopus supports multiple AI models. A 20% platform fee is applied on top of provider costs. Base prices per 1M tokens:
+Claude Fable 5.1 — $10 input / $50 output. Anthropic's most capable generally available model, the successor to Fable 5; opt-in for the most demanding reviews.
 Claude Fable 5 — $10 input / $50 output. Anthropic's Claude 5 frontier model; the top opt-in tier for the most demanding reviews.
 Claude Opus 5 — $5 input / $25 output. Premium, opt-in review model for a deeper read on tricky pull requests.
 Claude Opus 4.8 — $5 input / $25 output. The default review model on Octopus Cloud.


### PR DESCRIPTION
## What

Claude Fable 5.1 (`claude-fable-5-1`) is being offered as an opt-in review model at the same $10/$50 per 1M as Fable 5 (the catalog row itself is DB-driven and managed in the admin console). This PR covers the code-side surfaces:

- `apps/web/lib/cost.ts`: add `claude-fable-5-1` to `FALLBACK_PRICING` so usage never bills at $0 if the DB row is missing.
- `apps/web/lib/docs-content.ts` + `/docs/pricing` page: list Fable 5.1 alongside Fable 5.
- `CHANGELOG.md`: Unreleased entry.

Platform default is unchanged (Opus 4.8). No provider changes needed: reviews run on the text path, and the always-thinking model regex in `providers/thinking.ts` already matches `claude-fable-5-1`.

## Test

- `bun test` / `tsc` unaffected (data-only additions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3NtKFLyYaUHqsfG57z7AJ
