### PR TITLE
feat(auth): account-standing gate on API token minting and token auth

### DIFF
--- a/apps/web/app/(app)/settings/api-tokens/actions.ts
+++ b/apps/web/app/(app)/settings/api-tokens/actions.ts
@@ -6,6 +6,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { hasOrgPermission } from "@/lib/org-permissions";
 import { generateApiToken, hashToken, getTokenPrefix } from "@/lib/api-auth";
+import { getAccountStanding, ACCOUNT_HOLD_MESSAGE } from "@/lib/account-standing";
 
 export async function createApiToken(formData: FormData) {
   const session = await auth.api.getSession({ headers: await headers() });
@@ -30,6 +31,16 @@ export async function createApiToken(formData: FormData) {
   // requires tokens:manage (previously any member could do both).
   if (!member || !hasOrgPermission(member, "tokens:manage")) {
     return { error: "API token management permission required" };
+  }
+
+  // Account-standing gate (issue #788): shared-fingerprint / risk-held
+  // accounts with no product signal cannot mint tokens.
+  const standing = await getAccountStanding({
+    userId: session.user.id,
+    orgId: currentOrgId,
+  });
+  if (standing.held) {
+    return { error: ACCOUNT_HOLD_MESSAGE };
   }
 
   // Rate limit: max 5 tokens per hour per user

--- a/apps/web/app/api/agent/disconnect/route.ts
+++ b/apps/web/app/api/agent/disconnect/route.ts
@@ -10,6 +10,7 @@ const MAX_DISCONNECT_BODY_BYTES = 16 * 1024;
 
 export async function POST(request: Request) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/agent/heartbeat/route.ts
+++ b/apps/web/app/api/agent/heartbeat/route.ts
@@ -15,6 +15,7 @@ const MAX_HEARTBEAT_BODY_BYTES = 256 * 1024;
 
 export async function POST(request: Request) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/agent/llm-tasks/[id]/complete/route.ts
+++ b/apps/web/app/api/agent/llm-tasks/[id]/complete/route.ts
@@ -67,6 +67,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/agent/llm-tasks/route.ts
+++ b/apps/web/app/api/agent/llm-tasks/route.ts
@@ -23,6 +23,7 @@ const ORPHAN_REAP_MS = 10 * 60 * 1000;
 
 export async function GET(request: Request) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/agent/register/route.ts
+++ b/apps/web/app/api/agent/register/route.ts
@@ -22,6 +22,7 @@ const MAX_MACHINE_INFO_BYTES = 8 * 1024;
 
 export async function POST(request: Request) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/agent/status/route.ts
+++ b/apps/web/app/api/agent/status/route.ts
@@ -16,6 +16,7 @@ export async function GET(request: Request) {
   let authorized = false;
 
   const apiAuth = await authenticateApiToken(request);
+  if (apiAuth instanceof Response) return apiAuth; // account-standing hold (403), pass through
   if (apiAuth && apiAuth.org.id === orgId) {
     authorized = true;
   }

--- a/apps/web/app/api/agent/tasks/[id]/claim/route.ts
+++ b/apps/web/app/api/agent/tasks/[id]/claim/route.ts
@@ -12,6 +12,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/agent/tasks/[id]/result/route.ts
+++ b/apps/web/app/api/agent/tasks/[id]/result/route.ts
@@ -142,6 +142,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/agent/tasks/route.ts
+++ b/apps/web/app/api/agent/tasks/route.ts
@@ -7,6 +7,7 @@ import { isPostgresSafeText } from "@/lib/bounded-json";
 
 export async function GET(request: Request) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/analyze-deps/route.ts
+++ b/apps/web/app/api/analyze-deps/route.ts
@@ -32,6 +32,7 @@ export async function POST(req: NextRequest) {
   let installationId: number | null;
 
   const tokenAuth = await authenticateApiToken(req);
+  if (tokenAuth instanceof Response) return tokenAuth; // account-standing hold (403), pass through
   if (tokenAuth) {
     orgId = tokenAuth.org.id;
     userId = tokenAuth.user.id;

--- a/apps/web/app/api/cli/auth/approve/route.ts
+++ b/apps/web/app/api/cli/auth/approve/route.ts
@@ -2,6 +2,7 @@ import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { generateApiToken, hashToken, getTokenPrefix } from "@/lib/api-auth";
+import { getAccountStanding, ACCOUNT_HOLD_MESSAGE } from "@/lib/account-standing";
 
 export async function POST(request: Request) {
   const session = await auth.api.getSession({ headers: await headers() });
@@ -44,6 +45,17 @@ export async function POST(request: Request) {
   });
   if (!member) {
     return Response.json({ error: "Not a member of this organization" }, { status: 403 });
+  }
+
+  // Account-standing gate (issue #788): the signup farm minted its tokens
+  // through this device flow — held accounts with no product signal get a
+  // clear, actionable refusal instead of a token.
+  const standing = await getAccountStanding({
+    userId: session.user.id,
+    orgId: organizationId,
+  });
+  if (standing.held) {
+    return Response.json({ error: ACCOUNT_HOLD_MESSAGE }, { status: 403 });
   }
 
   const org = await prisma.organization.findUnique({

--- a/apps/web/app/api/cli/auth/verify/route.ts
+++ b/apps/web/app/api/cli/auth/verify/route.ts
@@ -2,6 +2,7 @@ import { authenticateApiToken } from "@/lib/api-auth";
 
 export async function POST(request: Request) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Invalid or expired token" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/chat/route.ts
+++ b/apps/web/app/api/cli/chat/route.ts
@@ -33,6 +33,7 @@ function getAnthropicClient(): Anthropic {
 
 export async function POST(request: Request) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/knowledge/[id]/route.ts
+++ b/apps/web/app/api/cli/knowledge/[id]/route.ts
@@ -7,6 +7,7 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/knowledge/route.ts
+++ b/apps/web/app/api/cli/knowledge/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@octopus/db";
 
 export async function GET(request: Request) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -27,6 +28,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/me/route.ts
+++ b/apps/web/app/api/cli/me/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@octopus/db";
 
 export async function GET(request: Request) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/repos/[id]/analyze/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/analyze/route.ts
@@ -9,6 +9,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/repos/[id]/index/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/index/route.ts
@@ -8,6 +8,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/repos/[id]/local-review/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/local-review/route.ts
@@ -11,6 +11,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/repos/[id]/review/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/review/route.ts
@@ -12,6 +12,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/repos/[id]/status/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/status/route.ts
@@ -7,6 +7,7 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/repos/by-remote/route.ts
+++ b/apps/web/app/api/cli/repos/by-remote/route.ts
@@ -22,6 +22,7 @@ import { prisma } from "@octopus/db";
  */
 export async function GET(request: NextRequest) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/repos/index-local/route.ts
+++ b/apps/web/app/api/cli/repos/index-local/route.ts
@@ -75,6 +75,7 @@ type Body = FirstBatchBody | SubsequentBatchBody;
 
 export async function POST(request: Request) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/repos/route.ts
+++ b/apps/web/app/api/cli/repos/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@octopus/db";
 
 export async function GET(request: Request) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/review-local/route.ts
+++ b/apps/web/app/api/cli/review-local/route.ts
@@ -41,6 +41,7 @@ type Body = {
 
 export async function POST(request: Request) {
   const auth = await authenticateApiToken(request);
+  if (auth instanceof Response) return auth; // account-standing hold (403), pass through
   if (!auth) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/cli/usage/route.ts
+++ b/apps/web/app/api/cli/usage/route.ts
@@ -5,6 +5,7 @@ import { getUtcMonthBounds } from "@/lib/billing-period";
 
 export async function GET(request: Request) {
   const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/apps/web/app/api/github-action/review/route.ts
+++ b/apps/web/app/api/github-action/review/route.ts
@@ -126,6 +126,7 @@ export async function POST(request: NextRequest) {
   // ── Dual auth ─────────────────────────────────────────────────────────────
 
   const apiAuth = await authenticateApiToken(request);
+  if (apiAuth instanceof Response) return apiAuth; // account-standing hold (403), pass through
   const hasAuthHeader = request.headers.get("authorization")?.startsWith("Bearer ") ?? false;
   let orgId: string;
   let isCommunityMode = false;

--- a/apps/web/app/api/pubby/auth/route.ts
+++ b/apps/web/app/api/pubby/auth/route.ts
@@ -12,6 +12,7 @@ export async function POST(req: Request) {
 
   // Try API token auth first (for headless agents)
   const apiAuth = await authenticateApiToken(req);
+  if (apiAuth instanceof Response) return apiAuth; // account-standing hold (403), pass through
   if (apiAuth) {
     // Agents can only subscribe to their org's agent channel
     const agentChannelMatch = channel_name.match(

--- a/apps/web/lib/__tests__/account-standing.test.ts
+++ b/apps/web/lib/__tests__/account-standing.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import { ORG_TYPE } from "@/lib/org-types";
+
+// Account-standing gate (signup-farm control, issue #788): held accounts —
+// shared device fingerprint or welcome-risk hold/block band — with no real
+// product signal (connected repo, Stripe customer, purchase, FRIENDLY type,
+// BYOK key, paid plan tier) cannot mint or use org API tokens. @octopus/db
+// mocked (same approach as org-create.test.ts).
+
+type OrgRow = {
+  id: string;
+  stripeCustomerId: string | null;
+  welcomeRiskScore: number | null;
+  type: number;
+  planTier: string;
+  anthropicApiKey: string | null;
+};
+
+const org = (overrides: Partial<OrgRow> = {}): OrgRow => ({
+  id: "org1",
+  stripeCustomerId: null,
+  welcomeRiskScore: null,
+  type: ORG_TYPE.STANDARD,
+  planTier: "free",
+  anthropicApiKey: null,
+  ...overrides,
+});
+
+let orgRow: OrgRow | null;
+let repoRow: { id: string; externalId: string } | null;
+let purchaseRow: { id: string } | null;
+let deviceRows: { fingerprint: string }[];
+let sharedGroups: { fingerprint: string; _count: { fingerprint: number } }[];
+let apiTokenRow: Record<string, unknown> | null;
+
+const client = {
+  organization: { findUnique: mock(() => Promise.resolve(orgRow)) },
+  repository: {
+    // Honors the one filter under test: NOT externalId startsWith "cli:".
+    findFirst: mock(
+      (args?: { where?: { NOT?: { externalId?: { startsWith?: string } } } }) => {
+        const excluded = args?.where?.NOT?.externalId?.startsWith;
+        if (repoRow && excluded && repoRow.externalId.startsWith(excluded)) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(repoRow);
+      },
+    ),
+  },
+  creditTransaction: { findFirst: mock(() => Promise.resolve(purchaseRow)) },
+  userDevice: {
+    findMany: mock(() => Promise.resolve(deviceRows)),
+    groupBy: mock(() => Promise.resolve(sharedGroups)),
+  },
+  orgApiToken: {
+    findUnique: mock(() => Promise.resolve(apiTokenRow)),
+    update: mock(() => Promise.resolve({})),
+  },
+};
+
+mock.module("@octopus/db", () => ({ prisma: client }));
+
+const { getAccountStanding, ACCOUNT_HOLD_MESSAGE } = await import(
+  "@/lib/account-standing"
+);
+const { authenticateApiToken } = await import("@/lib/api-auth");
+
+const FP = "a".repeat(64);
+
+beforeEach(() => {
+  // Default: clean account — no product signal, no risk, no shared devices.
+  orgRow = org();
+  repoRow = null;
+  purchaseRow = null;
+  deviceRows = [];
+  sharedGroups = [];
+  apiTokenRow = null;
+});
+
+describe("getAccountStanding", () => {
+  it("holds when the user's fingerprint is shared at/above the threshold", async () => {
+    deviceRows = [{ fingerprint: FP }];
+    sharedGroups = [{ fingerprint: FP, _count: { fingerprint: 1641 } }];
+    const standing = await getAccountStanding({ userId: "u1", orgId: "org1" });
+    expect(standing.held).toBe(true);
+    expect(standing.reasons.join(",")).toContain("shared_fingerprint");
+  });
+
+  it("holds when the org's welcome risk score is in the hold band", async () => {
+    orgRow = org({ welcomeRiskScore: 50 });
+    const standing = await getAccountStanding({ userId: "u1", orgId: "org1" });
+    expect(standing.held).toBe(true);
+    expect(standing.reasons).toContain("welcome_risk_hold");
+  });
+
+  it("does NOT hold when the org has a repository, even with risk signals", async () => {
+    orgRow = org({ welcomeRiskScore: 50 });
+    deviceRows = [{ fingerprint: FP }];
+    sharedGroups = [{ fingerprint: FP, _count: { fingerprint: 1641 } }];
+    repoRow = { id: "repo1", externalId: "12345" };
+    const standing = await getAccountStanding({ userId: "u1", orgId: "org1" });
+    expect(standing.held).toBe(false);
+    expect(standing.reasons).toEqual([]);
+  });
+
+  it("does NOT count a CLI-created repo (externalId cli:*) as a product signal", async () => {
+    // index-local.ts creates such rows on a token-authed call — self-mintable,
+    // so a farm could plant its own exemption. Must NOT clear a hold.
+    orgRow = org({ welcomeRiskScore: 50 });
+    repoRow = { id: "repo1", externalId: "cli:github:farm/planted" };
+    const standing = await getAccountStanding({ userId: "u1", orgId: "org1" });
+    expect(standing.held).toBe(true);
+    expect(standing.reasons).toContain("welcome_risk_hold");
+  });
+
+  it("does NOT hold when the org has a purchase, even with risk signals", async () => {
+    orgRow = org({ welcomeRiskScore: 50 });
+    deviceRows = [{ fingerprint: FP }];
+    sharedGroups = [{ fingerprint: FP, _count: { fingerprint: 1641 } }];
+    purchaseRow = { id: "tx1" };
+    const standing = await getAccountStanding({ userId: "u1", orgId: "org1" });
+    expect(standing.held).toBe(false);
+  });
+
+  it("does NOT hold when the org has a Stripe customer", async () => {
+    orgRow = org({ stripeCustomerId: "cus_123", welcomeRiskScore: 50 });
+    const standing = await getAccountStanding({ userId: "u1", orgId: "org1" });
+    expect(standing.held).toBe(false);
+  });
+
+  it("does NOT hold a FRIENDLY (comped) org", async () => {
+    orgRow = org({ welcomeRiskScore: 50, type: ORG_TYPE.FRIENDLY });
+    const standing = await getAccountStanding({ userId: "u1", orgId: "org1" });
+    expect(standing.held).toBe(false);
+  });
+
+  it("does NOT hold an org running on its own provider key (BYOK)", async () => {
+    orgRow = org({ welcomeRiskScore: 50, anthropicApiKey: "sk-ant-own-key" });
+    const standing = await getAccountStanding({ userId: "u1", orgId: "org1" });
+    expect(standing.held).toBe(false);
+  });
+
+  it("does NOT hold an org on a paid plan tier", async () => {
+    orgRow = org({ welcomeRiskScore: 50, planTier: "pro" });
+    const standing = await getAccountStanding({ userId: "u1", orgId: "org1" });
+    expect(standing.held).toBe(false);
+  });
+
+  it("does NOT hold a clean account", async () => {
+    const standing = await getAccountStanding({ userId: "u1", orgId: "org1" });
+    expect(standing.held).toBe(false);
+    expect(standing.reasons).toEqual([]);
+  });
+});
+
+describe("authenticateApiToken account-standing gate", () => {
+  const request = () =>
+    new Request("http://localhost/api/cli/chat", {
+      headers: { authorization: "Bearer oct_0123456789abcdef" },
+    });
+
+  it("rejects a token whose org is held with a 403 and the hold message", async () => {
+    apiTokenRow = {
+      id: "tok1",
+      expiresAt: null,
+      organization: {
+        ...org({ welcomeRiskScore: 50 }),
+        bannedAt: null,
+        deletedAt: null,
+      },
+      createdBy: { id: "u1" },
+    };
+    const result = await authenticateApiToken(request());
+    expect(result).toBeInstanceOf(Response);
+    const response = result as Response;
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe(ACCOUNT_HOLD_MESSAGE);
+  });
+
+  it("still authenticates a token whose org is not held", async () => {
+    apiTokenRow = {
+      id: "tok1",
+      expiresAt: null,
+      organization: {
+        ...org(),
+        bannedAt: null,
+        deletedAt: null,
+      },
+      createdBy: { id: "u1" },
+    };
+    const result = await authenticateApiToken(request());
+    expect(result).not.toBeInstanceOf(Response);
+    expect(result && !(result instanceof Response) && result.org.id).toBe("org1");
+  });
+});

--- a/apps/web/lib/__tests__/agent-task-security.test.ts
+++ b/apps/web/lib/__tests__/agent-task-security.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 
 type FakeAgent = {
   id: string;
@@ -135,7 +135,6 @@ const llmTaskUpdateMany = mock(() =>
 const pubbyTrigger = mock(() => Promise.resolve());
 const PRISMA_DB_NULL = Symbol("Prisma.DbNull");
 
-mock.module("@/lib/api-auth", () => ({ authenticateApiToken }));
 mock.module("@/lib/pubby", () => ({
   pubby: { trigger: pubbyTrigger },
 }));
@@ -166,6 +165,16 @@ mock.module("@octopus/db", () => ({
     },
   },
 }));
+
+// Snapshot the real api-auth exports (with @octopus/db already mocked above)
+// before mocking the module, and restore them after this file: bun module
+// mocks leak into later test files, and account-standing.test.ts exercises
+// the real authenticateApiToken.
+const realApiAuth = { ...(await import("@/lib/api-auth")) };
+mock.module("@/lib/api-auth", () => ({ authenticateApiToken }));
+afterAll(() => {
+  mock.module("@/lib/api-auth", () => realApiAuth);
+});
 
 const { POST: claimTask } =
   await import("@/app/api/agent/tasks/[id]/claim/route");

--- a/apps/web/lib/account-standing.ts
+++ b/apps/web/lib/account-standing.ts
@@ -1,0 +1,136 @@
+import { prisma } from "@octopus/db";
+import { isSharedFingerprintAbuse } from "@/lib/device-abuse";
+import {
+  hasOwnProviderKey,
+  PURCHASE_TXN_TYPES,
+  type ProviderKeyFields,
+} from "@/lib/entitlements";
+import { ORG_TYPE } from "@/lib/org-types";
+import { WELCOME_RISK } from "@/lib/welcome-credit";
+
+/**
+ * Account-standing gate for org API tokens (signup-farm control, issue #788).
+ *
+ * An account is HELD when either its device fingerprint is shared across many
+ * accounts (Sybil signal, see device-abuse.ts) or its org sits in the
+ * welcome-risk hold/block band (welcome-credit.ts) — UNLESS the org shows a
+ * real product signal (the same signals entitlements.ts treats as "paid"):
+ * a provider-connected repository, a Stripe customer, a paid credit
+ * transaction, FRIENDLY org type, an own provider key (BYOK), or a paid plan
+ * tier. The 1,699-account farm had none of these on any org.
+ */
+
+export const ACCOUNT_HOLD_MESSAGE =
+  "API tokens are not available for this account yet. Connect a repository or contact support.";
+
+/** Org risk score in the hold-or-block band (>= holdAt covers both). */
+export function isHeldRiskBand(welcomeRiskScore: number | null): boolean {
+  return welcomeRiskScore !== null && welcomeRiskScore >= WELCOME_RISK.holdAt;
+}
+
+export type ProductSignalOrg = {
+  id: string;
+  stripeCustomerId: string | null;
+  type: number;
+  planTier: string;
+} & ProviderKeyFields;
+
+/**
+ * True when the org shows a real product signal — the same signals
+ * entitlements.ts treats as "paid": a Stripe customer, FRIENDLY org type,
+ * an own provider key (BYOK), a paid plan tier, a provider-connected
+ * repository, or a purchase/subscription credit transaction. CLI-created
+ * repository rows (externalId "cli:<provider>:<fullName>", index-local.ts)
+ * do NOT count — any token holder can mint one post-auth, which would let a
+ * farm plant its own exemption. At most two single-row queries,
+ * short-circuiting on the first hit.
+ */
+export async function orgHasProductSignal(org: ProductSignalOrg): Promise<boolean> {
+  if (
+    org.stripeCustomerId ||
+    org.type === ORG_TYPE.FRIENDLY ||
+    org.planTier !== "free" ||
+    hasOwnProviderKey(org)
+  ) {
+    return true;
+  }
+  const repo = await prisma.repository.findFirst({
+    where: {
+      organizationId: org.id,
+      NOT: { externalId: { startsWith: "cli:" } },
+    },
+    select: { id: true },
+  });
+  if (repo) return true;
+  const purchase = await prisma.creditTransaction.findFirst({
+    where: { organizationId: org.id, type: { in: PURCHASE_TXN_TYPES } },
+    select: { id: true },
+  });
+  return purchase !== null;
+}
+
+export async function getAccountStanding(args: {
+  userId: string;
+  orgId: string;
+}): Promise<{ held: boolean; reasons: string[] }> {
+  const { userId, orgId } = args;
+
+  const org = await prisma.organization.findUnique({
+    where: { id: orgId },
+    select: {
+      id: true,
+      stripeCustomerId: true,
+      welcomeRiskScore: true,
+      type: true,
+      planTier: true,
+      anthropicApiKey: true,
+      openaiApiKey: true,
+      googleApiKey: true,
+      cohereApiKey: true,
+      grokApiKey: true,
+      openrouterApiKey: true,
+      alibabaApiKey: true,
+      claudeCodeApiKey: true,
+    },
+  });
+  // Callers verify org membership before this gate; a missing org is theirs
+  // to reject, not a hold.
+  if (!org) return { held: false, reasons: [] };
+
+  if (await orgHasProductSignal(org)) return { held: false, reasons: [] };
+
+  const reasons: string[] = [];
+
+  if (isHeldRiskBand(org.welcomeRiskScore)) {
+    reasons.push("welcome_risk_hold");
+  }
+
+  // Shared-fingerprint check across ALL of the user's devices in one grouped
+  // query (per-fingerprint countUsersSharingFingerprint would be N+1). Rows
+  // are unique per (user, fingerprint), so each group count is the number of
+  // OTHER accounts sharing that fingerprint — same semantics, same
+  // SHARED_FINGERPRINT_THRESHOLD (device-abuse.ts).
+  const devices = await prisma.userDevice.findMany({
+    where: { userId },
+    select: { fingerprint: true },
+  });
+  if (devices.length > 0) {
+    const shared = await prisma.userDevice.groupBy({
+      by: ["fingerprint"],
+      where: {
+        fingerprint: { in: devices.map((d) => d.fingerprint) },
+        userId: { not: userId },
+      },
+      _count: { fingerprint: true },
+    });
+    const maxShared = shared.reduce(
+      (max, group) => Math.max(max, group._count.fingerprint),
+      0,
+    );
+    if (isSharedFingerprintAbuse(maxShared)) {
+      reasons.push(`shared_fingerprint_${maxShared}`);
+    }
+  }
+
+  return { held: reasons.length > 0, reasons };
+}

--- a/apps/web/lib/api-auth.ts
+++ b/apps/web/lib/api-auth.ts
@@ -1,5 +1,10 @@
 import { prisma } from "@octopus/db";
 import { createHash } from "crypto";
+import {
+  ACCOUNT_HOLD_MESSAGE,
+  isHeldRiskBand,
+  orgHasProductSignal,
+} from "@/lib/account-standing";
 
 export async function authenticateApiToken(request: Request) {
   const authHeader = request.headers.get("authorization");
@@ -34,6 +39,19 @@ export async function authenticateApiToken(request: Request) {
   // Check if org is banned
   if (apiToken.organization.bannedAt || apiToken.organization.deletedAt) {
     return null;
+  }
+
+  // Account-standing hold (issue #788): stop tokens already minted by held
+  // orgs. Gated here on the org's risk band + missing product signal only
+  // (NOT the creator's device fingerprints) — the org row is already loaded,
+  // so the common not-held case costs zero extra queries; fingerprints are
+  // enforced at mint time via getAccountStanding. Callers must pass this
+  // Response through as-is.
+  if (
+    isHeldRiskBand(apiToken.organization.welcomeRiskScore) &&
+    !(await orgHasProductSignal(apiToken.organization))
+  ) {
+    return Response.json({ error: ACCOUNT_HOLD_MESSAGE }, { status: 403 });
   }
 
   // Update last used timestamp (fire and forget)

--- a/apps/web/lib/entitlements.ts
+++ b/apps/web/lib/entitlements.ts
@@ -24,14 +24,14 @@ import { ORG_TYPE } from "@/lib/org-types";
 const IS_SELF_HOSTED = process.env.NEXT_PUBLIC_OCTOPUS_SELF_HOSTED === "true";
 
 /** CreditTransaction.type values that represent a real (paid) purchase. */
-const PURCHASE_TXN_TYPES = ["purchase", "auto_reload", "subscription"];
+export const PURCHASE_TXN_TYPES = ["purchase", "auto_reload", "subscription"];
 
 /** True when the deployment is a self-hosted install (no billing path). */
 export function isSelfHosted(): boolean {
   return IS_SELF_HOSTED;
 }
 
-type ProviderKeyFields = {
+export type ProviderKeyFields = {
   anthropicApiKey: string | null;
   openaiApiKey: string | null;
   googleApiKey: string | null;
@@ -42,7 +42,7 @@ type ProviderKeyFields = {
   claudeCodeApiKey: string | null;
 };
 
-function hasOwnProviderKey(org: ProviderKeyFields): boolean {
+export function hasOwnProviderKey(org: ProviderKeyFields): boolean {
   return Boolean(
     org.anthropicApiKey ||
       org.openaiApiKey ||


### PR DESCRIPTION
## Summary

Part of #788, control P0-c. The farm minted 1,623 org API tokens through the CLI device flow and drove LLM usage with them. This adds an account-standing gate: an account is held when its device fingerprint is shared across many accounts (the existing Sybil signal in `device-abuse.ts`) or its org sits in the welcome-risk hold/block band, unless the org shows a real product signal. Held accounts cannot mint tokens, and tokens already minted by held orgs stop authenticating.

## Changes
- New `apps/web/lib/account-standing.ts`: `getAccountStanding({userId, orgId})` → `{held, reasons}`; `orgHasProductSignal(org)` matches the "paying org" definition in `entitlements.ts` (Stripe customer, FRIENDLY type, paid plan tier, own provider key, purchase/subscription/auto_reload transaction) plus a forge-connected repository. CLI-created repository rows (`externalId` `cli:*`) do not count, since any token holder can create one.
- `apps/web/lib/entitlements.ts`: exports `hasOwnProviderKey`, `ProviderKeyFields`, `PURCHASE_TXN_TYPES` so the definition lives in one place.
- Mint path 1, `settings/api-tokens/actions.ts` `createApiToken`: held → `{ error: ACCOUNT_HOLD_MESSAGE }`.
- Mint path 2, `api/cli/auth/approve/route.ts`: held → 403 with the same message.
- Auth time, `lib/api-auth.ts` `authenticateApiToken`: after the ban/delete check, returns a 403 `Response` when the token org is in the hold/block band and has no product signal (org row already loaded, zero extra queries in the common case; fingerprints are enforced at mint time). Return type is now `AuthResult | Response | null`; all 28 call sites got `if (x instanceof Response) return x;`, verified by grep and by tsc.
- `lib/__tests__/agent-task-security.test.ts`: its `mock.module("@/lib/api-auth")` leaked into later test files under bun; it now restores the real exports in `afterAll`. Behaviour-neutral, needed so the new api-auth tests are not order-dependent.

Message shown to held users: "API tokens are not available for this account yet. Connect a repository or contact support."

## Tests
- New `lib/__tests__/account-standing.test.ts` (12): held for shared fingerprint; held for hold band; not held with a forge repo, a purchase, a Stripe customer, FRIENDLY type, BYOK key, paid tier; a CLI-created repo does not exempt; api-auth returns 403 for a held-org token and still authenticates a clean one.
- Full `apps/web` suite: 1031 tests, 0 fail. `bun run typecheck` and eslint clean.

## Reviewer notes
- At auth time the gate checks the org risk band only, not the creator's fingerprints. Farm orgs that scored in the allow band keep working tokens until minting is re-attempted or a ban lands (the 1,699 are already banned).
- DB errors in the gate propagate (500), consistent with the existing token lookup. Fail-open here would recreate the hole.
- The approve route fetches the org twice (once inside the gate). Harmless on a human-paced path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zndCzrLf9nCP92ojuPT6j
