### PR TITLE
chore(cli): octp 0.3.0 release — version bump + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- New native CLI release: `octp` 0.3.0 — re-run the installer to pick it up. The binary now ships the current model catalog (Claude Fable 5 max tier; Claude Opus 4.8 replaces 4.6), and the repository wizard opens the signed GitHub App install flow.
+
+### Fixed
+- `octp update` compares against the installed version correctly. The previous binary always believed it was 0.1.0, so it kept offering an upgrade you already had.
+- The local repository index that `octp` builds no longer follows symlinks or reads files outside the repository, so a checkout cannot make the CLI read files from elsewhere on your machine.
+
 ## [1.0.128] - 2026-09-02
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octopus/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "Octopus CLI. Native single-binary distribution via curl/irm. Includes a first-run TUI onboarding wizard.",


### PR DESCRIPTION
## Summary

- `apps/cli/package.json`: 0.2.0 → 0.3.0. The only `octp` release so far is `octp-v0.2.0` (2026-07-05); the CLI source has since picked up the local-index security hardening, the current model catalog, the signed GitHub App install flow in the repo wizard, and (via #781) the `octp update` version fix.
- `CHANGELOG.md` `[Unreleased]`: consumer-facing notes for the 0.3.0 binary only — no docs/internal churn.

## Release steps (after merge)

Merge **after #781** so the binary carries the version-source fix, then tag the merge commit on `master`:

```
git tag octp-v0.3.0 <merge-sha> && git push origin octp-v0.3.0
```

`octp-release.yml` cross-compiles the five binaries and publishes the GitHub Release; `install.sh` / `install.ps1` pick it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)