### PR TITLE
feat(seo): docs-page WebPage/BreadcrumbList schema, Grok + Kimi pricing rows, question headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Documentation pages (About, Pricing, Integrations, CLI, GitHub Action) now carry WebPage and breadcrumb structured data linked to the Octopus organization entity. The pricing table lists Grok 4.6 and Kimi K3 (via OpenRouter), and three docs headings are phrased as the questions people ask.
+
+### Added
 - AI search readiness: `/llms-full.txt` (full documentation text, generated from the same corpus as Ask Octopus), an Organization schema with our public profiles on every marketing page, a Blog schema on the blog index, and explicit robots rules for ChatGPT search and Bing. `/llms.txt` now lists every supported AI vendor, the GitHub Action, CLI, MCP plugin and blog.
 
 ### Fixed

--- a/apps/web/app/(landing)/docs/about/page.tsx
+++ b/apps/web/app/(landing)/docs/about/page.tsx
@@ -6,6 +6,7 @@ import {
   IconEye,
   IconRocket,
 } from "@tabler/icons-react";
+import { docsPageJsonLd, jsonLd } from "@/lib/structured-data";
 import { GetInTouchModal } from "@/components/get-in-touch-modal";
 import { TrackedAnchor } from "@/components/tracked-link";
 
@@ -21,6 +22,19 @@ export const metadata = {
 export default function AboutPage() {
   return (
     <article className="max-w-3xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: jsonLd(
+            docsPageJsonLd({
+              title: metadata.title,
+              description: metadata.description,
+              path: "/docs/about",
+              crumb: "About",
+            }),
+          ),
+        }}
+      />
       <div className="mb-8">
         <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#555]">
           <IconInfoCircle className="size-4" />
