### PR TITLE
docs(models): Opus 5 is the Cloud default; Sonnet 4.6 retired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The Octopus Cloud default review model is now Claude Opus 5 (same $5/$25 price as Opus 4.8, which stays available). Organizations and repositories with an explicit model pin are unaffected. Claude Sonnet 4.6 is retired from the catalog; anything that pointed at it now uses Claude Sonnet 5 ($2/$10).
+
 ## [1.0.123] - 2026-09-01
 
 ### Added

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -210,8 +210,8 @@ This is ideal for teams that already have API agreements with AI providers or wa
         text: `Octopus supports multiple AI models. A 20% platform fee is applied on top of provider costs. Base prices per 1M tokens:
 Claude Fable 5.1 — $10 input / $50 output. Anthropic's most capable generally available model, the successor to Fable 5; opt-in for the most demanding reviews.
 Claude Fable 5 — $10 input / $50 output. Anthropic's Claude 5 frontier model; the top opt-in tier for the most demanding reviews.
-Claude Opus 5 — $5 input / $25 output. Premium, opt-in review model for a deeper read on tricky pull requests.
-Claude Opus 4.8 — $5 input / $25 output. The default review model on Octopus Cloud.
+Claude Opus 5 — $5 input / $25 output. The default review model on Octopus Cloud.
+Claude Opus 4.8 — $5 input / $25 output. Previous default; still available at the same price.
 Claude Opus 4 — $15 input / $75 output. Legacy high-quality review model.
 Claude Sonnet 4.6 and Claude Sonnet 4 — $3 input / $15 output. High quality and fast; Sonnet 4.6 is the default for self-hosted installs.
 Claude Haiku 4.5 — $1 input / $5 output. Lightweight tasks like title generation.


### PR DESCRIPTION
## What

Catalog changes made in the admin console today, reflected in the docs:

- Platform default review model moved from Claude Opus 4.8 to **Claude Opus 5** (same $5/$25). `docs-content.ts` model pricing text updated; Opus 4.8 stays listed as "previous default".
- Claude Sonnet 4.6 retired from the catalog (pins reassigned to Sonnet 5 at $2/$10). Changelog note under Unreleased.

Docs-only; no code path changes. The reviewer already reads the default from `available_models.isPlatformDefault`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3NtKFLyYaUHqsfG57z7AJ
