### PR TITLE
fix(repos): automatically index new repositories and review empty initial branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.139] - 2026-09-09
+
+### Fixed
+- New GitHub repositories now start indexing automatically after connection or discovery. A first pull request also recovers a repository missed by its creation webhook.
+- Pull requests against an empty initial branch can now be reviewed. GitHub's empty-tree response is no longer reported as a missing branch, while access and invalid-branch errors remain actionable.
+- Empty repositories are checked again after code is pushed, and abandoned indexing jobs recover during repository discovery.
+
 ## [1.0.138] - 2026-09-05
 
 ### Changed

--- a/apps/web/app/api/github/callback/route.ts
+++ b/apps/web/app/api/github/callback/route.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import crypto from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { revalidatePath } from "next/cache";
@@ -11,6 +12,7 @@ import {
 } from "@/lib/github";
 import { getGithubAppConfig } from "@/lib/github-app-config";
 import { grantDeferredWelcomeCredit } from "@/lib/org-create";
+import { enqueuePendingRepositoryIndexes } from "@/lib/repository-index-job";
 import { getRedis } from "@/lib/redis";
 import { writeAuditLog } from "@/lib/audit";
 import {
@@ -196,6 +198,7 @@ async function bindAndSyncInstallation(
     // First repo connect releases a deferred welcome grant (no-op otherwise).
     if (ghRepos.length > 0) {
       await grantDeferredWelcomeCredit(organizationId);
+      await enqueuePendingRepositoryIndexes(organizationId);
     }
   } catch (error) {
     console.error("[github/callback] repo sync error:", error);

--- a/apps/web/app/api/github/webhook/route.ts
+++ b/apps/web/app/api/github/webhook/route.ts
@@ -63,11 +63,35 @@ export async function POST(request: NextRequest) {
   const deliveryId = request.headers.get("x-github-delivery");
   const payloadSha256 = crypto.createHash("sha256").update(body).digest("hex");
   const payload = JSON.parse(body);
-  const tenantResolution = await resolveGithubWebhookTenant({
+  let tenantResolution = await resolveGithubWebhookTenant({
     provider: "github",
     installationId: payload.installation?.id,
     repositoryExternalId: payload.repository?.id,
   });
+
+  // A PR may arrive before repository.created (or before that subscription
+  // was enabled). Recover only inside the signed installation's mapped org.
+  const isReviewTrigger =
+    (event === "pull_request" && ["opened", "reopened", "synchronize", "ready_for_review"].includes(payload.action)) ||
+    (event === "issue_comment" && payload.action === "created" && payload.issue?.pull_request &&
+      /@octopus(?:review|-review)?\b/i.test(payload.comment?.body ?? ""));
+  if (isReviewTrigger && tenantResolution.status === "repository_not_owned" && tenantResolution.organizationId) {
+    const org = await prisma.organization.findFirst({
+      where: { id: tenantResolution.organizationId, deletedAt: null, bannedAt: null, autoDiscoverRepos: true },
+      select: { id: true, autoDiscoverRepos: true },
+    });
+    if (org?.autoDiscoverRepos) {
+      await applyRepositoryEvent(org.id, payload.installation.id, "created", payload.repository);
+      // Never construct a resolved tenant from the payload or an upsert result.
+      tenantResolution = await resolveGithubWebhookTenant({
+        provider: "github",
+        installationId: payload.installation.id,
+        repositoryExternalId: payload.repository.id,
+      });
+      revalidatePath("/");
+      revalidatePath("/repositories");
+    }
+  }
   const resolvedRepositoryTenant = isResolvedRepositoryTenant(tenantResolution)
     ? tenantResolution
     : null;
@@ -202,10 +226,10 @@ export async function POST(request: NextRequest) {
     // Find repository in DB and check autoReview
     const repo = await prisma.repository.findUnique({
       where: { id: resolvedRepositoryTenant.repositoryId },
-      select: { id: true, organizationId: true, autoReview: true, installationId: true },
+      select: { id: true, organizationId: true, autoReview: true, installationId: true, isActive: true, dismissedAt: true },
     });
 
-    if (!repo || repo.organizationId !== resolvedRepositoryTenant.organizationId) {
+    if (!repo || !repo.isActive || repo.dismissedAt || repo.organizationId !== resolvedRepositoryTenant.organizationId) {
       console.warn(`[webhook] Repo not found in DB — externalId: ${repoExternalId}`);
       return NextResponse.json({ ok: true });
     }
@@ -425,10 +449,10 @@ export async function POST(request: NextRequest) {
       // Find repository in DB
       const repo = await prisma.repository.findUnique({
         where: { id: resolvedRepositoryTenant.repositoryId },
-        select: { id: true, organizationId: true, installationId: true },
+        select: { id: true, organizationId: true, installationId: true, isActive: true, dismissedAt: true },
       });
 
-      if (!repo || repo.organizationId !== resolvedRepositoryTenant.organizationId) {
+      if (!repo || !repo.isActive || repo.dismissedAt || repo.organizationId !== resolvedRepositoryTenant.organizationId) {
         console.warn(`[webhook] Repo not found in DB — externalId: ${repoExternalId}, fullName: ${repoFullName}`);
         return NextResponse.json({ ok: true });
       }

--- a/apps/web/lib/__tests__/discover-repositories.test.ts
+++ b/apps/web/lib/__tests__/discover-repositories.test.ts
@@ -13,7 +13,11 @@ const findMany = mock(async (args: Loose) => {
   return orgs;
 });
 const update = mock(async () => ({ count: 1 }));
-mock.module("@octopus/db", () => ({ prisma: { organization: { findMany, updateMany: update } } }));
+const recoverIndexes = mock(async (_args: Loose) => ({ count: 0 }));
+mock.module("@octopus/db", () => ({ prisma: {
+  organization: { findMany, updateMany: update },
+  repository: { updateMany: recoverIndexes },
+} }));
 
 class GithubRateLimitError extends Error {
   constructor(readonly status = 429, readonly retryAfterSeconds: number | null = null) {
@@ -44,6 +48,7 @@ describe("discoverRepositories", () => {
     findManyArgs = null;
     findMany.mockClear();
     update.mockClear();
+    recoverIndexes.mockClear();
     syncOrgRepos.mockClear();
   });
 
@@ -61,6 +66,14 @@ describe("discoverRepositories", () => {
       { where: { id: "a" }, data: { reposSyncedAt: NOW } },
       { where: { id: "b" }, data: { reposSyncedAt: NOW } },
     ]);
+    expect(recoverIndexes.mock.calls[0][0]).toEqual({
+      where: {
+        organizationId: "a", provider: "github", isActive: true, dismissedAt: null,
+        indexStatus: "indexing", updatedAt: { lt: new Date("2026-09-03T09:42:00.000Z") },
+      },
+      data: { indexStatus: "failed" },
+    });
+    expect(recoverIndexes.mock.invocationCallOrder[0]).toBeLessThan(syncOrgRepos.mock.invocationCallOrder[0]);
   });
 
   it("counts a failing organization, still stamps it, and keeps sweeping", async () => {

--- a/apps/web/lib/__tests__/fixtures/github-webhook-tenant-enforcement-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/github-webhook-tenant-enforcement-harness.ts
@@ -20,6 +20,8 @@ let failNextLedgerWrite = false;
 let installationBindingCleared = false;
 let legacyRepositoryLookups = 0;
 let autoDiscoverEnabled = true;
+let createdRepository = false;
+let repositoryDismissed = false;
 const syncCalls: Array<{ organizationId: string; source: string }> = [];
 
 const webhookDeliveryStore = {
@@ -65,6 +67,7 @@ mock.module("@/lib/repo-sync", () => ({
   },
   applyRepositoryEvent: (organizationId: string, installationId: number, action: string) => {
     syncCalls.push({ organizationId, source: `repository.${action}@${installationId}` });
+    if (!repositoryDismissed) createdRepository = true;
     return Promise.resolve("created");
   },
 }));
@@ -122,7 +125,7 @@ mock.module("@octopus/db", () => ({
       }) => {
         if (args.where.provider_externalId_organizationId) {
           // Only the shared repository (9001) has a row; 9002 is brand new.
-          if (args.where.provider_externalId_organizationId.externalId !== "9001") {
+          if (args.where.provider_externalId_organizationId.externalId !== "9001" && !createdRepository) {
             return Promise.resolve(null);
           }
           return Promise.resolve({ id: "repo_b", organizationId: "org_b" });
@@ -136,6 +139,8 @@ mock.module("@octopus/db", () => ({
             fullName: "shared/repository",
             defaultBranch: "main",
             indexStatus: "pending",
+            isActive: true,
+            dismissedAt: repositoryDismissed ? new Date() : null,
           });
         }
         return Promise.resolve(null);
@@ -361,6 +366,34 @@ try {
   assert(installationBindingCleared, "uninstall did not clear the installation binding");
   assert(syncCalls.length === 0, "uninstall or earlier events unexpectedly triggered a repo sync");
 
+  // A first PR recovers a missed creation event before routing the review.
+  installationBindingCleared = false;
+  const firstPrBody = JSON.stringify({
+    ...JSON.parse(pullRequestBody()),
+    repository: { id: 9002, name: "brand-new", full_name: "shared/brand-new", default_branch: "main" },
+  });
+  const reviewsBeforeRecovery = reviewCalls.length;
+  autoDiscoverEnabled = false;
+  await POST(webhookRequest(firstPrBody));
+  await runAfterCallbacks();
+  assert(reviewCalls.length === reviewsBeforeRecovery && syncCalls.length === 0, "PR discovery ignored opt-out");
+  autoDiscoverEnabled = true;
+  repositoryDismissed = true;
+  await POST(webhookRequest(pullRequestBody()));
+  await POST(webhookRequest(issueCommentBody(), { eventType: "issue_comment" }));
+  await runAfterCallbacks();
+  assert(reviewCalls.length === reviewsBeforeRecovery, "a previously discovered, dismissed repository was reviewed");
+  await POST(webhookRequest(firstPrBody));
+  await runAfterCallbacks();
+  assert(reviewCalls.length === reviewsBeforeRecovery, "a dismissed repository was reviewed");
+  repositoryDismissed = false;
+  await POST(webhookRequest(firstPrBody));
+  await runAfterCallbacks();
+  assert(reviewCalls.length === reviewsBeforeRecovery + 1, "first PR was dropped after discovery");
+  assert(reviewCalls.at(-1)?.orgId === "org_b", "first PR crossed the installation boundary");
+  createdRepository = false;
+  syncCalls.length = 0;
+
   // Re-bind the installation for the repository lifecycle scenarios.
   installationBindingCleared = false;
   const repositoryCreatedBody = JSON.stringify({
@@ -442,6 +475,7 @@ try {
     repositoryCreatedUnmappedDropped: true,
     repositoryCreatedRespectsOptOut: true,
     installationRepositoriesSynced: true,
+    firstPrRecoversMissingRepository: true,
   }));
 } catch (error) {
   originalConsole.warn(error);

--- a/apps/web/lib/__tests__/fixtures/indexer-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/indexer-harness.ts
@@ -1,0 +1,116 @@
+import { mock } from "bun:test";
+import assert from "node:assert/strict";
+
+mock.module("server-only", () => ({}));
+let details: { default_branch: string } | null = { default_branch: "main" };
+const deleted: string[] = [];
+const embedded: string[][] = [];
+mock.module("@/lib/github", () => ({
+  getInstallationToken: async () => "test-token",
+  getRepositoryDetails: async () => details,
+  getFileContent: async () => null,
+}));
+mock.module("@/lib/bitbucket", () => ({}));
+mock.module("@/lib/gitlab", () => ({}));
+mock.module("@/lib/qdrant", () => ({
+  ensureCollection: async () => {},
+  deleteRepoChunks: async (id: string) => { deleted.push(id); },
+  deleteRepoFileChunks: async () => {},
+  upsertChunks: async () => {},
+}));
+mock.module("@/lib/embeddings", () => ({
+  createEmbeddings: async (texts: string[]) => {
+    embedded.push(texts);
+    return texts.map(() => [0.1]);
+  },
+}));
+const { indexRepository } = await import("@/lib/indexer");
+const emptySha = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+const responses = new Map<string, [number, unknown]>();
+const requests: string[] = [];
+globalThis.fetch = mock(async (input: string | URL | Request) => {
+  const url = String(input);
+  requests.push(url);
+  const suffix = url.replace("https://api.github.com/repos/acme/new", "");
+  const [status, body] = responses.get(suffix) ?? [500, { message: `Unexpected URL: ${url}` }];
+  return Response.json(body, { status });
+}) as typeof fetch;
+
+async function run(branch = "main") {
+  return indexRepository("repo-1", "acme/new", branch, 123);
+}
+function reset() {
+  responses.clear(); requests.length = 0; deleted.length = 0; embedded.length = 0;
+  details = { default_branch: "main" };
+  responses.set("/contributors?per_page=30", [200, []]);
+}
+
+// Empty commit: GitHub's tree 404 must be verified against the existing commit.
+reset();
+responses.set("/git/trees/main?recursive=1", [404, { message: "Git Repository is empty." }]);
+responses.set("/commits/main", [200, { commit: { tree: { sha: emptySha } } }]);
+assert.equal((await run()).totalFiles, 0);
+assert.deepEqual(deleted, ["repo-1"], "empty snapshots must clear an older index");
+assert.equal(embedded.length, 0, "empty trees must not be embedded");
+
+reset();
+responses.set("/git/trees/main?recursive=1", [409, { message: "Git Repository is empty." }]);
+assert.equal((await run()).totalVectors, 0);
+
+reset();
+responses.set("/git/trees/main?recursive=1", [200, { tree: [] }]);
+assert.equal((await run()).indexedFiles, 0);
+
+reset();
+responses.set("/git/trees/main?recursive=1", [200, {}]);
+await assert.rejects(run, /Invalid repository tree response/);
+assert.equal(deleted.length, 0);
+
+reset();
+responses.set("/git/trees/main?recursive=1", [404, { message: "Not Found" }]);
+responses.set("/commits/main", [404, { message: "Not Found" }]);
+await assert.rejects(run, /Branch 'main' not found/);
+assert.equal(deleted.length, 0);
+
+reset();
+responses.set("/git/trees/main?recursive=1", [404, {}]);
+responses.set("/commits/main", [200, { commit: { tree: { sha: "nonempty-tree" } } }]);
+await assert.rejects(run, /no tree for existing branch/);
+assert.equal(deleted.length, 0);
+
+reset(); details = null;
+responses.set("/git/trees/main?recursive=1", [404, {}]);
+await assert.rejects(run, /does not have access/);
+assert.equal(deleted.length, 0);
+
+for (const status of [403, 429, 500, 409]) {
+  reset(); responses.set("/git/trees/main?recursive=1", [status, { message: "Failure" }]);
+  await assert.rejects(run, new RegExp(`Failed to fetch tree: ${status}`));
+  assert.equal(deleted.length, 0);
+}
+
+reset();
+responses.set("/git/trees/main?recursive=1", [404, {}]);
+responses.set("/commits/main", [429, {}]);
+await assert.rejects(run, /Failed to verify branch.*429/);
+
+// Keep branch correction and branch names containing slashes working.
+reset(); details = { default_branch: "release/main" };
+responses.set("/git/trees/main?recursive=1", [404, {}]);
+responses.set("/git/trees/release%2Fmain?recursive=1", [404, {}]);
+responses.set("/commits/release%2Fmain", [200, { commit: { tree: { sha: emptySha } } }]);
+assert.equal((await run()).resolvedDefaultBranch, "release/main");
+
+// The same repository is indexable after its first push.
+reset();
+responses.set("/git/trees/main?recursive=1", [200, {
+  tree: [{ path: "index.ts", type: "blob", sha: "blob-1", size: 35 }],
+}]);
+responses.set("/git/blobs/blob-1", [200, {
+  encoding: "base64", content: Buffer.from("export const greeting = 'hello';\n").toString("base64"),
+}]);
+const populated = await run();
+assert.equal(populated.indexedFiles, 1);
+assert.ok(populated.totalVectors > 0);
+assert.equal(embedded.length, 1);
+console.log("14 indexing regressions passed");

--- a/apps/web/lib/__tests__/fixtures/repository-index-job-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/repository-index-job-harness.ts
@@ -1,0 +1,101 @@
+import { mock } from "bun:test";
+import assert from "node:assert/strict";
+
+mock.module("server-only", () => ({}));
+const row = {
+  id: "repo-1", organizationId: "org-1", fullName: "acme/new", defaultBranch: "main",
+  installationId: 123, indexStatus: "pending", totalFiles: 0,
+  organization: { githubInstallationId: 123 as number | null },
+};
+let currentRow: typeof row | null = row;
+let claimCount = 1;
+let indexFailure: Error | null = null;
+let cancelled = false;
+const queued: unknown[][] = [];
+const indexCalls: unknown[][] = [];
+const writes: Array<{ data: Record<string, unknown> }> = [];
+const queries: Array<{ where: Record<string, unknown> }> = [];
+const claims: Array<{ where: Record<string, unknown>; data: Record<string, unknown> }> = [];
+let controller = new AbortController();
+mock.module("@/lib/queue", () => ({
+  enqueue: async (...args: unknown[]) => { queued.push(args); return "job-1"; },
+}));
+mock.module("@/lib/indexing-abort", () => ({
+  createAbortController: () => { controller = new AbortController(); return controller; },
+  clearAbortController: () => {},
+}));
+mock.module("@octopus/db", () => ({
+  prisma: {
+    repository: {
+      findMany: async (args: { where: Record<string, unknown> }) => { queries.push(args); return [{ id: "repo-1" }]; },
+      findFirst: async (args: { where: Record<string, unknown> }) => { queries.push(args); return currentRow; },
+      updateMany: async (args: { where: Record<string, unknown>; data: Record<string, unknown> }) => {
+        claims.push(args); return { count: claimCount };
+      },
+      update: async (args: { data: Record<string, unknown> }) => { writes.push(args); return {}; },
+    },
+  },
+}));
+mock.module("@/lib/pubby", () => ({ pubby: { trigger: async () => {} } }));
+mock.module("@/lib/elasticsearch", () => ({ writeSyncLog: () => {}, deleteSyncLogs: async () => {} }));
+mock.module("@/lib/indexer", () => ({
+  indexRepository: async (...args: unknown[]) => {
+    indexCalls.push(args);
+    if (cancelled) { controller.abort(); throw new Error("Indexing cancelled"); }
+    if (indexFailure) throw indexFailure;
+    return {
+      indexedFiles: 0, totalFiles: 0, totalChunks: 0, totalVectors: 0,
+      contributors: [], contributorCount: 0, durationMs: 12, resolvedDefaultBranch: "master",
+    };
+  },
+}));
+const { enqueuePendingRepositoryIndexes, processRepositoryIndex } = await import("@/lib/repository-index-job");
+const job = { repositoryId: "repo-1", organizationId: "org-1" };
+
+await assert.rejects(() => processRepositoryIndex({ repositoryId: "repo-1", organizationId: "" }), /requires/);
+assert.equal(queries.length, 0, "invalid jobs must never issue an unscoped query");
+
+await enqueuePendingRepositoryIndexes("org-1");
+assert.deepEqual(queued, [["index-repository", job, { singletonKey: "repo-1", singletonSeconds: 60 }]]);
+assert.deepEqual(queries[0].where, {
+  organizationId: "org-1", provider: "github", isActive: true, dismissedAt: null,
+  organization: { deletedAt: null, bannedAt: null, autoDiscoverRepos: true },
+  OR: [{ indexStatus: { in: ["pending", "failed"] } }, { indexStatus: "indexed", totalFiles: 0 }],
+});
+
+await processRepositoryIndex(job);
+assert.equal(indexCalls.length, 1);
+assert.equal(indexCalls[0][3], 123, "the worker must use the org's bound installation");
+assert.equal(writes[0].data.indexStatus, "indexed");
+assert.equal(writes[0].data.defaultBranch, "master");
+assert.equal(writes[0].data.totalFiles, 0, "an empty base must be a completed snapshot");
+assert.equal(queries[1].where.organizationId, "org-1");
+assert.equal(queries[1].where.dismissedAt, null);
+assert.equal(queries[1].where.isActive, true);
+assert.deepEqual(queries[1].where.organization, { deletedAt: null, bannedAt: null, autoDiscoverRepos: true });
+
+claimCount = 0;
+await processRepositoryIndex(job);
+assert.equal(indexCalls.length, 1, "a competing review must keep its claim");
+claimCount = 1;
+currentRow = null;
+await processRepositoryIndex(job);
+assert.equal(indexCalls.length, 1, "removed or wrong-tenant rows must be skipped");
+currentRow = { ...row, organization: { githubInstallationId: null } };
+await processRepositoryIndex(job);
+currentRow = { ...row, organization: { githubInstallationId: 456 } };
+await processRepositoryIndex(job);
+assert.equal(indexCalls.length, 1, "disconnected or mismatched installations must not index");
+
+currentRow = row;
+indexFailure = new Error("GitHub unavailable");
+await assert.rejects(() => processRepositoryIndex(job), /GitHub unavailable/);
+assert.equal(claims.at(-1)?.data.indexStatus, "failed", "failures must release the claim for retry");
+indexFailure = null;
+await processRepositoryIndex(job);
+assert.equal(writes.length, 2, "a retry must be able to complete");
+
+cancelled = true;
+await processRepositoryIndex(job);
+assert.equal(claims.at(-1)?.data.indexStatus, "pending", "cancelled work must release its claim");
+console.log("Repository queue, tenant, claim, empty snapshot, failure, retry and cancellation checks passed");

--- a/apps/web/lib/__tests__/github-webhook-tenant-enforcement.test.ts
+++ b/apps/web/lib/__tests__/github-webhook-tenant-enforcement.test.ts
@@ -35,6 +35,7 @@ describe("GitHub webhook tenant enforcement", () => {
       repositoryCreatedUnmappedDropped: true,
       repositoryCreatedRespectsOptOut: true,
       installationRepositoriesSynced: true,
+      firstPrRecoversMissingRepository: true,
     });
   });
 });

--- a/apps/web/lib/__tests__/indexer.test.ts
+++ b/apps/web/lib/__tests__/indexer.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+describe("GitHub repository indexing", () => {
+  it("handles empty repositories without hiding access or branch failures", async () => {
+    const child = Bun.spawn([process.execPath, fileURLToPath(new URL("./fixtures/indexer-harness.ts", import.meta.url))], {
+      cwd: process.cwd(), stdout: "pipe", stderr: "pipe",
+    });
+    const [code, stdout, stderr] = await Promise.all([
+      child.exited, new Response(child.stdout).text(), new Response(child.stderr).text(),
+    ]);
+    expect(code, `${stdout}\n${stderr}`).toBe(0);
+  });
+});

--- a/apps/web/lib/__tests__/repo-sync.test.ts
+++ b/apps/web/lib/__tests__/repo-sync.test.ts
@@ -87,6 +87,9 @@ const writeAuditLog = mock(async () => {});
 const actualAudit = await import("@/lib/audit");
 mock.module("@/lib/audit", () => ({ ...actualAudit, writeAuditLog }));
 
+const enqueuePendingRepositoryIndexes = mock(async () => {});
+mock.module("@/lib/repository-index-job", () => ({ enqueuePendingRepositoryIndexes }));
+
 const { syncOrgRepos, applyRepositoryEvent } = await import("@/lib/repo-sync");
 
 const gh = (id: number, name: string) => ({
@@ -116,6 +119,7 @@ describe("syncOrgRepos", () => {
     grantDeferredWelcomeCredit.mockClear();
     trigger.mockClear();
     writeAuditLog.mockClear();
+    enqueuePendingRepositoryIndexes.mockClear();
   });
 
   it("reports brand-new repositories as created and refreshed ones as synced only", async () => {
@@ -129,6 +133,7 @@ describe("syncOrgRepos", () => {
     expect(upserts).toHaveLength(2);
     expect(upserts[1].create).toMatchObject({ externalId: "2", installationId: 111, isActive: true, organizationId: "org_1" });
     expect(grantDeferredWelcomeCredit).toHaveBeenCalledWith("org_1");
+    expect(enqueuePendingRepositoryIndexes).toHaveBeenCalledWith("org_1");
   });
 
   it("never resurrects a repository the user removed, and never deactivates dismissed rows", async () => {
@@ -247,6 +252,7 @@ describe("syncOrgRepos", () => {
     expect(trigger).toHaveBeenCalledWith("presence-org-org_1", "repos-discovered", { count: 2 });
 
     writeAuditLog.mockClear();
+    enqueuePendingRepositoryIndexes.mockClear();
     trigger.mockClear();
     existingRows.github = [{ externalId: "1", dismissedAt: null }, { externalId: "2", dismissedAt: null }];
     await syncOrgRepos("org_1", { source: "webhook" });
@@ -264,6 +270,7 @@ describe("applyRepositoryEvent (GitHub repository webhooks)", () => {
     grantDeferredWelcomeCredit.mockClear();
     trigger.mockClear();
     writeAuditLog.mockClear();
+    enqueuePendingRepositoryIndexes.mockClear();
   });
 
   it("writes one row from the payload on created and announces it", async () => {

--- a/apps/web/lib/__tests__/repository-index-job.test.ts
+++ b/apps/web/lib/__tests__/repository-index-job.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+describe("discovered repository indexing", () => {
+  it("queues eligible repositories and shares claims with PR indexing", async () => {
+    const child = Bun.spawn([process.execPath, fileURLToPath(new URL("./fixtures/repository-index-job-harness.ts", import.meta.url))], {
+      cwd: process.cwd(), stdout: "pipe", stderr: "pipe",
+    });
+    const [code, stdout, stderr] = await Promise.all([
+      child.exited, new Response(child.stdout).text(), new Response(child.stderr).text(),
+    ]);
+    expect(code, `${stdout}\n${stderr}`).toBe(0);
+  });
+});

--- a/apps/web/lib/discover-repositories.ts
+++ b/apps/web/lib/discover-repositories.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { prisma } from "@octopus/db";
 import { GithubRateLimitError } from "@/lib/github";
 import { syncOrgRepos } from "@/lib/repo-sync";
@@ -48,6 +49,19 @@ export async function discoverRepositories(now: Date = new Date()): Promise<{
 
   for (const org of orgs) {
     try {
+      // Recover claims left by a crashed indexing worker. Do this BEFORE sync
+      // upserts refresh updatedAt; 35 min exceeds the indexing queue's expiry.
+      await prisma.repository.updateMany({
+        where: {
+          organizationId: org.id,
+          provider: "github",
+          isActive: true,
+          dismissedAt: null,
+          indexStatus: "indexing",
+          updatedAt: { lt: new Date(now.getTime() - 35 * 60_000) },
+        },
+        data: { indexStatus: "failed" },
+      });
       const r = await syncOrgRepos(org.id, { source: "scheduled" });
       created += r.created;
       removed += r.removed;

--- a/apps/web/lib/indexer.ts
+++ b/apps/web/lib/indexer.ts
@@ -72,6 +72,7 @@ export async function indexRepository(
   let contributorCount = 0;
   let contributors: Contributor[] = [];
   let resolvedDefaultBranch: string | undefined;
+  let emptyRepository = false;
 
   if ((provider === "bitbucket" || provider === "gitlab") && organizationId) {
     // ── Bitbucket / GitLab indexing flow (clone-based) ──
@@ -252,10 +253,11 @@ export async function indexRepository(
 
     onLog(`Fetching repository tree for ${fullName}@${activeBranch}...`);
     let treeRes = await fetch(
-      `${GITHUB_API}/repos/${fullName}/git/trees/${activeBranch}?recursive=1`,
-      { headers },
+      `${GITHUB_API}/repos/${fullName}/git/trees/${encodeURIComponent(activeBranch)}?recursive=1`,
+      { headers, signal },
     );
 
+    let branchExists = false;
     if (!treeRes.ok && treeRes.status === 404) {
       const [owner, repoName] = fullName.split("/");
       const details = await getRepositoryDetails(installationId, owner, repoName, token);
@@ -269,23 +271,34 @@ export async function indexRepository(
         activeBranch = details.default_branch;
         resolvedDefaultBranch = details.default_branch;
         treeRes = await fetch(
-          `${GITHUB_API}/repos/${fullName}/git/trees/${activeBranch}?recursive=1`,
-          { headers },
+          `${GITHUB_API}/repos/${fullName}/git/trees/${encodeURIComponent(activeBranch)}?recursive=1`,
+          { headers, signal },
         );
       }
     }
 
-    if (!treeRes.ok) {
-      if (treeRes.status === 409) {
-        onLog(
-          `Repository '${fullName}' appears to be empty: there are no files to index. Push some code to the repository and try again.`,
-          "error",
-        );
-        throw new Error(
-          `Repository is empty: no files to index. Push some code and retry indexing.`,
-        );
+    // GitHub can return 404 for an existing branch whose commit references
+    // Git's empty tree. Verify the commit instead of calling it a missing branch.
+    if (!treeRes.ok && treeRes.status === 404) {
+      const commitRes = await fetch(
+        `${GITHUB_API}/repos/${fullName}/commits/${encodeURIComponent(activeBranch)}`,
+        { headers, signal },
+      );
+      if (commitRes.ok) {
+        branchExists = true;
+        const commit = await commitRes.json();
+        emptyRepository = commit.commit?.tree?.sha === "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+      } else if (commitRes.status !== 404 && commitRes.status !== 422) {
+        throw new Error(`Failed to verify branch '${activeBranch}': HTTP ${commitRes.status}`);
       }
+    }
+    if (!treeRes.ok && treeRes.status === 409) {
+      const error = await treeRes.json();
+      emptyRepository = error.message === "Git Repository is empty.";
+    }
+    if (!treeRes.ok && !emptyRepository) {
       if (treeRes.status === 404) {
+        if (branchExists) throw new Error(`GitHub returned no tree for existing branch '${activeBranch}' on ${fullName}`);
         onLog(`Branch '${activeBranch}' not found on ${fullName}`, "error");
         throw new Error(`Branch '${activeBranch}' not found on ${fullName}`);
       }
@@ -293,17 +306,12 @@ export async function indexRepository(
       throw new Error(`Failed to fetch tree: ${treeRes.status}`);
     }
 
-    const treeData = await treeRes.json();
-    const allItems = (treeData.tree as TreeItem[] | undefined) ?? [];
-
-    if (allItems.length === 0) {
-      onLog(
-        `Repository '${fullName}' appears to be empty: there are no files to index. Push some code to the repository and try again.`,
-        "error",
-      );
-      throw new Error(
-        `Repository is empty: no files to index. Push some code and retry indexing.`,
-      );
+    const treeData = emptyRepository ? { tree: [] } : await treeRes.json();
+    if (!Array.isArray(treeData.tree)) throw new Error("Invalid repository tree response from GitHub");
+    const allItems = treeData.tree as TreeItem[];
+    emptyRepository = allItems.length === 0;
+    if (emptyRepository) {
+      onLog(`Branch '${activeBranch}' has no files yet. Pull requests can still be reviewed.`, "info");
     }
 
     // Check for .octopusignore
@@ -457,6 +465,12 @@ export async function indexRepository(
   }
 
   if (allChunks.length === 0) {
+    if (emptyRepository) {
+      if (signal?.aborted) throw new Error("Indexing cancelled");
+      // An empty snapshot must not leave searchable chunks from an older tree.
+      await ensureCollection();
+      await deleteRepoChunks(repoId);
+    }
     onLog("No indexable content found", "warning");
     return {
       totalFiles: totalFileCount,

--- a/apps/web/lib/queue-workers.ts
+++ b/apps/web/lib/queue-workers.ts
@@ -14,6 +14,7 @@ import { reconcileAutoReloadAttempts } from "./credits";
 import { runOllamaPull } from "./ollama-admin";
 import { reapStuckReviews } from "./reap-stuck-reviews";
 import { discoverRepositories } from "./discover-repositories";
+import { processRepositoryIndex, type RepositoryIndexJob } from "./repository-index-job";
 import type { QueueConfig } from "./queue";
 
 export interface WelcomeEmailJob {
@@ -27,6 +28,10 @@ export interface ProcessReviewJob {
 }
 
 export async function registerWorkers(boss: PgBoss, config: QueueConfig): Promise<void> {
+  await boss.work<RepositoryIndexJob>("index-repository", { localConcurrency: 1 }, async (jobs) => {
+    for (const job of jobs) await processRepositoryIndex(job.data);
+  });
+
   await boss.work<WelcomeEmailJob>("welcome-email", async (jobs) => {
     for (const job of jobs) {
       console.log(`[queue] Processing welcome-email for ${job.data.email}`);

--- a/apps/web/lib/queue.ts
+++ b/apps/web/lib/queue.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { PgBoss } from "pg-boss";
 import type { SendOptions } from "pg-boss";
 import { prisma } from "@octopus/db";
@@ -101,6 +102,12 @@ export async function startQueue(): Promise<PgBoss> {
   // resumes where this one stopped.
   await boss.createQueue("discover-repositories", {
     retryLimit: 0,
+    expireInSeconds: 1800,
+  }).catch(() => {});
+
+  await boss.createQueue("index-repository", {
+    retryLimit: 2,
+    retryDelay: 60,
     expireInSeconds: 1800,
   }).catch(() => {});
 

--- a/apps/web/lib/repo-sync.ts
+++ b/apps/web/lib/repo-sync.ts
@@ -8,6 +8,7 @@ import { grantDeferredWelcomeCredit } from "@/lib/org-create";
 // the test process cannot break module load.
 import * as realtime from "@/lib/pubby";
 import { writeAuditLog } from "@/lib/audit";
+import { enqueuePendingRepositoryIndexes } from "@/lib/repository-index-job";
 
 /**
  * Org-scoped repository sync shared by the manual Sync button, the GitHub
@@ -250,6 +251,9 @@ export async function syncOrgRepos(
 
   notifyDiscovered(organizationId, opts.source, result.createdRepos);
 
+  await enqueuePendingRepositoryIndexes(organizationId)
+    .catch((err) => console.error("[repo-sync] Could not queue indexing; next sync will retry:", err));
+
   return result;
 }
 
@@ -318,6 +322,10 @@ export async function applyRepositoryEvent(
   if (outcome === "created") {
     await grantDeferredWelcomeCredit(organizationId);
     notifyDiscovered(organizationId, "webhook", result.createdRepos);
+  }
+  if (outcome !== "dismissed") {
+    await enqueuePendingRepositoryIndexes(organizationId)
+      .catch((err) => console.error("[repo-sync] Could not queue indexing; next sync will retry:", err));
   }
   return outcome;
 }

--- a/apps/web/lib/repository-index-job.ts
+++ b/apps/web/lib/repository-index-job.ts
@@ -1,0 +1,122 @@
+import "server-only";
+import { prisma } from "@octopus/db";
+import { enqueue } from "@/lib/queue";
+import type { LogLevel } from "@/lib/indexer";
+import { pubby } from "@/lib/pubby";
+import { deleteSyncLogs, writeSyncLog } from "@/lib/elasticsearch";
+import { createAbortController, clearAbortController } from "@/lib/indexing-abort";
+
+export interface RepositoryIndexJob {
+  repositoryId: string;
+  organizationId: string;
+}
+
+// Revisit empty snapshots as well: a repository can be discovered before its
+// first push. Failed enqueues remain eligible for the next discovery sweep.
+const needsIndex = {
+  OR: [
+    { indexStatus: { in: ["pending", "failed"] } },
+    { indexStatus: "indexed", totalFiles: 0 },
+  ],
+};
+
+export async function enqueuePendingRepositoryIndexes(organizationId: string, repositoryId?: string) {
+  const repos = await prisma.repository.findMany({
+    where: {
+      organizationId,
+      ...(repositoryId ? { id: repositoryId } : {}),
+      provider: "github",
+      isActive: true,
+      dismissedAt: null,
+      organization: { deletedAt: null, bannedAt: null, autoDiscoverRepos: true },
+      ...needsIndex,
+    },
+    select: { id: true },
+    orderBy: { indexedAt: { sort: "asc", nulls: "first" } },
+    take: 200,
+  });
+  for (const repo of repos) {
+    await enqueue("index-repository", { repositoryId: repo.id, organizationId }, {
+      singletonKey: repo.id,
+      singletonSeconds: 60,
+    });
+  }
+}
+
+export async function processRepositoryIndex(job: RepositoryIndexJob) {
+  if (!job || typeof job.repositoryId !== "string" || !job.repositoryId ||
+      typeof job.organizationId !== "string" || !job.organizationId) {
+    throw new Error("Repository indexing requires repositoryId and organizationId");
+  }
+  // Recheck ownership and standing when the job runs: the installation may
+  // have been disconnected, or the repository dismissed, while it was queued.
+  const repo = await prisma.repository.findFirst({
+    where: {
+      id: job.repositoryId,
+      organizationId: job.organizationId,
+      provider: "github",
+      isActive: true,
+      dismissedAt: null,
+      organization: { deletedAt: null, bannedAt: null, autoDiscoverRepos: true },
+    },
+    include: { organization: { select: { githubInstallationId: true } } },
+  });
+  const installationId = repo?.organization.githubInstallationId;
+  if (!repo || !installationId || (repo.installationId && repo.installationId !== installationId)) return;
+
+  // Share the reviewer's claim so a first PR and discovery cannot both index.
+  const claim = await prisma.repository.updateMany({
+    where: { id: repo.id, organizationId: job.organizationId, ...needsIndex },
+    data: { indexStatus: "indexing" },
+  });
+  if (!claim.count) return;
+
+  const controller = createAbortController(repo.id);
+  let timedOut = false;
+  // Abort before pg-boss expires the attempt, so the catch can release its claim.
+  const timeout = setTimeout(() => { timedOut = true; controller.abort(); }, 25 * 60_000);
+  const channel = `presence-org-${job.organizationId}`;
+  const notify = (status: string) => pubby.trigger(channel, "index-status", { repoId: repo.id, status })
+    .catch((err: unknown) => console.warn("[repository-index] notification failed:", err));
+  const log = (message: string, level: LogLevel = "info") => {
+    writeSyncLog({ orgId: job.organizationId, repoId: repo.id, message, level, timestamp: Date.now() });
+  };
+  try {
+    const { indexRepository } = await import("@/lib/indexer");
+    await deleteSyncLogs(job.organizationId, repo.id);
+    await notify("indexing");
+    const stats = await indexRepository(
+      repo.id, repo.fullName, repo.defaultBranch, installationId, log,
+      controller.signal, "github", job.organizationId,
+    );
+    await prisma.repository.update({
+      where: { id: repo.id },
+      data: {
+        indexStatus: "indexed",
+        indexedAt: new Date(),
+        totalFiles: stats.totalFiles,
+        indexedFiles: stats.indexedFiles,
+        totalChunks: stats.totalChunks,
+        totalVectors: stats.totalVectors,
+        contributorCount: stats.contributorCount,
+        contributors: JSON.parse(JSON.stringify(stats.contributors)),
+        indexDurationMs: stats.durationMs,
+        ...(stats.resolvedDefaultBranch ? { defaultBranch: stats.resolvedDefaultBranch } : {}),
+      },
+    });
+    log(`Indexing complete: ${stats.indexedFiles} files, ${stats.totalVectors} vectors`, "success");
+    await notify("indexed");
+  } catch (error) {
+    const isCancelled = controller.signal.aborted && !timedOut;
+    await prisma.repository.updateMany({
+      where: { id: repo.id, organizationId: job.organizationId, indexStatus: "indexing" },
+      data: { indexStatus: isCancelled ? "pending" : "failed" },
+    });
+    log(`Indexing failed: ${error instanceof Error ? error.message : String(error)}`, "error");
+    await notify(isCancelled ? "cancelled" : "failed");
+    if (!isCancelled) throw error;
+  } finally {
+    clearTimeout(timeout);
+    clearAbortController(repo.id);
+  }
+}

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import crypto from "node:crypto";
 import { prisma, type Prisma } from "@octopus/db";
 import { pubby } from "@/lib/pubby";
@@ -1039,52 +1040,59 @@ export async function processReview(pullRequestId: string): Promise<void> {
 
         console.log(`[reviewer] Indexing complete: ${indexStats.indexedFiles} files, ${indexStats.totalVectors} vectors`);
 
-        if (reviewCommentId) {
+        if (indexStats.totalChunks > 0) {
+          if (reviewCommentId) {
+            await providerUpdateComment(
+              reviewCommentId,
+              `> 🐙 **Octopus Review** — Indexing complete ✓ (${indexStats.indexedFiles} files, ${indexStats.totalVectors} vectors).\n>\n> Analyzing repository... (Step 2/3)`,
+            );
+          }
+
+          const { summary, purpose } = await summarizeRepository(repo.id, repo.fullName, org.id);
+          await prisma.repository.update({
+            where: { id: repo.id },
+            data: { summary, purpose },
+          });
+
+          console.log(`[reviewer] Summary complete: ${purpose}`);
+
+          await prisma.repository.update({
+            where: { id: repo.id },
+            data: { analysisStatus: "analyzing" },
+          });
+
+          pubby.trigger(indexChannel, "analysis-status", {
+            repoId: repo.id,
+            status: "analyzing",
+          }).catch((err) => console.error("[reviewer] Pubby analysis-status trigger failed:", err));
+
+          const analysis = await analyzeRepository(repo.id, repo.fullName, org.id);
+          await prisma.repository.update({
+            where: { id: repo.id },
+            data: {
+              analysis,
+              analysisStatus: "analyzed",
+              analyzedAt: new Date(),
+            },
+          });
+
+          pubby.trigger(indexChannel, "analysis-status", {
+            repoId: repo.id,
+            status: "analyzed",
+          }).catch((err) => console.error("[reviewer] Pubby analysis-status trigger failed:", err));
+
+          console.log(`[reviewer] Analysis complete`);
+
+          if (reviewCommentId) {
+            await providerUpdateComment(
+              reviewCommentId,
+              "> 🐙 **Octopus Review** — Repository indexed and analyzed ✓.\n>\n> Starting PR review... (Step 3/3)",
+            );
+          }
+        } else if (reviewCommentId) {
           await providerUpdateComment(
             reviewCommentId,
-            `> 🐙 **Octopus Review** — Indexing complete ✓ (${indexStats.indexedFiles} files, ${indexStats.totalVectors} vectors).\n>\n> Analyzing repository... (Step 2/3)`,
-          );
-        }
-
-        const { summary, purpose } = await summarizeRepository(repo.id, repo.fullName, org.id);
-        await prisma.repository.update({
-          where: { id: repo.id },
-          data: { summary, purpose },
-        });
-
-        console.log(`[reviewer] Summary complete: ${purpose}`);
-
-        await prisma.repository.update({
-          where: { id: repo.id },
-          data: { analysisStatus: "analyzing" },
-        });
-
-        pubby.trigger(indexChannel, "analysis-status", {
-          repoId: repo.id,
-          status: "analyzing",
-        }).catch((err) => console.error("[reviewer] Pubby analysis-status trigger failed:", err));
-
-        const analysis = await analyzeRepository(repo.id, repo.fullName, org.id);
-        await prisma.repository.update({
-          where: { id: repo.id },
-          data: {
-            analysis,
-            analysisStatus: "analyzed",
-            analyzedAt: new Date(),
-          },
-        });
-
-        pubby.trigger(indexChannel, "analysis-status", {
-          repoId: repo.id,
-          status: "analyzed",
-        }).catch((err) => console.error("[reviewer] Pubby analysis-status trigger failed:", err));
-
-        console.log(`[reviewer] Analysis complete`);
-
-        if (reviewCommentId) {
-          await providerUpdateComment(
-            reviewCommentId,
-            "> 🐙 **Octopus Review** — Repository indexed and analyzed ✓.\n>\n> Starting PR review... (Step 3/3)",
+            "> 🐙 **Octopus Review** — The base branch has no indexable content yet.\n>\n> Reviewing the changes in this pull request...",
           );
         }
 
@@ -1110,18 +1118,20 @@ export async function processReview(pullRequestId: string): Promise<void> {
           durationMs: indexStats.durationMs,
         });
 
-        await pubby.trigger(`presence-org-${org.id}`, "repo-analyzed", {
-          repoId: repo.id,
-          fullName: repo.fullName,
-        }).catch((err) => console.error("[reviewer] Pubby repo-analyzed trigger failed:", err));
+        if (indexStats.totalChunks > 0) {
+          await pubby.trigger(`presence-org-${org.id}`, "repo-analyzed", {
+            repoId: repo.id,
+            fullName: repo.fullName,
+          }).catch((err) => console.error("[reviewer] Pubby repo-analyzed trigger failed:", err));
 
-        eventBus.emit({
-          type: "repo-analyzed",
-          orgId: org.id,
-          repoFullName: repo.fullName,
-        });
+          eventBus.emit({
+            type: "repo-analyzed",
+            orgId: org.id,
+            repoFullName: repo.fullName,
+          });
+        }
 
-        console.log(`[reviewer] Phase 0 complete -- ${repo.fullName} indexed, analyzed, auto-review enabled`);
+        console.log(`[reviewer] Phase 0 complete -- ${repo.fullName} indexed, auto-review enabled`);
       }
     }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octopus/web",
-  "version": "1.0.138",
+  "version": "1.0.139",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octopus",
-  "version": "1.0.138",
+  "version": "1.0.139",
   "devDependencies": {
     "turbo": "^2"
   },


### PR DESCRIPTION
A new repository can have a valid default-branch commit with no files. GitHub returns 404 for that empty tree, which stopped Octopus before it could review the first PR. Repository discovery also created rows without scheduling their indexes.

This change verifies empty commits, accepts an empty base, and continues with the PR changes. GitHub connection and discovery now enqueue indexing; first-PR webhooks can recover missed discovery within the signed installation's organization. Workers preserve opt-outs and dismissed repositories, share indexing claims with reviews, support cancellation and retry, and revisit empty snapshots after code is pushed. The discovery sweep recovers abandoned claims before refreshing repository timestamps.

Includes release metadata and customer-facing notes for **1.0.139**. No schema or dependency changes.

Validation: lint, typecheck and production build passed. Web suite: 1,085 passed, 14 skipped; CLI: 123 passed, 2 skipped. Focused indexing/discovery/webhook regressions: 21 passed, including verified empty-tree 404, actual missing refs, access failures, malformed responses, tenant isolation, duplicate claims, cancellation and retries. Existing Terraform tests were intermittent in earlier runs and passed both independently and on the full rerun. Scoped Semgrep and Gitleaks scans found no findings.

Rollout: deploy the versioned image through the existing deployment workflow. Verify the GitHub App subscribes to Repository events for immediate creation discovery; the existing scheduled sweep and first-PR recovery remain fallback paths. Validate a first PR against an empty initial commit after deployment.
