### PR TITLE
fix(cli): report why a review did not start instead of "Review started"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Triggering a review from the CLI or the editor plugin (`octopus_review_pr`) on a pull request whose author is blocked, whose organization has reviews paused, or which is already being reviewed now returns that reason (HTTP 422 / 409) instead of "Review started".
+- Pricing docs said a 20% platform fee is applied on top of provider costs. Octopus Cloud bills usage at 2x the provider's list price; the docs and the pricing page now say so.
 
 ### Changed
 - Internal helper calls (finding validation, feedback classification, blog SEO metadata) and the self-host default review model now use Claude Sonnet 5 ($2/$10) instead of Sonnet 4.6 ($3/$15). These short JSON calls run with thinking off, so Sonnet 5's adaptive-thinking default can't eat their small token budgets. Sonnet 5 and Fable 5.1 are also in the self-host catalog seed, the pricing page and the docs.
-
-### Fixed
-- Pricing docs said a 20% platform fee is applied on top of provider costs. Octopus Cloud bills usage at 2x the provider's list price; the docs and the pricing page now say so.
 
 ## [1.0.125] - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Triggering a review from the CLI or the editor plugin (`octopus_review_pr`) on a pull request whose author is blocked, whose organization has reviews paused, or which is already being reviewed now returns that reason (HTTP 422 / 409) instead of "Review started".
+
 ## [1.0.125] - 2026-09-01
 
 ### Fixed

--- a/apps/web/app/api/cli/repos/[id]/review/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/review/route.ts
@@ -60,7 +60,7 @@ export async function POST(
         return Response.json({ error: `${prLabel} not found` }, { status: 404 });
       }
 
-      await startReviewFlow({
+      const outcome = await startReviewFlow({
         provider: repo.provider as "github" | "gitlab" | "bitbucket",
         installationId: repo.installationId ?? undefined,
         organizationId: result.org.id,
@@ -76,6 +76,12 @@ export async function POST(
         triggerCommentBody: "",
       });
 
+      if (!outcome.started) {
+        // Blocked author / paused org / duplicate: tell the caller instead of
+        // claiming a review started that never will.
+        const status = outcome.reason === "already_in_progress" ? 409 : 422;
+        return Response.json({ error: outcome.message, reason: outcome.reason }, { status });
+      }
       return Response.json({ message: "Review started", prNumber: details.number });
     } catch (err) {
       console.error(`[cli] Failed to fetch ${repo.provider} ${prLabel} #${prNumber}:`, err);

--- a/apps/web/lib/webhook-shared.ts
+++ b/apps/web/lib/webhook-shared.ts
@@ -35,6 +35,14 @@ async function postSkippedCheckRun(
  * Shared flow: upsert PR -> post placeholder comment -> notify dashboard -> start review.
  * Works for GitHub, Bitbucket, and GitLab.
  */
+/**
+ * Outcome of startReviewFlow. Webhooks ignore it; user-facing triggers
+ * (CLI / MCP) use it to say why nothing ran instead of "Review started".
+ */
+export type StartReviewResult =
+  | { started: true }
+  | { started: false; reason: "org_paused" | "already_in_progress" | "author_blocked"; message: string };
+
 export async function startReviewFlow(params: {
   provider: "github" | "bitbucket" | "gitlab";
   // GitHub-specific
@@ -52,7 +60,7 @@ export async function startReviewFlow(params: {
   headSha: string;
   triggerCommentId: number;
   triggerCommentBody: string;
-}) {
+}): Promise<StartReviewResult> {
   const {
     provider,
     installationId,
@@ -85,7 +93,7 @@ export async function startReviewFlow(params: {
 
   if (org?.reviewsPaused) {
     console.log(`[webhook] Reviews paused for org ${orgId}, skipping PR #${prNumber}`);
-    return;
+    return { started: false, reason: "org_paused", message: "Reviews are paused for this organization" };
   }
 
   // Check existing PR status to prevent duplicate reviews (cheap indexed lookup first)
@@ -108,7 +116,7 @@ export async function startReviewFlow(params: {
       });
     } else if (existingPr.headSha === headSha) {
       console.log(`[webhook] Review already in progress/queued for PR #${prNumber} (same SHA), skipping`);
-      return;
+      return { started: false, reason: "already_in_progress", message: `Review already in progress for PR #${prNumber}` };
     } else {
       console.log(`[webhook] New SHA detected for PR #${prNumber}, restarting review`);
     }
@@ -125,7 +133,7 @@ export async function startReviewFlow(params: {
     if (isBlocked) {
       console.log(`[webhook] PR author "${prAuthor}" is blocked for org ${orgId}, skipping PR #${prNumber}`);
       await postSkippedCheckRun(provider, installationId, repoFullName, headSha, `PR author "${prAuthor}" is in the blocked list`);
-      return;
+      return { started: false, reason: "author_blocked", message: `PR author "${prAuthor}" is in the blocked list` };
     }
   }
 
@@ -224,4 +232,5 @@ export async function startReviewFlow(params: {
 
   // Enqueue review job — pg-boss persists it in DB, survives container restarts
   await enqueue("process-review", { pullRequestId: pr.id });
+  return { started: true };
 }


### PR DESCRIPTION
## What

`POST /api/cli/repos/:id/review` (used by `octp` and the editor plugin's `octopus_review_pr`) answered "Review started" even when `startReviewFlow` silently skipped the PR. Seen live: a dependabot PR in an org that blocks bot authors returned "Review started" and nothing ran.

- `startReviewFlow` now returns `StartReviewResult`: `{ started: true }` or `{ started: false, reason: "org_paused" | "already_in_progress" | "author_blocked", message }`. The three early returns carry the reason; the success path returns `started: true` after enqueue.
- The CLI route responds `409` (already in progress) or `422` (paused / blocked) with `{ error, reason }`. Webhook callers ignore the return value, as before.

Changelog under Unreleased.

## Test

- `tsc` clean on `lib/webhook-shared.ts` and the CLI route (a naming clash with the auth `result` was caught and fixed during typecheck).
- Manual: after deploy, `octopus_review_pr` on `application-of-everything#13` (dependabot) should return the blocked-author message instead of "Review started".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3NtKFLyYaUHqsfG57z7AJ
