### PR TITLE
fix(cli-chat): inject reranked review chunks as <review_context> instead of discarding them

### DIFF
--- a/apps/web/app/api/cli/chat/route.ts
+++ b/apps/web/app/api/cli/chat/route.ts
@@ -11,6 +11,7 @@ import { rerankDocuments } from "@/lib/reranker";
 import Anthropic from "@anthropic-ai/sdk";
 import { requestAgentSearch } from "@/lib/agent-search";
 import { getReviewModel } from "@/lib/ai-client";
+import { buildCliChatSystemPrompt } from "@/lib/cli-chat-prompt";
 import { streamChat } from "@/lib/chat-stream";
 import { getOrgSpendLimitStatus } from "@/lib/cost";
 import {
@@ -175,6 +176,7 @@ export async function POST(request: Request) {
 
   const codeChunks = reranked.filter((d) => d._source === "code") as (typeof rawCodeChunks[number] & { _source: "code" })[];
   const knowledgeChunks = reranked.filter((d) => d._source === "knowledge") as (typeof rawKnowledgeChunks[number] & { _source: "knowledge" })[];
+  const reviewChunks = reranked.filter((d) => d._source === "review") as (typeof rawReviewChunks[number] & { _source: "review" })[];
 
   const repoMap = new Map(indexedRepos.map((r) => [r.id, r.fullName]));
   const codeContext = codeChunks
@@ -185,25 +187,18 @@ export async function POST(request: Request) {
     .map((c) => `### ${c.title}\n${c.text}`)
     .join("\n\n");
 
-  const systemPrompt = `You are Octopus Chat (CLI mode), an AI assistant with deep knowledge of the user's codebase.
-The current user is: ${result.user.name} (${result.user.email})
+  const reviewContext = reviewChunks
+    .map((c) => `### ${c.repoFullName} PR #${c.prNumber}: ${c.prTitle} (by ${c.author}, ${c.reviewDate})\n${c.text}`)
+    .join("\n\n");
 
-RULES:
-- Answer questions using the provided code and knowledge context
-- Cite file paths: \`path/to/file.ts:L42\`
-- Be concise and technical
-- Use fenced code blocks with language tags
-- If context is insufficient, say so honestly
-
-<codebase_context>
-${codeContext || "No code context available."}
-</codebase_context>
-
-<knowledge_context>
-${knowledgeContext || "No knowledge context available."}
-</knowledge_context>
-
-${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent ("${agentResult.agentName ?? "unknown"}").\nThis reflects the actual current state of the code on disk. Prefer over codebase_context when they conflict.\n\n${agentResult.summary}\n</local_agent_context>` : ""}`;
+  const systemPrompt = buildCliChatSystemPrompt({
+    userName: result.user.name,
+    userEmail: result.user.email,
+    codeContext,
+    knowledgeContext,
+    reviewContext,
+    agentResult,
+  });
 
   // Stream response
   const encoder = new TextEncoder();

--- a/apps/web/lib/__tests__/cli-chat-prompt.test.ts
+++ b/apps/web/lib/__tests__/cli-chat-prompt.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "bun:test";
+import { buildCliChatSystemPrompt } from "@/lib/cli-chat-prompt";
+
+const base = {
+  userName: "Cem",
+  userEmail: "cem@example.com",
+  codeContext: "",
+  knowledgeContext: "",
+  reviewContext: "",
+  agentResult: null,
+};
+
+describe("buildCliChatSystemPrompt", () => {
+  it("includes <review_context> with the PR header when review context is present", () => {
+    const prompt = buildCliChatSystemPrompt({
+      ...base,
+      reviewContext: "### org/repo PR #12: title (by alice, 2026-01-02)\nDon't use var.",
+    });
+    expect(prompt).toContain("<review_context>");
+    expect(prompt).toContain("### org/repo PR #12: title (by alice, 2026-01-02)");
+    expect(prompt).toContain("- Answer questions using the provided code, knowledge and past-review context");
+  });
+
+  it("omits <review_context> entirely when there are no review chunks", () => {
+    const prompt = buildCliChatSystemPrompt(base);
+    expect(prompt).not.toContain("<review_context>");
+  });
+
+  it("preserves the code/knowledge fallbacks when contexts are empty", () => {
+    const prompt = buildCliChatSystemPrompt(base);
+    expect(prompt).toContain("No code context available.");
+    expect(prompt).toContain("No knowledge context available.");
+  });
+
+  it("includes local_agent_context only when agentResult is given", () => {
+    const without = buildCliChatSystemPrompt(base);
+    expect(without).not.toContain("<local_agent_context>");
+
+    const withAgent = buildCliChatSystemPrompt({
+      ...base,
+      agentResult: { agentName: "dev-box", summary: "Found 2 matches." },
+    });
+    expect(withAgent).toContain("<local_agent_context>");
+    expect(withAgent).toContain('local agent ("dev-box")');
+    expect(withAgent).toContain("Found 2 matches.");
+  });
+});

--- a/apps/web/lib/cli-chat-prompt.ts
+++ b/apps/web/lib/cli-chat-prompt.ts
@@ -1,0 +1,40 @@
+/**
+ * Builds the system prompt for the CLI chat route (/api/cli/chat).
+ * Pure function — extracted from the route because Next.js forbids extra
+ * exports from route.ts.
+ */
+export function buildCliChatSystemPrompt({
+  userName,
+  userEmail,
+  codeContext,
+  knowledgeContext,
+  reviewContext,
+  agentResult,
+}: {
+  userName: string;
+  userEmail: string;
+  codeContext: string;
+  knowledgeContext: string;
+  reviewContext: string;
+  agentResult: { agentName: string | null; summary: string } | null;
+}): string {
+  return `You are Octopus Chat (CLI mode), an AI assistant with deep knowledge of the user's codebase.
+The current user is: ${userName} (${userEmail})
+
+RULES:
+- Answer questions using the provided code, knowledge and past-review context
+- Cite file paths: \`path/to/file.ts:L42\`
+- Be concise and technical
+- Use fenced code blocks with language tags
+- If context is insufficient, say so honestly
+
+<codebase_context>
+${codeContext || "No code context available."}
+</codebase_context>
+
+<knowledge_context>
+${knowledgeContext || "No knowledge context available."}
+</knowledge_context>
+
+${reviewContext ? `<review_context>\n${reviewContext}\n</review_context>\n\n` : ""}${agentResult ? `<local_agent_context>\nREAL-TIME results from a local agent ("${agentResult.agentName ?? "unknown"}").\nThis reflects the actual current state of the code on disk. Prefer over codebase_context when they conflict.\n\n${agentResult.summary}\n</local_agent_context>` : ""}`;
+}


### PR DESCRIPTION
Closes #768

## What

`/api/cli/chat` fetched 6 review chunks, let them compete for the 15 rerank slots, then dropped them: only code and knowledge contexts were built. Up to 6 slots could be spent on documents the model never saw.

## Changes

- Prompt assembly moved to `lib/cli-chat-prompt.ts` (`buildCliChatSystemPrompt`), since Next.js route files cannot export helpers. Prompt text is unchanged apart from the additions below.
- Reranked review chunks are now rendered as `<review_context>` using the same header format as the web route (`### repo PR #n: title (by author, date)`). The tag is omitted when none survive the rerank.
- RULES bullet now reads "Answer questions using the provided code, knowledge and past-review context".
- Retrieval limits and rerank parameters untouched.

## Tests

- New `cli-chat-prompt.test.ts` (4 cases): review context present and absent, code/knowledge fallbacks preserved, local agent block only when present.
- `bun test`, `tsc --noEmit`, eslint clean.

## Not in this PR

The CLI route does not truncate per chunk (the web route slices to 3000 chars). The new section follows the CLI route's existing untruncated code/knowledge handling. The Cohere-less fallback ordering noted in the issue is also left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175zE3idX8JUhbsLb4qCXk9
