### PR TITLE
feat(models): GPT-6 Astra launch — pricing row, KB, cost fallback, blog post

### DIFF
--- a/apps/web/app/(landing)/docs/pricing/page.tsx
+++ b/apps/web/app/(landing)/docs/pricing/page.tsx
@@ -128,6 +128,7 @@ export default function PricingPage() {
               <ModelRow model="Claude Haiku 4.5" input="$1" output="$5" />
               <ModelRow model="Gemini 2.5 Pro" input="$1.25" output="$10" />
               <ModelRow model="Gemini 2.5 Flash" input="$0.15" output="$0.60" />
+              <ModelRow model="GPT-6 Astra" input="$10" output="$50" />
               <ModelRow model="GPT-5.3 Codex" input="$1.75" output="$14" />
               <ModelRow model="Qwen3.8-Max" input="$2" output="$6" />
               <ModelRow model="Embeddings (text-embedding-3-large)" input="$0.13" output="—" />

--- a/apps/web/lib/cost.ts
+++ b/apps/web/lib/cost.ts
@@ -34,6 +34,8 @@ const FALLBACK_PRICING: Record<string, ModelPricing> = {
   "claude-haiku-4-5-20251001": { input: 1, output: 5 },
   "gemini-2.5-pro": { input: 1.25, output: 10 },
   "gemini-2.5-flash": { input: 0.15, output: 0.6 },
+  // OpenAI GPT-6 Astra (2026-09-03) list price; the DB catalog row is authoritative.
+  "gpt-6-astra": { input: 10, output: 50 },
   "gpt-5.3-codex": { input: 1.75, output: 14 },
   // Claude Code is subscription-billed (not per-token), so platform price is 0.
   "claude-code:sonnet": { input: 0, output: 0 },

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -217,6 +217,7 @@ Claude Sonnet 5 — $2 input / $10 output. Fast and strong; the default for self
 Claude Sonnet 4.6 and Claude Sonnet 4 — $3 input / $15 output. Previous Sonnet generation.
 Claude Haiku 4.5 — $1 input / $5 output. Lightweight tasks like title generation.
 Gemini 2.5 Pro — $1.25 input / $10 output. Gemini 2.5 Flash — $0.15 input / $0.60 output.
+GPT-6 Astra — $10 input / $50 output. OpenAI's flagship (released September 3, 2026); 1M-token context, opt-in review model; BYOK with an OpenAI key supported.
 GPT-5.3 Codex — $1.75 input / $14 output.
 Qwen3.8-Max — $2 input / $6 output. Alibaba Cloud Model Studio (Qwen), via the DashScope API; BYOK supported.
 Embeddings: text-embedding-3-large ($0.13) and text-embedding-3-small ($0.02).

--- a/apps/web/scripts/data/blog-posts/gpt-6-astra.md
+++ b/apps/web/scripts/data/blog-posts/gpt-6-astra.md
@@ -1,0 +1,79 @@
+---
+title: OpenAI GPT-6 Astra is now available in Octopus
+slug: gpt-6-astra-now-available
+excerpt: OpenAI released GPT-6 Astra on September 3, and it can now review your pull requests. What it is, what it costs, and when to pick it over your default.
+category: Product
+tags: [GPT-6 Astra, OpenAI, Models, Code Review, Pricing]
+authorName: Octopus Team
+---
+
+OpenAI released GPT-6 Astra on September 3, and it is already in Octopus. You can pick it as the review model for an organization or a single repository, on our cloud or with your own OpenAI key.
+
+## What it is
+
+GPT-6 Astra is OpenAI's new flagship, the successor to GPT-5.6 Sol. Three things about it matter for code review.
+
+It is big on context: a 1,050,000-token window and up to 128,000 output tokens in one answer, so a large diff plus the surrounding code fits without trimming. It reasons before it answers, with an effort setting that goes from low to max. And OpenAI trained it hard on finding bugs and security flaws: it is the first OpenAI model the company classifies as "Critical" for cybersecurity, and access to the most advanced exploit capabilities is limited to a separate program. For review work that is the interesting part. A model that is good at finding vulnerabilities in other people's code is also good at finding them in your pull request.
+
+On coding benchmarks it lands at the top of the pack rather than far ahead of it. OpenAI's own numbers, run at maximum effort, put it just under 58 percent on Terminal-Bench 4.0, ahead of Claude Fable 5.1 at 55.8 and Claude Opus 5 at 52.3, and at 74.1 percent on DeepSWE v1.1 against 67.4 for Fable 5.1. On Artificial Analysis's independent Coding Agent index the three are within a point of each other, with Fable 5 slightly ahead. So treat Astra as a reason to try, not as a verdict. Your own code is the benchmark that counts.
+
+OpenAI's announcement is at [openai.com/index/gpt-6-astra](https://openai.com/index/gpt-6-astra/), the model card with limits and prices at [developers.openai.com](https://developers.openai.com/api/docs/models/gpt-6-astra), and Vellum has a readable walk through the numbers at [vellum.ai](https://www.vellum.ai/blog/gpt-6-astra-benchmarks-explained).
+
+## Your default does not change
+
+Nothing changes unless you ask it to. Reviews keep running on the same model at the same cost. GPT-6 Astra is an option you switch on per organization or per repository in Settings, and you can switch back any time. Your review history, and everything Octopus has learned about your codebase, carry over.
+
+## What GPT-6 Astra costs
+
+OpenAI's list price is $10 per million input tokens and $50 per million output tokens, with cached input at $1. That is 2.5 times GPT-5.6 Sol and exactly the price of Claude Fable 5.1. Octopus Cloud bills usage at twice the provider's list price, which is our platform rate and the only fee, so on our credits that comes to $20 and $100. For comparison, list prices per million tokens:
+
+| Model | Input | Output |
+|---|---|---|
+| GPT-6 Astra | $10 | $50 |
+| Claude Fable 5.1 | $10 | $50 |
+| Claude Opus 5 (Cloud default) | $5 | $25 |
+| GPT-5.3 Codex | $1.75 | $14 |
+
+Output tokens are where review bills grow, because findings, explanations and suggested patches are all output. Against Opus 5, Astra costs twice as much on both sides. With your own OpenAI key, Octopus charges nothing for the model call and OpenAI bills you at list.
+
+Two OpenAI details you do not need to worry about on Octopus. Fast mode, which doubles the price for speed, is not used for reviews. And the long-context surcharge, which doubles input pricing on requests above 272,000 input tokens, is never triggered: Octopus caps the diff it sends at 300,000 characters, roughly 75,000 tokens, and tells you when a diff was cut.
+
+The full table is on the [pricing page](/docs/pricing).
+
+## When GPT-6 Astra is worth trying
+
+- Security-sensitive changes: authentication, payments, anything that parses untrusted input. This is where OpenAI's cyber training should show.
+- Very large pull requests. The 1M window means less trimming and more of the surrounding code in view.
+- Teams already standardized on OpenAI who want reviews billed to an account they control.
+- Any repository where you want a second opinion next to your Claude default on the changes that matter most.
+
+Keep your current model on routine work, at least until you have compared the two on your own code. That is what the per-repository setting is for.
+
+## A few things to know
+
+Octopus calls GPT-6 Astra through OpenAI's Chat Completions API with structured output, the same path as our other OpenAI models, and leaves the reasoning effort at OpenAI's default. The small helper calls around a review, such as classifying your replies to comments, run on a separate internal model and are not affected by which review model you pick.
+
+A reasoning model takes longer than one that answers straight away, so expect a longer wait on a big change.
+
+OpenAI is rolling Astra out in phases. Our OpenAI account already lists it, so reviews on Octopus credits work today. If you bring your own key and the model is not in your account yet, the review fails with OpenAI's error until your access arrives; switch back to your default in the meantime.
+
+OpenAI is listed on our [sub-processors page](/docs/sub-processors), and the [security overview](/docs/security-overview) describes what leaves your repository.
+
+## How to switch it on
+
+1. Open Settings in Octopus and go to Models.
+2. Choose GPT-6 Astra as the review model for your organization, or open a repository and pick it there.
+3. Optionally, paste an OpenAI key under API keys in Settings. Reviews then run on your account instead of our credits.
+4. Open a pull request. The next review runs on Astra.
+
+Self-hosting? Set `OPENAI_API_KEY` in your environment and add the model to your catalog; it then shows up in the same Settings dropdowns. The [self-hosting docs](/docs/self-hosting) have the details.
+
+## Questions we expect
+
+**Is Astra the new default?** No. The Octopus Cloud default stays [Claude Opus 5](/blog/claude-opus-5-now-available). GPT-6 Astra is opt-in.
+
+**Which id should I use in the API or CLI?** `gpt-6-astra`. That is OpenAI's official id, and it is what appears in usage reports.
+
+**Is it better than Fable 5.1 for reviews?** Same price, different strengths. Astra leads on OpenAI's terminal and security benchmarks, Fable 5.1 leads on the independent Artificial Analysis index. Run both on a few real pull requests and keep the one that finds what your team misses.
+
+Not sure whether it makes sense for your team? Reply to any Octopus email or ask in the app. It comes straight to us.


### PR DESCRIPTION
## Why

OpenAI released **GPT-6 Astra** on 2026-09-03 (`gpt-6-astra`; $10 / $50 per 1M list, cached $1; 1,050,000-token context, 128k output; reasoning effort low→max; Chat Completions + structured outputs supported). Our production OpenAI key already lists it (admin model discovery). Search interest is high right now, so we want the launch post live today.

## What

- `docs/pricing` page: `GPT-6 Astra $10 / $50` row next to the other OpenAI row.
- `lib/docs-content.ts` (Ask-Octopus KB): pricing line for GPT-6 Astra (needs a KB reseed after deploy).
- `lib/cost.ts`: static fallback `"gpt-6-astra": { input: 10, output: 50 }` (the DB catalog row stays authoritative; the row is added via the admin console).
- Blog post source `apps/web/scripts/data/blog-posts/gpt-6-astra.md`, slug `gpt-6-astra-now-available`, same structure as the Qwen and Fable 5.1 posts. Facts: OpenAI model card + announcement, Vellum's benchmark write-up (numbers attributed, rounded where sources differ). Humanizer pass applied; no em dashes.

No provider code change: the existing OpenAI path (chat.completions, `max_completion_tokens`, `json_schema` strict) covers Astra; `usesResponsesApi` only applies to codex models.

## Checks

- `bun test scripts/__tests__/publish-blog-post.test.ts`: 2 pass
- Dry publish via `blog-publish.yml` dispatched from this branch (see Actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbAThbRPYGBRufVyazrUad
