### PR TITLE
fix(auth): block the signup-farm email domain families

### DIFF
--- a/apps/web/lib/__tests__/email-validator.test.ts
+++ b/apps/web/lib/__tests__/email-validator.test.ts
@@ -23,6 +23,22 @@ describe("isDisposableDomain", () => {
     expect(isDisposableDomain("example.com")).toBe(false);
   });
 
+  it("blocks the signup-farm domain families and their subdomains (#788)", () => {
+    const farmRoots = [
+      "foodtrik.com",
+      "totalgamehub.net",
+      "foodhz.com",
+      "birdzpt.com",
+      "rainsase.com",
+    ];
+    for (const root of farmRoots) {
+      expect(isDisposableDomain(root)).toBe(true);
+      expect(isDisposableDomain(`x7kq2.${root}`)).toBe(true);
+    }
+    // Unrelated normal domain is unaffected.
+    expect(isDisposableDomain("example-company.com")).toBe(false);
+  });
+
   it("requires a dot before the root for subdomain matching (no raw substring)", () => {
     // Verify the subdomain check uses `.<root>` not raw endsWith.
     // Construct a domain that shares a suffix with a disposable root but

--- a/apps/web/lib/email-validator.ts
+++ b/apps/web/lib/email-validator.ts
@@ -2,7 +2,19 @@ import { promises as dns } from "node:dns";
 import disposableDomains from "disposable-domains";
 import { getRedis } from "./redis";
 
-const DISPOSABLE_LIST = disposableDomains as string[];
+// signup farm 2026-09, see #788
+const EXTRA_BLOCKED_DOMAINS = [
+  "foodtrik.com",
+  "totalgamehub.net",
+  "foodhz.com",
+  "birdzpt.com",
+  "rainsase.com",
+];
+
+const DISPOSABLE_LIST = [
+  ...(disposableDomains as string[]),
+  ...EXTRA_BLOCKED_DOMAINS,
+];
 const DISPOSABLE_SET = new Set<string>(DISPOSABLE_LIST);
 
 const DISPOSABLE_MX_SUFFIXES = [


### PR DESCRIPTION
## Summary

Part of #788 (signup-farm post-mortem), control P0-a. The farm registered 1,699 accounts across five registrable domains it controls. This adds those domains to the disposable-domain set so signups from them, and from any subdomain, are refused with the existing "Disposable email addresses are not allowed" message.

## Changes
- `apps/web/lib/email-validator.ts`: `EXTRA_BLOCKED_DOMAINS` (foodtrik.com, totalgamehub.net, foodhz.com, birdzpt.com, rainsase.com) spread into `DISPOSABLE_LIST`/`DISPOSABLE_SET`, so the existing exact + `.`-suffix match covers subdomains.
- `apps/web/lib/__tests__/email-validator.test.ts`: each root and a random subdomain are rejected; an unrelated domain is unaffected.

MX fail-open behaviour is deliberately unchanged.

## Tests
- `bun test lib/__tests__/email-validator.test.ts`: 6 pass (new test was red before the change).
- `bun run typecheck`, eslint: clean.

## Notes
The list is static in code. If the farm rotates domains, the upgrade path is an env- or DB-driven blocklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zndCzrLf9nCP92ojuPT6j