@@ -87,7 +101,7 @@ export default function AboutPage() {
       </Section>
 
       {/* Tech Stack */}
-      <Section title="Built With">
+      <Section title="What is Octopus built with?">
         <Paragraph>
           Octopus is built on modern, battle-tested technologies:
         </Paragraph>

--- a/apps/web/app/(landing)/docs/cli/page.tsx
+++ b/apps/web/app/(landing)/docs/cli/page.tsx
@@ -1,4 +1,5 @@
 import Link from "@/components/link";
+import { docsPageJsonLd, jsonLd } from "@/lib/structured-data";
 import { IconTerminal2 } from "@tabler/icons-react";
 import { CodeBlock } from "../self-hosting/code-block";
 
@@ -14,6 +15,19 @@ export const metadata = {
 export default function CLIPage() {
   return (
     <article className="prose-invert max-w-3xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: jsonLd(
+            docsPageJsonLd({
+              title: metadata.title,
+              description: metadata.description,
+              path: "/docs/cli",
+              crumb: "CLI",
+            }),
+          ),
+        }}
+      />
       <div className="mb-8">
         <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#555]">
           <IconTerminal2 className="size-4" />

--- a/apps/web/app/(landing)/docs/github-action/page.tsx
+++ b/apps/web/app/(landing)/docs/github-action/page.tsx
@@ -1,4 +1,5 @@
 import Link from "@/components/link";
+import { docsPageJsonLd, jsonLd } from "@/lib/structured-data";
 import {
   IconBrandGithub,
   IconKey,
@@ -94,6 +95,19 @@ jobs:
 export default function GitHubActionPage() {
   return (
     <article className="max-w-3xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: jsonLd(
+            docsPageJsonLd({
+              title: metadata.title,
+              description: metadata.description,
+              path: "/docs/github-action",
+              crumb: "GitHub Action",
+            }),
+          ),
+        }}
+      />
       <div className="mb-8">
         <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#555]">
           <IconBrandGithub className="size-4" />

--- a/apps/web/app/(landing)/docs/integrations/page.tsx
+++ b/apps/web/app/(landing)/docs/integrations/page.tsx
@@ -12,6 +12,7 @@ import {
   IconBug,
   IconServer,
 } from "@tabler/icons-react";
+import { docsPageJsonLd, jsonLd } from "@/lib/structured-data";
 
 export const metadata = {
   title: "Integrations — Octopus Docs",
@@ -25,6 +26,19 @@ export const metadata = {
 export default function IntegrationsPage() {
   return (
     <article className="max-w-3xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: jsonLd(
+            docsPageJsonLd({
+              title: metadata.title,
+              description: metadata.description,
+              path: "/docs/integrations",
+              crumb: "Integrations",
+            }),
+          ),
+        }}
+      />
       <div className="mb-8">
         <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#555]">
           <IconPlugConnected className="size-4" />

--- a/apps/web/app/(landing)/docs/pricing/page.tsx
+++ b/apps/web/app/(landing)/docs/pricing/page.tsx
@@ -1,4 +1,5 @@
 import Link from "@/components/link";
+import { docsPageJsonLd, jsonLd } from "@/lib/structured-data";
 import {
   IconSparkles,
   IconCreditCard,
@@ -20,6 +21,19 @@ export const metadata = {
 export default function PricingPage() {
   return (
     <article className="max-w-3xl">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: jsonLd(
+            docsPageJsonLd({
+              title: metadata.title,
+              description: metadata.description,
+              path: "/docs/pricing",
+              crumb: "Pricing",
+            }),
+          ),
+        }}
+      />
       <div className="mb-8">
         <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#555]">
           <IconCreditCard className="size-4" />
@@ -68,7 +82,7 @@ export default function PricingPage() {
       </Section>
 
       {/* BYO Keys */}
-      <Section title="Bring Your Own Keys">
+      <Section title="Can I use my own API keys?">
         <div className="mb-4 rounded-xl border border-white/[0.08] bg-white/[0.03] p-6">
           <div className="flex items-start gap-4">
             <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-white/[0.06] text-[#888]">
@@ -100,7 +114,7 @@ export default function PricingPage() {
       </Section>
 
       {/* Model pricing */}
-      <Section title="Model Pricing">
+      <Section title="How much does each model cost?">
         <P>
           Credit consumption varies by model. Octopus Cloud bills usage at 2x
           the provider&apos;s list price; that multiple is the platform rate, and
@@ -130,7 +144,9 @@ export default function PricingPage() {
               <ModelRow model="Gemini 2.5 Flash" input="$0.15" output="$0.60" />
               <ModelRow model="GPT-6 Astra" input="$10" output="$50" />
               <ModelRow model="GPT-5.3 Codex" input="$1.75" output="$14" />
+              <ModelRow model="Grok 4.6" input="$2" output="$6" />
               <ModelRow model="Qwen3.8-Max" input="$2" output="$6" />
+              <ModelRow model="Kimi K3 (via OpenRouter)" input="$3" output="$15" />
               <ModelRow model="Embeddings (text-embedding-3-large)" input="$0.13" output="—" />
               <ModelRow model="Embeddings (text-embedding-3-small)" input="$0.02" output="—" last />
             </tbody>

--- a/apps/web/lib/__tests__/structured-data.test.ts
+++ b/apps/web/lib/__tests__/structured-data.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
-import { ORGANIZATION_ENTITY, ORGANIZATION_JSON_LD, SOCIAL_PROFILES, jsonLd } from "@/lib/structured-data";
+import { ORGANIZATION_ENTITY, ORGANIZATION_JSON_LD, SOCIAL_PROFILES, docsPageJsonLd, jsonLd } from "@/lib/structured-data";
 import { docsContent } from "@/lib/docs-content";
 import { GET, renderLlmsFull } from "@/app/llms-full.txt/route";
 
@@ -13,11 +13,23 @@ describe("Organization entity", () => {
   });
 });
 
+describe("docsPageJsonLd", () => {
+  it("emits a WebPage tied to the organization plus a two-level breadcrumb", () => {
+    const g = docsPageJsonLd({ title: "Pricing — Octopus Docs", description: "d", path: "/docs/pricing", crumb: "Pricing" });
+    const [page, crumbs] = g["@graph"] as [Record<string, unknown>, { itemListElement: Array<{ name: string; item: string; position: number }> }];
+    expect(page["@type"]).toBe("WebPage");
+    expect(page.url).toBe("https://octopus-review.ai/docs/pricing");
+    expect((page.publisher as { "@id": string })["@id"]).toBe(ORGANIZATION_ENTITY["@id"]);
+    expect(crumbs.itemListElement.map((c) => [c.position, c.name])).toEqual([[1, "Docs"], [2, "Pricing"]]);
+    expect(crumbs.itemListElement[1].item).toBe("https://octopus-review.ai/docs/pricing");
+  });
+});
+
 describe("llms.txt files", () => {
   const short = readFileSync(new URL("../../public/llms.txt", import.meta.url), "utf8");
 
   it("llms.txt names every vendor and surface and links the full file", () => {
-    for (const needle of ["Grok", "Qwen", "OpenRouter", "GPT-6 Astra", "GitHub Action", "CLI", "MCP", "/blog", "llms-full.txt", "source-available"]) {
+    for (const needle of ["Grok", "Qwen", "OpenRouter", "GPT-6 Astra", "GitHub Action", "CLI", "MCP", "/blog", "llms-full.txt", "source-available", "Grok 4.6", "Kimi K3", "/docs/glossary", "/compare"]) {
       expect(short).toContain(needle);
     }
     expect(short).not.toMatch(/open[- ]source/i);

--- a/apps/web/lib/docs-content.ts
+++ b/apps/web/lib/docs-content.ts
@@ -219,7 +219,9 @@ Claude Haiku 4.5 — $1 input / $5 output. Lightweight tasks like title generati
 Gemini 2.5 Pro — $1.25 input / $10 output. Gemini 2.5 Flash — $0.15 input / $0.60 output.
 GPT-6 Astra — $10 input / $50 output. OpenAI's flagship (released September 3, 2026); 1M-token context, opt-in review model; BYOK with an OpenAI key supported.
 GPT-5.3 Codex — $1.75 input / $14 output.
+Grok 4.6 — $2 input / $6 output. xAI; BYOK supported.
 Qwen3.8-Max — $2 input / $6 output. Alibaba Cloud Model Studio (Qwen), via the DashScope API; BYOK supported.
+Kimi K3 (MoonshotAI, via OpenRouter) — $3 input / $15 output. Any OpenRouter model can be used with your own OpenRouter key.
 Embeddings: text-embedding-3-large ($0.13) and text-embedding-3-small ($0.02).
 Cohere rerank is used for re-ranking search results.
 Prompt caching reduces costs: cached reads are billed at 10% of the input price.`,

--- a/apps/web/lib/structured-data.ts
+++ b/apps/web/lib/structured-data.ts
@@ -40,6 +40,42 @@ export const ORGANIZATION_JSON_LD = {
   ...ORGANIZATION_ENTITY,
 } as const;
 
+/**
+ * WebPage + BreadcrumbList for a documentation page, tied to the Organization
+ * entity by @id. `path` is the route ("/docs/pricing"), `crumb` the label shown
+ * in the docs breadcrumb.
+ */
+export function docsPageJsonLd(input: {
+  title: string;
+  description: string;
+  path: string;
+  crumb: string;
+}) {
+  const url = `${SITE_URL}${input.path}`;
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebPage",
+        "@id": url,
+        url,
+        name: input.title,
+        description: input.description,
+        isPartOf: { "@type": "WebSite", "@id": `${SITE_URL}/#website`, url: SITE_URL, name: "Octopus" },
+        publisher: { "@id": ORGANIZATION_ID },
+        inLanguage: "en",
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: "Docs", item: `${SITE_URL}/docs/getting-started` },
+          { "@type": "ListItem", position: 2, name: input.crumb, item: url },
+        ],
+      },
+    ],
+  };
+}
+
 /** JSON for a <script type="application/ld+json"> body; closes no script tag early. */
 export function jsonLd(value: unknown): string {
   return JSON.stringify(value).replace(/<\/script>/gi, "<\\/script>");

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -8,7 +8,7 @@ Octopus is a source-available (Modified MIT) AI code review platform. It connect
 
 - Automated pull request review with codebase context (vector index over the whole repository, not just the diff)
 - Severity-rated findings and a per-PR quality score; re-review on new commits
-- Choice of AI vendor and model per organization or per repository: Anthropic Claude (Fable 5.1, Opus 5, Sonnet 5), OpenAI (GPT-6 Astra, GPT-5.3 Codex), Google Gemini, xAI Grok, Alibaba Cloud Qwen (Qwen3.8-Max), and any model on OpenRouter. Cloud default: Claude Opus 5.
+- Choice of AI vendor and model per organization or per repository: Anthropic Claude (Fable 5.1, Opus 5, Sonnet 5), OpenAI (GPT-6 Astra, GPT-5.3 Codex), Google Gemini, xAI Grok (Grok 4.6), Alibaba Cloud Qwen (Qwen3.8-Max), and any model on OpenRouter (e.g. Kimi K3). Cloud default: Claude Opus 5.
 - Bring your own API keys (Anthropic, OpenAI, Google, xAI, Alibaba Cloud Model Studio, OpenRouter) or pay with Octopus credits
 - Organization knowledge base: custom rules and guidelines the reviewer follows
 - Package analyzer, code chat, issue creation from findings, live review timeline
@@ -19,6 +19,7 @@ Octopus is a source-available (Modified MIT) AI code review platform. It connect
 - GitLab and Bitbucket integrations
 - GitHub Action for CI-triggered reviews: https://octopus-review.ai/docs/github-action
 - CLI `octp` for local and terminal workflows: https://octopus-review.ai/docs/cli
+- Claude Code integration (review from the agent): https://octopus-review.ai/docs/cli/claude-code-integration
 - MCP plugin for Claude Code and Cursor: https://github.com/octopusreview/octopus-plugin
 - Slack (ask questions about your codebase), Linear and Jira (create issues from findings): https://octopus-review.ai/docs/integrations
 - Self-hosting with Docker Compose: https://octopus-review.ai/docs/self-hosting
@@ -41,10 +42,12 @@ Usage-based. Free credits on signup, no subscription. Octopus Cloud bills AI usa
 - Sub-processors: https://octopus-review.ai/docs/sub-processors
 - Privacy: https://octopus-review.ai/docs/privacy
 - Terms: https://octopus-review.ai/docs/terms
+- Glossary: https://octopus-review.ai/docs/glossary
 
 ## More
 
 - Blog (model launches, product news): https://octopus-review.ai/blog
+- Compared with other AI reviewers: https://octopus-review.ai/compare
 - Compared with CodeRabbit: https://octopus-review.ai/vs-coderabbit
 - Full documentation text for LLMs: https://octopus-review.ai/llms-full.txt
 - Source: https://github.com/octopusreview/octopus


### PR DESCRIPTION
## Why

Second half of the GEO audit (first half shipped in #798). The five main docs pages had no structured data at all, the pricing table omitted two supported vendors (Grok, OpenRouter) even though both have live catalog rows, and the headings LLMs quote for "how much does it cost / which models" were declarative.

## What

- **`docsPageJsonLd({ title, description, path, crumb })`** in `lib/structured-data.ts`: a `@graph` with `WebPage` (publisher → the site Organization `@id`, `isPartOf` WebSite) and a two-level `BreadcrumbList` (Docs → page). Emitted on `/docs/about`, `/docs/pricing`, `/docs/integrations`, `/docs/cli`, `/docs/github-action` straight from each page's existing `metadata`.
- **Pricing table + Ask-Octopus KB**: `Grok 4.6 $2 / $6` and `Kimi K3 (via OpenRouter) $3 / $15`, the prices of the production catalog rows (`available_models`).
- **Question-form headings**: Pricing "How much does each model cost?", "Can I use my own API keys?"; About "What is Octopus built with?". No anchors link to the old ids.
- `llms.txt`: Glossary, Compare and Claude Code integration links; Grok 4.6 / Kimi K3 named.

## Tests

`structured-data.test.ts` gains a `docsPageJsonLd` case (WebPage url/publisher, breadcrumb positions); llms.txt assertions extended. Full `bun test`: 1079 pass. ESLint clean on touched files.

Remaining from the audit (deliberately not here): Product/Offer schema on pricing, an `ItemList` of posts on the blog index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbAThbRPYGBRufVyazrUad
