### PR TITLE
fix(web): use cosine similarity for feedback suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Reviews now use similarity consistently when suppressing findings that match previously dismissed feedback.
+
 ## [1.0.143] - 2026-09-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.145] - 2026-09-11
+
 ### Fixed
-- Reviews now use similarity consistently when suppressing findings that match previously dismissed feedback.
+- Reviews: feedback-based suppression now checks semantic similarity, preventing search ranking alone from hiding a finding.
+- Operators: feedback matching keeps the existing repository/organization scope and strict cosine threshold above 0.80. No database migration or reindex is required; failed or invalid feedback lookups retain findings.
 
 ## [1.0.144] - 2026-09-11
 

--- a/apps/web/lib/__tests__/feedback-suppression.test.ts
+++ b/apps/web/lib/__tests__/feedback-suppression.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+
+describe("semantic feedback suppression", () => {
+  it("uses dense similarity through the real Qdrant transport and review consumers", async () => {
+    const child = Bun.spawn(["bun", "lib/__tests__/fixtures/feedback-suppression-harness.ts"], {
+      cwd: import.meta.dir + "/../..",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [exit, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    expect({ exit, stderr, stdout }).toMatchObject({ exit: 0, stderr: "" });
+    expect(stdout).toContain("PASS semantic feedback similarity and review consumers");
+  });
+});

--- a/apps/web/lib/__tests__/fixtures/feedback-suppression-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/feedback-suppression-harness.ts
@@ -61,6 +61,7 @@ mock.module("@octopus/db", () => ({ prisma: {
   repository: { findUnique: async () => repo },
   systemConfig: { findUnique: async () => null },
   reviewIssue: { findMany: async () => [] },
+  reviewAttempt: { findFirst: async () => null },
   pullRequest: { findUnique: async () => pr, updateMany: async () => ({ count: 1 }) },
 } }));
 let embeddingFailure = false;

--- a/apps/web/lib/__tests__/fixtures/feedback-suppression-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/feedback-suppression-harness.ts
@@ -1,0 +1,254 @@
+import { mock } from "bun:test";
+import assert from "node:assert/strict";
+
+// A process-local HTTP service exercises the production Qdrant client/adapter.
+// No Qdrant, model, provider or database service is contacted by this fixture.
+const requests: { path: string; body: Record<string, unknown> }[] = [];
+let denseScore: unknown = 0.1;
+let feedback: unknown = "down";
+let searchFailure = false;
+let emptyResults = false;
+let collectionFailure = false;
+let resultOverride: unknown;
+let splitScores = false;
+const service = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 0,
+  async fetch(request) {
+    const path = new URL(request.url).pathname;
+    const body = request.method === "GET" ? {} : await request.json();
+    requests.push({ path, body });
+    if (path === "/") return Response.json({ version: "1.18.0" });
+    if (path === "/collections") {
+      if (collectionFailure) return Response.json({}, { status: 503 });
+      return Response.json({ result: { collections: [{ name: "feedback_patterns" }] }, status: "ok" });
+    }
+    if (path === "/collections/feedback_patterns") return Response.json({ result: true, status: "ok" });
+    const isFeedback = path.includes("/feedback_patterns/");
+    if (isFeedback && searchFailure) return Response.json({ status: { error: "fixture service failure" } }, { status: 503 });
+    const points = isFeedback && resultOverride !== undefined ? resultOverride : !isFeedback || emptyResults ? [] : [{
+      id: 1,
+      // Rank 1 in both RRF lists can score 1 even with weak dense similarity.
+      score: path.endsWith("/query") ? 1 : splitScores && body.vector?.[1] === 1 ? 0.1 : denseScore,
+      payload: { title: "Previously dismissed", description: "A different issue", feedback, repoId: "repo", orgId: "org" },
+    }];
+    // JSON exponent overflow exercises a non-finite numeric transport result.
+    const json = JSON.stringify({ result: path.endsWith("/query") ? { points } : points, status: "ok" });
+    return new Response(denseScore === Infinity ? json.replace('"score":null', '"score":1e999') : json, {
+      headers: { "content-type": "application/json" },
+    });
+  },
+});
+process.env.QDRANT_URL = service.url.toString();
+mock.module("server-only", () => ({}));
+mock.module("@/lib/embed-config", () => ({ getEmbedConfig: () => ({ dim: 3 }) }));
+
+const finding = {
+  severity: "🟠", title: "Missing null check", filePath: "src/check.ts", startLine: 1, endLine: 1,
+  category: "Bug", description: "A missing value causes this access to throw.", suggestion: "", confidence: 95,
+};
+const diff = "diff --git a/src/check.ts b/src/check.ts\n--- a/src/check.ts\n+++ b/src/check.ts\n@@ -1 +1 @@\n-return value;\n+return value.name;\n";
+const org = { id: "org", defaultReviewConfig: {}, reviewLanguage: "en" };
+const repo = {
+  id: "repo", fullName: "fixture/repo", organization: org, reviewConfig: {},
+  provider: "github", installationId: 1, indexStatus: "indexed", defaultBranch: "main",
+};
+const pr = {
+  id: "pr", repository: repo, number: 1, title: "Handle missing values", author: "fixture",
+  headSha: "a".repeat(40), reviewRequestVersion: 1, status: "pending",
+};
+mock.module("@octopus/db", () => ({ prisma: {
+  repository: { findUnique: async () => repo },
+  systemConfig: { findUnique: async () => null },
+  reviewIssue: { findMany: async () => [] },
+  pullRequest: { findUnique: async () => pr, updateMany: async () => ({ count: 1 }) },
+} }));
+let embeddingFailure = false;
+let embeddingVectors: number[][] | undefined;
+const embeddingCalls: { texts: string[]; tracking: unknown }[] = [];
+mock.module("@/lib/embeddings", () => ({ createEmbeddings: async (texts: string[], tracking: unknown) => {
+  embeddingCalls.push({ texts, tracking });
+  if (embeddingFailure) throw new Error("fixture embedding failure");
+  return embeddingVectors ?? texts.map(() => [1, 0, 0]);
+} }));
+mock.module("@/lib/reranker", () => ({ rerankDocuments: async () => [] }));
+mock.module("@/lib/knowledge-context", () => ({ getAlwaysIncludeKnowledge: async () => [], mergeKnowledgeChunks: () => [] }));
+mock.module("@/lib/review-routing", () => ({ resolveReviewModel: async () => "fixture-model" }));
+mock.module("@/lib/ai-usage", () => ({ logAiUsage: async () => {} }));
+mock.module("@/lib/ai-router", () => ({ createAiMessage: async () => ({
+  provider: "fixture", text: `Summary\n<!-- OCTOPUS_FINDINGS_START -->\n${JSON.stringify([finding])}\n<!-- OCTOPUS_FINDINGS_END -->`,
+  usage: { inputTokens: 1, outputTokens: 1 },
+}) }));
+mock.module("@/lib/review-validation", () => ({
+  gatherCrossFileContext: async () => "",
+  gatherVerificationContext: async () => new Map(),
+  validateFindings: async (findings: unknown[]) => findings,
+}));
+
+// Hosted review integration: keep generation, parsing, suppression and finding
+// persistence mapping real; replace external services and unrelated prerequisites.
+const archived: { findings: { title: string }[] }[] = [];
+const published: { body: string; comments: unknown[] }[] = [];
+mock.module("@/lib/review-attempt", () => ({
+  createReviewAttemptComment: async (_id: string, _head: string, _version: number, create: () => Promise<number>) => create(),
+  updateCurrentReview: async () => ({ count: 1 }),
+  saveReviewAttempt: async (_id: string, _pr: string, _coverage: unknown, _body: string, findings: { title: string }[]) => {
+    archived.push({ findings });
+    return false; // Stop after persistence/publication, before unrelated timeline indexing.
+  },
+}));
+mock.module("@/lib/github", () => ({
+  LargePrError: class LargePrError extends Error {},
+  getPullRequestReviewInput: async () => ({ rawDiff: diff, input: {
+    provider: "github", headSha: pr.headSha, baseSha: "b".repeat(40), inventoryComplete: true,
+    expectedFiles: 1, limitations: [],
+    files: [{ path: "src/check.ts", change: "modified", patch: "@@ -1 +1 @@\n-return value;\n+return value.name;\n", additions: 1, deletions: 1 }],
+  } }),
+  getPullRequestDetails: async () => ({ body: "Handle missing values" }),
+  createPullRequestComment: async () => 123,
+  updatePullRequestComment: async () => {},
+  createPullRequestReview: async (_installation: number, _owner: string, _repo: string, _number: number, body: string, _event: string, comments: unknown[]) => {
+    published.push({ body, comments });
+    return 456;
+  },
+  createCheckRun: async () => 789,
+  updateCheckRun: async () => {},
+  getRepositoryTree: async () => ["src/check.ts"],
+  getFileContent: async () => "return value.name;",
+  listReviewComments: async () => [],
+  listPullRequestReviewComments: async () => [],
+  listPullRequestIssueComments: async () => [],
+  listPullRequestReviews: async () => [],
+  getCommentReactions: async () => ({ thumbsUp: 0, thumbsDown: 0 }),
+}));
+mock.module("@/lib/bitbucket", () => ({}));
+mock.module("@/lib/gitlab", () => ({}));
+mock.module("@/lib/github-app-config", () => ({ getGithubAppConfig: async () => ({ slug: "fixture" }) }));
+mock.module("@/lib/queue", () => ({
+  loadQueueConfig: async () => ({ reviewTimeoutSeconds: 60, largeReviewTimeoutSeconds: 60 }),
+  computeStaleReclaimMs: () => 120000,
+  enqueue: async () => {}, enqueueAfter: async () => {},
+}));
+mock.module("@/lib/cost", () => ({ getOrgSpendLimitStatus: async () => ({ blocked: false }), shouldGuardConcurrency: async () => false }));
+mock.module("@/lib/pubby", () => ({ pubby: { trigger: async () => {} } }));
+mock.module("@/lib/events", () => ({ eventBus: { emit: () => {} } }));
+mock.module("@/lib/indexer", () => ({ indexRepository: async () => { throw new Error("unexpected indexing"); } }));
+mock.module("@/lib/review-repository-preparation", () => ({ ensureRepositoryAnalysis: async () => "ready", deferReviewForRepository: async () => {} }));
+mock.module("@/lib/elasticsearch", () => ({ writeSyncLog: () => {}, deleteSyncLogs: async () => {} }));
+mock.module("@/lib/repo-config", () => ({
+  fetchRepoConfigFile: async () => null, extractRepoConfigRules: async () => null,
+  buildRepoConfigUserBlock: () => "", normalizeRepoConfigFiles: () => [],
+}));
+
+try {
+  const { generateLocalReview } = await import("@/lib/review-core");
+  const { suppressFindingsFromFeedback } = await import("@/lib/feedback-suppression");
+  const { searchFeedbackPatterns } = await import("@/lib/qdrant");
+  const weak = await generateLocalReview({ diff, repoId: "repo", orgId: "org" });
+  assert.equal(weak.findings.length, 1, "a first-ranked RRF hit with cosine 0.1 must retain the finding");
+  denseScore = 0.95;
+  const strong = await generateLocalReview({ diff, repoId: "repo", orgId: "org" });
+  assert.equal(strong.findings.length, 0, "a strong negative cosine match suppresses the finding");
+
+  const originals = [finding];
+  const runStage = () => suppressFindingsFromFeedback(originals, { repoId: "repo", orgId: "org" });
+  for (const [score, vote, retained] of [
+    [0.95, "down", 0], [1, "down", 0], [0.800001, "down", 0],
+    [0.8, "down", 1], [0.79, "down", 1], [-1, "down", 1],
+    [0.99, "up", 1], [0.99, "unknown", 1], [0.99, null, 1],
+    [NaN, "down", 1], [Infinity, "down", 1], [1.01, "down", 1],
+    [-1.01, "down", 1], ["0.99", "down", 1], [null, "down", 1],
+  ] as const) {
+    denseScore = score;
+    feedback = vote;
+    const result = await runStage();
+    assert.equal(result.length, retained, `score=${String(score)} feedback=${String(vote)}`);
+    if (retained) assert.equal(result[0], finding, "retained findings preserve their identity and fields");
+  }
+  denseScore = 0.95;
+  feedback = "down";
+  assert.deepEqual(await searchFeedbackPatterns("repo", [1, 0, 0], "org"), [{ feedback: "down", cosineSimilarity: 0.95 }]);
+  const feedbackRequests = () => requests.filter(({ path }) => path.includes("/feedback_patterns/points/"));
+  for (const request of feedbackRequests()) {
+    assert.equal(request.path, "/collections/feedback_patterns/points/search", "suppression never consumes an RRF result");
+    assert.deepEqual(request.body, {
+      vector: [1, 0, 0], limit: 3, offset: 0, with_payload: true, with_vector: false,
+      filter: { should: [{ key: "repoId", match: { value: "repo" } }, { key: "orgId", match: { value: "org" } }] },
+    }, "the bounded request preserves the existing repo-or-org policy");
+  }
+  await searchFeedbackPatterns("repo", [1, 0, 0]);
+  assert.deepEqual(feedbackRequests().at(-1)?.body.filter, { must: [{ key: "repoId", match: { value: "repo" } }] });
+
+  for (const malformed of [null, {}, [null], [{ score: 0.99 }], [{ score: 0.99, payload: "down" }],
+    [{ score: 0.99, payload: { feedback: "down", repoId: "other", orgId: "other" } }]]) {
+    resultOverride = malformed;
+    assert.deepEqual(await runStage(), originals, "malformed or out-of-scope results retain findings");
+  }
+  resultOverride = [{ score: 0.95, payload: { feedback: "down", repoId: "another-repo", orgId: "org" } }];
+  assert.deepEqual(await runStage(), [], "same-org cross-repo feedback remains eligible under the existing policy");
+  assert.deepEqual(await searchFeedbackPatterns("repo", [1, 0, 0]), [], "repo-only callers do not accept another repository");
+  resultOverride = [0.1, 0.2, 0.3, 0.99].map((score) => ({ score, payload: { feedback: "down", repoId: "repo" } }));
+  assert.deepEqual(await runStage(), originals, "even an oversized service response cannot exceed three candidates");
+  resultOverride = undefined;
+  emptyResults = true;
+  assert.deepEqual(await runStage(), originals, "empty results retain findings");
+  emptyResults = false;
+  searchFailure = true;
+  assert.deepEqual(await runStage(), originals, "Qdrant failure retains findings");
+  searchFailure = false;
+
+  const searchCount = feedbackRequests().length;
+  for (const vectors of [[[]], [[0, 0, 0]], [[NaN, 0, 0]], [[Infinity, 0, 0]], [], [[1, 0, 0], [1, 0, 0]]]) {
+    embeddingVectors = vectors;
+    assert.deepEqual(await runStage(), originals, "invalid or unaligned embeddings retain findings");
+  }
+  assert.equal(feedbackRequests().length, searchCount, "invalid vectors never reach Qdrant");
+  embeddingVectors = undefined;
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => { warnings.push(args); };
+  try {
+    embeddingFailure = true;
+    assert.equal(await runStage(), originals, "embedding failure returns the original findings");
+    embeddingFailure = false;
+    collectionFailure = true;
+    assert.equal(await runStage(), originals, "collection failure returns the original findings");
+    collectionFailure = false;
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.equal(warnings.length, 2, "failures are reported without failing the review");
+  const beforeEmpty = { requests: requests.length, embeddings: embeddingCalls.length };
+  assert.deepEqual(await suppressFindingsFromFeedback([], { repoId: "repo", orgId: "org" }), []);
+  assert.deepEqual({ requests: requests.length, embeddings: embeddingCalls.length }, beforeEmpty, "empty findings skip remote work");
+  embeddingVectors = [[1, 0, 0], [0, 1, 0]];
+  splitScores = true;
+  const other = { ...finding, title: "Second finding", confidence: 91 };
+  assert.deepEqual(await suppressFindingsFromFeedback([finding, other], { repoId: "repo", orgId: "org" }), [other]);
+  assert.deepEqual(embeddingCalls.at(-1), {
+    texts: [`${finding.title} ${finding.description}`, `${other.title} ${other.description}`],
+    tracking: { organizationId: "org", operation: "embedding", repositoryId: "repo" },
+  }, "finding/vector alignment and embedding cost attribution are preserved");
+  embeddingVectors = undefined;
+  splitScores = false;
+  const { processReview } = await import("@/lib/reviewer");
+  for (const [score, vote, fails, retained] of [
+    [0.1, "down", false, 1], [0.8, "down", false, 1],
+    [0.95, "down", false, 0], [0.99, "up", false, 1], [0.95, "down", true, 1],
+  ] as const) {
+    denseScore = score;
+    feedback = vote;
+    searchFailure = fails;
+    const local = await generateLocalReview({ diff, repoId: "repo", orgId: "org" });
+    const before = archived.length;
+    await processReview("pr");
+    assert.equal(archived.length, before + 1, "hosted review reaches finding persistence");
+    assert.equal(local.findings.length, retained);
+    assert.deepEqual(archived.at(-1)?.findings.map((value) => value.title), local.findings.map((value) => value.title),
+      "hosted persistence and local output apply the same semantic suppression decision");
+    assert.equal(published.at(-1)?.comments.length, retained, "hosted inline publication uses the suppressed union");
+  }
+  console.log("PASS semantic feedback similarity and review consumers");
+} finally {
+  service.stop(true);
+}

--- a/apps/web/lib/__tests__/fixtures/feedback-suppression-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/feedback-suppression-harness.ts
@@ -87,13 +87,14 @@ mock.module("@/lib/review-validation", () => ({
 
 // Hosted review integration: keep generation, parsing, suppression and finding
 // persistence mapping real; replace external services and unrelated prerequisites.
-const archived: { findings: { title: string }[] }[] = [];
+const archived: { findings: { title: string }[]; coverage: unknown; body: string }[] = [];
+const summaries: string[] = [];
 const published: { body: string; comments: unknown[] }[] = [];
 mock.module("@/lib/review-attempt", () => ({
   createReviewAttemptComment: async (_id: string, _head: string, _version: number, create: () => Promise<number>) => create(),
   updateCurrentReview: async () => ({ count: 1 }),
   saveReviewAttempt: async (_id: string, _pr: string, _coverage: unknown, _body: string, findings: { title: string }[]) => {
-    archived.push({ findings });
+    archived.push({ findings, coverage: _coverage, body: _body });
     return false; // Stop after persistence/publication, before unrelated timeline indexing.
   },
 }));
@@ -106,7 +107,7 @@ mock.module("@/lib/github", () => ({
   } }),
   getPullRequestDetails: async () => ({ body: "Handle missing values" }),
   createPullRequestComment: async () => 123,
-  updatePullRequestComment: async () => {},
+  updatePullRequestComment: async (_installation: number, _owner: string, _repo: string, _id: number, body: string) => { summaries.push(body); },
   createPullRequestReview: async (_installation: number, _owner: string, _repo: string, _number: number, body: string, _event: string, comments: unknown[]) => {
     published.push({ body, comments });
     return 456;
@@ -231,6 +232,8 @@ try {
   }, "finding/vector alignment and embedding cost attribution are preserved");
   embeddingVectors = undefined;
   splitScores = false;
+  const { parseFindingsFromJson } = await import("@/lib/review-dedup");
+  const evidence: unknown[] = [];
   const { processReview } = await import("@/lib/reviewer");
   for (const [score, vote, fails, retained] of [
     [0.1, "down", false, 1], [0.8, "down", false, 1],
@@ -247,6 +250,15 @@ try {
     assert.deepEqual(archived.at(-1)?.findings.map((value) => value.title), local.findings.map((value) => value.title),
       "hosted persistence and local output apply the same semantic suppression decision");
     assert.equal(published.at(-1)?.comments.length, retained, "hosted inline publication uses the suppressed union");
+    assert.equal(parseFindingsFromJson(archived.at(-1)!.body)?.length, 1, "the archived raw model response preserves its findings markers");
+    assert.deepEqual(archived.at(-1)!.coverage, archived[0].coverage, "suppression does not change review coverage");
+    assert.equal(local.model, "fixture-model", "model routing is preserved");
+    assert.equal(local.summary, "Summary", "local summary excludes the findings protocol block");
+    assert.match(published.at(-1)!.body, new RegExp(`${retained} finding`), "summary count agrees with inline findings");
+    evidence.push({ cosineSimilarity: score, feedback: vote, searchFailure: fails, local, hosted: published.at(-1), summaryComment: summaries.at(-1), persistence: archived.at(-1) });
+  }
+  if (process.env.FEEDBACK_EVIDENCE_PATH) {
+    await Bun.write(process.env.FEEDBACK_EVIDENCE_PATH, JSON.stringify(evidence, null, 2));
   }
   console.log("PASS semantic feedback similarity and review consumers");
 } finally {

--- a/apps/web/lib/feedback-suppression.ts
+++ b/apps/web/lib/feedback-suppression.ts
@@ -1,0 +1,37 @@
+import "server-only";
+import { createEmbeddings } from "@/lib/embeddings";
+import { ensureFeedbackCollection, searchFeedbackPatterns } from "@/lib/qdrant";
+
+/** Shared hosted/local policy; the existing strict cosine threshold is unchanged. */
+export async function suppressFindingsFromFeedback<T extends { title: string; description: string }>(
+  findings: T[],
+  scope: { repoId: string; orgId: string },
+): Promise<T[]> {
+  if (findings.length === 0) return findings;
+  try {
+    await ensureFeedbackCollection();
+    const texts = findings.map((finding) => `${finding.title} ${finding.description}`);
+    const vectors = await createEmbeddings(texts, {
+      organizationId: scope.orgId,
+      operation: "embedding",
+      repositoryId: scope.repoId,
+    });
+    // A partial provider response cannot safely be aligned with the findings.
+    if (!Array.isArray(vectors) || vectors.length !== findings.length) return findings;
+
+    const retained: T[] = [];
+    for (let i = 0; i < findings.length; i++) {
+      const matches = await searchFeedbackPatterns(scope.repoId, vectors[i], scope.orgId);
+      if (!matches.some((match) => match.feedback === "down" && match.cosineSimilarity > 0.80)) {
+        retained.push(findings[i]);
+      }
+    }
+    if (retained.length < findings.length) {
+      console.log(`[feedback-suppression] Suppressed ${findings.length - retained.length} findings via semantic feedback matching`);
+    }
+    return retained;
+  } catch (error) {
+    console.warn("[feedback-suppression] Semantic feedback matching failed, continuing:", error);
+    return findings;
+  }
+}

--- a/apps/web/lib/qdrant.ts
+++ b/apps/web/lib/qdrant.ts
@@ -1028,18 +1028,31 @@ export async function upsertFeedbackPattern(point: {
   }
 }
 
+export type FeedbackSimilarityMatch = {
+  feedback: "up" | "down";
+  cosineSimilarity: number;
+};
+
+/**
+ * Suppression needs absolute dense similarity, never a hybrid/RRF rank score.
+ * The feedback collection's dense vector uses Cosine distance. Keep the same
+ * repo-or-organization scope as the existing feedback policy, bounded to three
+ * candidates per finding. With an org ID, other repositories in that org remain
+ * eligible.
+ */
 export async function searchFeedbackPatterns(
   repoId: string,
   queryVector: number[],
-  limit = 5,
   orgId?: string,
-  queryText?: string,
-): Promise<{ title: string; description: string; feedback: string; repoId: string; score: number }[]> {
-  if (queryVector.length === 0) return [];
-  const qdrant = getQdrantClient();
+): Promise<FeedbackSimilarityMatch[]> {
+  if (!Array.isArray(queryVector) || queryVector.length === 0) return [];
+  for (const value of queryVector) {
+    if (!Number.isFinite(value)) return [];
+  }
+  if (queryVector.every((value) => value === 0)) return [];
+
   try {
-    // Search repo-scoped patterns first
-    const filter: Record<string, unknown> = orgId
+    const filter = orgId
       ? {
           should: [
             { key: "repoId", match: { value: repoId } },
@@ -1049,49 +1062,25 @@ export async function searchFeedbackPatterns(
       : {
           must: [{ key: "repoId", match: { value: repoId } }],
         };
+    const points = await getQdrantClient().search(FEEDBACK_COLLECTION_NAME, {
+      vector: queryVector,
+      filter,
+      limit: 3,
+      with_payload: true,
+    });
 
-    let points: { payload?: Record<string, unknown> | null; score: number }[];
-
-    if (queryText) {
-      try {
-        const sparseQuery = generateSparseVector(queryText);
-        const result = await qdrant.query(FEEDBACK_COLLECTION_NAME, {
-          prefetch: [
-            { query: queryVector, limit: limit * 2, filter },
-            { query: { indices: sparseQuery.indices, values: sparseQuery.values }, using: SPARSE_VECTOR_NAME, limit: limit * 2, filter },
-          ],
-          query: { fusion: "rrf" },
-          limit,
-          with_payload: true,
-        });
-        points = result.points;
-      } catch (error) {
-        if (!isSparseVectorError(error)) throw error;
-        console.warn("[qdrant] Falling back to dense-only search", { collection: FEEDBACK_COLLECTION_NAME, error: error instanceof Error ? error.message : error });
-        points = await qdrant.search(FEEDBACK_COLLECTION_NAME, {
-          vector: queryVector,
-          filter,
-          limit,
-          with_payload: true,
-        });
-      }
-    } else {
-      points = await qdrant.search(FEEDBACK_COLLECTION_NAME, {
-        vector: queryVector,
-        filter,
-        limit,
-        with_payload: true,
-      });
-    }
-
-    return points.map((point) => ({
-      title: (point.payload?.title as string) ?? "",
-      description: (point.payload?.description as string) ?? "",
-      feedback: (point.payload?.feedback as string) ?? "",
-      repoId: (point.payload?.repoId as string) ?? "",
-      score: point.score,
-    }));
+    if (!Array.isArray(points)) return [];
+    return points.slice(0, 3).flatMap((point): FeedbackSimilarityMatch[] => {
+      const payload = point?.payload;
+      const cosineSimilarity = point?.score;
+      if (!payload || (payload.feedback !== "up" && payload.feedback !== "down")) return [];
+      if (payload.repoId !== repoId && (!orgId || payload.orgId !== orgId)) return [];
+      if (typeof cosineSimilarity !== "number" || !Number.isFinite(cosineSimilarity)
+        || cosineSimilarity < -1 || cosineSimilarity > 1) return [];
+      return [{ feedback: payload.feedback, cosineSimilarity }];
+    });
   } catch {
+    // Missing collections, provider errors and malformed results retain findings.
     return [];
   }
 }

--- a/apps/web/lib/review-core.ts
+++ b/apps/web/lib/review-core.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 /**
  * Core review generation logic extracted from reviewer.ts.
  * Used by both the standard PR review pipeline and the local-review API endpoint.
@@ -10,11 +12,10 @@ import { prisma } from "@octopus/db";
 import {
   searchSimilarChunks,
   searchKnowledgeChunks,
-  searchFeedbackPatterns,
-  ensureFeedbackCollection,
   searchReviewChunks,
 } from "@/lib/qdrant";
 import { createEmbeddings } from "@/lib/embeddings";
+import { suppressFindingsFromFeedback } from "@/lib/feedback-suppression";
 import { rerankDocuments } from "@/lib/reranker";
 import { resolveReviewLanguage } from "@/lib/review-language";
 import { getAlwaysIncludeKnowledge, mergeKnowledgeChunks } from "@/lib/knowledge-context";
@@ -526,36 +527,8 @@ Rules:
     findings = findings.filter((f) => !disabled.has(f.category.toLowerCase()));
   }
 
-  // Step 8: Semantic feedback matching — suppress known false positives
-  try {
-    await ensureFeedbackCollection();
-    const findingTexts = findings.map((f) => `${f.title} ${f.description}`);
-    if (findingTexts.length > 0) {
-      const findingVectors = await createEmbeddings(findingTexts, {
-        organizationId: org.id,
-        operation: "embedding",
-        repositoryId: repo.id,
-      });
-
-      const suppressedIndexes = new Set<number>();
-      for (let i = 0; i < findings.length; i++) {
-        const matches = await searchFeedbackPatterns(repo.id, findingVectors[i], 3, org.id, findingTexts[i]);
-        const falsePositiveMatch = matches.find(
-          (m) => m.feedback === "down" && m.score > 0.80,
-        );
-        if (falsePositiveMatch) {
-          suppressedIndexes.add(i);
-        }
-      }
-
-      if (suppressedIndexes.size > 0) {
-        findings = findings.filter((_, i) => !suppressedIndexes.has(i));
-        console.log(`[review-core] Suppressed ${suppressedIndexes.size} findings via semantic feedback matching`);
-      }
-    }
-  } catch (err) {
-    console.warn("[review-core] Semantic feedback matching failed, continuing:", err);
-  }
+  // Step 8: Suppress strong dense matches to previously dismissed findings.
+  findings = await suppressFindingsFromFeedback(findings, { repoId: repo.id, orgId: org.id });
 
   // Step 9: Two-pass validation — use Haiku to re-score confidence on all findings
   // with cross-file context for verifying function signatures, types, etc.

--- a/apps/web/lib/reviewer.ts
+++ b/apps/web/lib/reviewer.ts
@@ -11,7 +11,6 @@ import {
   ensureDiagramCollection,
   upsertDiagramChunk,
   deleteDiagramChunksByPR,
-  searchFeedbackPatterns,
   ensureFeedbackCollection,
   upsertFeedbackPattern,
   searchReviewChunks,
@@ -19,6 +18,7 @@ import {
 import { extractAllMermaidBlocks, extractNodeLabels, DIAGRAM_TYPE_LABELS } from "@/lib/mermaid-utils";
 import { loadQueueConfig, computeStaleReclaimMs, enqueue, enqueueAfter } from "@/lib/queue";
 import { createEmbeddings } from "@/lib/embeddings";
+import { suppressFindingsFromFeedback } from "@/lib/feedback-suppression";
 import { generateSparseVector } from "@/lib/sparse-vector";
 import { substitutePromptVars } from "@/lib/prompt-substitute";
 import { rerankDocuments } from "@/lib/reranker";
@@ -1906,39 +1906,8 @@ export async function processReview(pullRequestId: string): Promise<void> {
       }
     }
 
-    // Semantic feedback matching: suppress findings that match known false positive patterns
-    try {
-      await ensureFeedbackCollection();
-
-      // Build texts for ALL parsed findings (used for both inline filtering and summary filtering)
-      const allFindingTexts = allParsedFindings.map((f) => `${f.title} ${f.description}`);
-      if (allFindingTexts.length > 0) {
-        const allFindingVectors = await createEmbeddings(allFindingTexts, {
-          organizationId: org.id,
-          operation: "embedding",
-          repositoryId: repo.id,
-        });
-
-        const suppressedAllIndexes = new Set<number>();
-        for (let i = 0; i < allParsedFindings.length; i++) {
-          const matches = await searchFeedbackPatterns(repo.id, allFindingVectors[i], 3, org.id, allFindingTexts[i]);
-          const falsePositiveMatch = matches.find(
-            (m) => m.feedback === "down" && m.score > 0.80,
-          );
-          if (falsePositiveMatch) {
-            suppressedAllIndexes.add(i);
-          }
-        }
-
-        if (suppressedAllIndexes.size > 0) {
-          // Suppress dismissed-pattern findings from the union (single source).
-          allParsedFindings = allParsedFindings.filter((_, i) => !suppressedAllIndexes.has(i));
-          console.log(`[reviewer] Suppressed ${suppressedAllIndexes.size} findings via semantic feedback matching`);
-        }
-      }
-    } catch (err) {
-      console.warn("[reviewer] Semantic feedback matching failed, continuing:", err);
-    }
+    // Apply the shared policy to the full union before validation/presentation.
+    allParsedFindings = await suppressFindingsFromFeedback(allParsedFindings, { repoId: repo.id, orgId: org.id });
 
     // Two-pass validation: re-score confidence on the FULL union with cross-file
     // context. Runs once on allParsedFindings so both the summary table and the

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octopus/web",
-  "version": "1.0.144",
+  "version": "1.0.145",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octopus",
-  "version": "1.0.144",
+  "version": "1.0.145",
   "devDependencies": {
     "turbo": "^2"
   },


### PR DESCRIPTION
Feedback suppression used hybrid search ranks as though they were cosine similarity scores. This change uses dense cosine similarity, bounded to three candidates per finding, and shares the suppression stage between hosted and local reviews. Weak, invalid or failed lookups retain findings; positive feedback and the exact 0.80 boundary do not suppress.

Prepares release **1.0.145** with consumer and operator changelog entries. Master was merged through an additive commit, preserving the published review history and the capacity, retry and PNG coverage fixes in 1.0.143–1.0.144.

Operator note: the existing repository-or-organization feedback scope and strict `> 0.80` threshold remain unchanged. No database migration, reindex, dependency or model configuration change is required.

Validated commit `06295da9f5e762efa4611ee81161ec99ad957bf8`: full local lint, typecheck and build passed; tests passed with 1,385 passing, 16 skipped and no failures. Independent review passed. Validation-only no-mistakes run `01M2836D8B6ZMKCVZHP2X0B0C6` passed intent/review/test/document/lint without source changes. All GitHub CI checks passed ([run 34594065567](https://github.com/octopusreview/octopus/actions/runs/34594065567)). The automatic [Octopus review](https://github.com/octopusreview/octopus/pull/819#issuecomment-5633732661) passed at 4/5 with 9/9 files supplied, a valid completed assessment and zero findings. No duplicate review request was sent.

Pipeline attestation: the former run’s latest drift repair was stopped before its rebased head was published; both published and unpublished histories were preserved. The approved replacement retains no-mistakes intent/review/test/document/lint, skips its rebase/push/PR/CI automation, and uses a normal fast-forward Git push plus the same native CI and Octopus quality gates. No quality requirement is waived.

Closes #484. Part of #806.
