### PR TITLE
fix(review): pin "Last reviewed commit" to the full head SHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The review comment's `Last reviewed commit:` line is now written from the pull request's recorded head SHA (full 40 characters) instead of whatever the model wrote; re-reviews sometimes emitted the 7-character form, which merge gates that bind a review to an exact commit reject as malformed.
+
 ## [1.0.127] - 2026-09-02
 
 ### Fixed

--- a/apps/web/lib/__tests__/score-normalize.test.ts
+++ b/apps/web/lib/__tests__/score-normalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { normalizeScoreDenominators, reconcileScoreTable } from "@/lib/review-helpers";
+import { normalizeScoreDenominators, reconcileScoreTable, normalizeLastReviewedCommit } from "@/lib/review-helpers";
 
 const scoreSection = (rows: string) => `## 🐙 Octopus Review — PR #42
 
@@ -129,5 +129,25 @@ describe("reconcileScoreTable", () => {
   it("no-ops when there is no Score table", () => {
     const body = "### Summary\nAll good, nothing to score.\n";
     expect(reconcileScoreTable(body, noFindings)).toBe(body);
+  });
+});
+
+describe("normalizeLastReviewedCommit", () => {
+  const sha = "9e794def0fbfe8df5f37a871fcf65bbb6ee5421a";
+
+  it("replaces a short SHA with the full reviewed head", () => {
+    const body = "### Diagram\n(none)\n\nLast reviewed commit: 9e794de\n\n### Checklist";
+    expect(normalizeLastReviewedCommit(body, sha)).toBe(`### Diagram\n(none)\n\nLast reviewed commit: ${sha}\n\n### Checklist`);
+  });
+
+  it("replaces a paraphrased or placeholder value too", () => {
+    const body = "Last reviewed commit: current head";
+    expect(normalizeLastReviewedCommit(body, sha)).toBe(`Last reviewed commit: ${sha}`);
+  });
+
+  it("leaves the body alone without the line or without a valid head", () => {
+    expect(normalizeLastReviewedCommit("### Checklist\n- [ ] x", sha)).toBe("### Checklist\n- [ ] x");
+    expect(normalizeLastReviewedCommit("Last reviewed commit: 9e794de", null)).toBe("Last reviewed commit: 9e794de");
+    expect(normalizeLastReviewedCommit("Last reviewed commit: 9e794de", "not-a-sha")).toBe("Last reviewed commit: 9e794de");
   });
 });

--- a/apps/web/lib/review-helpers.ts
+++ b/apps/web/lib/review-helpers.ts
@@ -153,6 +153,21 @@ export const MIN_SCORE_WITHOUT_BLOCKING_FINDINGS = 4;
  * and fractions elsewhere in the body are preserved. Assumes denominators are
  * already `/5` (normalizeScoreDenominators runs first).
  */
+/**
+ * Pin the "Last reviewed commit:" line to the exact reviewed head SHA.
+ *
+ * The model writes this line from the prompt template and sometimes copies the
+ * short-SHA style of the example, or paraphrases it. Downstream consumers (merge
+ * gates that verify a review belongs to an exact commit) need the full
+ * 40-character SHA, so the value is rewritten from the pull request's recorded
+ * head rather than trusted from the model. Bodies without the line, or reviews
+ * without a known head, are returned unchanged.
+ */
+export function normalizeLastReviewedCommit(reviewBody: string, headSha: string | null | undefined): string {
+  if (!headSha || !/^[0-9a-f]{40}$/i.test(headSha)) return reviewBody;
+  return reviewBody.replace(/^([ \t]*)Last reviewed commit:[^\n]*$/m, `$1Last reviewed commit: ${headSha}`);
+}
+
 export function reconcileScoreTable(
   reviewBody: string,
   findings: { hasCritical: boolean; hasHigh: boolean; hasMedium: boolean },

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -78,6 +78,7 @@ import {
   generateVerificationQueries,
   resolveIndexClaimWait,
   normalizeScoreDenominators,
+  normalizeLastReviewedCommit,
   reconcileScoreTable,
   shouldFailReviewCheck,
   formatPastReviews,
@@ -1866,6 +1867,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
 
     // Fix wrong score denominators ("4/4" → "4/5") in the Score table
     reviewBody = normalizeScoreDenominators(reviewBody);
+    reviewBody = normalizeLastReviewedCommit(reviewBody, pr.headSha);
 
     // Strip empty diagram sections: remove "### Diagram" when there's no meaningful mermaid content.
     // Matches from "### Diagram" up to the next ### heading or end of string.

--- a/apps/web/prompts/SYSTEM_PROMPT.md
+++ b/apps/web/prompts/SYSTEM_PROMPT.md
@@ -208,7 +208,7 @@ If this PR contains meaningful code changes, choose the BEST diagram type (see <
 ```
 If the PR only changes documentation, config files, or text content (README, markdown, comments, .env examples, etc.), OMIT this section entirely — no diagram needed.
 
-Last reviewed commit: abc1234
+Last reviewed commit: <full 40-character commit SHA of the reviewed head>
 
 ### Checklist
 - [ ] No hardcoded secrets or credentials


### PR DESCRIPTION
## What

The review comment's `Last reviewed commit:` line is written by the model from the prompt template. Re-reviews sometimes copied the template example's 7-character style (`9e794de`) while first reviews wrote the full SHA. Consumers that bind a review to an exact commit (a merge gate in one of our own repos parses this line and requires the full 40-character SHA or `current head`) reject the short form as malformed, so a passing re-review could not unblock a merge.

- `review-helpers.ts`: `normalizeLastReviewedCommit(body, headSha)` rewrites the line's value from the pull request's recorded head (only when the head is a valid 40-hex SHA; bodies without the line are untouched).
- `reviewer.ts`: applied right after `normalizeScoreDenominators`, so both the initial and the re-review paths post the pinned value.
- `SYSTEM_PROMPT.md`: the example no longer shows a short SHA.
- Tests: 3 cases in `score-normalize.test.ts` (16/16 pass). Changelog under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3NtKFLyYaUHqsfG57z7AJ
