### PR TITLE
fix(installer): find octp releases beyond the first API page, and parse GitHub's real responses

### DIFF
--- a/.github/workflows/sync-installers-check.yml
+++ b/.github/workflows/sync-installers-check.yml
@@ -45,7 +45,8 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
       OCTOPUS_INSTALL_RESOLVE_ONLY: "1"
       # install.ps1 derives its default dir from USERPROFILE, which Linux lacks.
-      OCTOPUS_INSTALL_DIR: ${{ runner.temp }}/octp
+      # (Literal path: the `runner` context is not available in job-level env.)
+      OCTOPUS_INSTALL_DIR: /tmp/octp
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4
       - name: install.sh resolves a release

--- a/.github/workflows/sync-installers-check.yml
+++ b/.github/workflows/sync-installers-check.yml
@@ -3,12 +3,20 @@ name: sync-installers-check
 on:
   pull_request:
     paths:
-      - "apps/cli/install/install.sh"
-      - "apps/cli/install/install.ps1"
+      - "apps/cli/install/**"
       - "apps/web/public/install.sh"
       - "apps/web/public/install.ps1"
       - "scripts/sync-installers.sh"
       - ".github/workflows/sync-installers-check.yml"
+  # The installers resolve "latest octp release" against the live GitHub API.
+  # Platform releases can change what that lookup sees without touching any
+  # file here (#775), so also probe the live API daily.
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   check:
@@ -17,3 +25,37 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4
       - name: Verify installer sync
         run: scripts/sync-installers.sh --check
+
+  # Fixture-backed lookup tests (bash + PowerShell; ubuntu runners ship pwsh).
+  lookup-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      - name: Installer release-lookup tests
+        run: bun test install/install.test.ts
+        working-directory: apps/cli
+
+  # Live probe: both installers must resolve an octp-v* tag from the real API.
+  live-resolve:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      OCTOPUS_INSTALL_RESOLVE_ONLY: "1"
+      # install.ps1 derives its default dir from USERPROFILE, which Linux lacks.
+      OCTOPUS_INSTALL_DIR: ${{ runner.temp }}/octp
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v4
+      - name: install.sh resolves a release
+        run: |
+          set -o pipefail
+          bash apps/cli/install/install.sh | tee out.txt
+          grep -q "^Latest release: octp-v" out.txt
+      - name: install.ps1 resolves a release
+        shell: pwsh
+        run: |
+          $out = & pwsh -NoProfile -File apps/cli/install/install.ps1
+          $out | Write-Host
+          if (-not ($out -match "^Latest release: octp-v")) { throw "install.ps1 did not resolve an octp-v* release" }

--- a/apps/cli/install/install.ps1
+++ b/apps/cli/install/install.ps1
@@ -16,12 +16,18 @@
 #   $env:OCTOPUS_INSTALL_DIR   Override install directory
 #   $env:OCTOPUS_INSTALL_REPO  Override the GitHub repo (default: octopusreview/octopus)
 #   $env:OCTOPUS_INSTALL_TAG   Install a specific tag instead of latest
+#   $env:OCTOPUS_INSTALL_API   Override the GitHub API base URL (default: https://api.github.com)
+#   $env:OCTOPUS_INSTALL_RESOLVE_ONLY=1  Print the resolved tag and exit without downloading
+#   $env:GITHUB_TOKEN          Optional; authenticates the release lookup (higher API rate limit)
 
 $ErrorActionPreference = "Stop"
 
 $Repo        = if ($env:OCTOPUS_INSTALL_REPO) { $env:OCTOPUS_INSTALL_REPO } else { "octopusreview/octopus" }
 $InstallDir  = if ($env:OCTOPUS_INSTALL_DIR)  { $env:OCTOPUS_INSTALL_DIR }  else { Join-Path $env:USERPROFILE ".octopus\bin" }
 $BinaryName  = "octp.exe"
+$ApiBase     = if ($env:OCTOPUS_INSTALL_API) { $env:OCTOPUS_INSTALL_API } else { "https://api.github.com" }
+$ApiHeaders  = @{ "User-Agent" = "octp-installer" }
+if ($env:GITHUB_TOKEN) { $ApiHeaders["Authorization"] = "Bearer $($env:GITHUB_TOKEN)" }
 
 # ── Step 1: arch ─────────────────────────────────────────────────────────────
 
@@ -39,17 +45,38 @@ if ($env:OCTOPUS_INSTALL_TAG) {
   Write-Host "Looking up latest octp release on $Repo ..."
   # Find the most recent NON-DRAFT, NON-PRERELEASE octp-v* tag.
   # Users testing prerelease tags can override via $env:OCTOPUS_INSTALL_TAG.
-  $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=30" -Headers @{ "User-Agent" = "octp-installer" }
-  $tag = (
-    $releases |
-      Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name -like "octp-v*" } |
-      Select-Object -First 1
-  ).tag_name
+  # Platform releases (v1.0.x) are cut far more often than octp releases, so
+  # the newest octp-v* tag is usually NOT on the first page. Walk the pages
+  # (newest first, 100 per request) until one turns up or the list ends (#775).
+  $tag = $null
+  $page = 1
+  # 10 x 100 is also GitHub's listing cap (page 11 returns HTTP 422); don't raise it.
+  $maxPages = 10
+  while ($page -le $maxPages) {
+    $response = Invoke-RestMethod -Uri "$ApiBase/repos/$Repo/releases?per_page=100&page=$page" -Headers $ApiHeaders
+    # PowerShell 7 emits the JSON array as ONE object (so @(Invoke-RestMethod ...)
+    # would be a 1-element array holding the whole page) and 5.1 emits $null for
+    # an empty page. Piping enumerates both into a flat list of release objects.
+    $releases = @($response | Where-Object { $null -ne $_ })
+    if ($releases.Count -eq 0) { break }   # walked past the last page
+    $tag = (
+      $releases |
+        Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name -like "octp-v*" } |
+        Select-Object -First 1
+    ).tag_name
+    if ($tag) { break }
+    $page++
+  }
   if (-not $tag) {
     Write-Error "Could not find any non-prerelease octp-v* on $Repo. Pin a tag with `$env:OCTOPUS_INSTALL_TAG = 'octp-v0.X.Y'`."
     exit 1
   }
   Write-Host "Latest release: $tag"
+}
+
+if ($env:OCTOPUS_INSTALL_RESOLVE_ONLY -eq "1") {
+  Write-Host "Resolved $tag (OCTOPUS_INSTALL_RESOLVE_ONLY=1: nothing downloaded)."
+  exit 0
 }
 
 # ── Step 3: download ─────────────────────────────────────────────────────────

--- a/apps/cli/install/install.sh
+++ b/apps/cli/install/install.sh
@@ -22,6 +22,9 @@
 #   OCTOPUS_INSTALL_DIR  Override install directory (default: $HOME/.octopus/bin)
 #   OCTOPUS_INSTALL_REPO Override the GitHub repo (default: octopusreview/octopus)
 #   OCTOPUS_INSTALL_TAG  Install a specific tag instead of latest (e.g. octp-v0.2.0)
+#   OCTOPUS_INSTALL_API  Override the GitHub API base URL (default: https://api.github.com)
+#   OCTOPUS_INSTALL_RESOLVE_ONLY=1  Print the resolved tag and exit without downloading
+#   GITHUB_TOKEN         Optional; authenticates the release lookup (higher API rate limit)
 #
 # Exit codes:
 #   0 success
@@ -32,6 +35,15 @@ set -euo pipefail
 REPO="${OCTOPUS_INSTALL_REPO:-octopusreview/octopus}"
 INSTALL_DIR="${OCTOPUS_INSTALL_DIR:-$HOME/.octopus/bin}"
 BINARY_NAME="octp"
+API_BASE="${OCTOPUS_INSTALL_API:-https://api.github.com}"
+# Releases are listed newest-first, 100 per page; MAX_PAGES bounds the walk.
+# 10 x 100 is also GitHub's listing cap (page 11 returns HTTP 422), so don't
+# raise it — an octp release older than 1000 platform releases needs a re-cut.
+MAX_PAGES=10
+auth_header=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
 
 # ── Step 1: detect platform ──────────────────────────────────────────────────
 
@@ -83,23 +95,55 @@ else
   # POSIX class is used everywhere else for the same portability reason
   # (GNU `\s` would silently match "s" on busybox grep / BSD sed).
   # Users testing prerelease tags can still override via OCTOPUS_INSTALL_TAG.
-  api_url="https://api.github.com/repos/${REPO}/releases?per_page=30"
-  tag=$(
-    curl -fsSL "$api_url" \
-      | sed 's/},{/}\
+  #
+  # Platform releases (v1.0.x) are cut far more often than octp releases, so
+  # the newest octp-v* tag is usually NOT on the first page. Walk the pages
+  # (newest first, 100 per request) until one turns up or the list ends (#775).
+  # A no-match grep exits 1, which under `pipefail` would abort the whole
+  # script silently — hence the `|| true`.
+  tag=""
+  page=1
+  while [ "$page" -le "$MAX_PAGES" ]; do
+    api_url="${API_BASE}/repos/${REPO}/releases?per_page=100&page=${page}"
+    if ! body=$(curl -fsSL --retry 3 --retry-delay 1 ${auth_header[@]+"${auth_header[@]}"} "$api_url"); then
+      echo "Error: GitHub API request failed: $api_url" >&2
+      echo "If you are rate-limited, set GITHUB_TOKEN to authenticate the lookup." >&2
+      exit 1
+    fi
+    # GitHub pretty-prints its JSON (one field per line). Strip ALL whitespace
+    # first so the `},{` object boundaries and the empty page `[]` are literal;
+    # nothing we match on (tag names, draft/prerelease flags) contains spaces.
+    body=$(printf '%s' "$body" | tr -d '[:space:]')
+    # An empty array means we walked past the last page.
+    if [ "$body" = "[]" ]; then
+      break
+    fi
+    tag=$(
+      printf '%s' "$body" \
+        | sed 's/},{/}\
 {/g' \
-      | grep -v '"draft"[[:space:]]*:[[:space:]]*true' \
-      | grep -v '"prerelease"[[:space:]]*:[[:space:]]*true' \
-      | grep -E '"tag_name"[[:space:]]*:[[:space:]]*"octp-v' \
-      | head -1 \
-      | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
-  )
+        | grep -v '"draft"[[:space:]]*:[[:space:]]*true' \
+        | grep -v '"prerelease"[[:space:]]*:[[:space:]]*true' \
+        | grep -E '"tag_name"[[:space:]]*:[[:space:]]*"octp-v' \
+        | head -1 \
+        | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+    ) || true
+    if [ -n "$tag" ]; then
+      break
+    fi
+    page=$((page + 1))
+  done
   if [ -z "$tag" ]; then
     echo "Error: could not find any non-prerelease octp-v* on $REPO." >&2
     echo "If you are testing a prerelease, pin a tag with OCTOPUS_INSTALL_TAG=octp-v0.X.Y" >&2
     exit 1
   fi
   echo "Latest release: $tag"
+fi
+
+if [ "${OCTOPUS_INSTALL_RESOLVE_ONLY:-0}" = "1" ]; then
+  echo "Resolved $tag (OCTOPUS_INSTALL_RESOLVE_ONLY=1: nothing downloaded)."
+  exit 0
 fi
 
 # ── Step 3: download ─────────────────────────────────────────────────────────

--- a/apps/cli/install/install.test.ts
+++ b/apps/cli/install/install.test.ts
@@ -103,6 +103,8 @@ async function run(cmd: string[], extraEnv: Record<string, string> = {}) {
 const SH = ["bash", join(INSTALL_DIR, "install.sh")];
 const PS1 = ["pwsh", "-NoProfile", "-File", join(INSTALL_DIR, "install.ps1")];
 const hasPwsh = Bun.which("pwsh") !== null;
+// pwsh cold-starts in several seconds on CI runners; bun's default per-test timeout is 5 s.
+const PWSH_TIMEOUT_MS = 60_000;
 
 describe("install.sh release lookup", () => {
   test("finds the latest non-draft, non-prerelease octp release beyond the first page", async () => {
@@ -147,7 +149,7 @@ describe.skipIf(!hasPwsh)("install.ps1 release lookup", () => {
       `/repos/${REPO}/releases?per_page=100&page=1`,
       `/repos/${REPO}/releases?per_page=100&page=2`,
     ]);
-  });
+  }, PWSH_TIMEOUT_MS);
 
   test("fails clearly when no octp release exists on any page", async () => {
     pages = PAGES_WITHOUT_OCTP;
@@ -155,5 +157,5 @@ describe.skipIf(!hasPwsh)("install.ps1 release lookup", () => {
     const r = await run(PS1);
     expect(r.code).toBe(1);
     expect(r.stderr + r.stdout).toContain("Could not find any non-prerelease octp-v*");
-  });
+  }, PWSH_TIMEOUT_MS);
 });

--- a/apps/cli/install/install.test.ts
+++ b/apps/cli/install/install.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+/**
+ * Release-lookup tests for the native installers (install.sh / install.ps1).
+ *
+ * The scripts resolve "latest octp release" from the GitHub releases API.
+ * Platform releases (v1.0.x) are cut far more often than octp releases, so
+ * the newest octp-v* tag routinely sits beyond the first page — a single
+ * page-limited request finds nothing (#775). These tests point the scripts at
+ * a local fixture API (OCTOPUS_INSTALL_API) and run them in resolve-only mode
+ * (OCTOPUS_INSTALL_RESOLVE_ONLY=1) so no binary is downloaded.
+ */
+
+const INSTALL_DIR = import.meta.dir;
+const REPO = "octopusreview/octopus";
+
+type Release = { tag_name: string; draft: boolean; prerelease: boolean };
+
+// Mimic GitHub's field order: tag_name/draft/prerelease precede `assets`, which
+// is what lets the bash parser split objects on `},{` safely.
+function release(tag_name: string, opts: Partial<Release> = {}) {
+  return {
+    url: `https://api.github.com/repos/${REPO}/releases/1`,
+    tag_name,
+    name: tag_name,
+    draft: opts.draft ?? false,
+    prerelease: opts.prerelease ?? false,
+    assets: [
+      { name: "octp-linux-x64", browser_download_url: "https://example.invalid/a" },
+      { name: "octp-darwin-arm64", browser_download_url: "https://example.invalid/b" },
+    ],
+    body: "notes, with a fake \"tag_name\": \"octp-v9.9.9\" inside a string",
+  };
+}
+
+const platform = (from: number, count: number) =>
+  Array.from({ length: count }, (_, i) => release(`v1.0.${from - i}`));
+
+// Page 1: 100 platform releases, no octp. Page 2: more platform releases, then a
+// draft and a prerelease octp (must be skipped), then the real latest octp.
+const PAGES_WITH_OCTP_ON_PAGE_2 = [
+  platform(300, 100),
+  [
+    ...platform(200, 30),
+    release("octp-v0.3.0", { draft: true }),
+    release("octp-v0.2.1-rc.1", { prerelease: true }),
+    release("octp-v0.2.0"),
+    release("octp-v0.1.0"),
+  ],
+];
+const PAGES_WITHOUT_OCTP = [platform(300, 100), platform(200, 100), platform(100, 50)];
+
+let server: ReturnType<typeof Bun.serve>;
+let pages: unknown[][] = PAGES_WITH_OCTP_ON_PAGE_2;
+let requests: { url: string; authorization: string | null }[] = [];
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      requests.push({ url: url.pathname + url.search, authorization: req.headers.get("authorization") });
+      if (url.pathname !== `/repos/${REPO}/releases`) return new Response("not found", { status: 404 });
+      const page = Number(url.searchParams.get("page") ?? "1");
+      // api.github.com pretty-prints (2-space indent, one field per line); an
+      // exhausted page is "[\n\n]". Serve the same shape so the bash parser's
+      // whitespace handling is exercised, not just compact JSON.
+      return new Response(JSON.stringify(pages[page - 1] ?? [], null, 2), {
+        headers: { "content-type": "application/json; charset=utf-8" },
+      });
+    },
+  });
+});
+afterAll(() => server.stop(true));
+
+async function run(cmd: string[], extraEnv: Record<string, string> = {}) {
+  const proc = Bun.spawn(cmd, {
+    env: {
+      ...process.env,
+      OCTOPUS_INSTALL_API: `http://127.0.0.1:${server.port}`,
+      OCTOPUS_INSTALL_REPO: REPO,
+      OCTOPUS_INSTALL_RESOLVE_ONLY: "1",
+      // Isolate from the developer's shell: a pinned tag would skip the lookup,
+      // a real token would be sent to the fixture, and install.ps1 derives its
+      // default dir from USERPROFILE, which does not exist on Linux/macOS.
+      OCTOPUS_INSTALL_TAG: "",
+      GITHUB_TOKEN: "",
+      OCTOPUS_INSTALL_DIR: join(import.meta.dir, ".test-install-dir"),
+      ...extraEnv,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, code };
+}
+
+const SH = ["bash", join(INSTALL_DIR, "install.sh")];
+const PS1 = ["pwsh", "-NoProfile", "-File", join(INSTALL_DIR, "install.ps1")];
+const hasPwsh = Bun.which("pwsh") !== null;
+
+describe("install.sh release lookup", () => {
+  test("finds the latest non-draft, non-prerelease octp release beyond the first page", async () => {
+    pages = PAGES_WITH_OCTP_ON_PAGE_2;
+    requests = [];
+    const r = await run(SH);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("Latest release: octp-v0.2.0");
+    expect(requests.map((q) => q.url)).toEqual([
+      `/repos/${REPO}/releases?per_page=100&page=1`,
+      `/repos/${REPO}/releases?per_page=100&page=2`,
+    ]);
+  });
+
+  test("fails clearly when no octp release exists on any page", async () => {
+    pages = PAGES_WITHOUT_OCTP;
+    requests = [];
+    const r = await run(SH);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain("could not find any non-prerelease octp-v*");
+    // Walked every page, then stopped on the first empty one.
+    expect(requests.length).toBe(PAGES_WITHOUT_OCTP.length + 1);
+  });
+
+  test("sends a bearer token to the API when GITHUB_TOKEN is set", async () => {
+    pages = PAGES_WITH_OCTP_ON_PAGE_2;
+    requests = [];
+    const r = await run(SH, { GITHUB_TOKEN: "test-token" });
+    expect(r.code).toBe(0);
+    expect(requests[0]?.authorization).toBe("Bearer test-token");
+  });
+});
+
+describe.skipIf(!hasPwsh)("install.ps1 release lookup", () => {
+  test("finds the latest non-draft, non-prerelease octp release beyond the first page", async () => {
+    pages = PAGES_WITH_OCTP_ON_PAGE_2;
+    requests = [];
+    const r = await run(PS1);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("Latest release: octp-v0.2.0");
+    expect(requests.map((q) => q.url)).toEqual([
+      `/repos/${REPO}/releases?per_page=100&page=1`,
+      `/repos/${REPO}/releases?per_page=100&page=2`,
+    ]);
+  });
+
+  test("fails clearly when no octp release exists on any page", async () => {
+    pages = PAGES_WITHOUT_OCTP;
+    requests = [];
+    const r = await run(PS1);
+    expect(r.code).toBe(1);
+    expect(r.stderr + r.stdout).toContain("Could not find any non-prerelease octp-v*");
+  });
+});

--- a/apps/web/public/install.ps1
+++ b/apps/web/public/install.ps1
@@ -22,12 +22,18 @@
 #   $env:OCTOPUS_INSTALL_DIR   Override install directory
 #   $env:OCTOPUS_INSTALL_REPO  Override the GitHub repo (default: octopusreview/octopus)
 #   $env:OCTOPUS_INSTALL_TAG   Install a specific tag instead of latest
+#   $env:OCTOPUS_INSTALL_API   Override the GitHub API base URL (default: https://api.github.com)
+#   $env:OCTOPUS_INSTALL_RESOLVE_ONLY=1  Print the resolved tag and exit without downloading
+#   $env:GITHUB_TOKEN          Optional; authenticates the release lookup (higher API rate limit)
 
 $ErrorActionPreference = "Stop"
 
 $Repo        = if ($env:OCTOPUS_INSTALL_REPO) { $env:OCTOPUS_INSTALL_REPO } else { "octopusreview/octopus" }
 $InstallDir  = if ($env:OCTOPUS_INSTALL_DIR)  { $env:OCTOPUS_INSTALL_DIR }  else { Join-Path $env:USERPROFILE ".octopus\bin" }
 $BinaryName  = "octp.exe"
+$ApiBase     = if ($env:OCTOPUS_INSTALL_API) { $env:OCTOPUS_INSTALL_API } else { "https://api.github.com" }
+$ApiHeaders  = @{ "User-Agent" = "octp-installer" }
+if ($env:GITHUB_TOKEN) { $ApiHeaders["Authorization"] = "Bearer $($env:GITHUB_TOKEN)" }
 
 # ── Step 1: arch ─────────────────────────────────────────────────────────────
 
@@ -45,17 +51,38 @@ if ($env:OCTOPUS_INSTALL_TAG) {
   Write-Host "Looking up latest octp release on $Repo ..."
   # Find the most recent NON-DRAFT, NON-PRERELEASE octp-v* tag.
   # Users testing prerelease tags can override via $env:OCTOPUS_INSTALL_TAG.
-  $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=30" -Headers @{ "User-Agent" = "octp-installer" }
-  $tag = (
-    $releases |
-      Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name -like "octp-v*" } |
-      Select-Object -First 1
-  ).tag_name
+  # Platform releases (v1.0.x) are cut far more often than octp releases, so
+  # the newest octp-v* tag is usually NOT on the first page. Walk the pages
+  # (newest first, 100 per request) until one turns up or the list ends (#775).
+  $tag = $null
+  $page = 1
+  # 10 x 100 is also GitHub's listing cap (page 11 returns HTTP 422); don't raise it.
+  $maxPages = 10
+  while ($page -le $maxPages) {
+    $response = Invoke-RestMethod -Uri "$ApiBase/repos/$Repo/releases?per_page=100&page=$page" -Headers $ApiHeaders
+    # PowerShell 7 emits the JSON array as ONE object (so @(Invoke-RestMethod ...)
+    # would be a 1-element array holding the whole page) and 5.1 emits $null for
+    # an empty page. Piping enumerates both into a flat list of release objects.
+    $releases = @($response | Where-Object { $null -ne $_ })
+    if ($releases.Count -eq 0) { break }   # walked past the last page
+    $tag = (
+      $releases |
+        Where-Object { -not $_.draft -and -not $_.prerelease -and $_.tag_name -like "octp-v*" } |
+        Select-Object -First 1
+    ).tag_name
+    if ($tag) { break }
+    $page++
+  }
   if (-not $tag) {
     Write-Error "Could not find any non-prerelease octp-v* on $Repo. Pin a tag with `$env:OCTOPUS_INSTALL_TAG = 'octp-v0.X.Y'`."
     exit 1
   }
   Write-Host "Latest release: $tag"
+}
+
+if ($env:OCTOPUS_INSTALL_RESOLVE_ONLY -eq "1") {
+  Write-Host "Resolved $tag (OCTOPUS_INSTALL_RESOLVE_ONLY=1: nothing downloaded)."
+  exit 0
 }
 
 # ── Step 3: download ─────────────────────────────────────────────────────────

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -28,6 +28,9 @@
 #   OCTOPUS_INSTALL_DIR  Override install directory (default: $HOME/.octopus/bin)
 #   OCTOPUS_INSTALL_REPO Override the GitHub repo (default: octopusreview/octopus)
 #   OCTOPUS_INSTALL_TAG  Install a specific tag instead of latest (e.g. octp-v0.2.0)
+#   OCTOPUS_INSTALL_API  Override the GitHub API base URL (default: https://api.github.com)
+#   OCTOPUS_INSTALL_RESOLVE_ONLY=1  Print the resolved tag and exit without downloading
+#   GITHUB_TOKEN         Optional; authenticates the release lookup (higher API rate limit)
 #
 # Exit codes:
 #   0 success
@@ -38,6 +41,15 @@ set -euo pipefail
 REPO="${OCTOPUS_INSTALL_REPO:-octopusreview/octopus}"
 INSTALL_DIR="${OCTOPUS_INSTALL_DIR:-$HOME/.octopus/bin}"
 BINARY_NAME="octp"
+API_BASE="${OCTOPUS_INSTALL_API:-https://api.github.com}"
+# Releases are listed newest-first, 100 per page; MAX_PAGES bounds the walk.
+# 10 x 100 is also GitHub's listing cap (page 11 returns HTTP 422), so don't
+# raise it — an octp release older than 1000 platform releases needs a re-cut.
+MAX_PAGES=10
+auth_header=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
 
 # ── Step 1: detect platform ──────────────────────────────────────────────────
 
@@ -89,23 +101,55 @@ else
   # POSIX class is used everywhere else for the same portability reason
   # (GNU `\s` would silently match "s" on busybox grep / BSD sed).
   # Users testing prerelease tags can still override via OCTOPUS_INSTALL_TAG.
-  api_url="https://api.github.com/repos/${REPO}/releases?per_page=30"
-  tag=$(
-    curl -fsSL "$api_url" \
-      | sed 's/},{/}\
+  #
+  # Platform releases (v1.0.x) are cut far more often than octp releases, so
+  # the newest octp-v* tag is usually NOT on the first page. Walk the pages
+  # (newest first, 100 per request) until one turns up or the list ends (#775).
+  # A no-match grep exits 1, which under `pipefail` would abort the whole
+  # script silently — hence the `|| true`.
+  tag=""
+  page=1
+  while [ "$page" -le "$MAX_PAGES" ]; do
+    api_url="${API_BASE}/repos/${REPO}/releases?per_page=100&page=${page}"
+    if ! body=$(curl -fsSL --retry 3 --retry-delay 1 ${auth_header[@]+"${auth_header[@]}"} "$api_url"); then
+      echo "Error: GitHub API request failed: $api_url" >&2
+      echo "If you are rate-limited, set GITHUB_TOKEN to authenticate the lookup." >&2
+      exit 1
+    fi
+    # GitHub pretty-prints its JSON (one field per line). Strip ALL whitespace
+    # first so the `},{` object boundaries and the empty page `[]` are literal;
+    # nothing we match on (tag names, draft/prerelease flags) contains spaces.
+    body=$(printf '%s' "$body" | tr -d '[:space:]')
+    # An empty array means we walked past the last page.
+    if [ "$body" = "[]" ]; then
+      break
+    fi
+    tag=$(
+      printf '%s' "$body" \
+        | sed 's/},{/}\
 {/g' \
-      | grep -v '"draft"[[:space:]]*:[[:space:]]*true' \
-      | grep -v '"prerelease"[[:space:]]*:[[:space:]]*true' \
-      | grep -E '"tag_name"[[:space:]]*:[[:space:]]*"octp-v' \
-      | head -1 \
-      | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
-  )
+        | grep -v '"draft"[[:space:]]*:[[:space:]]*true' \
+        | grep -v '"prerelease"[[:space:]]*:[[:space:]]*true' \
+        | grep -E '"tag_name"[[:space:]]*:[[:space:]]*"octp-v' \
+        | head -1 \
+        | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+    ) || true
+    if [ -n "$tag" ]; then
+      break
+    fi
+    page=$((page + 1))
+  done
   if [ -z "$tag" ]; then
     echo "Error: could not find any non-prerelease octp-v* on $REPO." >&2
     echo "If you are testing a prerelease, pin a tag with OCTOPUS_INSTALL_TAG=octp-v0.X.Y" >&2
     exit 1
   fi
   echo "Latest release: $tag"
+fi
+
+if [ "${OCTOPUS_INSTALL_RESOLVE_ONLY:-0}" = "1" ]; then
+  echo "Resolved $tag (OCTOPUS_INSTALL_RESOLVE_ONLY=1: nothing downloaded)."
+  exit 0
 fi
 
 # ── Step 3: download ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #775

## What

`curl -fsSL https://octopus-review.ai/install.sh | bash` has been failing for every new user. Both installers resolved "latest octp release" from a single page of 30 GitHub releases. Platform releases (`v1.0.x`) are cut far more often than octp releases, so `octp-v0.2.0` fell off that page weeks ago and the lookup found nothing.

The failure was also silent: a no-match `grep` under `set -o pipefail` aborted the script before the "could not find" message printed. Users saw only "Looking up latest octp release" and exit 1.

## Changes

- **Paginate the lookup** in `install.sh` and `install.ps1`: 100 releases per page, newest first, stop at the first `octp-v*` that is neither draft nor prerelease, or at the first empty page. Capped at 10 pages, which is also GitHub's listing limit.
- **No more silent abort**: the parse pipeline tolerates a no-match, and an API request failure now prints the URL and a hint about `GITHUB_TOKEN`. The lookup `curl` also retries transient errors (a live run hit a 504 while testing).
- **Bash parser now handles GitHub's real output.** The API pretty-prints JSON, one field per line, so the existing `},{` line-splitting never split anything and the per-line draft/prerelease filter was a no-op. On today's data that meant the first `octp-v` string won regardless of flags: fed a page containing a draft `octp-v0.3.0`, the old pipeline picked the draft. The body is whitespace-stripped before parsing, which also makes the empty page (`[\n\n]`) detectable.
- **PowerShell loop fixed.** In PowerShell 7 `Invoke-RestMethod` emits a JSON array as one object, so `@(Invoke-RestMethod …)` was a one-element array holding the whole page: the count was never 0 and the filter compared arrays, not releases. Verified in a `pwsh` 7.4 container: it walked all 10 pages and found nothing. Now the response is enumerated through the pipeline, which also normalises Windows PowerShell 5.1's `$null` for an empty page.
- **Optional `GITHUB_TOKEN`** authenticates the lookup for CI or rate-limited networks. Opt-in, only sent to the API base, never logged. The binary download URL is unchanged and still hard-coded to `github.com`.
- **Test hooks**: `OCTOPUS_INSTALL_API` overrides the API base, `OCTOPUS_INSTALL_RESOLVE_ONLY=1` prints the resolved tag and exits before downloading. Both documented in the script headers.
- Public copies in `apps/web/public/` regenerated with `scripts/sync-installers.sh`; the drift check passes.

## Tests

- New `apps/cli/install/install.test.ts` (bun): a local fixture API serves pretty-printed pages the way api.github.com does, with the only valid octp release on page 2 behind a draft and a prerelease octp entry. Asserts the resolved tag, the exact page requests, the failure path when no octp release exists on any page, and that the bearer token reaches the API. The test env pins `OCTOPUS_INSTALL_TAG`, `GITHUB_TOKEN` and `OCTOPUS_INSTALL_DIR` so a developer's shell cannot leak into it. PowerShell cases run wherever `pwsh` exists (skipped on macOS, run on the ubuntu CI runner). Red before the fix, green after.
- CI (`sync-installers-check.yml`): adds the fixture tests and a live resolve probe for both scripts on installer PRs, plus a daily schedule so a future platform-release pile-up cannot break the installer without CI noticing.
- Verified live from this branch: `install.sh` resolves `octp-v0.2.0` and a full install into a scratch directory verifies the SHA256 and produces a working `octp 0.2.0`, under macOS `/bin/bash` 3.2 with and without a token. `install.ps1` verified in a `pwsh` 7.4 Linux container against both the fixture (2 requests when found, 3 when not) and the live API. `shellcheck` clean.

## Not in this PR

`octp update` on the 0.2.0 binary compares against a stale `CURRENT = "0.1.0"` constant, so it always reports an update available. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175zE3idX8JUhbsLb4qCXk9
