### PR TITLE
feat(seo): Product/Offer schema on pricing, ItemList of posts on the blog index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The pricing page carries a Product and Offer schema (free to start, usage billed at 2x provider list price), and the blog index lists its posts as structured data.
+
 ## [1.0.136] - 2026-09-04
 
 ### Added

--- a/apps/web/app/(landing)/blog/page.tsx
+++ b/apps/web/app/(landing)/blog/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { ORGANIZATION_ENTITY, SITE_URL, jsonLd } from "@/lib/structured-data";
+import { ORGANIZATION_ENTITY, SITE_URL, blogItemListJsonLd, jsonLd } from "@/lib/structured-data";
 import Link from "@/components/link";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
@@ -177,6 +177,7 @@ export default async function BlogPage({
     description:
       "Product news, model launches and engineering notes from the Octopus AI code review team.",
     publisher: ORGANIZATION_ENTITY,
+    mainEntity: blogItemListJsonLd(posts),
   };
 
   return (

--- a/apps/web/app/(landing)/docs/pricing/page.tsx
+++ b/apps/web/app/(landing)/docs/pricing/page.tsx
@@ -1,5 +1,5 @@
 import Link from "@/components/link";
-import { docsPageJsonLd, jsonLd } from "@/lib/structured-data";
+import { docsPageJsonLd, jsonLd, pricingProductJsonLd } from "@/lib/structured-data";
 import {
   IconSparkles,
   IconCreditCard,
@@ -33,6 +33,10 @@ export default function PricingPage() {
             }),
           ),
         }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: jsonLd(pricingProductJsonLd()) }}
       />
       <div className="mb-8">
         <div className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-[#555]">

--- a/apps/web/lib/__tests__/structured-data.test.ts
+++ b/apps/web/lib/__tests__/structured-data.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
-import { ORGANIZATION_ENTITY, ORGANIZATION_JSON_LD, SOCIAL_PROFILES, docsPageJsonLd, jsonLd } from "@/lib/structured-data";
+import {
+  ORGANIZATION_ENTITY,
+  ORGANIZATION_JSON_LD,
+  SOCIAL_PROFILES,
+  blogItemListJsonLd,
+  docsPageJsonLd,
+  jsonLd,
+  pricingProductJsonLd,
+} from "@/lib/structured-data";
 import { docsContent } from "@/lib/docs-content";
 import { GET, renderLlmsFull } from "@/app/llms-full.txt/route";
 
@@ -22,6 +30,30 @@ describe("docsPageJsonLd", () => {
     expect((page.publisher as { "@id": string })["@id"]).toBe(ORGANIZATION_ENTITY["@id"]);
     expect(crumbs.itemListElement.map((c) => [c.position, c.name])).toEqual([[1, "Docs"], [2, "Pricing"]]);
     expect(crumbs.itemListElement[1].item).toBe("https://octopus-review.ai/docs/pricing");
+  });
+});
+
+describe("pricingProductJsonLd", () => {
+  it("describes a free-to-start, usage-billed product sold by the organization", () => {
+    const p = pricingProductJsonLd();
+    expect(p["@type"]).toBe("Product");
+    expect(p.brand["@id"]).toBe(ORGANIZATION_ENTITY["@id"]);
+    expect(p.offers.price).toBe("0");
+    expect(p.offers.priceCurrency).toBe("USD");
+    expect(p.offers.description).toMatch(/2x the AI provider/);
+    expect(p.url).toBe("https://octopus-review.ai/docs/pricing");
+  });
+});
+
+describe("blogItemListJsonLd", () => {
+  it("lists posts in page order with absolute urls and dates", () => {
+    const list = blogItemListJsonLd([
+      { slug: "a", title: "A", publishedAt: new Date("2026-09-04T00:00:00Z") },
+      { slug: "b", title: "B", publishedAt: null },
+    ]);
+    expect(list.numberOfItems).toBe(2);
+    expect(list.itemListElement[0]).toMatchObject({ position: 1, url: "https://octopus-review.ai/blog/a", name: "A", datePublished: "2026-09-04T00:00:00.000Z" });
+    expect(list.itemListElement[1]).not.toHaveProperty("datePublished");
   });
 });
 

--- a/apps/web/lib/structured-data.ts
+++ b/apps/web/lib/structured-data.ts
@@ -76,6 +76,52 @@ export function docsPageJsonLd(input: {
   };
 }
 
+/**
+ * Product + Offer for /docs/pricing. Octopus has no per-seat plan: signup is
+ * free with starter credits and usage is billed at 2x provider list price, so
+ * the Offer is price 0 with the usage terms in its description.
+ */
+export function pricingProductJsonLd() {
+  const url = `${SITE_URL}/docs/pricing`;
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    "@id": `${SITE_URL}/#product`,
+    name: "Octopus AI Code Review",
+    description:
+      "AI code review for pull requests on GitHub, GitLab and Bitbucket. Usage-based: free credits on signup, then AI usage billed at 2x the provider's list price. No per-seat fee. Bring your own API keys to pay providers directly.",
+    brand: { "@id": ORGANIZATION_ID },
+    url,
+    category: "Developer Tools",
+    offers: {
+      "@type": "Offer",
+      url,
+      price: "0",
+      priceCurrency: "USD",
+      availability: "https://schema.org/InStock",
+      description:
+        "Free to start with starter credits. Reviews are billed per token at 2x the AI provider's list price; with your own API keys the model call is free.",
+      seller: { "@id": ORGANIZATION_ID },
+    },
+  };
+}
+
+/** Blog index ItemList: the posts shown on the page, in order. */
+export function blogItemListJsonLd(posts: Array<{ slug: string; title: string; publishedAt: Date | null }>) {
+  return {
+    "@type": "ItemList",
+    itemListOrder: "https://schema.org/ItemListOrderDescending",
+    numberOfItems: posts.length,
+    itemListElement: posts.map((post, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: `${SITE_URL}/blog/${post.slug}`,
+      name: post.title,
+      ...(post.publishedAt ? { datePublished: post.publishedAt.toISOString() } : {}),
+    })),
+  };
+}
+
 /** JSON for a <script type="application/ld+json"> body; closes no script tag early. */
 export function jsonLd(value: unknown): string {
   return JSON.stringify(value).replace(/<\/script>/gi, "<\\/script>");


### PR DESCRIPTION
## Why

The last two items of the GEO audit (after #798 and #799): `/docs/pricing` had no Product/Offer structured data, and the `Blog` schema on `/blog` did not enumerate the posts, so crawlers had to follow every link to learn titles and dates.

## What

- `pricingProductJsonLd()` in `lib/structured-data.ts`: `Product` (brand and seller → the Organization `@id`) with an `Offer` of price `0` USD and the usage-billing terms in its description (free starter credits, then 2x provider list price, BYOK free). Emitted on `/docs/pricing` next to the existing WebPage/BreadcrumbList script.
- `blogItemListJsonLd(posts)`: `ItemList` (descending, absolute urls, `datePublished` when set) attached as `mainEntity` of the `Blog` schema on `/blog`, built from the posts already fetched for the page.

## Tests

`structured-data.test.ts`: Product/Offer shape and ItemList ordering/dates (6 pass). ESLint and `tsc` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbAThbRPYGBRufVyazrUad
