### PR TITLE
docs(pricing): state the real 2x platform rate, not a 20% fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Pricing docs said a 20% platform fee is applied on top of provider costs. Octopus Cloud bills usage at 2x the provider's list price; the docs and the pricing page now say so.
+
 ## [1.0.125] - 2026-09-01
 
 ### Fixed

--- a/apps/web/app/(landing)/docs/pricing/page.tsx
+++ b/apps/web/app/(landing)/docs/pricing/page.tsx
@@ -102,8 +102,10 @@ export default function PricingPage() {
       {/* Model pricing */}
       <Section title="Model Pricing">
         <P>
-          Credit consumption varies by model. A 20% platform fee is applied on
-          top of provider costs. Below are the base prices per 1M tokens:
+          Credit consumption varies by model. Octopus Cloud bills usage at 2x
+          the provider's list price; that multiple is the platform rate, and
+          there are no other fees. Below are the provider list prices per 1M
+          tokens:
         </P>
         <div className="mb-4 overflow-x-auto rounded-lg border border-white/[0.06]">
           <table className="w-full text-sm">

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -207,7 +207,7 @@ This is ideal for teams that already have API agreements with AI providers or wa
       },
       {
         heading: "Model Pricing",
-        text: `Octopus supports multiple AI models. A 20% platform fee is applied on top of provider costs. Base prices per 1M tokens:
+        text: `Octopus supports multiple AI models. Octopus Cloud bills usage at 2x the provider's list price. That multiple is the platform rate, and there are no other fees. Provider list prices per 1M tokens:
 Claude Fable 5.1 — $10 input / $50 output. Anthropic's most capable generally available model, the successor to Fable 5; opt-in for the most demanding reviews.
 Claude Fable 5 — $10 input / $50 output. Anthropic's Claude 5 frontier model; the top opt-in tier for the most demanding reviews.
 Claude Opus 5 — $5 input / $25 output. The default review model on Octopus Cloud.


### PR DESCRIPTION
## What

The docs (`docs-content.ts` Model Pricing) and `/docs/pricing` said "a 20% platform fee is applied on top of provider costs". Cloud billing actually applies `PLATFORM_MARKUP` = 2x on the provider list price (verified against charged `ai_usages` rows: charged / base = 2.000 with the 1h cache-write multiplier). The pages now say so plainly; the table stays in provider list prices.

Changelog entry under Unreleased. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3NtKFLyYaUHqsfG57z7AJ
