### PR TITLE
fix(docs): escape apostrophe on the pricing page so lint passes

### DIFF
--- a/apps/web/app/(landing)/docs/pricing/page.tsx
+++ b/apps/web/app/(landing)/docs/pricing/page.tsx
@@ -103,7 +103,7 @@ export default function PricingPage() {
       <Section title="Model Pricing">
         <P>
           Credit consumption varies by model. Octopus Cloud bills usage at 2x
-          the provider's list price; that multiple is the platform rate, and
+          the provider&apos;s list price; that multiple is the platform rate, and
           there are no other fees. Below are the provider list prices per 1M
           tokens:
         </P>


### PR DESCRIPTION
master CI has been red since the pricing copy changed to "the provider's list price": `react/no-unescaped-entities` at `docs/pricing/page.tsx:106`. One-character fix so PR checks can go green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175zE3idX8JUhbsLb4qCXk9