### PR TITLE
fix(cli): onboarding — open the approval URL, Cloud-first review-model step, catalogue refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `octp onboard`: the sign-in step opens the approval page in your browser (Enter opens it again, Esc goes back) and the sign-in choice reads "Cloud (Octopus hosted)". On Cloud the review-model step offers "Use org default" first, since Cloud reviews follow the organization's model setting; a provider picked here only overrides local `octp review` runs. Ollama (local) is offered only for self-hosted instances and unreleased providers are no longer listed. The model catalogue matches the current Cloud catalog (default Claude Opus 5; GPT-6 Astra and GPT-5.3 Codex for OpenAI).
+
+### Added
+- `GET /api/cli/models`: the organization's effective review model (provider, model, whether it is the platform default, which providers have an org API key), used by the CLI wizard for display.
+
+### Fixed
+- `octp onboard` no longer prints a React "Cannot update a component while rendering a different component" warning when no provider is selected.
+
 ## [1.0.137] - 2026-09-05
 
 ### Added

--- a/apps/cli/src/OnboardWizard.tsx
+++ b/apps/cli/src/OnboardWizard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, render } from "ink";
 import { Header } from "./components/Header.js";
 import { WelcomeStep } from "./steps/WelcomeStep.js";
@@ -12,6 +12,7 @@ import { ValidateStep } from "./steps/ValidateStep.js";
 import { RepoStep } from "./steps/RepoStep.js";
 import { DoneStep } from "./steps/DoneStep.js";
 import { loadConfig, type OctopusConfig } from "./lib/config.js";
+import { buildSequence } from "./lib/sequence.js";
 
 /**
  * Linear wizard with conditional skips via useMemo<StepKey[]>. Each step is
@@ -19,7 +20,7 @@ import { loadConfig, type OctopusConfig } from "./lib/config.js";
  * wizard owns the answer accumulator and the step index. Add a new step by
  * (1) adding a key to StepKey, (2) appending the component to the switch
  * below, and (3) including/excluding it in the sequence useMemo based on
- * environment (self-hosted vs hosted, etc.).
+ * environment (self-hosted vs Cloud, etc.).
  *
  * Full flow: Welcome → Auth → Org → Provider → Model → BYOK → Validate →
  * Repo → Done.
@@ -43,11 +44,11 @@ export type StepKey =
 
 const STEPS: { key: StepKey; label: string }[] = [
   { key: "welcome", label: "Welcome" },
-  { key: "auth", label: "Auth" },
+  { key: "auth", label: "Sign in" },
   { key: "org", label: "Org" },
   { key: "provider", label: "Provider" },
   { key: "model", label: "Model" },
-  { key: "byok", label: "BYOK" },
+  { key: "byok", label: "Key" },
   { key: "ollama-setup", label: "Ollama" },
   { key: "validate", label: "Validate" },
   { key: "repo", label: "Repo" },
@@ -71,31 +72,18 @@ export function OnboardWizard({ reset = false }: OnboardWizardProps = {}) {
   // this true as it advances.
   const [providerConfirmed, setProviderConfirmed] = useState(false);
 
-  // Conditional sequence. Steps that don't apply for the current answers
-  // are filtered out:
-  //   - For Ollama, the "ollama-setup" step does everything (URL prompt,
-  //     daemon probe, model picker/puller) so the separate "model", "byok",
-  //     and "validate" steps are all redundant. Validate would just re-probe
-  //     the same URL ollama-setup already probed; byok asks for a key
-  //     Ollama doesn't have. Skipping them gets the user to Done faster
-  //     and removes empty tabs from the header.
-  //   - "ollama-setup" is also skipped for non-Ollama providers.
-  //
-  // The Ollama-vs-rest reshape only takes effect once ProviderStep has
-  // been passed through this session (`providerConfirmed`). Before that
-  // we show the full sequence so a --reset user who wants to switch
-  // away from Ollama isn't confused by the Ollama tab in the header.
-  const sequence = useMemo<StepKey[]>(() => {
-    const isOllama = providerConfirmed && answers.provider === "ollama";
-    return STEPS.map((s) => s.key).filter((k) => {
-      if (isOllama) {
-        if (k === "model" || k === "byok" || k === "validate") return false;
-      } else {
-        if (k === "ollama-setup") return false;
-      }
-      return true;
-    });
-  }, [answers.provider, providerConfirmed]);
+  // Conditional sequence (see lib/sequence.ts). The provider-dependent
+  // reshape only takes effect once ProviderStep has been passed this
+  // session (`providerConfirmed`), so a --reset user still sees the full
+  // sequence while on Sign in / Org.
+  const sequence = useMemo<StepKey[]>(
+    () =>
+      buildSequence(
+        STEPS.map((s) => s.key),
+        { provider: answers.provider, model: answers.model, providerConfirmed },
+      ),
+    [answers.provider, answers.model, providerConfirmed],
+  );
 
   // One-shot: load existing config and use as initial answers (--reset).
   useEffect(() => {
@@ -114,10 +102,29 @@ export function OnboardWizard({ reset = false }: OnboardWizardProps = {}) {
     [sequence],
   );
 
-  const next = (patch: Partial<OctopusConfig> = {}) => {
-    setAnswers((a) => ({ ...a, ...patch }));
-    setStepIndex((i) => Math.min(i + 1, sequence.length - 1));
-  };
+  // Stable identity: steps list `onNext` in effect deps (AuthStep's poll,
+  // ByokStep's pass-through), so a new function per render would restart
+  // them. Keys set to `undefined` in a patch are removed (Cloud clears a
+  // seeded selfHostedBaseUrl this way).
+  const sequenceLengthRef = React.useRef(sequence.length);
+  sequenceLengthRef.current = sequence.length;
+
+  const next = useCallback((patch: Partial<OctopusConfig> = {}) => {
+    setAnswers((a) => {
+      const merged: Partial<OctopusConfig> = { ...a, ...patch };
+      for (const key of Object.keys(patch) as (keyof OctopusConfig)[]) {
+        if (patch[key] === undefined) delete merged[key];
+      }
+      return merged;
+    });
+    setStepIndex((i) => Math.min(i + 1, sequenceLengthRef.current - 1));
+  }, []);
+
+  // Patch-less advance with a stable identity for steps whose patch is not
+  // part of the saved prefs (Byok's byokSaved) or that send none.
+  const advance = useCallback(() => next(), [next]);
+
+  const isCloud = !answers.selfHostedBaseUrl;
 
   // Jump back to a specific step key. Used by OrgStep → Auth ("switch org")
   // and ValidateStep → BYOK ("edit key").
@@ -130,10 +137,11 @@ export function OnboardWizard({ reset = false }: OnboardWizardProps = {}) {
     <Box flexDirection="column" paddingY={1}>
       <Header steps={headerSteps} activeKey={activeKey} />
       {activeKey === "welcome" && <WelcomeStep onNext={() => next()} />}
-      {activeKey === "auth" && <AuthStep onNext={(p) => next(p)} />}
-      {activeKey === "org" && <OrgStep onNext={() => next()} onSwitchOrg={() => jumpTo("auth")} />}
+      {activeKey === "auth" && <AuthStep onNext={next} />}
+      {activeKey === "org" && <OrgStep onNext={advance} onSwitchOrg={() => jumpTo("auth")} />}
       {activeKey === "provider" && (
         <ProviderStep
+          isCloud={isCloud}
           onNext={(p) => {
             setProviderConfirmed(true);
             next(p);
@@ -141,13 +149,10 @@ export function OnboardWizard({ reset = false }: OnboardWizardProps = {}) {
         />
       )}
       {activeKey === "model" && (
-        <ModelStep provider={answers.provider ?? ""} onNext={(p) => next(p)} />
+        <ModelStep provider={answers.provider ?? ""} onNext={next} />
       )}
       {activeKey === "byok" && (
-        <ByokStep
-          provider={answers.provider ?? ""}
-          onNext={() => next()}
-        />
+        <ByokStep provider={answers.provider ?? ""} onNext={advance} />
       )}
       {activeKey === "ollama-setup" && (
         <OllamaSetupStep
@@ -158,11 +163,11 @@ export function OnboardWizard({ reset = false }: OnboardWizardProps = {}) {
       {activeKey === "validate" && (
         <ValidateStep
           provider={answers.provider ?? ""}
-          onNext={() => next()}
+          onNext={advance}
           onEditKey={() => jumpTo("byok")}
         />
       )}
-      {activeKey === "repo" && <RepoStep onNext={() => next()} />}
+      {activeKey === "repo" && <RepoStep onNext={advance} />}
       {activeKey === "done" && <DoneStep answers={answers} />}
     </Box>
   );

--- a/apps/cli/src/__tests__/hosting.test.ts
+++ b/apps/cli/src/__tests__/hosting.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { HOSTED_BASE_URL, buildHostingPatch, isCloudBaseUrl } from "../lib/hosting";
+
+describe("hosting", () => {
+  it("treats the Cloud URL (and no URL) as Cloud", () => {
+    expect(isCloudBaseUrl(HOSTED_BASE_URL)).toBe(true);
+    expect(isCloudBaseUrl(`${HOSTED_BASE_URL}/`)).toBe(true);
+    expect(isCloudBaseUrl(undefined)).toBe(true);
+    expect(isCloudBaseUrl("https://octopus.internal.acme.com")).toBe(false);
+  });
+
+  it("Cloud clears a seeded self-hosted URL, self-hosted sets it", () => {
+    expect(buildHostingPatch(HOSTED_BASE_URL)).toEqual({ selfHostedBaseUrl: undefined });
+    expect("selfHostedBaseUrl" in buildHostingPatch(HOSTED_BASE_URL)).toBe(true);
+    expect(buildHostingPatch("https://octopus.internal.acme.com")).toEqual({
+      selfHostedBaseUrl: "https://octopus.internal.acme.com",
+    });
+  });
+});

--- a/apps/cli/src/__tests__/models.test.ts
+++ b/apps/cli/src/__tests__/models.test.ts
@@ -21,8 +21,8 @@ describe("modelsFor", () => {
 
 describe("defaultModelFor", () => {
   it("returns the isDefault model when one is marked", () => {
-    expect(defaultModelFor("anthropic")?.modelId).toBe("claude-sonnet-4-6-20250619");
-    expect(defaultModelFor("openai")?.modelId).toBe("gpt-4o");
+    expect(defaultModelFor("anthropic")?.modelId).toBe("claude-opus-5");
+    expect(defaultModelFor("openai")?.modelId).toBe("gpt-5.3-codex");
     expect(defaultModelFor("google")?.modelId).toBe("gemini-2.5-pro");
     expect(defaultModelFor("alibaba")?.modelId).toBe("qwen3.8-max-0902");
   });

--- a/apps/cli/src/__tests__/providers.test.ts
+++ b/apps/cli/src/__tests__/providers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { PROVIDERS, providersByType } from "../lib/providers";
+import { PROVIDERS, buildProviderItems, defaultProvider, displayNameFor, providersByType } from "../lib/providers";
 
 describe("PROVIDERS catalogue", () => {
   it("every provider has a unique slug", () => {
@@ -43,5 +43,39 @@ describe("providersByType", () => {
 
   it("returns local including ollama", () => {
     expect(providersByType("local").map((p) => p.slug)).toContain("ollama");
+  });
+});
+
+describe("defaultProvider / displayNameFor", () => {
+  it("recommends a ready direct-API provider", () => {
+    const p = defaultProvider();
+    expect(p?.slug).toBe("anthropic");
+    expect(p?.status).toBe("ready");
+  });
+
+  it("names known slugs and falls back to the slug for stale ones", () => {
+    expect(displayNameFor("anthropic")).toBe("Claude (Anthropic)");
+    expect(displayNameFor("no-such-provider")).toBe("no-such-provider");
+  });
+});
+
+describe("buildProviderItems", () => {
+  it("never lists coming-soon providers", () => {
+    for (const cloud of [true, false]) {
+      const values = buildProviderItems(PROVIDERS, { cloud }).map((i) => i.value);
+      for (const p of PROVIDERS.filter((p) => p.status === "coming-soon")) expect(values).not.toContain(p.slug);
+      expect(values.some((v) => v.startsWith("__heading_"))).toBe(false);
+    }
+  });
+
+  it("hides local providers on Cloud and shows them for self-hosted", () => {
+    expect(buildProviderItems(PROVIDERS, { cloud: true }).map((i) => i.value)).not.toContain("ollama");
+    expect(buildProviderItems(PROVIDERS, { cloud: false }).map((i) => i.value)).toContain("ollama");
+  });
+
+  it("keeps catalogue order and human labels", () => {
+    const items = buildProviderItems(PROVIDERS, { cloud: true });
+    expect(items[0]).toEqual({ label: "Claude (Anthropic)", value: "anthropic" });
+    expect(items.map((i) => i.value)).toEqual(["anthropic", "openai", "google", "alibaba"]);
   });
 });

--- a/apps/cli/src/__tests__/sequence.test.ts
+++ b/apps/cli/src/__tests__/sequence.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import { buildSequence } from "../lib/sequence";
+
+const ALL = ["welcome", "auth", "org", "provider", "model", "byok", "ollama-setup", "validate", "repo", "done"] as const;
+
+describe("buildSequence", () => {
+  it("hides only the Ollama tab before the provider step is passed", () => {
+    expect(buildSequence(ALL, { provider: "ollama", providerConfirmed: false })).toEqual(
+      ["welcome", "auth", "org", "provider", "model", "byok", "validate", "repo", "done"],
+    );
+  });
+
+  it("Cloud org default (no provider) goes straight to repo", () => {
+    expect(buildSequence(ALL, { provider: "", providerConfirmed: true })).toEqual(
+      ["welcome", "auth", "org", "provider", "repo", "done"],
+    );
+  });
+
+  it("Ollama replaces model, key and validate with its own setup", () => {
+    expect(buildSequence(ALL, { provider: "ollama", providerConfirmed: true })).toEqual(
+      ["welcome", "auth", "org", "provider", "ollama-setup", "repo", "done"],
+    );
+  });
+
+  it("recommended pair skips the model picker but keeps key and validate", () => {
+    expect(buildSequence(ALL, { provider: "anthropic", model: "claude-opus-5", providerConfirmed: true })).toEqual(
+      ["welcome", "auth", "org", "provider", "byok", "validate", "repo", "done"],
+    );
+  });
+
+  it("a provider without a model keeps the model picker", () => {
+    expect(buildSequence(ALL, { provider: "openai", providerConfirmed: true })).toEqual(
+      ["welcome", "auth", "org", "provider", "model", "byok", "validate", "repo", "done"],
+    );
+  });
+});

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -40,7 +40,7 @@ export async function doctorCommand(_argv: string[]): Promise<number> {
   if (config.model) line("ok", "model", config.model);
   else line("warn", "model", "not chosen");
   if (config.selfHostedBaseUrl) line("ok", "self-hosted base URL", config.selfHostedBaseUrl);
-  else line("skip", "self-hosted base URL", "using hosted (octopus-review.ai)");
+  else line("skip", "self-hosted base URL", "using Cloud (Octopus hosted, octopus-review.ai)");
 
   // ── Credentials ────────────────────────────────────────────────────────────
   console.log("\nAuth:");

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -91,7 +91,7 @@ Usage:
 Flags:
   --token <oct_...>              API token; skips the browser
                                  (exposes the token via process args (ps) and shell history; for CI prefer 'octp setup-token')
-  --api-url <url>                Server base URL (default: hosted, or your saved server)
+  --api-url <url>                Server base URL (default: Cloud (Octopus hosted), or your saved server)
   --insecure                     Allow sending the token over cleartext HTTP (not recommended)
   --help, -h                     This help
 `);

--- a/apps/cli/src/lib/hosting.ts
+++ b/apps/cli/src/lib/hosting.ts
@@ -1,0 +1,19 @@
+/**
+ * Where Octopus runs for this user: Cloud (Octopus hosted, octopus-review.ai)
+ * or a self-hosted instance. Cloud is the default and is not stored in prefs.
+ */
+export const HOSTED_BASE_URL = "https://octopus-review.ai";
+
+export function isCloudBaseUrl(baseUrl: string | null | undefined): boolean {
+  if (!baseUrl) return true;
+  return baseUrl.replace(/\/+$/, "") === HOSTED_BASE_URL;
+}
+
+/**
+ * Prefs patch for the chosen base URL. Cloud explicitly clears
+ * `selfHostedBaseUrl` so a value seeded by `octp onboard --reset` from an
+ * earlier self-hosted run cannot survive a switch back to Cloud.
+ */
+export function buildHostingPatch(baseUrl: string): { selfHostedBaseUrl?: string } {
+  return baseUrl && !isCloudBaseUrl(baseUrl) ? { selfHostedBaseUrl: baseUrl } : { selfHostedBaseUrl: undefined };
+}

