### PR TITLE
fix(review): analyze discovered repositories before their first review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.140] - 2026-09-09
+
+### Fixed
+- A repository's first pull request now waits for repository analysis even when automatic discovery has already finished indexing. Concurrent first reviews share the analysis, and waiting reviews retry automatically.
+
 ## [1.0.139] - 2026-09-09
 
 ### Fixed

--- a/apps/web/lib/__tests__/fixtures/review-repository-preparation-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/review-repository-preparation-harness.ts
@@ -1,0 +1,137 @@
+import { mock } from "bun:test";
+import assert from "node:assert/strict";
+
+mock.module("server-only", () => ({}));
+const repo = {
+  id: "repo-1", organizationId: "org-1", fullName: "acme/new",
+  indexStatus: "indexed", totalChunks: 8, analysisStatus: "none", updatedAt: new Date(),
+};
+type Where = {
+  id: string; organizationId: string; analysisStatus?: string;
+  OR?: Array<{ analysisStatus: unknown; updatedAt?: { lt: Date } }>;
+};
+type Write = { where: Where; data: Record<string, unknown> };
+const calls: string[] = [];
+const notifications: string[] = [];
+const writes: Write[] = [];
+const queued: unknown[][] = [];
+let failAt: "summary" | "analysis" | undefined;
+let holdSummary: (() => Promise<void>) | undefined;
+let prStatus = "reviewing";
+let queueFailure = false;
+mock.module("@octopus/db", () => ({
+  prisma: {
+    repository: {
+      findFirst: async ({ where }: { where: Where }) =>
+        where.id === repo.id && where.organizationId === repo.organizationId ? { ...repo } : null,
+      updateMany: async (write: Write) => {
+        assert.equal(write.where.id, repo.id);
+        assert.equal(write.where.organizationId, repo.organizationId);
+        const staleBefore = write.where.OR?.[1]?.updatedAt?.lt;
+        if (write.data.analysisStatus === "analyzing" &&
+            (repo.indexStatus !== "indexed" || repo.totalChunks === 0 || repo.analysisStatus === "analyzed" ||
+              (repo.analysisStatus === "analyzing" && (!staleBefore || repo.updatedAt >= staleBefore)))) {
+          return { count: 0 };
+        }
+        if (write.where.analysisStatus && repo.analysisStatus !== write.where.analysisStatus) return { count: 0 };
+        Object.assign(repo, write.data, { updatedAt: new Date() });
+        writes.push(write);
+        return { count: 1 };
+      },
+      update: async (write: Write) => {
+        assert.equal(write.where.organizationId, repo.organizationId);
+        Object.assign(repo, write.data, { updatedAt: new Date() });
+        writes.push(write);
+        calls.push("persist-analysis");
+        return repo;
+      },
+    },
+    pullRequest: {
+      update: async ({ data }: { data: { status: string } }) => { prStatus = data.status; },
+    },
+  },
+}));
+mock.module("@/lib/summarizer", () => ({
+  summarizeRepository: async (...args: unknown[]) => {
+    assert.deepEqual(args, [repo.id, repo.fullName, repo.organizationId]);
+    calls.push("summary");
+    if (holdSummary) await holdSummary();
+    if (failAt === "summary") throw new Error("Summary unavailable");
+    return { summary: "Application summary", purpose: "Application purpose" };
+  },
+}));
+mock.module("@/lib/analyzer", () => ({
+  analyzeRepository: async (...args: unknown[]) => {
+    assert.deepEqual(args, [repo.id, repo.fullName, repo.organizationId]);
+    calls.push("analysis");
+    if (failAt === "analysis") throw new Error("Analysis unavailable");
+    return "Repository analysis";
+  },
+}));
+mock.module("@/lib/pubby", () => ({ pubby: { trigger: async (_channel: string, event: string) => { notifications.push(event); } } }));
+mock.module("@/lib/events", () => ({ eventBus: { emit: () => {} } }));
+mock.module("@/lib/queue", () => ({
+  enqueueAfter: async (...args: unknown[]) => {
+    assert.equal(prStatus, "pending", "deferred reviews must be claimable by the retry worker");
+    queued.push(args);
+    return queueFailure ? null : "job-1";
+  },
+}));
+const { ensureRepositoryAnalysis, deferReviewForRepository } = await import("@/lib/review-repository-preparation");
+const prepare = () => ensureRepositoryAnalysis(repo.id, repo.organizationId);
+
+// Discovery already indexed this repository; the first review must still analyze it.
+assert.equal(await prepare(), "ready");
+assert.deepEqual(calls, ["summary", "analysis", "persist-analysis"]);
+assert.equal(repo.analysisStatus, "analyzed");
+assert.equal(writes.at(-1)?.data.analysis, "Repository analysis");
+assert.ok(notifications.includes("repo-analyzed"));
+calls.length = 0;
+assert.equal(await prepare(), "ready");
+assert.deepEqual(calls, [], "completed analysis should be reused on later reviews");
+
+repo.analysisStatus = "none";
+repo.indexStatus = "indexing";
+assert.equal(await prepare(), "waiting");
+assert.deepEqual(calls, [], "analysis must wait for the indexing worker");
+repo.indexStatus = "indexed";
+repo.totalChunks = 0;
+assert.equal(await prepare(), "empty");
+assert.equal(repo.analysisStatus, "none", "an empty base must not claim a completed AI analysis");
+assert.deepEqual(calls, []);
+repo.totalChunks = 8;
+
+// Two first PRs must share a single analysis and wait until it is persisted.
+let release!: () => void;
+let started!: () => void;
+const hasStarted = new Promise<void>((resolve) => { started = resolve; });
+holdSummary = () => new Promise<void>((resolve) => { release = resolve; started(); });
+const first = prepare();
+await hasStarted;
+assert.equal(await prepare(), "waiting");
+assert.deepEqual(calls, ["summary"]);
+release();
+assert.equal(await first, "ready");
+assert.equal(await prepare(), "ready");
+assert.deepEqual(calls, ["summary", "analysis", "persist-analysis"]);
+holdSummary = undefined;
+
+for (const failure of ["summary", "analysis"] as const) {
+  repo.analysisStatus = "none";
+  failAt = failure;
+  await assert.rejects(prepare, /unavailable/);
+  assert.equal(repo.analysisStatus, "failed", "a failed analysis must release its claim for retry");
+  assert.equal(repo.indexStatus, "indexed", "analysis failure must preserve the completed index");
+  failAt = undefined;
+  assert.equal(await prepare(), "ready");
+}
+repo.analysisStatus = "analyzing";
+repo.updatedAt = new Date(Date.now() - 36 * 60_000);
+assert.equal(await prepare(), "ready", "an abandoned analysis should recover");
+await assert.rejects(() => ensureRepositoryAnalysis(repo.id, "other-org"), /not found/);
+
+await deferReviewForRepository("pr-1");
+assert.deepEqual(queued, [["process-review", { pullRequestId: "pr-1" }, 30]]);
+queueFailure = true;
+await assert.rejects(() => deferReviewForRepository("pr-1"), /Could not enqueue/);
+console.log("Analysis sequencing, empty bases, concurrency, retries and ownership checks passed");

