### PR TITLE
docs(cli): describe the native octp CLI; single version source for update.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Octopus analyzes pull and merge requests via GitHub, GitLab, and Bitbucket webho
 - **Repo Config Files** — Honor `.octopus.md`, `AGENTS.md`, or `CLAUDE.md` as repo-scoped review rules, extracted in a sandboxed pass
 - **Slack Integration** — Ask questions about your codebase directly from Slack
 - **Linear & Jira Integration** — Create issues from review findings with one click
-- **CLI** — `@octp/cli` for local review runs, plus a Claude Code skill for terminal workflows
+- **CLI** — `octp`, a native single-binary CLI for local review runs (`curl -fsSL https://octopus-review.ai/install.sh | bash`), plus a Claude Code skill for terminal workflows
 - **Review Output Language** — Org-level setting for the prose language of summaries and findings (code stays in source language)
 - **Repository Graph** — Structural and semantic edges across your codebase
 - **Real-time Updates** — Live dashboard updates via WebSocket (Pubby)
@@ -57,7 +57,7 @@ Octopus analyzes pull and merge requests via GitHub, GitLab, and Bitbucket webho
 octopus/
 ├── apps/
 │   ├── web/              # Next.js web application
-│   └── cli/              # octp CLI (@octp/cli)
+│   └── cli/              # octp CLI (native single binary)
 ├── packages/
 │   └── db/               # Prisma schema & shared DB client
 └── tools/

--- a/apps/cli/src/commands/update.ts
+++ b/apps/cli/src/commands/update.ts
@@ -2,10 +2,11 @@ import { loadCredentials } from "../lib/credentials.js";
 import { getJson } from "../lib/api.js";
 import { hasFlag } from "../lib/args.js";
 import { error, info, success, c } from "../lib/output.js";
+import pkg from "../../package.json" with { type: "json" };
 
-// Must track VERSION in index.tsx. The compiled binary has no package.json to
-// read from at runtime, so the current version is hardcoded here.
-const CURRENT = "0.1.0";
+// Version comes from package.json, inlined by the bundler at compile time —
+// the compiled binary has no package.json to read from at runtime.
+const CURRENT = pkg.version;
 
 const RELEASES_URL = "https://api.github.com/repos/octopusreview/octopus/releases";
 const TAG_PREFIX = "octp-v";

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -22,8 +22,9 @@ import { accountCommand } from "./commands/account.js";
 import { ensureProfilesMigrated, isValidProfileName, ensureProfile, setActiveProfile } from "./lib/profile.js";
 import { setActiveProfileOverride } from "./lib/paths.js";
 import { flagValue } from "./lib/args.js";
+import pkg from "../package.json" with { type: "json" };
 
-const VERSION = "0.2.0";
+const VERSION = pkg.version;
 
 /** Remove a `--flag <value>` pair from argv (the value is dropped only when the
  *  next token isn't itself a flag). Used to peel the global --account/--profile


### PR DESCRIPTION
## Summary

- `README.md`: the CLI is described as the native single-binary `octp` (curl installer) instead of the superseded npm `@octp/cli`.
- `apps/cli/src/commands/update.ts` hardcoded `CURRENT = "0.1.0"` while the CLI is 0.2.0. It and `index.tsx`'s `VERSION` literal now read `apps/cli/package.json` (Bun inlines the JSON import at compile time), so the release flow's version bump is the single source of truth.

## Verification

- `cd apps/cli && bun run typecheck` — clean
- `bun test` — 111 pass / 2 skip / 0 fail
- `bun src/index.tsx --version` → `0.2.0` (unchanged)

Historical notes ("replaces the previous npm-published @octp/cli") and `CHANGELOG.md` are intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nbamv223vVATSB2YUDHXGi
