### PR TITLE
fix(indexer): count only blobs in totalFiles for the GitHub-tree path

### DIFF
--- a/apps/web/lib/__tests__/index-chunking.test.ts
+++ b/apps/web/lib/__tests__/index-chunking.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "bun:test";
+import { treeBlobs } from "@/lib/index-chunking";
+
+describe("treeBlobs", () => {
+  it("drops tree entries and keeps blob entries in order", () => {
+    const items = [
+      { type: "blob", path: "a.ts" },
+      { type: "tree", path: "src" },
+      { type: "blob", path: "src/b.ts" },
+      { type: "tree", path: "src/lib" },
+      { type: "blob", path: "src/lib/c.ts" },
+    ];
+    expect(treeBlobs(items)).toEqual([
+      { type: "blob", path: "a.ts" },
+      { type: "blob", path: "src/b.ts" },
+      { type: "blob", path: "src/lib/c.ts" },
+    ]);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(treeBlobs([])).toEqual([]);
+  });
+});

--- a/apps/web/lib/index-chunking.ts
+++ b/apps/web/lib/index-chunking.ts
@@ -28,6 +28,11 @@ const IGNORE_PATHS = [
   "package-lock.json", "bun.lock", "yarn.lock", "pnpm-lock.yaml",
 ];
 
+/** Git-tree entries that are files (`type === "blob"`), not directories. */
+export function treeBlobs<T extends { type: string }>(items: T[]): T[] {
+  return items.filter((item) => item.type === "blob");
+}
+
 export function shouldIndex(path: string, size?: number, ig?: Ignore): boolean {
   if (size && size > MAX_FILE_SIZE) return false;
   if (IGNORE_PATHS.some((p) => path.includes(p))) return false;

--- a/apps/web/lib/indexer.ts
+++ b/apps/web/lib/indexer.ts
@@ -10,7 +10,7 @@ import * as gitlabLib from "@/lib/gitlab";
 import { ensureCollection, upsertChunks, deleteRepoChunks, deleteRepoFileChunks } from "@/lib/qdrant";
 import { generateSparseVectors } from "@/lib/sparse-vector";
 import { parseOctopusIgnore, type Ignore } from "@/lib/octopus-ignore";
-import { shouldIndex, chunkText, MAX_FILE_SIZE } from "@/lib/index-chunking";
+import { shouldIndex, chunkText, treeBlobs, MAX_FILE_SIZE } from "@/lib/index-chunking";
 
 const execFileAsync = promisify(execFile);
 
@@ -322,12 +322,11 @@ export async function indexRepository(
       }
     }
 
-    const files: TreeItem[] = allItems.filter(
-      (item) => item.type === "blob" && shouldIndex(item.path, item.size, ig),
-    );
-    totalFileCount = allItems.length;
+    const blobs = treeBlobs(allItems);
+    const files: TreeItem[] = blobs.filter((item) => shouldIndex(item.path, item.size, ig));
+    totalFileCount = blobs.length;
 
-    onLog(`Found ${allItems.length} total files, ${files.length} eligible for indexing`, "success");
+    onLog(`Found ${blobs.length} total files, ${files.length} eligible for indexing`, "success");
 
     // 1b. Fetch contributors
     try {


### PR DESCRIPTION
Closes #769

## What

`totalFileCount = allItems.length` counted directory (`tree`) entries, so `Files: indexed/total` overstated unindexed files everywhere it is shown: CLI `repo status`, the repositories table, the status API, and the chat repo context. A repo with 186 files and 50 directories read as 170/236, implying 66 unindexed files when only 16 were skipped.

## Changes

- `treeBlobs(items)` in `lib/index-chunking.ts` filters a git tree to blob entries.
- GitHub-tree path in `indexRepository`: eligible files filter over blobs, `totalFileCount = blobs.length`, and the "Found N total files" log uses the same number. The local-clone path already counted files only and is untouched.

## Tests

- New `index-chunking.test.ts`: `treeBlobs` drops tree entries and keeps blobs in order; empty input.
- `bun test`, `tsc --noEmit`, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175zE3idX8JUhbsLb4qCXk9