--- a/apps/web/lib/__tests__/review-repository-preparation.test.ts
+++ b/apps/web/lib/__tests__/review-repository-preparation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+describe("repository preparation before PR review", () => {
+  it("analyzes a discovered index once, waits for peers and retries failures", async () => {
+    const child = Bun.spawn([process.execPath, fileURLToPath(new URL("./fixtures/review-repository-preparation-harness.ts", import.meta.url))], {
+      cwd: process.cwd(), stdout: "pipe", stderr: "pipe",
+    });
+    const [code, stdout, stderr] = await Promise.all([
+      child.exited, new Response(child.stdout).text(), new Response(child.stderr).text(),
+    ]);
+    expect(code, `${stdout}\n${stderr}`).toBe(0);
+  });
+});

--- a/apps/web/lib/review-repository-preparation.ts
+++ b/apps/web/lib/review-repository-preparation.ts
@@ -1,0 +1,75 @@
+import "server-only";
+import { prisma } from "@octopus/db";
+import { summarizeRepository } from "@/lib/summarizer";
+import { analyzeRepository } from "@/lib/analyzer";
+import { enqueueAfter } from "@/lib/queue";
+import { pubby } from "@/lib/pubby";
+import { eventBus } from "@/lib/events";
+
+// Allow both AI calls to finish before recovering an abandoned analysis claim.
+const STALE_ANALYSIS_MS = 35 * 60_000;
+
+export async function ensureRepositoryAnalysis(
+  repositoryId: string,
+  organizationId: string,
+  onStart?: () => Promise<void>,
+): Promise<"ready" | "empty" | "waiting"> {
+  // Read fresh state: discovery or a different PR may have finished indexing.
+  const repo = await prisma.repository.findFirst({
+    where: { id: repositoryId, organizationId },
+    select: { fullName: true, indexStatus: true, totalChunks: true, analysisStatus: true },
+  });
+  if (!repo) throw new Error("Repository not found for analysis");
+  if (repo.indexStatus !== "indexed") return "waiting";
+  if (repo.totalChunks === 0) return "empty";
+  if (repo.analysisStatus === "analyzed") return "ready";
+
+  const claim = await prisma.repository.updateMany({
+    where: {
+      id: repositoryId,
+      organizationId,
+      indexStatus: "indexed",
+      totalChunks: { gt: 0 },
+      OR: [
+        { analysisStatus: { notIn: ["analyzing", "analyzed"] } },
+        { analysisStatus: "analyzing", updatedAt: { lt: new Date(Date.now() - STALE_ANALYSIS_MS) } },
+      ],
+    },
+    data: { analysisStatus: "analyzing" },
+  });
+  if (!claim.count) return "waiting";
+
+  const channel = `presence-org-${organizationId}`;
+  const notify = (status: string) => pubby.trigger(channel, "analysis-status", { repoId: repositoryId, status })
+    .catch((err: unknown) => console.error("[reviewer] Analysis notification failed:", err));
+  try {
+    await notify("analyzing");
+    await onStart?.();
+    const { summary, purpose } = await summarizeRepository(repositoryId, repo.fullName, organizationId);
+    const analysis = await analyzeRepository(repositoryId, repo.fullName, organizationId);
+    await prisma.repository.update({
+      where: { id: repositoryId, organizationId },
+      data: { summary, purpose, analysis, analysisStatus: "analyzed", analyzedAt: new Date() },
+    });
+    await notify("analyzed");
+    await pubby.trigger(channel, "repo-analyzed", { repoId: repositoryId, fullName: repo.fullName })
+      .catch((err: unknown) => console.error("[reviewer] Repository analysis notification failed:", err));
+    eventBus.emit({ type: "repo-analyzed", orgId: organizationId, repoFullName: repo.fullName });
+    return "ready";
+  } catch (error) {
+    await prisma.repository.updateMany({
+      where: { id: repositoryId, organizationId, analysisStatus: "analyzing" },
+      data: { analysisStatus: "failed" },
+    });
+    await notify("failed");
+    throw error;
+  }
+}
+
+export async function deferReviewForRepository(pullRequestId: string): Promise<void> {
+  // "queued" is reserved for an active large-review job and cannot be claimed
+  // again until its stale timeout. A prerequisite retry must be claimable now.
+  await prisma.pullRequest.update({ where: { id: pullRequestId }, data: { status: "pending" } });
+  const jobId = await enqueueAfter("process-review", { pullRequestId }, 30);
+  if (!jobId) throw new Error("Could not enqueue review after repository preparation");
+}

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -111,8 +111,7 @@ import {
   parseFindingsFromSummaryTable,
 } from "@/lib/review-dedup";
 import type { LogLevel } from "@/lib/indexer";
