### PR TITLE
chore(models): move internal helper calls to Claude Sonnet 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Internal helper calls (finding validation, feedback classification, blog SEO metadata) and the self-host default review model now use Claude Sonnet 5 ($2/$10) instead of Sonnet 4.6 ($3/$15). These short JSON calls run with thinking off, so Sonnet 5's adaptive-thinking default can't eat their small token budgets. Sonnet 5 and Fable 5.1 are also in the self-host catalog seed, the pricing page and the docs.
+
 ## [1.0.125] - 2026-09-01
 
 ### Fixed

--- a/apps/web/app/(app)/usage/page.tsx
+++ b/apps/web/app/(app)/usage/page.tsx
@@ -98,6 +98,7 @@ function activityFor(operation: string): Activity | null {
 function shortModelLabel(model: string): string {
   if (model.startsWith("claude-opus-4-6")) return "Claude Opus 4.6";
   if (model.startsWith("claude-opus-4")) return "Claude Opus 4";
+  if (model.startsWith("claude-sonnet-5")) return "Claude Sonnet 5";
   if (model.startsWith("claude-sonnet-4-6")) return "Claude Sonnet 4.6";
   if (model.startsWith("claude-sonnet-4")) return "Claude Sonnet 4";
   if (model.startsWith("claude-haiku-4-5")) return "Claude Haiku 4.5";

--- a/apps/web/app/(landing)/docs/pricing/page.tsx
+++ b/apps/web/app/(landing)/docs/pricing/page.tsx
@@ -119,6 +119,7 @@ export default function PricingPage() {
               <ModelRow model="Claude Fable 5" input="$10" output="$50" />
               <ModelRow model="Claude Opus 5" input="$5" output="$25" />
               <ModelRow model="Claude Opus 4.8" input="$5" output="$25" />
+              <ModelRow model="Claude Sonnet 5" input="$2" output="$10" />
               <ModelRow model="Claude Sonnet 4.6" input="$3" output="$15" />
               <ModelRow model="Claude Sonnet 4" input="$3" output="$15" />
               <ModelRow model="Claude Opus 4" input="$15" output="$75" />

--- a/apps/web/app/api/blog/route.ts
+++ b/apps/web/app/api/blog/route.ts
@@ -251,8 +251,9 @@ export async function POST(request: NextRequest) {
       try {
         const client = new Anthropic();
         const response = await client.messages.create({
-          model: "claude-sonnet-4-6",
+          model: "claude-sonnet-5",
           max_tokens: 300,
+          thinking: { type: "disabled" },
           messages: [
             {
               role: "user",

--- a/apps/web/lib/__tests__/thinking.test.ts
+++ b/apps/web/lib/__tests__/thinking.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   resolveThinking,
+  resolveThinkingOverride,
   resolveEffort,
   asThinkingEffort,
   ALWAYS_THINKING_MAX_TOKENS_FLOOR,
@@ -88,5 +89,21 @@ describe("resolveEffort", () => {
     process.env.FABLE_THINKING_EFFORT = "bogus";
     expect(resolveEffort()).toBe(DEFAULT_THINKING_EFFORT);
     delete process.env.FABLE_THINKING_EFFORT;
+  });
+});
+
+describe("resolveThinkingOverride", () => {
+  it("turns thinking off when a caller asks and the model allows it", () => {
+    expect(resolveThinkingOverride("claude-sonnet-5", "disabled", undefined)).toEqual({ type: "disabled" });
+  });
+
+  it("keeps adaptive thinking on always-thinking models even if asked to disable", () => {
+    expect(resolveThinkingOverride("claude-fable-5-1", "disabled", { type: "adaptive" })).toEqual({ type: "adaptive" });
+    expect(resolveThinkingOverride("claude-opus-5", "disabled", { type: "adaptive" })).toEqual({ type: "adaptive" });
+  });
+
+  it("passes the resolved value through when nothing was requested", () => {
+    expect(resolveThinkingOverride("claude-sonnet-5", undefined, undefined)).toBeUndefined();
+    expect(resolveThinkingOverride("claude-fable-5-1", undefined, { type: "adaptive" })).toEqual({ type: "adaptive" });
   });
 });

--- a/apps/web/lib/ai-client.ts
+++ b/apps/web/lib/ai-client.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@octopus/db";
 
-export const HARDCODED_REVIEW_MODEL = "claude-sonnet-4-6";
+export const HARDCODED_REVIEW_MODEL = "claude-sonnet-5";
 export const HARDCODED_EMBED_MODEL = "text-embedding-3-large";
 
 async function getPlatformDefault(category: "llm" | "embedding"): Promise<string | null> {

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -213,7 +213,8 @@ Claude Fable 5 — $10 input / $50 output. Anthropic's Claude 5 frontier model; 
 Claude Opus 5 — $5 input / $25 output. The default review model on Octopus Cloud.
 Claude Opus 4.8 — $5 input / $25 output. Previous default; still available at the same price.
 Claude Opus 4 — $15 input / $75 output. Legacy high-quality review model.
-Claude Sonnet 4.6 and Claude Sonnet 4 — $3 input / $15 output. High quality and fast; Sonnet 4.6 is the default for self-hosted installs.
+Claude Sonnet 5 — $2 input / $10 output. Fast and strong; the default for self-hosted installs.
+Claude Sonnet 4.6 and Claude Sonnet 4 — $3 input / $15 output. Previous Sonnet generation.
 Claude Haiku 4.5 — $1 input / $5 output. Lightweight tasks like title generation.
 Gemini 2.5 Pro — $1.25 input / $10 output. Gemini 2.5 Flash — $0.15 input / $0.60 output.
 GPT-5.3 Codex — $1.75 input / $14 output.

--- a/apps/web/lib/providers/anthropic.ts
+++ b/apps/web/lib/providers/anthropic.ts
@@ -2,7 +2,7 @@ import "server-only";
 import Anthropic from "@anthropic-ai/sdk";
 import type { Provider, AiCreateParams, AiResponse } from "./index";
 import { splitSystemForCache, type CacheTtl } from "./system-cache";
-import { resolveThinking } from "./thinking";
+import { resolveThinking, resolveThinkingOverride } from "./thinking";
 import { stripLoneSurrogates } from "./sanitize";
 
 let platformClient: Anthropic | null = null;
@@ -52,6 +52,7 @@ export const anthropicProvider: Provider = {
       useTool,
       params.effort,
     );
+    const thinkingParam = resolveThinkingOverride(params.model, params.thinking, thinking);
 
     // Streaming here is purely between this process and the Anthropic API —
     // finalMessage() buffers the SSE chunks and returns the same complete
@@ -62,7 +63,7 @@ export const anthropicProvider: Provider = {
       {
         model: params.model,
         max_tokens: maxTokens,
-        ...(thinking ? { thinking } : {}),
+        ...(thinkingParam ? { thinking: thinkingParam } : {}),
         ...(outputConfig ? { output_config: outputConfig } : {}),
         // Strip lone UTF-16 surrogates from all text: a diff/file body truncated
         // mid-emoji can leave an unpaired surrogate, which serializes to invalid

--- a/apps/web/lib/providers/index.ts
+++ b/apps/web/lib/providers/index.ts
@@ -57,6 +57,13 @@ export type AiCreateParams = {
    * it. Falls back to the env/built-in default when unset.
    */
   effort?: ThinkingEffort;
+  /**
+   * Set to "disabled" for short utility calls (classification, metadata,
+   * validation JSON) so models that default to adaptive thinking (Sonnet 5,
+   * Opus 4.7+) don't spend the small max_tokens budget on thinking. Ignored on
+   * always-thinking models, which reject thinking-off.
+   */
+  thinking?: "disabled";
 };
 
 export type AiResponse = {

--- a/apps/web/lib/providers/thinking.ts
+++ b/apps/web/lib/providers/thinking.ts
@@ -38,6 +38,22 @@ export function resolveEffort(): ThinkingEffort {
   return asThinkingEffort(process.env.FABLE_THINKING_EFFORT) ?? DEFAULT_THINKING_EFFORT;
 }
 
+/**
+ * A caller's explicit `thinking: "disabled"` wins on models that allow it.
+ * Always-thinking models (Fable/Mythos/Opus 5) reject thinking-off, so they
+ * keep whatever resolveThinking produced.
+ */
+export function resolveThinkingOverride(
+  model: string,
+  requested: "disabled" | undefined,
+  resolved: { type: "adaptive" } | undefined,
+): { type: "adaptive" } | { type: "disabled" } | undefined {
+  if (requested === "disabled" && !ALWAYS_THINKING_MODEL_RX.test(model)) {
+    return { type: "disabled" };
+  }
+  return resolved;
+}
+
 export type ResolvedThinking = {
   maxTokens: number;
   thinking?: { type: "adaptive" };

--- a/apps/web/lib/review-validation.ts
+++ b/apps/web/lib/review-validation.ts
@@ -221,7 +221,7 @@ export async function gatherVerificationContext(
 
 // ─── Two-Pass Validation ────────────────────────────────────────────────────
 
-export const VALIDATION_MODEL = "claude-sonnet-4-6";
+export const VALIDATION_MODEL = "claude-sonnet-5";
 
 export async function validateFindings(
   findings: InlineFinding[],
@@ -275,6 +275,8 @@ export async function validateFindings(
       // Raised from 2048 to fit per-finding citations/refutations without the
       // validator truncating its own JSON.
       maxTokens: 4096,
+      // Sonnet 5 defaults to adaptive thinking; this is a JSON-out utility call.
+      thinking: "disabled",
       messages: [
         {
           role: "user",

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -172,7 +172,7 @@ async function emitReviewStatus(orgId: string, event: ReviewEvent) {
 
 // --- LLM-based reply intent classification ---
 
-const FEEDBACK_CLASSIFICATION_MODEL = "claude-sonnet-4-6";
+const FEEDBACK_CLASSIFICATION_MODEL = "claude-sonnet-5";
 
 // GitLab commit-status context name — the merge-gating check GitLab MRs can
 // require. Kept as one constant so every finalize path uses the same name
@@ -232,6 +232,7 @@ Reply ONLY with a JSON array of strings, one per entry, in order. Example: ["dis
       {
         model: FEEDBACK_CLASSIFICATION_MODEL,
         maxTokens: 256,
+        thinking: "disabled",
         system: systemPrompt,
         messages: [{ role: "user", content: userMessage }],
       },

--- a/apps/web/scripts/backfill-blog-taxonomy.ts
+++ b/apps/web/scripts/backfill-blog-taxonomy.ts
@@ -44,8 +44,9 @@ async function generateSeo(content: string): Promise<GeneratedSeo> {
   try {
     const client = new Anthropic();
     const response = await client.messages.create({
-      model: "claude-sonnet-4-6",
+      model: "claude-sonnet-5",
       max_tokens: 300,
+      thinking: { type: "disabled" },
       messages: [
         {
           role: "user",

--- a/apps/web/scripts/review-simulator.ts
+++ b/apps/web/scripts/review-simulator.ts
@@ -8,7 +8,7 @@
  *
  * Options:
  *   --skip-llm       Skip LLM calls, only replay dedup on existing findings
- *   --model <id>     Model override (default: claude-sonnet-4-6)
+ *   --model <id>     Model override (default: claude-sonnet-5)
  *   --output <path>  Output HTML file path
  */
 
@@ -51,7 +51,7 @@ function parseArgs(): { prUrl: string; skipLlm: boolean; model: string; output?:
   const args = process.argv.slice(2);
   let prUrl = "";
   let skipLlm = false;
-  let model = "claude-sonnet-4-6";
+  let model = "claude-sonnet-5";
   let output: string | undefined;
 
   for (let i = 0; i < args.length; i++) {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -713,12 +713,14 @@ async function main() {
     // Anthropic
     // Claude 5 frontier model; top opt-in "max" tier. sortOrder -1 pins it above
     // the 0-indexed list without a duplicate order value.
+    { modelId: "claude-fable-5-1", displayName: "Claude Fable 5.1", provider: "anthropic", category: "llm", inputPrice: 10, outputPrice: 50, sortOrder: -2 },
     { modelId: "claude-fable-5", displayName: "Claude Fable 5", provider: "anthropic", category: "llm", inputPrice: 10, outputPrice: 50, sortOrder: -1 },
     // Opus 5 uses Anthropic's published undated API id ("claude-opus-5"); no dated
     // canonical id was published, and inventing one would fail the API call + the
     // exact-key pricing lookup in cost.ts. Premium tier — not the platform default.
     { modelId: "claude-opus-5", displayName: "Claude Opus 5", provider: "anthropic", category: "llm", inputPrice: 5, outputPrice: 25, sortOrder: 0 },
     { modelId: "claude-opus-4-8", displayName: "Claude Opus 4.8", provider: "anthropic", category: "llm", inputPrice: 5, outputPrice: 25, sortOrder: 1 },
+    { modelId: "claude-sonnet-5", displayName: "Claude Sonnet 5", provider: "anthropic", category: "llm", inputPrice: 2, outputPrice: 10, sortOrder: 2 },
     { modelId: "claude-sonnet-4-6-20250619", displayName: "Claude Sonnet 4.6", provider: "anthropic", category: "llm", inputPrice: 3, outputPrice: 15, sortOrder: 2 },
     { modelId: "claude-sonnet-4-20250514", displayName: "Claude Sonnet 4", provider: "anthropic", category: "llm", inputPrice: 3, outputPrice: 15, sortOrder: 3 },
     { modelId: "claude-opus-4-20250514", displayName: "Claude Opus 4", provider: "anthropic", category: "llm", inputPrice: 15, outputPrice: 75, sortOrder: 4 },


### PR DESCRIPTION
## What

Claude Sonnet 4.6 was retired from the catalog; the code still hardcoded it for internal helpers. This moves them to `claude-sonnet-5` ($2/$10 vs $3/$15, better model):

- `VALIDATION_MODEL` (finding validation), `FEEDBACK_CLASSIFICATION_MODEL`, blog SEO metadata (`api/blog` + backfill script), `review-simulator` default, and `HARDCODED_REVIEW_MODEL` (self-host fallback / settings display).

Sonnet 5 runs **adaptive thinking by default when `thinking` is omitted**, which would spend the tiny `max_tokens` budgets of these JSON calls (256 / 300 / 4096) on thinking. So:

- `AiCreateParams.thinking?: "disabled"` (new, opt-in) → Anthropic provider passes `thinking: {type: "disabled"}` through `resolveThinkingOverride()`, which ignores the request on always-thinking models (Fable/Mythos/Opus 5 reject thinking-off). Unit tests added (`thinking.test.ts`, 3 cases).
- Direct SDK calls (blog SEO, backfill) set `thinking: { type: "disabled" }` explicitly.

Also: Sonnet 5 + Fable 5.1 rows in the self-host catalog seed (`sortOrder` is non-unique; no renumbering), Sonnet 5 on `/docs/pricing` + docs-content (now the self-host default), Usage page label, changelog.

Review path is untouched: orgs pinned to Sonnet 5 keep the router's default behavior (adaptive thinking, budget-aware).

## Test

- `bun test lib/__tests__/thinking.test.ts lib/__tests__/score-normalize.test.ts` → 27 pass.
- `tsc` clean on touched files (`lib/providers/*`, `review-validation.ts`, `ai-client.ts`, `api/blog`, usage page, docs/pricing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3NtKFLyYaUHqsfG57z7AJ
