### PR TITLE
fix(auth): block firegameplay.com and make the signup domain blocklist env-extensible

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,10 @@ OCTOPUS_SELF_HOSTED=
 DISABLE_ADMIN_SEED=
 OCTOPUS_ADMIN_EMAIL=
 OCTOPUS_ADMIN_PASSWORD=
+# Comma-separated list of extra email domains refused at signup, subdomains
+# included (e.g. "foo.com,bar.net"). Merged into the disposable-domain blocklist
+# at startup; use it to block abusive domains without a code release.
+SIGNUP_BLOCKED_DOMAINS=
 
 # Review worker
 # Only containers with this set to "true" will consume pg-boss "process-review"

--- a/apps/web/lib/__tests__/email-validator.test.ts
+++ b/apps/web/lib/__tests__/email-validator.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "bun:test";
-import { isDisposableDomain } from "@/lib/email-validator";
+import {
+  isDisposableDomain,
+  parseBlockedDomainsEnv,
+} from "@/lib/email-validator";
 
 describe("isDisposableDomain", () => {
   it("flags a known disposable root domain", () => {
@@ -44,5 +47,43 @@ describe("isDisposableDomain", () => {
     // Construct a domain that shares a suffix with a disposable root but
     // without the leading dot — it must not match.
     expect(isDisposableDomain("legitmail.com")).toBe(false);
+  });
+
+  it("blocks the rotated signup-farm domain firegameplay.com and its subdomains (#788)", () => {
+    expect(isDisposableDomain("firegameplay.com")).toBe(true);
+    expect(isDisposableDomain("k3zp9.firegameplay.com")).toBe(true);
+  });
+});
+
+describe("parseBlockedDomainsEnv", () => {
+  it("returns an empty list for undefined or empty input", () => {
+    expect(parseBlockedDomainsEnv(undefined)).toEqual([]);
+    expect(parseBlockedDomainsEnv("")).toEqual([]);
+    expect(parseBlockedDomainsEnv(" , ,")).toEqual([]);
+  });
+
+  it("trims, lowercases, and splits on commas", () => {
+    expect(parseBlockedDomainsEnv(" Foo.com , BAR.NET")).toEqual([
+      "foo.com",
+      "bar.net",
+    ]);
+  });
+
+  it("strips a leading @ or dot and a trailing dot", () => {
+    expect(parseBlockedDomainsEnv("@foo.com,bar.net.,.baz.org")).toEqual([
+      "foo.com",
+      "bar.net",
+      "baz.org",
+    ]);
+  });
+
+  it("ignores entries without a dot so a bare TLD cannot block everything", () => {
+    expect(parseBlockedDomainsEnv("com,foo.com,net.")).toEqual(["foo.com"]);
+  });
+
+  it("de-duplicates entries", () => {
+    expect(parseBlockedDomainsEnv("foo.com,FOO.COM,@foo.com.")).toEqual([
+      "foo.com",
+    ]);
   });
 });

--- a/apps/web/lib/email-validator.ts
+++ b/apps/web/lib/email-validator.ts
@@ -9,11 +9,31 @@ const EXTRA_BLOCKED_DOMAINS = [
   "foodhz.com",
   "birdzpt.com",
   "rainsase.com",
+  "firegameplay.com",
 ];
+
+// Parses SIGNUP_BLOCKED_DOMAINS (comma-separated registrable domains) into a
+// normalized, de-duplicated list. Entries without a dot (a bare TLD such as
+// "com") are ignored: the suffix match below would otherwise refuse every
+// address under that TLD. Exported for tests.
+export function parseBlockedDomainsEnv(value: string | undefined): string[] {
+  if (!value) return [];
+  const seen = new Set<string>();
+  for (const raw of value.split(",")) {
+    const domain = raw
+      .trim()
+      .toLowerCase()
+      .replace(/^[@.]+/, "")
+      .replace(/\.+$/, "");
+    if (domain.includes(".")) seen.add(domain);
+  }
+  return [...seen];
+}
 
 const DISPOSABLE_LIST = [
   ...(disposableDomains as string[]),
   ...EXTRA_BLOCKED_DOMAINS,
+  ...parseBlockedDomainsEnv(process.env.SIGNUP_BLOCKED_DOMAINS),
 ];
 const DISPOSABLE_SET = new Set<string>(DISPOSABLE_LIST);
 


### PR DESCRIPTION
## Summary

Follow-up to #789 and #788. The farm moved to a sixth domain, `firegameplay.com`, within a day of the five-domain blocklist going live, and 4 accounts on it got through after the v1.0.131 deploy. This blocks it and makes the extra blocklist extensible at runtime so the next rotation does not need a release.

## Changes
- `apps/web/lib/email-validator.ts`: `firegameplay.com` added to `EXTRA_BLOCKED_DOMAINS`. New exported `parseBlockedDomainsEnv(value)` reads `SIGNUP_BLOCKED_DOMAINS` (comma-separated registrable domains): trims, lowercases, strips a leading `@` or `.` and trailing dots, de-duplicates, and ignores entries without a dot so `com` cannot block every `.com` address. The result is merged into the disposable set at module load, so the existing exact and `.<root>` suffix match covers subdomains.
- `.env.example`: documents `SIGNUP_BLOCKED_DOMAINS` next to the signup and admin-seed settings.

MX and DNS fail-open behaviour unchanged.

## Tests
- `lib/__tests__/email-validator.test.ts` (12 pass): firegameplay.com root and a random subdomain rejected; parser cases for empty input, trim and lowercase, `@`/dot stripping, de-duplication, and dotless entries ignored.
- `bun run typecheck` and eslint clean.

## Ops note
To block a new domain without a release: add it to `SIGNUP_BLOCKED_DOMAINS` in `/opt/octopus/.env.production` and redeploy with `apply_stack=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zndCzrLf9nCP92ojuPT6j
