### PR TITLE
feat(auth): per-IP and per-/24 daily signup cap

### DIFF
--- a/apps/web/lib/__tests__/signup-velocity.test.ts
+++ b/apps/web/lib/__tests__/signup-velocity.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+// Unit tests for the hard signup-velocity cap (lib/signup-velocity.ts), the
+// pre-create block wired into auth.ts databaseHooks.user.create.before.
+// @octopus/db is mocked; user.count answers the exact-IP query with ipCount
+// and the /24 startsWith query with subnetCount.
+
+let ipCount: number;
+let subnetCount: number;
+
+const userCount = mock(
+  (args: {
+    where: {
+      signupIp: string | { startsWith: string };
+      createdAt?: { gte: Date };
+    };
+  }) =>
+    Promise.resolve(
+      typeof args.where.signupIp === "string" ? ipCount : subnetCount,
+    ),
+);
+
+mock.module("@octopus/db", () => ({
+  prisma: { user: { count: userCount } },
+}));
+
+const { checkSignupVelocity } = await import("@/lib/signup-velocity");
+
+beforeEach(() => {
+  ipCount = 0;
+  subnetCount = 0;
+  userCount.mockClear();
+  delete process.env.SIGNUP_VELOCITY_CAP;
+  delete process.env.SIGNUP_MAX_PER_IP_DAY;
+  delete process.env.SIGNUP_MAX_PER_SUBNET_DAY;
+});
+
+describe("checkSignupVelocity", () => {
+  it("allows a signup under both caps", async () => {
+    ipCount = 4; // < default 5
+    subnetCount = 14; // < default 15
+    const result = await checkSignupVelocity("94.23.11.7");
+    expect(result.blocked).toBe(false);
+    expect(userCount).toHaveBeenCalledTimes(2);
+  });
+
+  it("blocks at the per-IP cap", async () => {
+    ipCount = 5; // this signup would be the 6th from the IP today
+    const result = await checkSignupVelocity("94.23.11.7");
+    expect(result.blocked).toBe(true);
+    if (result.blocked) {
+      expect(result.reason).toBe("ip");
+      expect(result.ipCount).toBe(5);
+    }
+  });
+
+  it("blocks at the /24 subnet cap", async () => {
+    ipCount = 2;
+    subnetCount = 15; // this signup would be the 16th from the /24 today
+    const result = await checkSignupVelocity("94.23.11.7");
+    expect(result.blocked).toBe(true);
+    if (result.blocked) {
+      expect(result.reason).toBe("subnet");
+      expect(result.subnetCount).toBe(15);
+    }
+    // The subnet query must count on the first-three-octets prefix.
+    const subnetCall = userCount.mock.calls.find(
+      (c) => typeof c[0].where.signupIp !== "string",
+    );
+    expect(subnetCall?.[0].where.signupIp).toEqual({
+      startsWith: "94.23.11.",
+    });
+    // Both counts must be windowed to the last 24h — without the createdAt
+    // clause the daily cap silently becomes an all-time cap.
+    expect(userCount.mock.calls.length).toBe(2);
+    for (const call of userCount.mock.calls) {
+      const gte = call[0].where.createdAt?.gte;
+      expect(gte).toBeInstanceOf(Date);
+      expect(gte!.getTime()).toBeGreaterThan(Date.now() - 24.1 * 3600e3);
+      expect(gte!.getTime()).toBeLessThan(Date.now() - 23.9 * 3600e3);
+    }
+  });
+
+  it("honours env overrides for both caps", async () => {
+    process.env.SIGNUP_MAX_PER_IP_DAY = "2";
+    ipCount = 2;
+    const perIp = await checkSignupVelocity("94.23.11.7");
+    expect(perIp.blocked).toBe(true);
+
+    process.env.SIGNUP_MAX_PER_IP_DAY = "10";
+    process.env.SIGNUP_MAX_PER_SUBNET_DAY = "3";
+    ipCount = 1;
+    subnetCount = 3;
+    const perSubnet = await checkSignupVelocity("94.23.11.7");
+    expect(perSubnet.blocked).toBe(true);
+  });
+
+  it("skips missing IPs", async () => {
+    for (const ip of [null, undefined, ""]) {
+      const result = await checkSignupVelocity(ip);
+      expect(result.blocked).toBe(false);
+    }
+    expect(userCount).not.toHaveBeenCalled();
+  });
+
+  it("skips private and loopback IPs", async () => {
+    ipCount = 100;
+    subnetCount = 100;
+    for (const ip of [
+      "10.0.0.5",
+      "127.0.0.1",
+      "192.168.1.20",
+      "172.16.4.2",
+      "172.31.255.1",
+      "169.254.0.9",
+      "::1",
+      // better-auth's getIp masks IPv6 to /64, so ::1 / :: reach the check
+      // as the expanded all-zeros form — must be treated as loopback too.
+      "0000:0000:0000:0000:0000:0000:0000:0000",
+      "fd12:3456::1",
+      "fe80::abcd",
+    ]) {
+      const result = await checkSignupVelocity(ip);
+      expect(result.blocked).toBe(false);
+    }
+    expect(userCount).not.toHaveBeenCalled();
+  });
+
+  it("caps public IPv6 by the getIp-normalized (/64-masked) form", async () => {
+    // The auth.ts hook resolves the IP with better-auth's getIp, which hands
+    // us the expanded /64-masked lowercase form — the same string
+    // session.create.after stamps into signupIp. The exact-IP query must run
+    // on that string verbatim (an effective per-/64 cap), and no /24 query.
+    const normalized = "2001:0db8:0000:0000:0000:0000:0000:0000";
+    ipCount = 5;
+    const result = await checkSignupVelocity(normalized);
+    expect(result.blocked).toBe(true);
+    if (result.blocked) expect(result.reason).toBe("ip");
+    expect(userCount).toHaveBeenCalledTimes(1);
+    expect(userCount.mock.calls[0]?.[0].where.signupIp).toBe(normalized);
+  });
+
+  it("honours the kill switch", async () => {
+    process.env.SIGNUP_VELOCITY_CAP = "off";
+    ipCount = 1000;
+    subnetCount = 1000;
+    const result = await checkSignupVelocity("94.23.11.7");
+    expect(result.blocked).toBe(false);
+    expect(userCount).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,5 +1,5 @@
 import { betterAuth } from "better-auth";
-import { APIError } from "better-auth/api";
+import { APIError, getIp } from "better-auth/api";
 import { magicLink } from "better-auth/plugins";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { prisma } from "@octopus/db";
@@ -10,6 +10,7 @@ import { enqueueAfter } from "./queue";
 import { reasonToMessage, validateEmailForSignup } from "./email-validator";
 import { normalizeEmail } from "./email-normalize";
 import { assertUserNotBanned } from "./session-guard";
+import { checkSignupVelocity } from "./signup-velocity";
 
 // Email/password sign-in + sign-up (and the first-boot admin seed) are a
 // self-hosted opt-in. On the multi-tenant SaaS, sign-in is OAuth + magic-link.
@@ -86,6 +87,19 @@ export const auth = betterAuth({
         },
       }
     : {}),
+  user: {
+    additionalFields: {
+      // Declared so the adapter persists the signupIp the user.create.before
+      // hook stamps (transformInput drops fields not in the schema). Never
+      // client-writable, never returned in API responses.
+      signupIp: {
+        type: "string",
+        required: false,
+        input: false,
+        returned: false,
+      },
+    },
+  },
   databaseHooks: {
     session: {
       create: {
@@ -126,7 +140,7 @@ export const auth = betterAuth({
     },
     user: {
       create: {
-        before: async (user) => {
+        before: async (user, ctx) => {
           const normalizedEmail = normalizeEmail(user.email);
 
           // If an account already owns the canonical identity, fail with a
@@ -162,7 +176,52 @@ export const auth = betterAuth({
               message: reasonToMessage(result.reason),
             });
           }
-          return { data: { ...user, email: normalizedEmail } };
+
+          // Hard signup-velocity cap (issue #788): unlike the welcome-credit
+          // scorer, this BLOCKS user creation. Resolve the IP with better-auth's
+          // own getIp + the live options so the string is byte-identical to
+          // what session.create.after stamps into signupIp (getIp normalizes:
+          // IPv6 is expanded and /64-masked — making the exact-IP cap an
+          // effective per-/64 cap — and ::ffff: v4-mapped becomes dotted-quad).
+          const requestHeaders = ctx?.headers ?? ctx?.request?.headers;
+          const ip =
+            ctx && requestHeaders
+              ? getIp(new Headers(requestHeaders), ctx.context.options)
+              : null;
+          const velocity = await checkSignupVelocity(ip);
+          if (velocity.blocked) {
+            await writeAuditLog({
+              action: "auth.signup_blocked_velocity",
+              category: "auth",
+              actorEmail: normalizedEmail,
+              targetType: "user",
+              ipAddress: ip,
+              metadata: {
+                reason: velocity.reason,
+                ip,
+                ipCount: velocity.ipCount,
+                subnetCount: velocity.subnetCount,
+              },
+            });
+            throw new APIError("TOO_MANY_REQUESTS", {
+              message:
+                "Too many sign-ups from this network today. Please try again tomorrow or contact support.",
+            });
+          }
+
+          // Stamp signupIp at create time, not only at first session, so the
+          // velocity count sees users who never open a session and a parallel
+          // burst of verifies can only overshoot the cap by the concurrent
+          // INSERT window (milliseconds), not the whole burst.
+          // session.create.after's set-once update guards on `signupIp: null`,
+          // so rows created before this change keep first-session semantics.
+          return {
+            data: {
+              ...user,
+              email: normalizedEmail,
+              ...(ip ? { signupIp: ip } : {}),
+            },
+          };
         },
         after: async (user) => {
           await writeAuditLog({

--- a/apps/web/lib/signup-velocity.ts
+++ b/apps/web/lib/signup-velocity.ts
@@ -1,0 +1,80 @@
+import { prisma } from "@octopus/db";
+
+/**
+ * Hard signup-velocity cap — a pre-create BLOCK, unlike the welcome-credit
+ * scorer which only withholds the bonus. Runs in auth.ts
+ * `databaseHooks.user.create.before` (covers magic link AND OAuth) and counts
+ * existing users whose signupIp matches the requester's IP (exact, then /24)
+ * over the last 24h. The signup-farm post-mortem (issue #788): 94 hosting IPs
+ * at ~120 signups each sailed past every per-request limiter; this bounds
+ * accounts-per-IP-per-day instead of requests-per-minute.
+ *
+ * Kill switch: SIGNUP_VELOCITY_CAP=off. Caps env-tunable via
+ * SIGNUP_MAX_PER_IP_DAY (default 5) and SIGNUP_MAX_PER_SUBNET_DAY (default 15).
+ * No IP, or a private/loopback IP (self-host behind an unset proxy), skips the
+ * cap entirely — never punish an absent signal.
+ */
+
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+
+function envInt(name: string, fallback: number): number {
+  const v = Number(process.env[name]);
+  return Number.isFinite(v) && v > 0 ? v : fallback;
+}
+
+/**
+ * Private / loopback / link-local ranges (v4 + v6) where velocity is
+ * meaningless. The caller passes better-auth's getIp() output, so IPv6
+ * arrives expanded and /64-masked — ::1 / :: reach us as the all-zeros form,
+ * hence the `0000:...` prefix alongside the raw `::1` (kept for direct calls).
+ */
+const PRIVATE_IP_RE =
+  /^(10\.|127\.|192\.168\.|169\.254\.|172\.(1[6-9]|2\d|3[01])\.|::1$|0000:0000:0000:0000:|f[cd][0-9a-f]{2}:|fe80:)/i;
+
+/** "94.23.11.7" → "94.23.11." — null for anything that isn't dotted-quad IPv4. */
+function ipv4Prefix24(ip: string): string | null {
+  const m = /^(\d{1,3}\.\d{1,3}\.\d{1,3})\.\d{1,3}$/.exec(ip);
+  return m ? `${m[1]}.` : null;
+}
+
+export type SignupVelocityResult =
+  | { blocked: false }
+  | {
+      blocked: true;
+      reason: "ip" | "subnet";
+      ipCount: number;
+      subnetCount: number | null;
+    };
+
+/**
+ * Decide whether a signup from `ip` exceeds the 24h velocity caps.
+ * `blocked: true` means the caller must reject the user creation.
+ */
+export async function checkSignupVelocity(
+  ip: string | null | undefined,
+): Promise<SignupVelocityResult> {
+  if (process.env.SIGNUP_VELOCITY_CAP === "off") return { blocked: false };
+  if (!ip || PRIVATE_IP_RE.test(ip)) return { blocked: false };
+
+  const since = new Date(Date.now() - WINDOW_MS);
+  const ipCount = await prisma.user.count({
+    where: { signupIp: ip, createdAt: { gte: since } },
+  });
+  if (ipCount >= envInt("SIGNUP_MAX_PER_IP_DAY", 5)) {
+    return { blocked: true, reason: "ip", ipCount, subnetCount: null };
+  }
+
+  // For IPv6 the exact match above is already a /64 cap: the caller feeds us
+  // better-auth's getIp() output, which masks IPv6 to its /64.
+  const prefix = ipv4Prefix24(ip);
+  if (!prefix) return { blocked: false }; // ponytail: no v6 subnet query; add a /48 rule if v6 farms show up
+
+  const subnetCount = await prisma.user.count({
+    where: { signupIp: { startsWith: prefix }, createdAt: { gte: since } },
+  });
+  if (subnetCount >= envInt("SIGNUP_MAX_PER_SUBNET_DAY", 15)) {
+    return { blocked: true, reason: "subnet", ipCount, subnetCount };
+  }
+
+  return { blocked: false };
+}


### PR DESCRIPTION
## Summary

Part of #788, control P0-d. The farm used 94 hosting IPs at roughly 120 signups each; every existing limiter is per request per minute, so it never fired. This adds a hard cap on accounts per IP per day and per IPv4 /24 per day, enforced before the user row is created.

## Changes
- New `apps/web/lib/signup-velocity.ts`: `checkSignupVelocity(ip)` counts users by `signupIp` over the last 24h. Blocks at `SIGNUP_MAX_PER_IP_DAY` (default 5) or `SIGNUP_MAX_PER_SUBNET_DAY` (default 15, IPv4 /24 via a prefix match). Missing, private, loopback and link-local IPs skip the cap. Kill switch `SIGNUP_VELOCITY_CAP=off`. IPv6 gets the exact-IP cap only, which is effectively a /64 cap because better-auth masks IPv6 to /64 before it reaches us.
- `apps/web/lib/auth.ts` `databaseHooks.user.create.before` (covers magic link and OAuth): resolves the IP with better-auth's own `getIp(headers, options)`, the same function `session.create.after` uses to stamp `signupIp`, so the compared strings are byte-identical (a reviewer caught that `getClientIp` produced a different string for IPv6). On block: writes an `auth.signup_blocked_velocity` audit row and throws `APIError("TOO_MANY_REQUESTS")` with "Too many sign-ups from this network today. Please try again tomorrow or contact support."
- `signupIp` is now also stamped at create time (declared as a non-input, non-returned `additionalFields` entry so the adapter persists it). This closes the count-then-create gap: accounts that never open a session are counted, and a parallel burst can only overshoot by the concurrent INSERT window. The existing set-once update in `session.create.after` guards on `signupIp: null`, so older rows keep first-session semantics.

No new dependencies. Welcome scorer untouched.

## Tests
- New `lib/__tests__/signup-velocity.test.ts` (8): under-cap allow, per-IP block at cap, /24 block at cap (asserts the prefix query shape), env overrides for both caps, missing-IP skip, private/loopback skip including the normalized `0000:…` loopback form, IPv6 exact-only, kill switch.
- `welcome-credit` + `org-create` suites still green. `bun run typecheck` and eslint clean.

## Reviewer notes
- Fail-closed on DB error is deliberate: a prisma failure in the count fails the signup, which would fail on the INSERT anyway. A fail-open catch would recreate the welcome-scorer bypass documented in #788.
- For magic link the cap fires at link click (user create), not at send. A legitimate sixth-of-the-day office user sees the 429 on the verify step.
- The /24 query compiles to `LIKE 'a.b.c.%'`, which the `signupIp` btree may not serve under a non-C collation. User-create only, so not a hot path.
- Defaults (5 per IP, 15 per /24) are for a public SaaS. Self-hosters behind a NAT with many users should raise them or set the kill switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zndCzrLf9nCP92ojuPT6j