--- a/apps/cli/src/lib/models.ts
+++ b/apps/cli/src/lib/models.ts
@@ -4,7 +4,7 @@
  * is one fetch swap.
  *
  * Prices are USD per million tokens (input / output). Reference prices as
- * of 2026-05; keep in sync with apps/web/lib/cost.ts and the AvailableModel
+ * of 2026-09 (Octopus Cloud catalog); keep in sync with apps/web/lib/cost.ts and the AvailableModel
  * Prisma rows seeded in packages/db/prisma/seed.ts.
  */
 export type ModelInfo = {
@@ -27,17 +27,16 @@ export type ModelInfo = {
 // FALLBACK_PRICING + seed.ts exactly.
 export const MODELS_BY_PROVIDER: Record<string, ModelInfo[]> = {
   anthropic: [
+    { modelId: "claude-fable-5-1", displayName: "Claude Fable 5.1", inputPrice: 10, outputPrice: 50 },
     { modelId: "claude-fable-5", displayName: "Claude Fable 5", inputPrice: 10, outputPrice: 50 },
-    { modelId: "claude-opus-5", displayName: "Claude Opus 5", inputPrice: 5, outputPrice: 25 },
-    { modelId: "claude-sonnet-4-6-20250619", displayName: "Claude Sonnet 4.6", inputPrice: 3, outputPrice: 15, isDefault: true },
+    { modelId: "claude-opus-5", displayName: "Claude Opus 5", inputPrice: 5, outputPrice: 25, isDefault: true },
+    { modelId: "claude-sonnet-5", displayName: "Claude Sonnet 5", inputPrice: 2, outputPrice: 10 },
     { modelId: "claude-opus-4-8", displayName: "Claude Opus 4.8", inputPrice: 5, outputPrice: 25 },
     { modelId: "claude-haiku-4-5-20251001", displayName: "Claude Haiku 4.5", inputPrice: 1, outputPrice: 5 },
   ],
   openai: [
-    { modelId: "gpt-4o", displayName: "GPT-4o", inputPrice: 2.5, outputPrice: 10, isDefault: true },
-    { modelId: "gpt-4o-mini", displayName: "GPT-4o mini", inputPrice: 0.15, outputPrice: 0.6 },
-    { modelId: "o4-mini", displayName: "o4-mini (reasoning)", inputPrice: 1.1, outputPrice: 4.4 },
-    { modelId: "codex-mini-latest", displayName: "Codex mini", inputPrice: 1.5, outputPrice: 6 },
+    { modelId: "gpt-6-astra", displayName: "GPT-6 Astra", inputPrice: 10, outputPrice: 50 },
+    { modelId: "gpt-5.3-codex", displayName: "GPT-5.3 Codex", inputPrice: 1.75, outputPrice: 14, isDefault: true },
   ],
   google: [
     { modelId: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro", inputPrice: 1.25, outputPrice: 10, isDefault: true },

--- a/apps/cli/src/lib/providers.ts
+++ b/apps/cli/src/lib/providers.ts
@@ -108,3 +108,30 @@ export const PROVIDERS: ProviderInfo[] = [
 export function providersByType(type: ProviderType): ProviderInfo[] {
   return PROVIDERS.filter((p) => p.type === type);
 }
+
+/** The provider the wizard recommends when the user does not want to choose. */
+export function defaultProvider(): ProviderInfo | undefined {
+  return PROVIDERS.find((p) => p.status === "ready" && p.type === "direct");
+}
+
+/** Human name for a provider slug; falls back to the slug for unknown/stale values. */
+export function displayNameFor(slug: string): string {
+  return PROVIDERS.find((p) => p.slug === slug)?.displayName ?? slug;
+}
+
+export type ProviderItem = { label: string; value: string };
+
+/**
+ * Selectable rows for the provider picker. Coming-soon providers are never
+ * listed (they used to be selectable and led to a dead end). Local providers
+ * (Ollama) are hidden on Cloud, where reviews run on Octopus servers.
+ */
+export function buildProviderItems(
+  providers: readonly ProviderInfo[],
+  options: { cloud: boolean },
+): ProviderItem[] {
+  return providers
+    .filter((p) => p.status === "ready")
+    .filter((p) => !(options.cloud && p.type === "local"))
+    .map((p) => ({ label: p.displayName, value: p.slug }));
+}

--- a/apps/cli/src/lib/sequence.ts
+++ b/apps/cli/src/lib/sequence.ts
@@ -1,0 +1,32 @@
+/**
+ * Which wizard steps apply for the answers so far. Pure so it can be unit
+ * tested without a TTY.
+ *
+ *  - Before the provider step has been passed this session, only the
+ *    Ollama setup tab is hidden (we do not know the provider yet).
+ *  - No provider (Cloud "use org default", or Esc): reviews use the
+ *    server-side org default, so model / key / validate / Ollama are moot.
+ *  - Ollama: its setup step replaces model / key / validate.
+ *  - Provider with a model already chosen (the recommended pair): skip the
+ *    model picker.
+ */
+export type WizardAnswers = {
+  provider?: string;
+  model?: string;
+  providerConfirmed: boolean;
+};
+
+export function buildSequence<K extends string>(all: readonly K[], answers: WizardAnswers): K[] {
+  const drop = new Set<string>();
+  if (!answers.providerConfirmed) {
+    drop.add("ollama-setup");
+  } else if (!answers.provider) {
+    for (const k of ["model", "byok", "validate", "ollama-setup"]) drop.add(k);
+  } else if (answers.provider === "ollama") {
+    for (const k of ["model", "byok", "validate"]) drop.add(k);
+  } else {
+    drop.add("ollama-setup");
+    if (answers.model) drop.add("model");
+  }
+  return all.filter((k) => !drop.has(k));
+}

--- a/apps/cli/src/steps/AuthStep.tsx
+++ b/apps/cli/src/steps/AuthStep.tsx
@@ -3,9 +3,10 @@ import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import TextInput from "ink-text-input";
 import { getJson, normalizeBaseUrl, postJson } from "../lib/api.js";
+import { openBrowser } from "../lib/auth.js";
 import { saveCredentials, type Credentials } from "../lib/credentials.js";
+import { HOSTED_BASE_URL, buildHostingPatch } from "../lib/hosting.js";
 
-const HOSTED_BASE_URL = "https://octopus-review.ai";
 const POLL_INTERVAL_MS = 2000;
 
 type Mode = "choose-mode" | "self-hosted-url" | "requesting" | "waiting" | "approved" | "failed" | "skipped";
@@ -22,26 +23,26 @@ type PollResponse =
 
 export type AuthStepProps = {
   /**
-   * Called with `selfHostedBaseUrl` set only when the user chose self-hosted.
-   * Hosted is the default so we do not store it in prefs.
+   * Called with `selfHostedBaseUrl` set when the user chose self-hosted and
+   * explicitly cleared (undefined) for Cloud, so a --reset-seeded value does
+   * not survive a switch back to Cloud.
    */
   onNext: (patch: { selfHostedBaseUrl?: string }) => void;
 };
 
-function buildPatch(baseUrl: string): { selfHostedBaseUrl?: string } {
-  return baseUrl && baseUrl !== HOSTED_BASE_URL ? { selfHostedBaseUrl: baseUrl } : {};
-}
+const buildPatch = buildHostingPatch;
 
 /**
  * Step 2 of the onboarding wizard.
  *
- *   choose-mode      → "Hosted (octopus-review.ai)" vs "Self-hosted (enter URL)"
+ *   choose-mode      → "Cloud (Octopus hosted)" vs "Self-hosted (enter URL)"
  *     ↓
- *   self-hosted-url  → text input for base URL (skipped in hosted mode)
+ *   self-hosted-url  → text input for base URL (skipped on Cloud)
  *     ↓
  *   requesting       → POST /api/cli/auth/device, get { deviceCode, expiresAt }
  *     ↓
- *   waiting          → render the URL + deviceCode, poll /api/cli/auth/poll every 2s
+ *   waiting          → open the approval URL in the browser (Enter re-opens),
+ *                      print it as fallback, poll /api/cli/auth/poll every 2s
  *     ↓
  *   approved         → write credentials, call onNext({ baseUrl })
  *
@@ -55,6 +56,7 @@ export function AuthStep({ onNext }: AuthStepProps) {
   const [deviceCode, setDeviceCode] = useState<string>("");
   const [expiresAt, setExpiresAt] = useState<Date | null>(null);
   const [error, setError] = useState<string>("");
+  const [openState, setOpenState] = useState<"idle" | "opened" | "failed">("idle");
 
   // Global Esc → skip the whole step (user can configure auth later).
   // Now also allowed during `requesting` so the wizard isn't hard-locked
@@ -70,6 +72,21 @@ export function AuthStep({ onNext }: AuthStepProps) {
     if (key.escape && mode !== "approved" && mode !== "waiting") {
       setMode("skipped");
       onNext(buildPatch(baseUrl || HOSTED_BASE_URL));
+    }
+    if (mode === "waiting") {
+      // Enter re-opens the approval page; Esc abandons this device code and
+      // returns to the Cloud / self-hosted choice (the poll effect is torn
+      // down by the mode change).
+      if (key.return && baseUrl && deviceCode) {
+        void openBrowser(`${baseUrl}/cli/authorize?code=${deviceCode}`).then((ok) =>
+          setOpenState(ok ? "opened" : "failed"),
+        );
+      } else if (key.escape) {
+        setDeviceCode("");
+        setExpiresAt(null);
+        setOpenState("idle");
+        setMode("choose-mode");
+      }
     }
     if (mode === "failed") {
       if (key.return) {
@@ -160,6 +177,21 @@ export function AuthStep({ onNext }: AuthStepProps) {
     return `${baseUrl}/cli/authorize?code=${deviceCode}`;
   }, [baseUrl, deviceCode]);
 
+  // Open the approval page once per device code. Shell-free spawn (see
+  // lib/auth.ts); the URL stays on screen as the fallback for headless / SSH
+  // sessions where nothing can open.
+  useEffect(() => {
+    if (mode !== "waiting" || !verificationUrl) return;
+    let cancelled = false;
+    setOpenState("idle");
+    openBrowser(verificationUrl).then((ok) => {
+      if (!cancelled) setOpenState(ok ? "opened" : "failed");
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, verificationUrl]);
+
   // ── Render ─────────────────────────────────────────────────────────────────
 
   if (mode === "choose-mode") {
@@ -169,9 +201,9 @@ export function AuthStep({ onNext }: AuthStepProps) {
         <Text> </Text>
         <SelectInput
           items={[
-            { label: "Hosted — octopus-review.ai", value: "hosted" },
-            { label: "Self-hosted — I run my own instance", value: "self-hosted" },
-            { label: "Skip — I'll configure auth later", value: "skip" },
+            { label: "Cloud (Octopus hosted) - octopus-review.ai", value: "hosted" },
+            { label: "Self-hosted - I run my own instance", value: "self-hosted" },
+            { label: "Skip - I'll sign in later", value: "skip" },
           ]}
           onSelect={(item) => {
             if (item.value === "hosted") {
@@ -230,16 +262,22 @@ export function AuthStep({ onNext }: AuthStepProps) {
   if (mode === "waiting") {
     return (
       <Box flexDirection="column">
-        <Text bold>Open this URL in your browser to approve:</Text>
+        <Text bold>Approve this sign-in in your browser</Text>
         <Text> </Text>
         <Text color="cyan">{verificationUrl}</Text>
+        {openState === "opened" ? (
+          <Text dimColor>Opened in your browser. Approve there, or use the URL above.</Text>
+        ) : null}
+        {openState === "failed" ? (
+          <Text color="yellow">Could not open a browser (headless/SSH?). Open the URL above manually.</Text>
+        ) : null}
         <Text> </Text>
         <Text dimColor>Waiting for approval … (polls every {POLL_INTERVAL_MS / 1000}s)</Text>
         {expiresAt ? (
           <Text dimColor>Code expires at {expiresAt.toLocaleTimeString()}.</Text>
         ) : null}
         <Text> </Text>
-        <Text dimColor>Ctrl+C to abort</Text>
+        <Text dimColor>Enter: open browser again · Esc: back · Ctrl+C: quit</Text>
       </Box>
     );
   }

--- a/apps/cli/src/steps/ByokStep.tsx
+++ b/apps/cli/src/steps/ByokStep.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import TextInput from "ink-text-input";
 import { setByokKey } from "../lib/byok.js";
 import { hintFor } from "../lib/keys.js";
+import { displayNameFor } from "../lib/providers.js";
 
 export type ByokStepProps = {
   provider: string;
@@ -36,22 +37,26 @@ export function ByokStep({ provider, onNext }: ByokStepProps) {
     }
   });
 
-  // No provider selected (the user skipped ProviderStep) — pass through.
-  if (!provider) {
-    onNext({ byokSaved: false });
-    return null;
-  }
+  // No provider selected (org default / skipped) — pass through. Runs in an
+  // effect: calling onNext during render updates the wizard while this step
+  // is rendering ("Cannot update a component while rendering a different
+  // component").
+  useEffect(() => {
+    if (!provider) onNext({ byokSaved: false });
+  }, [provider, onNext]);
+
+  if (!provider) return null;
 
   if (mode === "intro") {
     return (
       <Box flexDirection="column">
-        <Text bold>API key for {provider}</Text>
+        <Text bold>API key for {displayNameFor(provider)}</Text>
         <Text dimColor>{hint.placeholder}</Text>
         <Text> </Text>
         <SelectInput
           items={[
             { label: "I want to enter an API key", value: "enter" },
-            { label: "Skip — I'm using subscription / CLI / local mode", value: "skip" },
+            { label: "Skip - review with Octopus credits", value: "skip" },
           ]}
           onSelect={(item) => {
             if (item.value === "enter") setMode("entering");
@@ -68,7 +73,7 @@ export function ByokStep({ provider, onNext }: ByokStepProps) {
   if (mode === "entering") {
     return (
       <Box flexDirection="column">
-        <Text bold>API key for {provider}</Text>
+        <Text bold>API key for {displayNameFor(provider)}</Text>
         {hint.dashboardUrl ? (
           <Text dimColor>Get one at <Text color="cyan">{hint.dashboardUrl}</Text></Text>
         ) : null}
@@ -103,7 +108,7 @@ export function ByokStep({ provider, onNext }: ByokStepProps) {
         />
         {error ? <Text color="red">{error}</Text> : null}
         <Text> </Text>
-        <Text dimColor>Enter to save · Esc to skip (use platform key instead)</Text>
+        <Text dimColor>Enter to save · Esc to skip (review with Octopus credits)</Text>
       </Box>
     );
   }

--- a/apps/cli/src/steps/DoneStep.tsx
+++ b/apps/cli/src/steps/DoneStep.tsx
@@ -3,6 +3,8 @@ import { Box, Text, useApp } from "ink";
 import { loadConfig, saveConfig, type OctopusConfig } from "../lib/config.js";
 import { loadCredentials } from "../lib/credentials.js";
 import { loadByok } from "../lib/byok.js";
+import { isCloudBaseUrl } from "../lib/hosting.js";
+import { displayNameFor } from "../lib/providers.js";
 
 export type DoneStepProps = {
   answers: Partial<OctopusConfig>;
@@ -83,22 +85,32 @@ export function DoneStep({ answers }: DoneStepProps) {
       <Text color="green" bold>You're set 🐙</Text>
       <Text> </Text>
       <Text bold>Summary</Text>
-      <Text>  Server:   {summary.baseUrl ? <Text color="cyan">{summary.baseUrl}</Text> : <Text dimColor>not signed in</Text>}</Text>
-      <Text>  Org:      {summary.orgName ?? <Text dimColor>—</Text>}</Text>
-      <Text>  Provider: {summary.provider ?? <Text dimColor>not chosen</Text>}</Text>
+      <Text>
+        {"  Server:   "}
+        {summary.baseUrl ? (
+          <Text color="cyan">{isCloudBaseUrl(summary.baseUrl) ? "Cloud (octopus-review.ai)" : summary.baseUrl}</Text>
+        ) : (
+          <Text dimColor>not signed in</Text>
+        )}
+      </Text>
+      <Text>  Org:      {summary.orgName ?? <Text dimColor>-</Text>}</Text>
+      <Text>
+        {"  Provider: "}
+        {summary.provider ? displayNameFor(summary.provider) : <Text dimColor>org default (set in Settings)</Text>}
+      </Text>
       {summary.provider === "ollama" && !summary.model ? (
         <Text>  Model:    <Text dimColor>configure per-repo (no default picked)</Text></Text>
       ) : (
-        <Text>  Model:    {summary.model ?? <Text dimColor>not chosen</Text>}</Text>
+        <Text>  Model:    {summary.model ?? <Text dimColor>org default</Text>}</Text>
       )}
-      <Text>  BYOK key: {summary.byokSaved ? <Text color="green">saved</Text> : <Text dimColor>none</Text>}</Text>
+      <Text>  Billing:  {summary.byokSaved ? <Text color="green">your API key</Text> : <Text>Octopus credits</Text>}</Text>
       {summary.provider === "ollama" ? (
         <Text>  Ollama URL: <Text color="cyan">{summary.ollamaBaseUrl ?? "http://localhost:11434 (default)"}</Text></Text>
       ) : null}
       <Text> </Text>
       <Text bold>Next steps</Text>
       <Text>  • Run <Text color="cyan">octp review</Text> in any git repo to review your local changes before committing.</Text>
-      <Text>  • Connect a repo at <Text color="cyan">/settings/integrations</Text> for cloud reviews on every PR — and for richer context-aware <Text color="cyan">octp review</Text> output.</Text>
+      <Text>  • Connect a repo at <Text color="cyan">{`${summary.baseUrl ?? "https://octopus-review.ai"}/settings/integrations`}</Text> for reviews on every PR, and for richer context-aware <Text color="cyan">octp review</Text> output.</Text>
       <Text>  • Re-run this wizard any time with <Text color="cyan">octp onboard --reset</Text>.</Text>
     </Box>
   );

--- a/apps/cli/src/steps/ModelStep.tsx
+++ b/apps/cli/src/steps/ModelStep.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import { defaultModelFor, formatPrice, modelsFor } from "../lib/models.js";
+import { displayNameFor } from "../lib/providers.js";
 
 export type ModelStepProps = {
   provider: string;
@@ -22,12 +23,12 @@ export function ModelStep({ provider, onNext }: ModelStepProps) {
   // so handle Enter (in addition to Esc) when there's no provider. Without
   // this, Enter does nothing on that screen and the user is soft-locked
   // on a step whose own instructions are wrong.
+  const models = modelsFor(provider);
+
   useInput((_input, key) => {
     if (key.escape) onNext({ model: "" });
-    if (key.return && !provider) onNext({ model: "" });
+    if (key.return && (!provider || models.length === 0)) onNext({ model: "" });
   });
-
-  const models = modelsFor(provider);
 
   if (!provider) {
     return (
@@ -41,22 +42,11 @@ export function ModelStep({ provider, onNext }: ModelStepProps) {
   if (models.length === 0) {
     return (
       <Box flexDirection="column">
-        <Text bold>No models seeded for "{provider}" yet</Text>
+        <Text bold>No models listed for {displayNameFor(provider)}</Text>
         <Text> </Text>
-        <Text>This provider is coming soon. You can finish onboarding now;</Text>
-        <Text>the model picker will populate once the backend ships.</Text>
+        <Text>You can finish onboarding now and pick a model later in Settings.</Text>
         <Text> </Text>
-        <SelectInput
-          items={[
-            { label: "Continue without a model", value: "skip" },
-            { label: "Go back to provider picker", value: "back" },
-          ]}
-          onSelect={(item) => {
-            if (item.value === "skip") onNext({ model: "" });
-            // "back" is handled by the wizard's Esc/back arrow — for now treat as skip.
-            else onNext({ model: "" });
-          }}
-        />
+        <Text dimColor>Press Enter to continue.</Text>
       </Box>
     );
   }
@@ -72,14 +62,18 @@ export function ModelStep({ provider, onNext }: ModelStepProps) {
 
   return (
     <Box flexDirection="column">
-      <Text bold>Pick a model for {provider}</Text>
+      <Text bold>Pick a model for {displayNameFor(provider)}</Text>
       {def ? (
         <Text dimColor>
           Recommended: {def.displayName} ({formatPrice(def)})
         </Text>
       ) : null}
       <Text> </Text>
-      <SelectInput items={items} onSelect={(item) => onNext({ model: item.value })} />
+      <SelectInput
+        items={items}
+        initialIndex={Math.max(0, items.findIndex((i) => i.value === def?.modelId))}
+        onSelect={(item) => onNext({ model: item.value })}
+      />
       <Text> </Text>
       <Text dimColor>Use ↑/↓ to move, Enter to select · Esc to skip</Text>
     </Box>

--- a/apps/cli/src/steps/ProviderStep.tsx
+++ b/apps/cli/src/steps/ProviderStep.tsx
@@ -1,65 +1,126 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
-import { PROVIDERS, type ProviderInfo } from "../lib/providers.js";
+import { getJson } from "../lib/api.js";
+import { loadCredentials } from "../lib/credentials.js";
+import { defaultModelFor } from "../lib/models.js";
+import { PROVIDERS, buildProviderItems, defaultProvider } from "../lib/providers.js";
 
 export type ProviderStepProps = {
-  onNext: (patch: { provider: string }) => void;
+  onNext: (patch: { provider: string; model?: string }) => void;
+  /** Cloud (Octopus hosted) vs a self-hosted instance; decided in the sign-in step. */
+  isCloud: boolean;
 };
 
-const TYPE_ORDER: ProviderInfo["type"][] = ["direct", "harness", "gateway", "local"];
-const TYPE_LABEL: Record<ProviderInfo["type"], string> = {
-  direct: "Direct API",
-  harness: "Agent harnesses",
-  gateway: "Gateways",
-  local: "Local",
-};
+type OrgModel = { provider: string; model: string; displayName: string | null; isPlatformDefault: boolean };
 
 /**
- * Render the catalogue as a single SelectInput with type labels as
- * non-selectable separators. ink-select-input does not support headers,
- * so we use disabled items with a leading dash convention; the selector
- * skips them via the `isItemSelectable` we wrap around the items list.
+ * Review model step.
  *
- * Coming-soon providers are still shown (so users see what's planned)
- * but disabled — selecting them moves on with a one-line note that
- * onboarding completes but reviews won't run until the backend lands.
+ * On Cloud the org's review model is a server-side setting; the provider and
+ * model picked here only override local `octp review` runs. So the first
+ * screen offers the org default (Enter) and a local override as the second
+ * choice. Self-hosted users get the recommended provider/model pair first.
+ * The full picker lists ready providers only; Ollama (local) is hidden on
+ * Cloud because Cloud reviews run on Octopus servers.
  */
-export function ProviderStep({ onNext }: ProviderStepProps) {
+export function ProviderStep({ onNext, isCloud }: ProviderStepProps) {
+  const [showAll, setShowAll] = useState(false);
+  const [orgModel, setOrgModel] = useState<OrgModel | null>(null);
+
   useInput((_input, key) => {
-    if (key.escape) onNext({ provider: "" }); // skip — onboarding finishes without a provider
+    if (key.escape) onNext({ provider: "" }); // org default / skip
   });
 
-  // Build a flat list with type headings interleaved. Headings are inert
-  // (selecting one is a no-op handled in onSelect).
-  type Item = { label: string; value: string; isHeading?: boolean; disabled?: boolean };
-  const items: Item[] = [];
-  for (const type of TYPE_ORDER) {
-    const inType = PROVIDERS.filter((p) => p.type === type);
-    if (inType.length === 0) continue;
-    items.push({ label: `── ${TYPE_LABEL[type]} ──`, value: `__heading_${type}`, isHeading: true });
-    for (const p of inType) {
-      const suffix = p.status === "coming-soon" ? " (coming soon)" : "";
-      items.push({
-        label: `  ${p.displayName}${suffix}`,
-        value: p.slug,
-        disabled: p.status === "coming-soon",
+  // Display-only: name the org's current review model when the server can
+  // tell us. Any failure (older server without the route, offline, timeout)
+  // leaves the screen unchanged.
+  useEffect(() => {
+    if (!isCloud) return;
+    let cancelled = false;
+    (async () => {
+      const creds = await loadCredentials();
+      if (!creds || cancelled) return;
+      const res = await getJson<OrgModel>(`${creds.baseUrl}/api/cli/models`, {
+        headers: { Authorization: `Bearer ${creds.token}` },
+        signal: AbortSignal.timeout(3000),
       });
-    }
+      if (!cancelled && res.ok && res.data?.model) setOrgModel(res.data);
+    })().catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isCloud]);
+
+  const recommended = defaultProvider();
+  const recommendedModel = recommended ? defaultModelFor(recommended.slug) : null;
+
+  if (!showAll && isCloud) {
+    const current = orgModel?.displayName ?? orgModel?.model;
+    return (
+      <Box flexDirection="column">
+        <Text bold>Review model</Text>
+        <Text dimColor>
+          Reviews on Cloud use your org's default model{current ? `: ${current}` : ""}. A change here
+          only overrides local "octp review" runs.
+        </Text>
+        <Text> </Text>
+        <SelectInput
+          items={[
+            { label: "Use org default (recommended)", value: "default" },
+            { label: "Set a local override (choose provider and model)", value: "override" },
+          ]}
+          onSelect={(item) => {
+            if (item.value === "default") onNext({ provider: "" });
+            else setShowAll(true);
+          }}
+        />
+        <Text> </Text>
+        <Text dimColor>Enter to continue · Esc to skip</Text>
+      </Box>
+    );
   }
+
+  if (!showAll && recommended && recommendedModel) {
+    return (
+      <Box flexDirection="column">
+        <Text bold>Review model</Text>
+        <Text dimColor>The provider runs your code reviews. You can change this later.</Text>
+        <Text> </Text>
+        <SelectInput
+          items={[
+            {
+              label: `Use recommended: ${recommended.displayName} / ${recommendedModel.displayName}`,
+              value: "recommended",
+            },
+            { label: "Choose a different provider", value: "choose" },
+          ]}
+          onSelect={(item) => {
+            if (item.value === "recommended") {
+              onNext({ provider: recommended.slug, model: recommendedModel.modelId });
+            } else {
+              setShowAll(true);
+            }
+          }}
+        />
+        <Text> </Text>
+        <Text dimColor>Enter to continue · Esc to skip</Text>
+      </Box>
+    );
+  }
+
+  const items = buildProviderItems(PROVIDERS, { cloud: isCloud });
 
   return (
     <Box flexDirection="column">
       <Text bold>Pick an AI provider</Text>
-      <Text dimColor>The provider runs your code reviews. You can change this later.</Text>
+      <Text dimColor>
+        {isCloud
+          ? "Overrides the model for local \"octp review\" runs only. Cloud PR reviews keep the org default."
+          : "The provider runs your code reviews. You can change this later."}
+      </Text>
       <Text> </Text>
-      <SelectInput
-        items={items}
-        onSelect={(item) => {
-          if (item.value.startsWith("__heading_")) return; // ignore
-          onNext({ provider: item.value });
-        }}
-      />
+      <SelectInput items={items} onSelect={(item) => onNext({ provider: item.value })} />
       <Text> </Text>
       <Text dimColor>Use ↑/↓ to move, Enter to select · Esc to skip</Text>
     </Box>

--- a/apps/cli/src/steps/RepoStep.tsx
+++ b/apps/cli/src/steps/RepoStep.tsx
@@ -4,6 +4,7 @@ import SelectInput from "ink-select-input";
 import { loadCredentials } from "../lib/credentials.js";
 import { getJson } from "../lib/api.js";
 import { openBrowser } from "../lib/auth.js";
+import { isCloudBaseUrl } from "../lib/hosting.js";
 
 export type RepoStepProps = {
   onNext: () => void;
@@ -66,10 +67,9 @@ export function RepoStep({ onNext }: RepoStepProps) {
         return;
       }
 
-      // Self-hosted users: skip the repo step entirely. The hosted GitHub
+      // Self-hosted users: skip the repo step entirely. The Cloud GitHub
       // App install flow is irrelevant for them.
-      const isHosted = creds.baseUrl === "https://octopus-review.ai";
-      if (!isHosted) {
+      if (!isCloudBaseUrl(creds.baseUrl)) {
         onNext();
         return;
       }

--- a/apps/cli/src/steps/ValidateStep.tsx
+++ b/apps/cli/src/steps/ValidateStep.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
 import { validateProvider, type ValidateResult } from "../lib/validate.js";
+import { displayNameFor } from "../lib/providers.js";
 
 export type ValidateStepProps = {
   provider: string;
@@ -69,7 +70,7 @@ export function ValidateStep({ provider, onNext, onEditKey }: ValidateStepProps)
   if (phase === "validating") {
     return (
       <Box flexDirection="column">
-        <Text>Validating {provider} credentials …</Text>
+        <Text>Validating {displayNameFor(provider)} credentials …</Text>
       </Box>
     );
   }
@@ -78,7 +79,7 @@ export function ValidateStep({ provider, onNext, onEditKey }: ValidateStepProps)
     return (
       <Box flexDirection="column">
         <Text color="green">
-          ✓ {provider} reachable
+          ✓ {displayNameFor(provider)} reachable
           {typeof result.modelCount === "number"
             ? ` — ${result.modelCount} model${result.modelCount === 1 ? "" : "s"} available.`
             : "."}

--- a/apps/web/app/api/cli/models/route.ts
+++ b/apps/web/app/api/cli/models/route.ts
@@ -1,0 +1,38 @@
+import { authenticateApiToken } from "@/lib/api-auth";
+import { prisma } from "@octopus/db";
+import { resolveReviewModelPin } from "@/lib/ai-client";
+import { getProviderForModel } from "@/lib/ai-router";
+import { ORG_KEY_COLUMNS, buildCliModelsResponse } from "@/lib/cli-models";
+
+// The org's effective review model for the CLI onboarding wizard (display
+// only). Same auth as /api/cli/me; no writes.
+export async function GET(request: Request) {
+  const result = await authenticateApiToken(request);
+  if (result instanceof Response) return result; // account-standing hold (403), pass through
+  if (!result) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { model, pinned } = await resolveReviewModelPin(result.org.id);
+  const [provider, catalogRow, org] = await Promise.all([
+    getProviderForModel(model),
+    prisma.availableModel.findUnique({ where: { modelId: model }, select: { displayName: true } }),
+    prisma.organization.findUnique({
+      where: { id: result.org.id },
+      select: Object.fromEntries(Object.values(ORG_KEY_COLUMNS).map((c) => [c, true])) as Record<
+        (typeof ORG_KEY_COLUMNS)[keyof typeof ORG_KEY_COLUMNS],
+        true
+      >,
+    }),
+  ]);
+
+  return Response.json(
+    buildCliModelsResponse({
+      model,
+      pinned,
+      provider: String(provider),
+      displayName: catalogRow?.displayName ?? null,
+      keys: org ?? {},
+    }),
+  );
+}

--- a/apps/web/lib/__tests__/cli-models.test.ts
+++ b/apps/web/lib/__tests__/cli-models.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { buildCliModelsResponse, byokProvidersFrom } from "@/lib/cli-models";
+
+describe("cli-models", () => {
+  it("reports only providers with a key, never the key itself", () => {
+    const res = buildCliModelsResponse({
+      model: "claude-opus-5",
+      pinned: false,
+      provider: "anthropic",
+      displayName: "Claude Opus 5",
+      keys: { anthropicApiKey: "sk-ant-secret", openaiApiKey: null, grokApiKey: "" },
+    });
+    expect(res).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-5",
+      displayName: "Claude Opus 5",
+      isPlatformDefault: true,
+      byokProviders: ["anthropic"],
+    });
+    expect(JSON.stringify(res)).not.toContain("sk-ant");
+  });
+
+  it("marks a pinned org/repo model as not the platform default", () => {
+    expect(buildCliModelsResponse({ model: "gpt-6-astra", pinned: true, provider: "openai", displayName: null, keys: {} }).isPlatformDefault).toBe(false);
+    expect(byokProvidersFrom({ openaiApiKey: "x", alibabaApiKey: "y" })).toEqual(["openai", "alibaba"]);
+  });
+});

--- a/apps/web/lib/cli-models.ts
+++ b/apps/web/lib/cli-models.ts
@@ -1,0 +1,47 @@
+/**
+ * Shape of GET /api/cli/models: what the org's reviews run on right now, so the
+ * CLI can say "Reviews on Cloud use your org's default model: X". Read-only,
+ * booleans only for keys (never key material).
+ */
+export const ORG_KEY_COLUMNS = {
+  anthropic: "anthropicApiKey",
+  openai: "openaiApiKey",
+  google: "googleApiKey",
+  grok: "grokApiKey",
+  openrouter: "openrouterApiKey",
+  alibaba: "alibabaApiKey",
+} as const;
+
+export type OrgKeyColumn = (typeof ORG_KEY_COLUMNS)[keyof typeof ORG_KEY_COLUMNS];
+
+export type CliModelsResponse = {
+  provider: string;
+  model: string;
+  displayName: string | null;
+  /** true when no org/repo pin exists and the platform default applies. */
+  isPlatformDefault: boolean;
+  /** Providers for which the org has its own API key configured. */
+  byokProviders: string[];
+};
+
+export function byokProvidersFrom(keys: Partial<Record<OrgKeyColumn, string | null>>): string[] {
+  return (Object.entries(ORG_KEY_COLUMNS) as [string, OrgKeyColumn][])
+    .filter(([, column]) => Boolean(keys[column]))
+    .map(([provider]) => provider);
+}
+
+export function buildCliModelsResponse(input: {
+  model: string;
+  pinned: boolean;
+  provider: string;
+  displayName: string | null;
+  keys: Partial<Record<OrgKeyColumn, string | null>>;
+}): CliModelsResponse {
+  return {
+    provider: input.provider,
+    model: input.model,
+    displayName: input.displayName,
+    isPlatformDefault: !input.pinned,
+    byokProviders: byokProvidersFrom(input.keys),
+  };
+}


### PR DESCRIPTION
## Why

A first-time Cloud user ran `octp onboard` and hit three things: the sign-in step printed the approval URL and made them copy it; a React warning ("Cannot update a component (OnboardWizard) while rendering a different component") leaked into the terminal; and after choosing Cloud they were pushed through a long provider list (Direct API / harnesses / gateways / Local, selectable "coming soon" rows, Ollama) and a model picker whose default was the retired Sonnet 4.6.

Four parallel code readers plus adversarial verification established (with file:line evidence) that: `lib/auth.ts` already has a shell-free `openBrowser` used by `octp login` but not by the wizard; `ByokStep` was the only step calling `onNext` during render; the wizard's provider/model are **local-only** overrides for `octp review` (they never change the org's server-side review model); and Cloud vs self-hosted is known from the sign-in patch, so Ollama can be hidden without a server call.

## What

**CLI (`apps/cli`)**
- **AuthStep**: opens the approval page automatically on entering "waiting" (`openBrowser`, spawn without a shell), Enter opens it again, Esc returns to the mode choice; the URL stays printed with an "Opened in your browser" / "Could not open a browser (headless/SSH?)" line. Choice labels: `Cloud (Octopus hosted) - octopus-review.ai`, `Self-hosted - I run my own instance`, `Skip - I'll sign in later`.
- **`lib/hosting.ts`**: `HOSTED_BASE_URL`, `isCloudBaseUrl`, `buildHostingPatch` (Cloud explicitly clears a `--reset`-seeded `selfHostedBaseUrl`). Used by AuthStep, RepoStep, DoneStep.
- **ProviderStep** (rewritten): Cloud → `Use org default (recommended)` (Enter) / `Set a local override`; the copy names the org's current model when `GET /api/cli/models` answers (3 s timeout, silent fallback for older servers/offline). Self-hosted → `Use recommended: Claude (Anthropic) / Claude Opus 5` / `Choose a different provider`. Full list via `buildProviderItems`: ready providers only, no heading rows, Ollama hidden on Cloud.
- **`lib/sequence.ts` `buildSequence`** (pure): no provider → skip model/key/validate/Ollama; recommended pair → skip the model picker; Ollama → its setup replaces model/key/validate; before the provider step only the Ollama tab is hidden (as today).
- **Warning fix**: ByokStep's no-provider pass-through moved into `useEffect`; the wizard's `next` is a stable `useCallback` that drops `undefined` keys, plus a patch-less `advance` for steps whose patch is not a pref.
- **ModelStep**: Enter picks the recommended model (`initialIndex`); provider names via `displayNameFor`; dead "Go back to provider picker" item removed.
- **Catalogue** (`lib/models.ts`): aligned with the Cloud catalog so a local override always prices server-side: Anthropic Opus 5 (default), Fable 5.1, Fable 5, Sonnet 5, Opus 4.8, Haiku 4.5 (Sonnet 4.6 dropped); OpenAI GPT-6 Astra + GPT-5.3 Codex (default) instead of GPT-4o/o4-mini which are not in the catalog.
- **DoneStep**: `Server: Cloud (octopus-review.ai)`, `Provider: org default (set in Settings)`, `Billing: Octopus credits | your API key`, full settings URL. Header tabs `Sign in` / `Key`. `octp doctor` / `octp login --help` copy.

**Server (`apps/web`)**
- `GET /api/cli/models` (same auth as `/api/cli/me`): `{ provider, model, displayName, isPlatformDefault, byokProviders }` from `resolveReviewModelPin` + `getProviderForModel` + the catalog row; org keys reported as provider names only (`lib/cli-models.ts`).

## Flows after this PR

- Cloud, default: Welcome → Sign in → Org → Review model (Enter) → Repo → Done.
- Cloud, override: … → Review model → provider list → Model → Key → Validate → Repo → Done.
- Self-hosted, recommended: … → Review model (Enter) → Key → Validate → Done.
- Self-hosted, Ollama: unchanged.

## Tests

- CLI: 123 pass. New `sequence.test.ts`, `hosting.test.ts`; `providers.test.ts` (`buildProviderItems` never lists coming-soon rows, hides Ollama on Cloud, keeps order; `defaultProvider`, `displayNameFor`); `models.test.ts` defaults updated.
- Web: 1083 pass; new `cli-models.test.ts` (booleans only, no key material in the response; pinned vs platform default).
- `tsc --noEmit` clean for both packages; ESLint clean on touched web files.

Not covered by automated tests (Ink needs a TTY): the screens themselves. Manual run: `bun run apps/cli/src/index.tsx onboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbAThbRPYGBRufVyazrUad
