### PR TITLE
feat(seo): AI-search readiness — Organization schema, llms.txt / llms-full.txt, vendor copy fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- AI search readiness: `/llms-full.txt` (full documentation text, generated from the same corpus as Ask Octopus), an Organization schema with our public profiles on every marketing page, a Blog schema on the blog index, and explicit robots rules for ChatGPT search and Bing. `/llms.txt` now lists every supported AI vendor, the GitHub Action, CLI, MCP plugin and blog.
+
+### Fixed
+- The About page, FAQ and homepage said reviews run on "Claude and OpenAI" or "Claude, OpenAI, Gemini or Qwen"; they now name all supported vendors, including Grok and OpenRouter.
+
 ## [1.0.135] - 2026-09-04
 
 ### Added

--- a/apps/web/app/(landing)/blog/[slug]/page.tsx
+++ b/apps/web/app/(landing)/blog/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ORGANIZATION_ENTITY } from "@/lib/structured-data";
 import { notFound } from "next/navigation";
 import Link from "@/components/link";
 import { headers } from "next/headers";
@@ -93,14 +94,7 @@ export default async function BlogPostPage({
       "@type": "Person",
       name: post.authorName,
     },
-    publisher: {
-      "@type": "Organization",
-      name: "Octopus",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://octopus-review.ai/logo.svg",
-      },
-    },
+    publisher: ORGANIZATION_ENTITY,
     mainEntityOfPage: {
       "@type": "WebPage",
       "@id": canonicalUrl,

--- a/apps/web/app/(landing)/blog/page.tsx
+++ b/apps/web/app/(landing)/blog/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ORGANIZATION_ENTITY, SITE_URL, jsonLd } from "@/lib/structured-data";
 import Link from "@/components/link";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
@@ -167,8 +168,20 @@ export default async function BlogPage({
   const TAG_SIZE = ["text-xs", "text-xs", "text-sm", "text-sm"];
   const TAG_TONE = ["text-[#666]", "text-[#888]", "text-[#aaa]", "text-white"];
 
+  const blogJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    "@id": `${SITE_URL}/blog#blog`,
+    name: "Octopus Blog",
+    url: `${SITE_URL}/blog`,
+    description:
+      "Product news, model launches and engineering notes from the Octopus AI code review team.",
+    publisher: ORGANIZATION_ENTITY,
+  };
+
   return (
     <div className="min-h-screen bg-[#0c0c0c] text-white">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLd(blogJsonLd) }} />
       <LandingDesktopNav isLoggedIn={isLoggedIn} />
       <LandingMobileNav isLoggedIn={isLoggedIn} />
 

--- a/apps/web/app/(landing)/docs/about/page.tsx
+++ b/apps/web/app/(landing)/docs/about/page.tsx
@@ -95,7 +95,7 @@ export default function AboutPage() {
           <TechCard name="Next.js" detail="App Router, React 19" />
           <TechCard name="Prisma" detail="PostgreSQL ORM" />
           <TechCard name="Qdrant" detail="Vector search" />
-          <TechCard name="Claude & OpenAI" detail="AI review engine" />
+          <TechCard name="Claude, GPT, Gemini, Grok, Qwen" detail="AI review models, plus OpenRouter" />
           <TechCard name="Tailwind CSS" detail="Styling" />
           <TechCard name="TypeScript" detail="End-to-end type safety" />
         </div>

--- a/apps/web/app/(landing)/docs/faq/page.tsx
+++ b/apps/web/app/(landing)/docs/faq/page.tsx
@@ -18,7 +18,7 @@ const generalFaqs = [
   },
   {
     q: "How does Octopus review my code?",
-    a: "When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Claude, OpenAI, Google Gemini, or Qwen) for analysis. The results are posted as PR comments with severity indicators: 🔴 Critical, 🟠 Major, 🟡 Minor, 🔵 Suggestion, 💡 Tip.",
+    a: "When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Anthropic Claude, OpenAI GPT, Google Gemini, xAI Grok, Alibaba Qwen, or any model on OpenRouter) for analysis. The results are posted as PR comments with severity indicators: 🔴 Critical, 🟠 Major, 🟡 Minor, 🔵 Suggestion, 💡 Tip.",
   },
   {
     q: "Which programming languages does Octopus support?",

--- a/apps/web/app/(landing)/layout.tsx
+++ b/apps/web/app/(landing)/layout.tsx
@@ -1,4 +1,5 @@
 import { AskOctopus } from "@/components/ask-octopus";
+import { ORGANIZATION_JSON_LD, jsonLd } from "@/lib/structured-data";
 
 export default function LandingLayout({
   children,
@@ -7,6 +8,10 @@ export default function LandingLayout({
 }) {
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLd(ORGANIZATION_JSON_LD) }}
+      />
       {children}
       <AskOctopus />
     </>

--- a/apps/web/app/(landing)/page.tsx
+++ b/apps/web/app/(landing)/page.tsx
@@ -1,4 +1,5 @@
 import Link from "@/components/link";
+import { ORGANIZATION_ENTITY } from "@/lib/structured-data";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
@@ -35,7 +36,7 @@ const landingFaqs = [
   },
   {
     q: "How does the automated review work?",
-    a: "When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Claude, OpenAI, Google Gemini, or Qwen) for analysis. Findings are posted directly on the PR with severity ratings: Critical, Major, Minor, Suggestion, and Tip.",
+    a: "When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Anthropic Claude, OpenAI GPT, Google Gemini, xAI Grok, Alibaba Qwen, or any model on OpenRouter) for analysis. Findings are posted directly on the PR with severity ratings: Critical, Major, Minor, Suggestion, and Tip.",
   },
   {
     q: "Which programming languages are supported?",
@@ -82,7 +83,9 @@ const productJsonLd = {
     "Real-time WebSocket updates",
     "Knowledge base for custom review rules",
     "CLI for terminal-based workflows",
+    "Choice of AI vendor: Anthropic Claude, OpenAI GPT, Google Gemini, xAI Grok, Alibaba Qwen, or OpenRouter",
   ],
+  publisher: ORGANIZATION_ENTITY,
 };
 
 const faqJsonLd = {

--- a/apps/web/app/llms-full.txt/route.ts
+++ b/apps/web/app/llms-full.txt/route.ts
@@ -1,0 +1,31 @@
+import { docsContent } from "@/lib/docs-content";
+
+// llms-full.txt (llmstxt.org): the full-detail companion to /llms.txt.
+// Generated from the same plain-text corpus that feeds Ask Octopus, so it
+// cannot drift from the docs the way a hand-maintained copy would.
+export const revalidate = 86400;
+
+export function renderLlmsFull(): string {
+  const parts: string[] = [
+    "# Octopus — full documentation text",
+    "",
+    "> AI code review for pull requests on GitHub, GitLab and Bitbucket, with full-repository context. Cloud service at https://octopus-review.ai; self-hosting optional. Short index: https://octopus-review.ai/llms.txt",
+    "",
+  ];
+  for (const doc of docsContent) {
+    parts.push(`## ${doc.title}`, "");
+    for (const section of doc.sections) {
+      parts.push(`### ${section.heading}`, "", section.text.trim(), "");
+    }
+  }
+  return parts.join("\n");
+}
+
+export async function GET() {
+  return new Response(renderLlmsFull(), {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -33,6 +33,9 @@ export default function robots(): MetadataRoute.Robots {
       { userAgent: "Google-Extended", allow: "/", disallow },
       { userAgent: "PerplexityBot", allow: "/", disallow },
       { userAgent: "CCBot", allow: "/", disallow },
+      // AI search (as opposed to training) crawlers: ChatGPT search and Bing/Copilot.
+      { userAgent: "OAI-SearchBot", allow: "/", disallow },
+      { userAgent: "Bingbot", allow: "/", disallow },
     ],
     sitemap: "https://octopus-review.ai/sitemap.xml",
   };

--- a/apps/web/lib/__tests__/structured-data.test.ts
+++ b/apps/web/lib/__tests__/structured-data.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { ORGANIZATION_ENTITY, ORGANIZATION_JSON_LD, SOCIAL_PROFILES, jsonLd } from "@/lib/structured-data";
+import { docsContent } from "@/lib/docs-content";
+import { GET, renderLlmsFull } from "@/app/llms-full.txt/route";
+
+describe("Organization entity", () => {
+  it("is one addressable entity with public profiles", () => {
+    expect(ORGANIZATION_ENTITY["@id"]).toBe("https://octopus-review.ai/#organization");
+    expect(SOCIAL_PROFILES.length).toBeGreaterThanOrEqual(5);
+    for (const url of ORGANIZATION_JSON_LD.sameAs) expect(url).toMatch(/^https:\/\//);
+    expect(jsonLd({ a: "</script><script>alert(1)" })).not.toContain("</script>");
+  });
+});
+
+describe("llms.txt files", () => {
+  const short = readFileSync(new URL("../../public/llms.txt", import.meta.url), "utf8");
+
+  it("llms.txt names every vendor and surface and links the full file", () => {
+    for (const needle of ["Grok", "Qwen", "OpenRouter", "GPT-6 Astra", "GitHub Action", "CLI", "MCP", "/blog", "llms-full.txt", "source-available"]) {
+      expect(short).toContain(needle);
+    }
+    expect(short).not.toMatch(/open[- ]source/i);
+    expect(short.startsWith("# Octopus\n\n> ")).toBe(true);
+  });
+
+  it("llms-full.txt is served as text and carries every documented page", async () => {
+    const res = await GET();
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    const body = await res.text();
+    expect(body).toBe(renderLlmsFull());
+    for (const doc of docsContent) expect(body).toContain(`## ${doc.title}`);
+    expect(body).toContain("GPT-6 Astra");
+  });
+});

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -59,7 +59,7 @@ Self-Host Ready — Run Octopus on your own infrastructure with one Docker Compo
 A: Octopus is an AI-powered code review tool that connects to GitHub, GitLab, and Bitbucket, indexes your codebase for deep context, and automatically reviews every pull request (and GitLab merge request) — posting findings as inline comments with severity levels.
 
 Q: How does the automated review work?
-A: When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Claude, OpenAI, or Google Gemini) for analysis. Findings are posted directly on the PR with severity ratings: Critical, Major, Minor, Suggestion, and Tip.
+A: When a pull request is opened, Octopus fetches the diff, retrieves relevant context from your indexed codebase using vector search, and sends it to an LLM (Anthropic Claude, OpenAI GPT, Google Gemini, xAI Grok, Alibaba Qwen, or any model on OpenRouter) for analysis. Findings are posted directly on the PR with severity ratings: Critical, Major, Minor, Suggestion, and Tip.
 
 Q: Which programming languages are supported?
 A: Octopus is language-agnostic. It reviews any text-based code file — TypeScript, Python, Go, Rust, Java, C#, Ruby, PHP, Swift, Kotlin, and more.
@@ -335,7 +335,7 @@ Running without Docker: Install Bun, set up PostgreSQL and Qdrant locally, run b
 A: Octopus is a source-available, AI-powered code review tool that indexes your codebase and automatically reviews pull requests with context-aware findings.
 
 Q: How does Octopus review code?
-A: When a PR is opened, Octopus fetches the diff, retrieves relevant code context via vector search, and uses an LLM (Claude, OpenAI, or Google Gemini) to analyze changes. Findings are posted as inline PR comments.
+A: When a PR is opened, Octopus fetches the diff, retrieves relevant code context via vector search, and uses an LLM (Anthropic Claude, OpenAI GPT, Google Gemini, xAI Grok, Alibaba Qwen, or any model on OpenRouter) to analyze changes. Findings are posted as inline PR comments.
 
 Q: What languages does Octopus support?
 A: Octopus is language-agnostic. It supports TypeScript, JavaScript, Python, Go, Rust, Java, C#, Ruby, PHP, Swift, Kotlin, Scala, C, C++, Vue, Svelte, Astro, HTML, CSS, SQL, GraphQL, and more.
@@ -435,7 +435,7 @@ Embeddings: Numerical vector representations of text. Octopus uses OpenAI text-e
 
 Knowledge Base: Custom documents uploaded to an organization (coding guidelines, architecture decisions, style guides) that Octopus references during reviews.
 
-LLM (Large Language Model): AI models like Claude (Anthropic), GPT (OpenAI), and Gemini (Google) that analyze code and generate review findings.
+LLM (Large Language Model): AI models like Claude (Anthropic), GPT (OpenAI), Gemini (Google), Grok (xAI) and Qwen (Alibaba) that analyze code and generate review findings.
 
 .octopusignore: A file in your repository root (same syntax as .gitignore) that tells Octopus which files to skip during indexing and review.
 

--- a/apps/web/lib/structured-data.ts
+++ b/apps/web/lib/structured-data.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared schema.org entities for the marketing site. One Organization entity
+ * (with sameAs profiles) is emitted site-wide from the landing layout and
+ * referenced by @id from page-level schemas, so search engines and LLM
+ * crawlers resolve "Octopus" to one entity and its public profiles.
+ */
+export const SITE_URL = "https://octopus-review.ai";
+export const ORGANIZATION_ID = `${SITE_URL}/#organization`;
+
+export const SOCIAL_PROFILES = [
+  "https://github.com/octopusreview",
+  "https://x.com/octopus_review",
+  "https://www.linkedin.com/company/octopus-review",
+  "https://www.reddit.com/r/octopusreview/",
+  "https://www.youtube.com/@OctopusReview",
+  "https://bsky.app/profile/octopus-review.ai",
+] as const;
+
+export const AI_VENDORS_SENTENCE =
+  "Anthropic Claude, OpenAI GPT, Google Gemini, xAI Grok, Alibaba Qwen, or any model on OpenRouter";
+
+/** Organization without @context, for embedding as publisher/author. */
+export const ORGANIZATION_ENTITY = {
+  "@type": "Organization",
+  "@id": ORGANIZATION_ID,
+  name: "Octopus",
+  alternateName: "Octopus Review",
+  url: SITE_URL,
+  logo: {
+    "@type": "ImageObject",
+    url: `${SITE_URL}/logo.svg`,
+  },
+  description:
+    "Octopus is an AI code review service that reviews every pull request on GitHub, GitLab and Bitbucket with full-repository context and posts severity-rated findings inline.",
+  sameAs: [...SOCIAL_PROFILES],
+} as const;
+
+export const ORGANIZATION_JSON_LD = {
+  "@context": "https://schema.org",
+  ...ORGANIZATION_ENTITY,
+} as const;
+
+/** JSON for a <script type="application/ld+json"> body; closes no script tag early. */
+export function jsonLd(value: unknown): string {
+  return JSON.stringify(value).replace(/<\/script>/gi, "<\\/script>");
+}

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,38 +1,51 @@
 # Octopus
 
-> AI-powered code review tool
+> AI code review for pull requests. Octopus reviews every PR on GitHub, GitLab and Bitbucket with full-repository context and posts severity-rated findings inline. Cloud service at octopus-review.ai; self-hosting is optional.
 
-Octopus is a source-available, AI-powered code review platform. It connects to GitHub, GitLab, and Bitbucket repositories, indexes codebases using vector embeddings, and automatically reviews pull requests — posting findings as inline comments with severity levels.
+Octopus is a source-available (Modified MIT) AI code review platform. It connects to your repositories, indexes the codebase with vector search, and reviews each pull request as it is opened or updated. Findings are posted as inline review comments with a severity (Critical, Major, Minor, Suggestion, Tip), a short explanation and, where useful, a suggested patch, plus a per-PR score table. Reviews re-run when the PR changes, and replies to review comments are understood and acted on.
 
-## Core Features
+## Core features
 
-- **Automated PR Review**: AI analyzes pull request diffs with full codebase context
-- **Severity Ratings**: Findings rated as 🔴 Critical, 🟠 Major, 🟡 Minor, 🔵 Suggestion, 💡 Tip
-- **Codebase Indexing**: Vector search over your entire codebase for context-aware reviews
-- **Multi-Provider AI**: Supports Anthropic Claude, OpenAI, and Google Gemini models
-- **Organization Knowledge**: Custom rules and guidelines per organization
-- **Re-review**: Address feedback and re-trigger reviews on updated code
+- Automated pull request review with codebase context (vector index over the whole repository, not just the diff)
+- Severity-rated findings and a per-PR quality score; re-review on new commits
+- Choice of AI vendor and model per organization or per repository: Anthropic Claude (Fable 5.1, Opus 5, Sonnet 5), OpenAI (GPT-6 Astra, GPT-5.3 Codex), Google Gemini, xAI Grok, Alibaba Cloud Qwen (Qwen3.8-Max), and any model on OpenRouter. Cloud default: Claude Opus 5.
+- Bring your own API keys (Anthropic, OpenAI, Google, xAI, Alibaba Cloud Model Studio, OpenRouter) or pay with Octopus credits
+- Organization knowledge base: custom rules and guidelines the reviewer follows
+- Package analyzer, code chat, issue creation from findings, live review timeline
 
-## Integrations
+## Ways to use it
 
-- GitHub (App installation)
-- GitLab (OAuth)
-- Bitbucket (OAuth webhooks)
-- Linear (issue creation from findings)
-- Slack (ask questions about your codebase)
+- GitHub App (recommended on cloud): automatic reviews on every pull request
+- GitLab and Bitbucket integrations
+- GitHub Action for CI-triggered reviews: https://octopus-review.ai/docs/github-action
+- CLI `octp` for local and terminal workflows: https://octopus-review.ai/docs/cli
+- MCP plugin for Claude Code and Cursor: https://github.com/octopusreview/octopus-plugin
+- Slack (ask questions about your codebase), Linear and Jira (create issues from findings): https://octopus-review.ai/docs/integrations
+- Self-hosting with Docker Compose: https://octopus-review.ai/docs/self-hosting
 
 ## Pricing
 
-Usage-based billing with credits. Free tier available. Pay only for AI tokens consumed during reviews.
+Usage-based. Free credits on signup, no subscription. Octopus Cloud bills AI usage at 2x the provider's list price and charges nothing else; with your own API keys the model call is free and the provider bills you. Provider list prices per 1M tokens are on https://octopus-review.ai/docs/pricing.
 
-## Links
+## Documentation
 
-- Website: https://octopus-review.ai
-- Docs: https://octopus-review.ai/docs/about
+- About: https://octopus-review.ai/docs/about
+- Getting started: https://octopus-review.ai/docs/getting-started
 - Pricing: https://octopus-review.ai/docs/pricing
 - FAQ: https://octopus-review.ai/docs/faq
-- CLI: https://octopus-review.ai/docs/cli
 - Integrations: https://octopus-review.ai/docs/integrations
-- Self-Hosting: https://octopus-review.ai/docs/self-hosting
+- CLI: https://octopus-review.ai/docs/cli
+- GitHub Action: https://octopus-review.ai/docs/github-action
+- Self-hosting: https://octopus-review.ai/docs/self-hosting
+- Security overview: https://octopus-review.ai/docs/security-overview
+- Sub-processors: https://octopus-review.ai/docs/sub-processors
 - Privacy: https://octopus-review.ai/docs/privacy
 - Terms: https://octopus-review.ai/docs/terms
+
+## More
+
+- Blog (model launches, product news): https://octopus-review.ai/blog
+- Compared with CodeRabbit: https://octopus-review.ai/vs-coderabbit
+- Full documentation text for LLMs: https://octopus-review.ai/llms-full.txt
+- Source: https://github.com/octopusreview/octopus
+- Contact: support@octopus-review.ai


### PR DESCRIPTION
## Why

A GEO (generative-engine optimization) audit of octopus-review.ai found: AI crawlers are allowed but the entity is weak (no Organization schema, no `sameAs` linking our GitHub/X/LinkedIn/Reddit/YouTube/Bluesky profiles), `/llms.txt` is stale (lists three vendors, no GitHub Action/CLI/MCP/blog), `/llms-full.txt` is a 404, the blog index has no schema, and the About page, FAQ and homepage still tell LLMs that reviews run on "Claude & OpenAI" or "Claude, OpenAI, Gemini or Qwen". LLM answers about "which models does Octopus support" quote exactly those passages.

## What

- **`lib/structured-data.ts`** — `ORGANIZATION_ENTITY` (`@id https://octopus-review.ai/#organization`, `sameAs` six profiles taken from the footer), `ORGANIZATION_JSON_LD`, `jsonLd()` (escapes `</script>`). Emitted once from `app/(landing)/layout.tsx`, so every marketing, docs and blog page carries it.
- Homepage `SoftwareApplication`: `publisher` → the entity; `featureList` gains the vendor choice. Blog index: new `Blog` schema. Blog posts: publisher stub → the shared entity (adds `sameAs`).
- **`/llms.txt`** rewritten to the current product (all vendors incl. GPT-6 Astra, Grok, Qwen, OpenRouter; GitHub App/Action, CLI, MCP plugin, Slack/Linear/Jira, self-host; pricing model; docs, blog, comparison, source, `llms-full.txt`). Still says source-available, never "open source".
- **`/llms-full.txt`** — new route rendering the Ask-Octopus docs corpus (`lib/docs-content.ts`, 55 sections) as markdown text, so it cannot drift from the docs. `revalidate` 1 day.
- `robots.ts`: explicit `OAI-SearchBot` and `Bingbot` groups (same allow/disallow).
- Copy: About "Built With" card, homepage + FAQ "how does the review work" answers, and three KB sentences now name every supported vendor. Sub-processor and training-data statements untouched (legal).

## Tests

New `lib/__tests__/structured-data.test.ts`: entity @id + https `sameAs`, `jsonLd` escaping, `llms.txt` names every vendor/surface and never says open source, `/llms-full.txt` is `text/plain` and contains every doc title. Full `bun test`: 1078 pass. ESLint clean on touched files.

Follow-ups (not here): per-page `WebPage` + `BreadcrumbList` on docs pages, Product/Offer schema on pricing, question-style headings on About/Pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbAThbRPYGBRufVyazrUad
