### PR TITLE
fix(indexer): apply MAX_FILE_SIZE and .octopusignore in incremental (merged-PR) indexing

### DIFF
--- a/apps/web/lib/__tests__/incremental-index.test.ts
+++ b/apps/web/lib/__tests__/incremental-index.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 
 // ── Mock external dependencies before importing ──
 
+// `server-only` is a Next.js marker module that throws outside a Server
+// Component context; neutralize it for bun test (same as sibling tests).
+mock.module("server-only", () => ({}));
+
 let mockDeleteRepoFileChunks = mock(() => Promise.resolve());
 let mockEnsureCollection = mock(() => Promise.resolve());
 let mockUpsertChunks = mock(() => Promise.resolve());
@@ -35,6 +39,7 @@ let mockGhGetFileContent = mock((_installationId: number, _owner: string, _repo:
 mock.module("@/lib/github", () => ({
   getInstallationToken: (...args: unknown[]) => mockGetInstallationToken(...args),
   getFileContent: (...args: unknown[]) => mockGhGetFileContent(...(args as Parameters<typeof mockGhGetFileContent>)),
+  getRepositoryDetails: () => Promise.resolve(null),
 }));
 
 mock.module("@/lib/bitbucket", () => ({
@@ -42,11 +47,16 @@ mock.module("@/lib/bitbucket", () => ({
   getAccessToken: () => Promise.resolve("bb-token"),
 }));
 
+let mockParseOctopusIgnore = mock((_content: string) => ({ ignores: () => false }));
+
 mock.module("@/lib/octopus-ignore", () => ({
-  parseOctopusIgnore: () => ({ ignores: () => false }),
+  parseOctopusIgnore: (...args: unknown[]) => mockParseOctopusIgnore(...(args as [string])),
 }));
 
-import { incrementalIndex } from "@/lib/indexer";
+// Static imports are hoisted above the mock.module calls, which would load the
+// real module graph (and its throwing "server-only" import) first — dynamic
+// import after the mocks fixes the ordering (same as ai-router.test.ts).
+const { incrementalIndex } = await import("@/lib/indexer");
 
 // ── Tests ──
 
@@ -63,6 +73,7 @@ describe("incrementalIndex", () => {
       if (filePath === "README.md") return Promise.resolve("# Test Repo\n\nThis is a test.\n");
       return Promise.resolve(null);
     });
+    mockParseOctopusIgnore = mock((_content: string) => ({ ignores: () => false }));
   });
 
   it("deletes old chunks and indexes modified files", async () => {
@@ -212,6 +223,60 @@ describe("incrementalIndex", () => {
     // Should still index the successful file
     expect(mockUpsertChunks).toHaveBeenCalledTimes(1);
     expect(result.newVectors).toBeGreaterThan(0);
+  });
+
+  it("skips fetched files that exceed MAX_FILE_SIZE bytes", async () => {
+    mockGhGetFileContent = mock((_installationId: number, _owner: string, _repo: string, _branch: string, filePath: string) => {
+      if (filePath === "src/big.ts") return Promise.resolve("a".repeat(100_001));
+      return Promise.resolve(null);
+    });
+
+    const result = await incrementalIndex(
+      "repo-1",
+      "owner/repo",
+      "main",
+      12345,
+      [{ filename: "src/big.ts", status: "modified" }],
+      "github",
+    );
+
+    expect(mockUpsertChunks).not.toHaveBeenCalled();
+    expect(result.newVectors).toBe(0);
+  });
+
+  it("honours .octopusignore from the default branch", async () => {
+    mockGhGetFileContent = mock((_installationId: number, _owner: string, _repo: string, _branch: string, filePath: string) => {
+      if (filePath === ".octopusignore") return Promise.resolve("src/secret.ts\n");
+      if (filePath === "src/secret.ts") return Promise.resolve("const key = 'hush';\n");
+      if (filePath === "src/utils.ts") return Promise.resolve("export const x = 1;\n");
+      return Promise.resolve(null);
+    });
+    mockParseOctopusIgnore = mock((_content: string) => ({
+      ignores: (path: string) => path === "src/secret.ts",
+    }));
+
+    const result = await incrementalIndex(
+      "repo-1",
+      "owner/repo",
+      "main",
+      12345,
+      [
+        { filename: "src/secret.ts", status: "modified" },
+        { filename: "src/utils.ts", status: "modified" },
+      ],
+      "github",
+    );
+
+    // The ignored path must never be fetched
+    const fetchedPaths = mockGhGetFileContent.mock.calls.map((c) => c[4]);
+    expect(fetchedPaths).not.toContain("src/secret.ts");
+
+    // Only the non-ignored file is indexed
+    const upsertArgs = mockUpsertChunks.mock.calls[0] as [{ payload: { filePath: string } }[]];
+    const filePaths = upsertArgs[0].map((p) => p.payload.filePath);
+    expect(filePaths).toContain("src/utils.ts");
+    expect(filePaths).not.toContain("src/secret.ts");
+    expect(result.updatedFiles).toBe(1);
   });
 
   it("sets correct payload fields on upserted points", async () => {

--- a/apps/web/lib/__tests__/index-chunking.test.ts
+++ b/apps/web/lib/__tests__/index-chunking.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "bun:test";
+import { exceedsMaxFileSize, MAX_FILE_SIZE } from "@/lib/index-chunking";
+
+describe("exceedsMaxFileSize", () => {
+  it("returns false at exactly MAX_FILE_SIZE bytes", () => {
+    expect(exceedsMaxFileSize("a".repeat(MAX_FILE_SIZE))).toBe(false);
+  });
+
+  it("returns true one byte over MAX_FILE_SIZE", () => {
+    expect(exceedsMaxFileSize("a".repeat(MAX_FILE_SIZE + 1))).toBe(true);
+  });
+
+  it("measures bytes, not chars, for multibyte content", () => {
+    // "é" is 2 bytes in UTF-8: char length is under the cap, byte length is over
+    const s = "é".repeat(60_000);
+    expect(s.length).toBeLessThan(MAX_FILE_SIZE);
+    expect(exceedsMaxFileSize(s)).toBe(true);
+  });
+});

--- a/apps/web/lib/index-chunking.ts
+++ b/apps/web/lib/index-chunking.ts
@@ -12,6 +12,11 @@ export const MAX_FILE_SIZE = 100_000; // 100 KB — skip larger files (binaries,
 export const CHUNK_SIZE = 1500; // ~375 tokens
 export const CHUNK_OVERLAP = 200;
 
+/** Byte-size gate for content fetched without size metadata — mirrors the tree-item size check in shouldIndex. */
+export function exceedsMaxFileSize(content: string): boolean {
+  return Buffer.byteLength(content, "utf8") > MAX_FILE_SIZE;
+}
+
 const CODE_EXTENSIONS = new Set([
   ".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs", ".java", ".rb",
   ".c", ".cpp", ".h", ".hpp", ".cs", ".swift", ".kt", ".scala",

--- a/apps/web/lib/indexer.ts
+++ b/apps/web/lib/indexer.ts
@@ -10,7 +10,7 @@ import * as gitlabLib from "@/lib/gitlab";
 import { ensureCollection, upsertChunks, deleteRepoChunks, deleteRepoFileChunks } from "@/lib/qdrant";
 import { generateSparseVectors } from "@/lib/sparse-vector";
 import { parseOctopusIgnore, type Ignore } from "@/lib/octopus-ignore";
-import { shouldIndex, chunkText, MAX_FILE_SIZE } from "@/lib/index-chunking";
+import { shouldIndex, chunkText, MAX_FILE_SIZE, exceedsMaxFileSize } from "@/lib/index-chunking";
 
 const execFileAsync = promisify(execFile);
 
@@ -542,6 +542,31 @@ export async function indexRepository(
   };
 }
 
+/** Load .octopusignore from the default branch for the incremental path; absence or fetch errors mean "no ignore". */
+async function loadIncrementalIgnore(
+  provider: string,
+  fullName: string,
+  defaultBranch: string,
+  installationId: number,
+  organizationId?: string,
+): Promise<Ignore | undefined> {
+  try {
+    let content: string | null = null;
+    if (provider === "github") {
+      const [owner, repoName] = fullName.split("/");
+      content = await ghGetFileContent(installationId, owner, repoName, defaultBranch, ".octopusignore");
+    } else if (provider === "bitbucket" && organizationId) {
+      const [workspace, repoSlug] = fullName.split("/");
+      content = await bitbucketLib.getFileContent(organizationId, workspace, repoSlug, defaultBranch, ".octopusignore");
+    } else if (provider === "gitlab" && organizationId) {
+      content = await gitlabLib.getFileContent(organizationId, fullName, defaultBranch, ".octopusignore");
+    }
+    return content ? parseOctopusIgnore(content) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Incrementally re-index only the changed files from a merged PR.
  * Deletes old chunks for changed/removed files, fetches & indexes added/modified files.
@@ -559,8 +584,13 @@ export async function incrementalIndex(
   const removed = changedFiles
     .filter((f) => f.status === "removed")
     .map((f) => f.filename);
-  const addedOrModified = changedFiles
-    .filter((f) => f.status !== "removed" && shouldIndex(f.filename))
+  // Extension/path rules first (no I/O); only fetch .octopusignore when something survives them.
+  const candidates = changedFiles.filter((f) => f.status !== "removed" && shouldIndex(f.filename));
+  const ig = candidates.length > 0
+    ? await loadIncrementalIgnore(provider, fullName, defaultBranch, installationId, organizationId)
+    : undefined;
+  const addedOrModified = candidates
+    .filter((f) => shouldIndex(f.filename, undefined, ig))
     .map((f) => f.filename);
 
   // 1. Delete chunks for all changed files (removed + modified + added that had old version)
@@ -583,6 +613,10 @@ export async function incrementalIndex(
         const [owner, repoName] = fullName.split("/");
         const content = await ghGetFileContent(installationId, owner, repoName, defaultBranch, filePath);
         if (!content || content.includes("\0")) continue;
+        if (exceedsMaxFileSize(content)) {
+          console.warn(`[indexer:incremental] Skipping ${filePath}: exceeds ${MAX_FILE_SIZE} bytes`);
+          continue;
+        }
         const chunks = chunkText(content, filePath);
         for (const chunk of chunks) {
           allChunks.push({ text: chunk.text, filePath, startLine: chunk.startLine, endLine: chunk.endLine });
@@ -597,6 +631,10 @@ export async function incrementalIndex(
       try {
         const content = await bitbucketLib.getFileContent(organizationId, workspace, repoSlug, defaultBranch, filePath);
         if (!content || content.includes("\0")) continue;
+        if (exceedsMaxFileSize(content)) {
+          console.warn(`[indexer:incremental] Skipping ${filePath}: exceeds ${MAX_FILE_SIZE} bytes`);
+          continue;
+        }
         const chunks = chunkText(content, filePath);
         for (const chunk of chunks) {
           allChunks.push({ text: chunk.text, filePath, startLine: chunk.startLine, endLine: chunk.endLine });
@@ -610,6 +648,10 @@ export async function incrementalIndex(
       try {
         const content = await gitlabLib.getFileContent(organizationId, fullName, defaultBranch, filePath);
         if (!content || content.includes("\0")) continue;
+        if (exceedsMaxFileSize(content)) {
+          console.warn(`[indexer:incremental] Skipping ${filePath}: exceeds ${MAX_FILE_SIZE} bytes`);
+          continue;
+        }
         const chunks = chunkText(content, filePath);
         for (const chunk of chunks) {
           allChunks.push({ text: chunk.text, filePath, startLine: chunk.startLine, endLine: chunk.endLine });


### PR DESCRIPTION
Closes #767

## What

`incrementalIndex` (the merged-PR webhook path) called `shouldIndex(filename)` with neither a size nor the repo's `.octopusignore`, so it indexed files the full index would skip: anything over 100 KB, and anything the customer excluded. The next full reindex then purged them again, so coverage of those files flip-flopped depending on which path ran last.

## Changes

- `exceedsMaxFileSize(content)` in `lib/index-chunking.ts`: a byte-length gate (`Buffer.byteLength`, matching the tree-item size the full index uses, not char length).
- `incrementalIndex`: skips oversized fetched content in all three provider loops with an `[indexer:incremental]` warning; loads `.octopusignore` from the default branch (per provider, absence or errors mean no ignore) before filtering, and only when at least one changed file passes the extension/path rules, so PRs touching only non-indexable files cost no extra API call.
- Full-index paths untouched.

## Tests

- New `index-chunking.test.ts`: exact cap, one byte over, and multibyte content that is under the char count but over the byte count.
- `incremental-index.test.ts`: two new cases. An oversized file is never chunked or upserted, and an `.octopusignore`-listed path is never fetched or indexed. The file also needed `mock.module("server-only")`, a dynamic import after the mocks, and a `getRepositoryDetails` stub to run at all on current master (it failed at module load before this change).
- `bun test` (12 pass), `tsc --noEmit`, eslint clean.

## Notes

A path newly matched by `.octopusignore` is filtered out before the delete step, so stale chunks of a previously leaked file wait for the next full reindex to be purged, same as extension-filtered files today. Actively purging those on the next touching PR would be a cheap follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175zE3idX8JUhbsLb4qCXk9