-import { summarizeRepository } from "@/lib/summarizer";
-import { analyzeRepository } from "@/lib/analyzer";
+import { ensureRepositoryAnalysis, deferReviewForRepository } from "@/lib/review-repository-preparation";
 import { writeSyncLog, deleteSyncLogs } from "@/lib/elasticsearch";
 import { logAiUsage } from "@/lib/ai-usage";
 import { resolveReviewModel } from "@/lib/review-routing";
@@ -887,7 +886,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
   }
 
   try {
-    // Phase 0: Auto-index & analyze if repository hasn't been indexed yet
+    // Phase 0: Ensure the repository is indexed before preparing review context
     if (repo.indexStatus !== "indexed") {
       console.log(`[reviewer] Repository ${repo.fullName} not indexed (status: ${repo.indexStatus}). Starting auto-index...`);
 
@@ -907,27 +906,24 @@ export async function processReview(pullRequestId: string): Promise<void> {
         const currentStatus = fresh?.indexStatus ?? "failed";
 
         if (currentStatus === "indexed") {
-          // Peer already finished -- skip straight to review
+          // Peer already finished -- continue to the analysis prerequisite
           console.log(`[reviewer] Repository ${repo.fullName} already indexed by another process, continuing with review`);
           if (reviewCommentId) {
             await providerUpdateComment(
               reviewCommentId,
-              "> 🐙 **Octopus Review** — Repository already indexed ✓.\n>\n> Starting PR review...",
+              "> 🐙 **Octopus Review** — Repository already indexed ✓.\n>\n> Preparing repository analysis...",
             );
           }
         } else if (currentStatus === "indexing") {
           // Peer still running -- yield this worker and retry later
           console.log(`[reviewer] Repository ${repo.fullName} is being indexed by another process, re-queuing PR ${pullRequestId}`);
-          await prisma.pullRequest.update({
-            where: { id: pullRequestId },
-            data: { status: "queued" },
-          });
           if (reviewCommentId) {
             await providerUpdateComment(
               reviewCommentId,
-              "> 🐙 **Octopus Review** — Repository indexing is in progress (started by another review).\n>\n> This review has been re-queued and will start automatically once indexing completes.",
+              "> 🐙 **Octopus Review** — Repository indexing is in progress.\n>\n> This review has been re-queued and will start automatically once indexing completes.",
             );
           }
+          await deferReviewForRepository(pullRequestId);
           return;
         } else {
           // Peer failed -- attempt conditional reclaim
@@ -1019,6 +1015,7 @@ export async function processReview(pullRequestId: string): Promise<void> {
           where: { id: repo.id },
           data: {
             indexStatus: "indexed",
+            analysisStatus: "none",
             indexedAt: new Date(),
             indexedFiles: indexStats.indexedFiles,
             totalFiles: indexStats.totalFiles,
@@ -1039,62 +1036,6 @@ export async function processReview(pullRequestId: string): Promise<void> {
         }).catch((err) => console.error("[reviewer] Pubby index-status trigger failed:", err));
 
         console.log(`[reviewer] Indexing complete: ${indexStats.indexedFiles} files, ${indexStats.totalVectors} vectors`);
-
-        if (indexStats.totalChunks > 0) {
-          if (reviewCommentId) {
-            await providerUpdateComment(
-              reviewCommentId,
-              `> 🐙 **Octopus Review** — Indexing complete ✓ (${indexStats.indexedFiles} files, ${indexStats.totalVectors} vectors).\n>\n> Analyzing repository... (Step 2/3)`,
-            );
-          }
-
-          const { summary, purpose } = await summarizeRepository(repo.id, repo.fullName, org.id);
-          await prisma.repository.update({
-            where: { id: repo.id },
-            data: { summary, purpose },
-          });
-
-          console.log(`[reviewer] Summary complete: ${purpose}`);
-
-          await prisma.repository.update({
-            where: { id: repo.id },
-            data: { analysisStatus: "analyzing" },
-          });
-
-          pubby.trigger(indexChannel, "analysis-status", {
-            repoId: repo.id,
-            status: "analyzing",
-          }).catch((err) => console.error("[reviewer] Pubby analysis-status trigger failed:", err));
-
-          const analysis = await analyzeRepository(repo.id, repo.fullName, org.id);
-          await prisma.repository.update({
-            where: { id: repo.id },
-            data: {
-              analysis,
-              analysisStatus: "analyzed",
-              analyzedAt: new Date(),
-            },
-          });
-
-          pubby.trigger(indexChannel, "analysis-status", {
-            repoId: repo.id,
-            status: "analyzed",
-          }).catch((err) => console.error("[reviewer] Pubby analysis-status trigger failed:", err));
-
-          console.log(`[reviewer] Analysis complete`);
-
-          if (reviewCommentId) {
-            await providerUpdateComment(
-              reviewCommentId,
-              "> 🐙 **Octopus Review** — Repository indexed and analyzed ✓.\n>\n> Starting PR review... (Step 3/3)",
-            );
-          }
-        } else if (reviewCommentId) {
-          await providerUpdateComment(
-            reviewCommentId,
-            "> 🐙 **Octopus Review** — The base branch has no indexable content yet.\n>\n> Reviewing the changes in this pull request...",
-          );
-        }
 
         await prisma.repository.update({
           where: { id: repo.id },
@@ -1117,19 +1058,6 @@ export async function processReview(pullRequestId: string): Promise<void> {
           totalVectors: indexStats.totalVectors,
           durationMs: indexStats.durationMs,
         });
-
-        if (indexStats.totalChunks > 0) {
-          await pubby.trigger(`presence-org-${org.id}`, "repo-analyzed", {
-            repoId: repo.id,
-            fullName: repo.fullName,
-          }).catch((err) => console.error("[reviewer] Pubby repo-analyzed trigger failed:", err));
-
-          eventBus.emit({
-            type: "repo-analyzed",
-            orgId: org.id,
-            repoFullName: repo.fullName,
-          });
-        }
 
         console.log(`[reviewer] Phase 0 complete -- ${repo.fullName} indexed, auto-review enabled`);
       }
@@ -1214,6 +1142,33 @@ export async function processReview(pullRequestId: string): Promise<void> {
         await enqueueAfter("process-review", { pullRequestId: pr.id }, 30);
         return;
       }
+    }
+
+    const preparation = await ensureRepositoryAnalysis(repo.id, org.id, async () => {
+      if (reviewCommentId) {
+        await providerUpdateComment(
+          reviewCommentId,
+          "> 🐙 **Octopus Review** — Repository indexed ✓.\n>\n> Analyzing repository before reviewing this pull request... (Step 2/3)",
+        );
+      }
+    });
+    if (preparation === "waiting") {
+      if (reviewCommentId) {
+        await providerUpdateComment(
+          reviewCommentId,
+          "> 🐙 **Octopus Review** — Repository indexing or analysis is in progress.\n>\n> This review will retry automatically once repository preparation completes.",
+        );
+      }
+      await deferReviewForRepository(pullRequestId);
+      return;
+    }
+    if (reviewCommentId) {
+      await providerUpdateComment(
+        reviewCommentId,
+        preparation === "empty"
+          ? "> 🐙 **Octopus Review** — The base branch has no indexable content yet.\n>\n> Reviewing the changes in this pull request..."
+          : "> 🐙 **Octopus Review** — Repository indexed and analyzed ✓.\n>\n> Starting PR review... (Step 3/3)",
+      );
     }
 
     // Step 1: Mark as reviewing (idempotent — the guard may have set it already)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octopus/web",
-  "version": "1.0.139",
+  "version": "1.0.140",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octopus",
-  "version": "1.0.139",
+  "version": "1.0.140",
   "devDependencies": {
     "turbo": "^2"
   },


### PR DESCRIPTION
A first PR can arrive after automatic discovery has already indexed the repository. Previously, repository analysis only ran inside the reviewer's own indexing branch, so that PR skipped analysis. The reviewer now checks analysis independently after indexing and billing admission, summarizes and analyzes a nonempty repository before reviewing its changes, and reuses completed analysis on subsequent reviews.

Concurrent first reviews share an analysis claim. Waiting reviews are explicitly scheduled for retry with a claimable status instead of waiting for stale-job recovery. Analysis failures release the claim while preserving the completed index. Empty bases proceed to reviewing PR changes without claiming that repository analysis ran.

Includes version 1.0.140 and a customer-facing changelog entry; builds on the discovery and empty-main fixes merged in #802. No database migrations or dependency changes.

Validation: lint, typecheck and production build passed; 1,086 web tests and 123 CLI tests passed (16 environment-gated skips). The existing intermittent Terraform runtime-secret test failed on the first full run, then all 12 Terraform tests passed independently and the full suite passed. Added regressions cover a discovery-completed index, analysis order and reuse, competing first reviews, empty bases, failure recovery, tenant scope and scheduled retries.
