### PR TITLE
feat(providers): add Alibaba Cloud Model Studio (Qwen) as a review vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Alibaba Cloud Model Studio as a review provider: Qwen models (starting with `qwen3.8-max-0902`, $2/$6 per 1M tokens) via the OpenAI-compatible DashScope endpoint, with per-organization BYOK, `DASHSCOPE_API_KEY` as the platform key and `DASHSCOPE_BASE_URL` to select the China endpoint. Thinking mode follows the model default and can be switched off per call.
+
 ### Changed
 - New native CLI release: `octp` 0.3.0 — re-run the installer to pick it up. The binary now ships the current model catalog (Claude Fable 5 max tier; Claude Opus 4.8 replaces 4.6), and the repository wizard opens the signed GitHub App install flow.
 

--- a/apps/cli/src/__tests__/models.test.ts
+++ b/apps/cli/src/__tests__/models.test.ts
@@ -24,6 +24,7 @@ describe("defaultModelFor", () => {
     expect(defaultModelFor("anthropic")?.modelId).toBe("claude-sonnet-4-6-20250619");
     expect(defaultModelFor("openai")?.modelId).toBe("gpt-4o");
     expect(defaultModelFor("google")?.modelId).toBe("gemini-2.5-pro");
+    expect(defaultModelFor("alibaba")?.modelId).toBe("qwen3.8-max-0902");
   });
 
   it("returns null for an empty catalogue", () => {

--- a/apps/cli/src/__tests__/providers.test.ts
+++ b/apps/cli/src/__tests__/providers.test.ts
@@ -12,6 +12,7 @@ describe("PROVIDERS catalogue", () => {
     expect(ready).toContain("anthropic");
     expect(ready).toContain("openai");
     expect(ready).toContain("google");
+    expect(ready).toContain("alibaba");
   });
 
   it("every provider has displayName and blurb populated", () => {

--- a/apps/cli/src/lib/keys.ts
+++ b/apps/cli/src/lib/keys.ts
@@ -35,6 +35,11 @@ export const KEY_HINTS: Record<string, KeyHint> = {
     dashboardUrl: "https://console.x.ai",
     minLength: 20,
   },
+  alibaba: {
+    placeholder: "sk-…",
+    dashboardUrl: "https://modelstudio.console.alibabacloud.com/?tab=model#/api-key",
+    minLength: 20,
+  },
   openrouter: {
     placeholder: "sk-or-…",
     dashboardUrl: "https://openrouter.ai/keys",

--- a/apps/cli/src/lib/models.ts
+++ b/apps/cli/src/lib/models.ts
@@ -43,6 +43,9 @@ export const MODELS_BY_PROVIDER: Record<string, ModelInfo[]> = {
     { modelId: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro", inputPrice: 1.25, outputPrice: 10, isDefault: true },
     { modelId: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash", inputPrice: 0.15, outputPrice: 0.6 },
   ],
+  alibaba: [
+    { modelId: "qwen3.8-max-0902", displayName: "Qwen3.8-Max-0902", inputPrice: 2, outputPrice: 6, isDefault: true },
+  ],
   // Coming-soon providers: empty until their model lists are seeded by the
   // backend. The CLI handles the empty case with a friendly message.
   "claude-code": [],

--- a/apps/cli/src/lib/providers.ts
+++ b/apps/cli/src/lib/providers.ts
@@ -45,6 +45,13 @@ export const PROVIDERS: ProviderInfo[] = [
     blurb: "Direct Google Generative AI API. BYOK.",
     status: "ready",
   },
+  {
+    slug: "alibaba",
+    displayName: "Alibaba Cloud Model Studio",
+    type: "direct",
+    blurb: "OpenAI-compatible DashScope API (Qwen models). BYOK.",
+    status: "ready",
+  },
 
   // Coming soon — tracked under Workstream 5.
   {

--- a/apps/cli/src/lib/validate.ts
+++ b/apps/cli/src/lib/validate.ts
@@ -9,7 +9,7 @@ import { loadConfig, DEFAULT_OLLAMA_BASE_URL } from "./config.js";
  *   openai     → GET /v1/models
  *   google     → GET /v1beta/models?key=…
  *   grok       → GET /v1/models (OpenAI-compatible at https://api.x.ai/v1)
- *   alibaba    → GET /v1/models (OpenAI-compatible at https://dashscope-intl.aliyuncs.com/compatible-mode/v1)
+ *   alibaba    → GET /v1/models (OpenAI-compatible at https://dashscope-intl.aliyuncs.com/compatible-mode/v1, or DASHSCOPE_BASE_URL)
  *   openrouter → GET /api/v1/models (no auth even, but we send the key for sanity)
  *   ollama     → GET http://localhost:11434/api/tags (local; no key needed)
  *
@@ -33,8 +33,12 @@ export async function validateProvider(provider: string): Promise<ValidateResult
       return await validateOpenAi("https://api.openai.com/v1/models", key);
     case "grok":
       return await validateOpenAi("https://api.x.ai/v1/models", key);
-    case "alibaba":
-      return await validateOpenAi("https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models", key);
+    case "alibaba": {
+      // Keys are region-scoped; honour the same override the server uses so a
+      // China-region key validates against the China endpoint.
+      const base = (process.env.DASHSCOPE_BASE_URL?.trim() || "https://dashscope-intl.aliyuncs.com/compatible-mode/v1").replace(/\/+$/, "");
+      return await validateOpenAi(`${base}/models`, key);
+    }
     case "openrouter":
       return await validateOpenAi("https://openrouter.ai/api/v1/models", key);
     case "google":

--- a/apps/cli/src/lib/validate.ts
+++ b/apps/cli/src/lib/validate.ts
@@ -9,6 +9,7 @@ import { loadConfig, DEFAULT_OLLAMA_BASE_URL } from "./config.js";
  *   openai     → GET /v1/models
  *   google     → GET /v1beta/models?key=…
  *   grok       → GET /v1/models (OpenAI-compatible at https://api.x.ai/v1)
+ *   alibaba    → GET /v1/models (OpenAI-compatible at https://dashscope-intl.aliyuncs.com/compatible-mode/v1)
  *   openrouter → GET /api/v1/models (no auth even, but we send the key for sanity)
  *   ollama     → GET http://localhost:11434/api/tags (local; no key needed)
  *
@@ -32,6 +33,8 @@ export async function validateProvider(provider: string): Promise<ValidateResult
       return await validateOpenAi("https://api.openai.com/v1/models", key);
     case "grok":
       return await validateOpenAi("https://api.x.ai/v1/models", key);
+    case "alibaba":
+      return await validateOpenAi("https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models", key);
     case "openrouter":
       return await validateOpenAi("https://openrouter.ai/api/v1/models", key);
     case "google":

--- a/apps/web/app/(app)/actions.ts
+++ b/apps/web/app/(app)/actions.ts
@@ -283,6 +283,7 @@ export async function updateApiKeys(
   const cohereApiKey = (formData.get("cohereApiKey") as string)?.trim() || null;
   const grokApiKey = (formData.get("grokApiKey") as string)?.trim() || null;
   const openrouterApiKey = (formData.get("openrouterApiKey") as string)?.trim() || null;
+  const alibabaApiKey = (formData.get("alibabaApiKey") as string)?.trim() || null;
 
   if (openaiApiKey && !openaiApiKey.startsWith("sk-")) {
     return { error: "Invalid OpenAI API key format." };
@@ -304,6 +305,10 @@ export async function updateApiKeys(
     return { error: "Invalid OpenRouter API key format." };
   }
 
+  if (alibabaApiKey && !alibabaApiKey.startsWith("sk-")) {
+    return { error: "Invalid Alibaba Cloud Model Studio API key format." };
+  }
+
   // Only update keys that have new values — empty fields keep the existing key.
   // Keys are encrypted at rest with the same helper used for OAuth tokens.
   const data: Record<string, string | null> = {};
@@ -313,6 +318,7 @@ export async function updateApiKeys(
   if (cohereApiKey) data.cohereApiKey = encryptString(cohereApiKey);
   if (grokApiKey) data.grokApiKey = encryptString(grokApiKey);
   if (openrouterApiKey) data.openrouterApiKey = encryptString(openrouterApiKey);
+  if (alibabaApiKey) data.alibabaApiKey = encryptString(alibabaApiKey);
 
   // Per-org provider config: gateway/base-URL overrides + gateway API keys.
   // These clear when submitted empty — a present-but-empty field sets the
@@ -356,7 +362,7 @@ export async function updateApiKeys(
   return { success: true };
 }
 
-const VALID_KEY_FIELDS = ["openaiApiKey", "anthropicApiKey", "googleApiKey", "cohereApiKey", "grokApiKey", "openrouterApiKey"] as const;
+const VALID_KEY_FIELDS = ["openaiApiKey", "anthropicApiKey", "googleApiKey", "cohereApiKey", "grokApiKey", "openrouterApiKey", "alibabaApiKey"] as const;
 
 export async function removeApiKey(
   keyField: (typeof VALID_KEY_FIELDS)[number],

--- a/apps/web/app/(app)/settings/api-keys-form.tsx
+++ b/apps/web/app/(app)/settings/api-keys-form.tsx
@@ -23,6 +23,7 @@ export function ApiKeysForm({
   cohereApiKey,
   grokApiKey,
   openrouterApiKey,
+  alibabaApiKey,
   isOwner,
 }: {
   // Masked previews (e.g. "sk-abc••••••••wxyz"), not full keys. The server masks
@@ -33,12 +34,13 @@ export function ApiKeysForm({
   cohereApiKey: string | null;
   grokApiKey: string | null;
   openrouterApiKey: string | null;
+  alibabaApiKey: string | null;
   isOwner: boolean;
 }) {
   const [state, formAction, pending] = useActionState(updateApiKeys, {});
   const [removing, startTransition] = useTransition();
 
-  function handleRemove(keyField: "openaiApiKey" | "anthropicApiKey" | "googleApiKey" | "cohereApiKey" | "grokApiKey" | "openrouterApiKey") {
+  function handleRemove(keyField: "openaiApiKey" | "anthropicApiKey" | "googleApiKey" | "cohereApiKey" | "grokApiKey" | "openrouterApiKey" | "alibabaApiKey") {
     startTransition(async () => {
       try {
         await removeApiKey(keyField);
@@ -280,6 +282,43 @@ export function ApiKeysForm({
             </p>
           </div>
 
+          <Separator />
+
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="alibabaApiKey">Alibaba Cloud Model Studio</Label>
+              {alibabaApiKey ? (
+                <Badge variant="outline" className="gap-1 text-[10px] font-normal">
+                  {alibabaApiKey}
+                  {isOwner && (
+                    <button
+                      type="button"
+                      onClick={() => handleRemove("alibabaApiKey")}
+                      disabled={removing}
+                      className="text-muted-foreground hover:text-destructive -mr-1 ml-0.5"
+                    >
+                      <IconX size={12} />
+                    </button>
+                  )}
+                </Badge>
+              ) : (
+                <Badge variant="secondary" className="text-[10px] font-normal">
+                  Not set
+                </Badge>
+              )}
+            </div>
+            <Input
+              id="alibabaApiKey"
+              name="alibabaApiKey"
+              type="password"
+              placeholder="sk-..."
+              disabled={!isOwner}
+              autoComplete="off"
+            />
+            <p className="text-xs text-muted-foreground">
+              Required for Qwen models.
+            </p>
+          </div>
           {state.error && (
             <p className="text-sm text-destructive">{state.error}</p>
           )}

--- a/apps/web/app/(app)/settings/api-keys/page.tsx
+++ b/apps/web/app/(app)/settings/api-keys/page.tsx
@@ -41,6 +41,7 @@ export default async function ApiKeysPage() {
           cohereApiKey: true,
           grokApiKey: true,
           openrouterApiKey: true,
+          alibabaApiKey: true,
         },
       },
     },
@@ -59,6 +60,7 @@ export default async function ApiKeysPage() {
       cohereApiKey={maskStoredKey(member.organization.cohereApiKey)}
       grokApiKey={maskStoredKey(member.organization.grokApiKey)}
       openrouterApiKey={maskStoredKey(member.organization.openrouterApiKey)}
+      alibabaApiKey={maskStoredKey(member.organization.alibabaApiKey)}
       isOwner={canManage}
     />
   );

--- a/apps/web/app/(landing)/docs/security-overview/page.tsx
+++ b/apps/web/app/(landing)/docs/security-overview/page.tsx
@@ -55,7 +55,8 @@ export default function SecurityOverviewPage() {
       <Section title="3. Secrets handling">
         <P>
           BYOK API keys (Anthropic / OpenAI / Google / Cohere / Grok /
-          OpenRouter / ACPX / OpenCode) are stored as nullable columns on the
+          OpenRouter / Alibaba Cloud Model Studio / ACPX / OpenCode) are
+          stored as nullable columns on the
           Organization row, accessible only through the AI router on the
           server. They are never returned over the API, never logged, and
           never sent to the LLM provider as anything other than an HTTP

--- a/apps/web/app/(landing)/docs/self-hosting/page.tsx
+++ b/apps/web/app/(landing)/docs/self-hosting/page.tsx
@@ -292,6 +292,8 @@ docker compose exec ollama ollama pull nomic-embed-text`}</CodeBlock>
           <EnvVar name="GOOGLE_API_KEY" example="AIza..." description="Gemini models" />
           <EnvVar name="GROK_API_KEY" example="xai-..." description="xAI Grok models" />
           <EnvVar name="OPENROUTER_API_KEY" example="sk-or-..." description="OpenRouter — many model vendors via one key" />
+          <EnvVar name="DASHSCOPE_API_KEY" example="sk-..." description="Alibaba Cloud Model Studio (Qwen) models" />
+          <EnvVar name="DASHSCOPE_BASE_URL" example="https://dashscope.aliyuncs.com/compatible-mode/v1" description="Optional: DashScope endpoint override (default is the international endpoint; set the China endpoint here)" />
           <EnvVar name="OLLAMA_SERVER_URL" example="http://localhost:11434" description="Self-hosted Ollama (ollama: model ids); optional OLLAMA_USERNAME / OLLAMA_PASSWORD for a proxied host" />
           <EnvVar name="ACP_BASE_URL" example="https://acpx.example.com" description="ACPX gateway (acp: model ids); set together with ACP_API_KEY" />
           <EnvVar name="OPENCODE_BASE_URL" example="https://opencode.example.com" description="OpenCode gateway (opencode: model ids); set together with OPENCODE_API_KEY" />

--- a/apps/web/app/api/admin/models/discover/route.ts
+++ b/apps/web/app/api/admin/models/discover/route.ts
@@ -3,6 +3,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
 import { isAdminApiAuthorized } from "@/lib/admin-auth";
 import { prisma } from "@octopus/db";
+import { alibabaBaseUrl } from "@/lib/providers/alibaba-request";
 
 // Vendor admin "pull latest from provider": ask each provider's own API which
 // models exist, and diff against the available_models catalog. Lets the admin
@@ -130,6 +131,26 @@ async function discoverGrok(catalog: Set<string>): Promise<ProviderResult> {
   };
 }
 
+async function discoverAlibaba(catalog: Set<string>): Promise<ProviderResult> {
+  const key = process.env.DASHSCOPE_API_KEY;
+  if (!key) return { keyConfigured: false, newUpstream: [], inCatalogNotUpstream: [] };
+  // DashScope compatible-mode is OpenAI-compatible (same as the alibaba provider adapter).
+  const client = new OpenAI({ apiKey: key, baseURL: alibabaBaseUrl() });
+  const list = await client.models.list();
+  const upstreamIds = new Set<string>();
+  const upstream: DiscoveredModel[] = [];
+  for (const m of list.data) {
+    if (!/^qwen/i.test(m.id)) continue;
+    upstreamIds.add(m.id);
+    upstream.push({ id: m.id, displayName: titleCase(m.id) });
+  }
+  return {
+    keyConfigured: true,
+    newUpstream: upstream.filter((m) => !catalog.has(m.id)),
+    inCatalogNotUpstream: [...catalog].filter((id) => !upstreamIds.has(id)),
+  };
+}
+
 // OpenRouter lists 300+ models; surface only notable labs (plus anything Kimi)
 // so the panel isn't flooded. Ids are namespaced "lab/model" (the grok/
 // openrouter adapters pass them verbatim).
@@ -207,16 +228,17 @@ export async function GET(request: NextRequest) {
     }
   };
 
-  const [anthropic, openai, google, grok, openrouter] = await Promise.all([
+  const [anthropic, openai, google, grok, openrouter, alibaba] = await Promise.all([
     settle(() => discoverAnthropic(byProvider("anthropic"))),
     settle(() => discoverOpenAI(byProvider("openai"))),
     settle(() => discoverGoogle(byProvider("google"))),
     settle(() => discoverGrok(byProvider("grok"))),
     settle(() => discoverOpenRouter(byProvider("openrouter"))),
+    settle(() => discoverAlibaba(byProvider("alibaba"))),
   ]);
 
   return NextResponse.json({
     ok: true,
-    providers: { anthropic, openai, google, grok, openrouter },
+    providers: { anthropic, openai, google, grok, openrouter, alibaba },
   });
 }

--- a/apps/web/lib/__tests__/ai-router.test.ts
+++ b/apps/web/lib/__tests__/ai-router.test.ts
@@ -50,6 +50,7 @@ describe("resolveProvider", () => {
   it("infers real providers from model-name prefixes", async () => {
     expect(await resolveProvider("claude-sonnet-4-20250514")).toBe("anthropic");
     expect(await resolveProvider("gpt-4o")).toBe("openai");
+    expect(await resolveProvider("qwen3.8-max-0902")).toBe("alibaba");
     expect(await resolveProvider("gemini-2.0-flash")).toBe("google");
     expect(await resolveProvider("claude-code:sonnet")).toBe("claude-code");
   });

--- a/apps/web/lib/__tests__/alibaba-provider.test.ts
+++ b/apps/web/lib/__tests__/alibaba-provider.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// `server-only` throws outside a Next.js server context; neutralise it.
+mock.module("server-only", () => ({}));
+
+// Capture the exact wire body the adapter hands to the OpenAI SDK.
+let captured: Record<string, unknown> | null = null;
+let canned: Record<string, unknown> = {};
+mock.module("openai", () => {
+  class StubOpenAI {
+    chat = {
+      completions: {
+        create: (body: Record<string, unknown>) => {
+          captured = body;
+          return Promise.resolve(canned);
+        },
+      },
+    };
+  }
+  return { default: StubOpenAI };
+});
+
+const { alibabaProvider } = await import("@/lib/providers/alibaba");
+const { ALIBABA_THINKING_MAX_TOKENS_FLOOR } = await import("@/lib/providers/alibaba-request");
+
+const ok = (content: string | null, finish_reason = "stop") => ({
+  choices: [{ message: { content }, finish_reason }],
+  usage: { prompt_tokens: 120, completion_tokens: 30, prompt_tokens_details: { cached_tokens: 100 } },
+});
+
+describe("alibabaProvider.create — wire contract", () => {
+  beforeEach(() => {
+    captured = null;
+    canned = ok("answer");
+  });
+
+  it("sends max_completion_tokens (never max_tokens) and the system message first", async () => {
+    await alibabaProvider.create(
+      { model: "qwen3.8-max-0902", maxTokens: 8192, system: "sys", messages: [{ role: "user", content: "hi" }] },
+      "sk-byok",
+    );
+    expect(captured).not.toBeNull();
+    expect(captured!.max_completion_tokens).toBe(ALIBABA_THINKING_MAX_TOKENS_FLOOR);
+    expect("max_tokens" in captured!).toBe(false);
+    expect(captured!.messages).toEqual([
+      { role: "system", content: "sys" },
+      { role: "user", content: "hi" },
+    ]);
+    expect(captured!.enable_thinking).toBe(true);
+  });
+
+  it("turns thinking off with the exact cap when the caller disables it", async () => {
+    await alibabaProvider.create(
+      { model: "qwen3.8-max-0902", maxTokens: 256, thinking: "disabled", messages: [{ role: "user", content: "x" }] },
+      "sk-byok",
+    );
+    expect(captured!.enable_thinking).toBe(false);
+    expect(captured!.max_completion_tokens).toBe(256);
+  });
+
+  it("runs structured output thinking-off with a strict json_schema response_format", async () => {
+    canned = ok('{"a":1}');
+    await alibabaProvider.create(
+      {
+        model: "qwen3.8-max-0902",
+        maxTokens: 4096,
+        messages: [{ role: "user", content: "x" }],
+        responseSchema: { name: "Out", schema: { type: "object", properties: { a: { type: "number" } } } },
+      },
+      "sk-byok",
+    );
+    expect(captured!.enable_thinking).toBe(false);
+    expect(captured!.max_completion_tokens).toBe(4096);
+    expect(captured!.response_format).toEqual({
+      type: "json_schema",
+      json_schema: { name: "Out", schema: { type: "object", properties: { a: { type: "number" } } }, strict: true },
+    });
+  });
+
+  it("omits the vendor field for models outside the hybrid-thinking family", async () => {
+    await alibabaProvider.create(
+      { model: "qwen-plus", maxTokens: 2048, messages: [{ role: "user", content: "x" }] },
+      "sk-byok",
+    );
+    expect("enable_thinking" in captured!).toBe(false);
+    expect(captured!.max_completion_tokens).toBe(2048);
+  });
+
+  it("maps usage: completion_tokens as output, cached_tokens as cache reads, no cache writes", async () => {
+    const res = await alibabaProvider.create(
+      { model: "qwen3.8-max-0902", maxTokens: 8192, messages: [{ role: "user", content: "x" }] },
+      "sk-byok",
+    );
+    expect(res.provider).toBe("alibaba");
+    expect(res.text).toBe("answer");
+    expect(res.usage).toEqual({ inputTokens: 120, outputTokens: 30, cacheReadTokens: 100, cacheWriteTokens: 0 });
+  });
+
+  it("fails loudly when thinking consumed the whole completion budget", async () => {
+    canned = ok(null, "length");
+    await expect(
+      alibabaProvider.create({ model: "qwen3.8-max-0902", maxTokens: 8192, messages: [{ role: "user", content: "x" }] }, "sk-byok"),
+    ).rejects.toThrow(/max_completion_tokens/);
+  });
+
+  it("does not treat a plain empty stop as a thinking failure", async () => {
+    canned = ok("", "stop");
+    const res = await alibabaProvider.create(
+      { model: "qwen3.8-max-0902", maxTokens: 8192, messages: [{ role: "user", content: "x" }] },
+      "sk-byok",
+    );
+    expect(res.text).toBe("");
+  });
+});

--- a/apps/web/lib/__tests__/alibaba-request.test.ts
+++ b/apps/web/lib/__tests__/alibaba-request.test.ts
@@ -21,24 +21,35 @@ describe("alibabaBaseUrl", () => {
 
 describe("alibabaRequestShape", () => {
   it("keeps thinking on by default and raises the completion cap to the floor", () => {
-    expect(alibabaRequestShape({ maxTokens: 8192 })).toEqual({
+    expect(alibabaRequestShape({ model: "qwen3.8-max-0902", maxTokens: 8192 })).toEqual({
       maxCompletionTokens: ALIBABA_THINKING_MAX_TOKENS_FLOOR,
       enableThinking: true,
     });
-    expect(alibabaRequestShape({ maxTokens: 65_536 })).toEqual({ maxCompletionTokens: 65_536, enableThinking: true });
+    expect(alibabaRequestShape({ model: "qwen3.8-max", maxTokens: 65_536 })).toEqual({ maxCompletionTokens: 65_536, enableThinking: true });
   });
 
   it("turns thinking off and uses the exact cap when the caller asks", () => {
-    expect(alibabaRequestShape({ maxTokens: 256, thinking: "disabled" })).toEqual({
+    expect(alibabaRequestShape({ model: "qwen3.8-max-0902", maxTokens: 256, thinking: "disabled" })).toEqual({
       maxCompletionTokens: 256,
       enableThinking: false,
     });
   });
 
   it("turns thinking off for structured-output calls", () => {
-    expect(alibabaRequestShape({ maxTokens: 4096, responseSchema: { name: "x", schema: {} } })).toEqual({
+    expect(alibabaRequestShape({ model: "qwen3.8-max-0902", maxTokens: 4096, responseSchema: { name: "x", schema: {} } })).toEqual({
       maxCompletionTokens: 4096,
       enableThinking: false,
+    });
+  });
+
+  it("leaves models outside the hybrid-thinking family untouched (no vendor field, exact cap)", () => {
+    expect(alibabaRequestShape({ model: "qwen-plus", maxTokens: 8192 })).toEqual({
+      maxCompletionTokens: 8192,
+      enableThinking: undefined,
+    });
+    expect(alibabaRequestShape({ model: "qwen2.5-coder-32b-instruct", maxTokens: 4096, thinking: "disabled" })).toEqual({
+      maxCompletionTokens: 4096,
+      enableThinking: undefined,
     });
   });
 });

--- a/apps/web/lib/__tests__/alibaba-request.test.ts
+++ b/apps/web/lib/__tests__/alibaba-request.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "bun:test";
+import {
+  ALIBABA_DEFAULT_BASE_URL,
+  ALIBABA_THINKING_MAX_TOKENS_FLOOR,
+  alibabaBaseUrl,
+  alibabaRequestShape,
+} from "@/lib/providers/alibaba-request";
+
+describe("alibabaBaseUrl", () => {
+  it("defaults to the international endpoint", () => {
+    expect(alibabaBaseUrl({})).toBe(ALIBABA_DEFAULT_BASE_URL);
+    expect(alibabaBaseUrl({ DASHSCOPE_BASE_URL: "   " })).toBe(ALIBABA_DEFAULT_BASE_URL);
+  });
+
+  it("honours DASHSCOPE_BASE_URL (China endpoint) and trims trailing slashes", () => {
+    expect(alibabaBaseUrl({ DASHSCOPE_BASE_URL: "https://dashscope.aliyuncs.com/compatible-mode/v1/" })).toBe(
+      "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    );
+  });
+});
+
+describe("alibabaRequestShape", () => {
+  it("keeps thinking on by default and raises the completion cap to the floor", () => {
+    expect(alibabaRequestShape({ maxTokens: 8192 })).toEqual({
+      maxCompletionTokens: ALIBABA_THINKING_MAX_TOKENS_FLOOR,
+      enableThinking: true,
+    });
+    expect(alibabaRequestShape({ maxTokens: 65_536 })).toEqual({ maxCompletionTokens: 65_536, enableThinking: true });
+  });
+
+  it("turns thinking off and uses the exact cap when the caller asks", () => {
+    expect(alibabaRequestShape({ maxTokens: 256, thinking: "disabled" })).toEqual({
+      maxCompletionTokens: 256,
+      enableThinking: false,
+    });
+  });
+
+  it("turns thinking off for structured-output calls", () => {
+    expect(alibabaRequestShape({ maxTokens: 4096, responseSchema: { name: "x", schema: {} } })).toEqual({
+      maxCompletionTokens: 4096,
+      enableThinking: false,
+    });
+  });
+});

--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -2978,4 +2978,32 @@ describe("AiUsage cost snapshot", () => {
     expect(createdAiUsage[0].chargedCostUsd).toBeNull();
     expect(orgState).toEqual({ creditBalance: 20, freeCreditBalance: 8 });
   });
+
+  it("bills platform-key alibaba usage when the org has no Alibaba key", async () => {
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({
+        anthropicApiKey: null,
+        openaiApiKey: null,
+        cohereApiKey: null,
+        googleApiKey: null,
+        grokApiKey: null,
+        openrouterApiKey: null,
+        alibabaApiKey: null,
+        claudeCodeApiKey: null,
+        claudeCodeAuthMode: null,
+      } as never),
+    );
+
+    await logAiUsage({
+      provider: "alibaba",
+      model: "m",
+      operation: "review",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      organizationId: "org_1",
+    });
+
+    expect(createdAiUsage[0].usedOwnKey).toBe(false);
+    expect(createdAiUsage[0].chargedCostUsd).toBeGreaterThan(0);
+  });
 });

--- a/apps/web/lib/__tests__/billing.test.ts
+++ b/apps/web/lib/__tests__/billing.test.ts
@@ -2867,6 +2867,7 @@ describe("AiUsage cost snapshot", () => {
         googleApiKey: null,
         grokApiKey: null,
         openrouterApiKey: null,
+        alibabaApiKey: null,
         claudeCodeApiKey: null,
         claudeCodeAuthMode: null,
       } as never),
@@ -2898,6 +2899,7 @@ describe("AiUsage cost snapshot", () => {
         googleApiKey: null,
         grokApiKey: null,
         openrouterApiKey: null,
+        alibabaApiKey: null,
         claudeCodeApiKey: null,
         claudeCodeAuthMode: null,
       } as never),
@@ -2928,6 +2930,7 @@ describe("AiUsage cost snapshot", () => {
         googleApiKey: null,
         grokApiKey: null,
         openrouterApiKey: null,
+        alibabaApiKey: null,
         claudeCodeApiKey: null,
         claudeCodeAuthMode: null,
       } as never),
@@ -2935,6 +2938,35 @@ describe("AiUsage cost snapshot", () => {
 
     await logAiUsage({
       provider: "anthropic",
+      model: "m",
+      operation: "review",
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      organizationId: "org_1",
+    });
+
+    expect(createdAiUsage[0].usedOwnKey).toBe(true);
+    expect(createdAiUsage[0].chargedCostUsd).toBeNull();
+    expect(orgState).toEqual({ creditBalance: 20, freeCreditBalance: 8 });
+  });
+
+  it("stores null chargedCostUsd for own-Alibaba-key usage and never deducts", async () => {
+    mockOrganizationFindUnique = mock(() =>
+      Promise.resolve({
+        anthropicApiKey: null,
+        openaiApiKey: null,
+        cohereApiKey: null,
+        googleApiKey: null,
+        grokApiKey: null,
+        openrouterApiKey: null,
+        alibabaApiKey: "sk-ali-user",
+        claudeCodeApiKey: null,
+        claudeCodeAuthMode: null,
+      } as never),
+    );
+
+    await logAiUsage({
+      provider: "alibaba",
       model: "m",
       operation: "review",
       inputTokens: 1_000_000,

--- a/apps/web/lib/__tests__/review-routing.test.ts
+++ b/apps/web/lib/__tests__/review-routing.test.ts
@@ -74,6 +74,7 @@ describe("Opus 5 pricing (#opus-5 launch)", () => {
   it("claude-opus-5 has fallback pricing so it never bills $0", async () => {
     const { fallbackPricedModels } = await import("@/lib/cost");
     expect(fallbackPricedModels()).toContain("claude-opus-5");
+    expect(fallbackPricedModels()).toContain("qwen3.8-max-0902");
   });
 
   it("claude-opus-4-8 (replaces Opus 4.6) has fallback pricing", async () => {

--- a/apps/web/lib/__tests__/spend-limit.test.ts
+++ b/apps/web/lib/__tests__/spend-limit.test.ts
@@ -13,6 +13,7 @@ type OrgRow = {
   cohereApiKey: string | null;
   grokApiKey: string | null;
   openrouterApiKey: string | null;
+  alibabaApiKey: string | null;
   claudeCodeApiKey: string | null;
   claudeCodeAuthMode: string | null;
   monthlySpendLimitUsd: number | null;
@@ -37,6 +38,7 @@ function baseOrg(overrides: Partial<OrgRow> = {}): OrgRow {
     cohereApiKey: null,
     grokApiKey: null,
     openrouterApiKey: null,
+    alibabaApiKey: null,
     claudeCodeApiKey: null,
     claudeCodeAuthMode: null,
     monthlySpendLimitUsd: null,
@@ -79,6 +81,18 @@ describe("getOrgSpendLimitStatus — BYOK admission (B4)", () => {
     org = baseOrg({ anthropicApiKey: "sk-ant", creditBalance: 0, freeCreditBalance: 0 });
     provider = "anthropic";
     expect(await getOrgSpendLimitStatus("o")).toEqual({ blocked: false });
+  });
+
+  it("exempts an org with its own Alibaba Cloud Model Studio key when the review provider is alibaba", async () => {
+    org = baseOrg({ alibabaApiKey: "sk-ali", creditBalance: 0, freeCreditBalance: 0 });
+    provider = "alibaba";
+    expect(await getOrgSpendLimitStatus("o")).toEqual({ blocked: false });
+  });
+
+  it("does not let an Alibaba key exempt usage on another provider", async () => {
+    org = baseOrg({ alibabaApiKey: "sk-ali", creditBalance: 0, freeCreditBalance: 0 });
+    provider = "anthropic";
+    expect(await getOrgSpendLimitStatus("o")).toEqual({ blocked: true, reason: "no_credits" });
   });
 
   it("does NOT exempt when the org's only key is for a provider it does not use", async () => {

--- a/apps/web/lib/ai-router.ts
+++ b/apps/web/lib/ai-router.ts
@@ -29,6 +29,7 @@ const PROVIDER_FALLBACK: Record<string, AiProvider> = {
   // Native OpenRouter ids are vendor/model (e.g. "openai/gpt-4o") and resolve
   // via the AvailableModel DB cache above, not this prefix.
   "openrouter/": "openrouter",
+  "qwen3.8-max": "alibaba", // Alibaba Cloud Model Studio (DashScope), e.g. qwen3.8-max-0902
   "ollama:": "ollama", // namespaced local models, e.g. "ollama:qwen2.5-coder:32b"
   "acp:": "acp", // OpenAI-compatible gateway (Agent Communication Protocol)
   "opencode:": "opencode", // OpenAI-compatible gateway
@@ -93,6 +94,7 @@ type OrgKeys = {
   googleApiKey: string | null;
   grokApiKey: string | null;
   openrouterApiKey: string | null;
+  alibabaApiKey: string | null;
 };
 
 async function getOrgKeys(orgId: string): Promise<OrgKeys> {
@@ -104,6 +106,7 @@ async function getOrgKeys(orgId: string): Promise<OrgKeys> {
       googleApiKey: true,
       grokApiKey: true,
       openrouterApiKey: true,
+      alibabaApiKey: true,
     },
   });
   return {
@@ -112,6 +115,7 @@ async function getOrgKeys(orgId: string): Promise<OrgKeys> {
     googleApiKey: org?.googleApiKey ? decryptStringMaybeLegacy(org.googleApiKey) : null,
     grokApiKey: org?.grokApiKey ? decryptStringMaybeLegacy(org.grokApiKey) : null,
     openrouterApiKey: org?.openrouterApiKey ? decryptStringMaybeLegacy(org.openrouterApiKey) : null,
+    alibabaApiKey: org?.alibabaApiKey ? decryptStringMaybeLegacy(org.alibabaApiKey) : null,
   };
 }
 
@@ -122,6 +126,7 @@ function getOrgKeyForProvider(keys: OrgKeys, provider: AiProvider): string | nul
     case "google": return keys.googleApiKey;
     case "grok": return keys.grokApiKey;
     case "openrouter": return keys.openrouterApiKey;
+    case "alibaba": return keys.alibabaApiKey;
     // Ollama runs on the operator's own infra — env-configured, no per-org key.
     case "ollama": return null;
     // Local-agent bridge dispatches to a laptop; provider.create() reads org

--- a/apps/web/lib/ai-usage.ts
+++ b/apps/web/lib/ai-usage.ts
@@ -3,7 +3,7 @@ import { calcCost, getModelPricing } from "./cost";
 import { deductCredits } from "./credits";
 
 type LogAiUsageParams = {
-  provider: "anthropic" | "openai" | "google" | "cohere" | "grok" | "openrouter" | "ollama" | "local" | "acp" | "opencode" | "claude-code" | "mock" | "mock-fail";
+  provider: "anthropic" | "openai" | "google" | "cohere" | "grok" | "openrouter" | "alibaba" | "ollama" | "local" | "acp" | "opencode" | "claude-code" | "mock" | "mock-fail";
   model: string;
   operation: string;
   inputTokens: number;
@@ -25,6 +25,7 @@ export async function logAiUsage(params: LogAiUsageParams): Promise<void> {
         googleApiKey: true,
         grokApiKey: true,
         openrouterApiKey: true,
+        alibabaApiKey: true,
         claudeCodeApiKey: true,
         claudeCodeAuthMode: true,
       },
@@ -42,6 +43,7 @@ export async function logAiUsage(params: LogAiUsageParams): Promise<void> {
       (params.provider === "cohere" && !!org.cohereApiKey) ||
       (params.provider === "grok" && !!org.grokApiKey) ||
       (params.provider === "openrouter" && !!org.openrouterApiKey) ||
+      (params.provider === "alibaba" && !!org.alibabaApiKey) ||
       // Claude Code: api-key mode bills against the org key; subscription mode
       // shells out to the local `claude` CLI (the user's own auth) — own-key.
       (params.provider === "claude-code" &&

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -39,6 +39,8 @@ const FALLBACK_PRICING: Record<string, ModelPricing> = {
   "claude-code:sonnet": { input: 0, output: 0 },
   // OpenRouter Hermes 3 8B — estimate (~$0.10/$0.15 per 1M in/out).
   "openrouter/nousresearch/hermes-3-llama-3.1-8b": { input: 0.1, output: 0.15 },
+  // Alibaba Cloud Model Studio — Qwen3.8-Max list price (international region).
+  "qwen3.8-max-0902": { input: 2, output: 6 },
   "text-embedding-3-large": { input: 0.13, output: 0 },
   "rerank-v3.5": { input: 2000.0, output: 0 },
 };
@@ -147,6 +149,7 @@ function orgOwnsKeyForProvider(
     cohereApiKey: string | null;
     grokApiKey: string | null;
     openrouterApiKey: string | null;
+    alibabaApiKey: string | null;
     claudeCodeApiKey: string | null;
     claudeCodeAuthMode: string | null;
   },
@@ -159,6 +162,7 @@ function orgOwnsKeyForProvider(
     case "cohere": return !!org.cohereApiKey;
     case "grok": return !!org.grokApiKey;
     case "openrouter": return !!org.openrouterApiKey;
+    case "alibaba": return !!org.alibabaApiKey;
     case "claude-code":
       return !!org.claudeCodeApiKey || org.claudeCodeAuthMode === "subscription";
     // Operator-infra / local-agent / gateways / test doubles: never platform-billed.
@@ -188,6 +192,7 @@ export async function getOrgSpendLimitStatus(
       cohereApiKey: true,
       grokApiKey: true,
       openrouterApiKey: true,
+      alibabaApiKey: true,
       claudeCodeApiKey: true,
       claudeCodeAuthMode: true,
       monthlySpendLimitUsd: true,

--- a/apps/web/lib/entitlements.ts
+++ b/apps/web/lib/entitlements.ts
@@ -38,6 +38,7 @@ type ProviderKeyFields = {
   cohereApiKey: string | null;
   grokApiKey: string | null;
   openrouterApiKey: string | null;
+  alibabaApiKey: string | null;
   claudeCodeApiKey: string | null;
 };
 
@@ -49,6 +50,7 @@ function hasOwnProviderKey(org: ProviderKeyFields): boolean {
       org.cohereApiKey ||
       org.grokApiKey ||
       org.openrouterApiKey ||
+      org.alibabaApiKey ||
       org.claudeCodeApiKey,
   );
 }
@@ -95,6 +97,7 @@ export async function getOrgEntitlements(orgId: string): Promise<OrgEntitlements
       cohereApiKey: true,
       grokApiKey: true,
       openrouterApiKey: true,
+      alibabaApiKey: true,
       claudeCodeApiKey: true,
       liveTelemetryEnabled: true,
       allowVendorMemberVisibility: true,

--- a/apps/web/lib/providers/alibaba-request.ts
+++ b/apps/web/lib/providers/alibaba-request.ts
@@ -26,13 +26,31 @@ export function alibabaBaseUrl(env: Record<string, string | undefined> = process
  */
 export const ALIBABA_THINKING_MAX_TOKENS_FLOOR = 32_768;
 
-export type AlibabaRequestShape = { maxCompletionTokens: number; enableThinking: boolean };
+/**
+ * Models this adapter knows to be hybrid-thinking (thinking on by default,
+ * accept `enable_thinking`, 131k output ceiling). Everything else routed to
+ * the alibaba provider (any `provider = "alibaba"` catalog row, e.g. a plain
+ * qwen-plus) is called as a vanilla OpenAI-compatible model: no vendor
+ * extension, caller's max tokens verbatim — same reasoning as the Anthropic
+ * always-thinking floor being scoped to a known model set.
+ */
+export const ALIBABA_HYBRID_THINKING_MODEL_RX = /^qwen3\.8-max/;
+
+export type AlibabaRequestShape = {
+  maxCompletionTokens: number;
+  /** undefined = omit the vendor field entirely (model is not known to support it). */
+  enableThinking: boolean | undefined;
+};
 
 export function alibabaRequestShape(params: {
+  model: string;
   maxTokens: number;
   thinking?: "disabled";
   responseSchema?: unknown;
 }): AlibabaRequestShape {
+  if (!ALIBABA_HYBRID_THINKING_MODEL_RX.test(params.model)) {
+    return { maxCompletionTokens: params.maxTokens, enableThinking: undefined };
+  }
   const enableThinking = params.thinking !== "disabled" && params.responseSchema === undefined;
   const maxCompletionTokens = enableThinking
     ? Math.max(params.maxTokens, ALIBABA_THINKING_MAX_TOKENS_FLOOR)

--- a/apps/web/lib/providers/alibaba-request.ts
+++ b/apps/web/lib/providers/alibaba-request.ts
@@ -1,0 +1,41 @@
+/**
+ * Request-shaping helpers for the Alibaba Cloud Model Studio (DashScope)
+ * provider. Kept free of `server-only` so they can be unit-tested.
+ */
+
+/** International (Singapore) endpoint. The China endpoint is
+ *  https://dashscope.aliyuncs.com/compatible-mode/v1 — set DASHSCOPE_BASE_URL. */
+export const ALIBABA_DEFAULT_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
+
+/** DASHSCOPE_BASE_URL overrides the default; trailing slashes are trimmed. */
+export function alibabaBaseUrl(env: Record<string, string | undefined> = process.env): string {
+  const raw = env.DASHSCOPE_BASE_URL?.trim();
+  return (raw ? raw : ALIBABA_DEFAULT_BASE_URL).replace(/\/+$/, "");
+}
+
+/**
+ * Qwen3.8-Max is a hybrid-thinking model with thinking ON by default. In
+ * compatible mode thinking is toggled with the vendor extension
+ * `enable_thinking`, and `max_completion_tokens` caps thinking + answer
+ * together (DashScope deprecates `max_tokens`). Two rules:
+ *  - a caller's explicit `thinking: "disabled"` turns thinking off;
+ *  - structured-output (json_schema) calls also run thinking-off, because the
+ *    vendor docs warn thinking-mode JSON may not be strictly valid.
+ * When thinking stays on, the cap is raised to a floor so the chain of thought
+ * cannot starve the answer (the model's output ceiling is 131k tokens).
+ */
+export const ALIBABA_THINKING_MAX_TOKENS_FLOOR = 32_768;
+
+export type AlibabaRequestShape = { maxCompletionTokens: number; enableThinking: boolean };
+
+export function alibabaRequestShape(params: {
+  maxTokens: number;
+  thinking?: "disabled";
+  responseSchema?: unknown;
+}): AlibabaRequestShape {
+  const enableThinking = params.thinking !== "disabled" && params.responseSchema === undefined;
+  const maxCompletionTokens = enableThinking
+    ? Math.max(params.maxTokens, ALIBABA_THINKING_MAX_TOKENS_FLOOR)
+    : params.maxTokens;
+  return { maxCompletionTokens, enableThinking };
+}

--- a/apps/web/lib/providers/alibaba.ts
+++ b/apps/web/lib/providers/alibaba.ts
@@ -1,0 +1,82 @@
+import "server-only";
+import OpenAI from "openai";
+import type { Provider, AiCreateParams, AiResponse } from "./index";
+import { alibabaBaseUrl, alibabaRequestShape } from "./alibaba-request";
+
+/**
+ * Alibaba Cloud Model Studio (DashScope). OpenAI-compatible REST at
+ * `https://dashscope-intl.aliyuncs.com/compatible-mode/v1` (override with
+ * DASHSCOPE_BASE_URL, e.g. the China endpoint) — reuse the OpenAI SDK with a
+ * custom baseURL. The org BYOK key is resolved + decrypted by the ai-router
+ * facade and passed in as `apiKey`. Keys are region-scoped: an international
+ * key does not work against the China endpoint and vice versa.
+ */
+let platformClient: OpenAI | null = null;
+
+function getClient(apiKey?: string | null): OpenAI {
+  const baseURL = alibabaBaseUrl();
+  if (apiKey) return new OpenAI({ apiKey, baseURL });
+  if (!platformClient) {
+    platformClient = new OpenAI({
+      apiKey: process.env.DASHSCOPE_API_KEY ?? "",
+      baseURL,
+    });
+  }
+  return platformClient;
+}
+
+export const alibabaProvider: Provider = {
+  name: "alibaba",
+  // The Qwen3.8-Max family supports response_format json_schema (strict).
+  supportsJsonSchema: true,
+  async create(params: AiCreateParams, apiKey?: string | null): Promise<AiResponse> {
+    const client = getClient(apiKey);
+
+    const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+    if (params.system) messages.push({ role: "system", content: params.system });
+    for (const m of params.messages) messages.push({ role: m.role, content: m.content });
+
+    const { maxCompletionTokens, enableThinking } = alibabaRequestShape(params);
+
+    const body = {
+      model: params.model,
+      // DashScope recommends max_completion_tokens (caps thinking + answer);
+      // max_tokens is deprecated there.
+      max_completion_tokens: maxCompletionTokens,
+      messages,
+      ...(params.responseSchema
+        ? {
+            response_format: {
+              type: "json_schema" as const,
+              json_schema: {
+                name: params.responseSchema.name,
+                schema: params.responseSchema.schema,
+                strict: true,
+              },
+            },
+          }
+        : {}),
+      // Vendor extension (not in the OpenAI SDK types); serialized as-is.
+      enable_thinking: enableThinking,
+    };
+
+    const response = await client.chat.completions.create(
+      body as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming,
+    );
+
+    const text = response.choices[0]?.message?.content ?? "";
+
+    return {
+      text,
+      provider: "alibaba",
+      model: params.model,
+      usage: {
+        inputTokens: response.usage?.prompt_tokens ?? 0,
+        // completion_tokens includes reasoning tokens (billed as output).
+        outputTokens: response.usage?.completion_tokens ?? 0,
+        cacheReadTokens: response.usage?.prompt_tokens_details?.cached_tokens ?? 0,
+        cacheWriteTokens: 0,
+      },
+    };
+  },
+};

--- a/apps/web/lib/providers/alibaba.ts
+++ b/apps/web/lib/providers/alibaba.ts
@@ -57,14 +57,25 @@ export const alibabaProvider: Provider = {
           }
         : {}),
       // Vendor extension (not in the OpenAI SDK types); serialized as-is.
-      enable_thinking: enableThinking,
+      // Omitted for models not known to accept it.
+      ...(enableThinking === undefined ? {} : { enable_thinking: enableThinking }),
     };
 
     const response = await client.chat.completions.create(
       body as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming,
     );
 
-    const text = response.choices[0]?.message?.content ?? "";
+    const choice = response.choices[0];
+    const text = choice?.message?.content ?? "";
+
+    // With thinking on, hitting the completion cap during reasoning returns
+    // finish_reason "length" and an empty answer (the budget went to
+    // reasoning_content). Fail loudly instead of returning "" as a success.
+    if (enableThinking && !text && choice?.finish_reason === "length") {
+      throw new Error(
+        `DashScope hit max_completion_tokens (${maxCompletionTokens}) while thinking and returned no answer; raise maxTokens or disable thinking`,
+      );
+    }
 
     return {
       text,

--- a/apps/web/lib/providers/index.ts
+++ b/apps/web/lib/providers/index.ts
@@ -6,6 +6,7 @@ import { ollamaProvider } from "./ollama";
 import { localProvider } from "./local";
 import { grokProvider } from "./grok";
 import { openrouterProvider } from "./openrouter";
+import { alibabaProvider } from "./alibaba";
 import { acpProvider } from "./acp";
 import { opencodeProvider } from "./opencode";
 import { claudeCodeProvider } from "./claude-code";
@@ -21,6 +22,7 @@ export type AiProvider =
   | "local"
   | "grok"
   | "openrouter"
+  | "alibaba"
   | "acp"
   | "opencode"
   | "claude-code"
@@ -115,6 +117,7 @@ const PROVIDERS: Partial<Record<AiProvider, Provider>> = {
   local: localProvider,
   grok: grokProvider,
   openrouter: openrouterProvider,
+  alibaba: alibabaProvider,
   acp: acpProvider,
   opencode: opencodeProvider,
   "claude-code": claudeCodeProvider,

--- a/packages/db/prisma/migrations/20260902120000_add_alibaba_key/migration.sql
+++ b/packages/db/prisma/migrations/20260902120000_add_alibaba_key/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."organizations" ADD COLUMN     "alibabaApiKey" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -117,6 +117,7 @@ model Organization {
   googleApiKey         String?
   grokApiKey           String?
   openrouterApiKey     String?
+  alibabaApiKey        String?
   // Custom Ollama base URL — overrides OLLAMA_SERVER_URL env when set. Used
   // for self-hosted Octopus instances pointing at a non-default Ollama host
   // (a different container, a different machine on the LAN, etc.).

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -737,6 +737,8 @@ async function main() {
     // OpenRouter — the "openrouter/…"-namespaced id forces OpenRouter routing.
     // Price is an estimate (~$0.10/$0.15 per 1M in/out for Hermes 3 8B).
     { modelId: "openrouter/nousresearch/hermes-3-llama-3.1-8b", displayName: "Nous Hermes 3 8B (OpenRouter)", provider: "openrouter", category: "llm", inputPrice: 0.1, outputPrice: 0.15, sortOrder: 10 },
+    // Alibaba Cloud Model Studio — "qwen3.8-max"-prefixed ids route to DashScope.
+    { modelId: "qwen3.8-max-0902", displayName: "Qwen3.8-Max-0902", provider: "alibaba", category: "llm", inputPrice: 2, outputPrice: 6, sortOrder: 11 },
     // Ollama (local — runs on the operator's own machine, zero cost)
     { modelId: "ollama:qwen2.5-coder:32b", displayName: "Qwen 2.5 Coder 32B (Ollama)", provider: "ollama", category: "llm", inputPrice: 0, outputPrice: 0, sortOrder: 20 },
     { modelId: "ollama:llama3.3", displayName: "Llama 3.3 (Ollama)", provider: "ollama", category: "llm", inputPrice: 0, outputPrice: 0, sortOrder: 21 },


### PR DESCRIPTION
## What

Adds **Alibaba Cloud Model Studio** (vendor id `alibaba`) as a review vendor, mirroring the Grok wiring layer by layer. The checklist was `git grep -il grok` (excluding docs/blog); every file in it has its alibaba counterpart, and nothing else changed (no default-model or other-vendor changes).

| Layer | Change |
|---|---|
| Provider | `lib/providers/alibaba.ts` (OpenAI SDK + DashScope compatible-mode baseURL) and `alibaba-request.ts` (pure, unit-tested request shaping). Default base URL `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`; `DASHSCOPE_BASE_URL` selects the China endpoint. Platform key `DASHSCOPE_API_KEY`. |
| Routing | `AiProvider` union + registry; `PROVIDER_FALLBACK` `"qwen3.8-max" → alibaba`; `getOrgKeys` decrypts `alibabaApiKey`. |
| BYOK | Prisma `Organization.alibabaApiKey` + migration `20260902120000_add_alibaba_key`; settings form/page field; `updateApiKeys` validates (`sk-` prefix) and encrypts at rest; `removeApiKey` accepts the field. |
| Billing | `cost.ts`: org key check for the spend-limit gate + `FALLBACK_PRICING["qwen3.8-max-0902"] = $2/$6`; `ai-usage.ts`: own-key usage not charged; `entitlements.ts`: own-key counts as paid. |
| Admin | `/api/admin/models/discover` lists Qwen models from DashScope `GET /models`. |
| CLI | key hint + dashboard URL, key validation against DashScope `/models` (honours `DASHSCOPE_BASE_URL`, keys are region-scoped), model list (`qwen3.8-max-0902`), provider entry (ready). |
| Catalog / docs | seed row `qwen3.8-max-0902` ($2/$6, provider alibaba); self-hosting env table (`DASHSCOPE_API_KEY`, `DASHSCOPE_BASE_URL`); security-overview BYOK list; changelog. |

## DashScope facts applied (official docs)

- `max_completion_tokens` is the recommended cap (thinking + answer); `max_tokens` is deprecated there.
- Qwen3.8-Max family supports `response_format: json_schema` (strict) → `supportsJsonSchema: true`, same spread as grok.
- `qwen3.8-max-0902` is a hybrid-thinking model with thinking **on by default**; toggled with the vendor field `enable_thinking`. The adapter sends it on every call: off when the caller passes `thinking: "disabled"` (the knob added in #777) or when a `responseSchema` is set (docs warn thinking-mode JSON may not be strictly valid); otherwise on, with the completion cap raised to a 32,768 floor so the chain of thought cannot starve the answer (model output ceiling 131,072). Both the vendor field and the floor are scoped to the hybrid-thinking family (`/^qwen3\.8-max/`); any other model routed to the provider is called as a vanilla OpenAI-compatible model. If thinking still consumes the whole budget (`finish_reason: length`, empty answer) the adapter throws instead of returning an empty success.
- Usage: `completion_tokens` includes reasoning tokens (billed as output); `prompt_tokens_details.cached_tokens` → cache reads.
- Keys are region-scoped (an international key does not work on the China endpoint).

## Not in this PR

- The production catalog row (`available_models`) is DB-driven and is added in the admin console after deploy; the seed row covers dev/self-host.
- octopus-admin's discover panel (separate repo) needs an `alibaba` entry to render the new `providers.alibaba` key.

## Test

- `apps/web`: `bun test` → 1019 pass, 0 fail (new: `alibaba-provider.test.ts` wire-contract test with a mocked OpenAI SDK, `alibaba-request.test.ts`, alibaba cases in `spend-limit.test.ts`, `billing.test.ts` own-key and platform-billed, `ai-router.test.ts`, `review-routing.test.ts` pricing pin).
- `apps/cli`: `bun test` → 113 pass, 0 fail (ready/default asserts for alibaba).
- An independent 4-lens adversarial review (checklist completeness, DashScope correctness incl. confirming the OpenAI SDK posts the params object verbatim so `enable_thinking` reaches the wire, billing/security invariants, test adequacy) drove the second commit; cache-read pricing was checked against the vendor list ($0.17 explicit / $0.25 implicit per 1M vs the 0.1× formula = $0.20) and left as is.
- `tsc` clean on all touched files (Prisma client regenerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpAfVkoSS7YGshLufJoYXf

