### PR TITLE
fix(web): account for declared binary PNGs in review coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.144] - 2026-09-11
+
+### Fixed
+- GitHub reviews can assess accompanying text when an added or modified PNG has a validated provider binary declaration. Coverage lists those images as excluded and not reviewed; missing source patches and incomplete model assessments still block a complete result.
+
 ## [1.0.143] - 2026-09-11
 
 ### Fixed

--- a/apps/web/lib/__tests__/fixtures/review-assessment-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/review-assessment-harness.ts
@@ -82,6 +82,38 @@ function plan(oversized = false) {
   return result;
 }
 const requestFor = (p: ReturnType<typeof plan>, model = "gpt-test"): AiCreateParams => createCoveredReviewRequest({ model, system: "Trusted review template", number: 1, title: "Validators", author: "fixture", diff: p.diff, coverage: p.coverage, comment: "@octopus context", repoConfig: "" });
+// Exercise the PNG adapter through the actual assessment and report interfaces.
+const { fetchGitHubReviewInput } = await import("../../github-review-input");
+const pngPath = "docs/screenshot.png";
+const pngDeclaration = `diff --git a/${pngPath} b/${pngPath}\nnew file mode 100644\nindex 0000000..ccccccc\nBinary files /dev/null and b/${pngPath} differ\n`;
+const mixedInput = await fetchGitHubReviewInput({
+  expectedHead: "a".repeat(40), maxPatchChars: 10000,
+  fetchDiff: async () => pngDeclaration,
+  readJson: async suffix => suffix ? [
+    { filename: "README.md", status: "added", additions: 1, deletions: 0, patch: "@@ -0,0 +1 @@\n+Product documentation\n" },
+    { filename: pngPath, status: "added", additions: 0, deletions: 0, sha: "c".repeat(40) },
+  ] : { head: { sha: "a".repeat(40) }, base: { sha: "b".repeat(40) }, changed_files: 2 },
+});
+const mixed = prepareReviewInput(mixedInput.input, { maxChars: 10000 });
+assert.equal(reviewCheckResult(mixed.coverage, false, 0).conclusion, "failure");
+output = { choices: [{ message: { content: valid }, finish_reason: "stop" }] };
+await executeCoveredReview(requestFor(mixed), mixed.coverage, "template-v1", request => openaiProvider.create(request, "fake"));
+assert.equal(mixed.coverage.assessment?.state, "completed");
+assert.equal(reviewCheckResult(mixed.coverage, false, 0).conclusion, "success");
+assert.equal(mixed.coverage.files.find(file => file.path === pngPath)?.state, "excluded");
+const mixedReport = applyReviewCoverage(valid, mixed.coverage, "mixed-png");
+assert.ok(mixedReport.includes("not reviewed"));
+assert.ok(mixedReport.includes("**4/5**"));
+const binaryOnly = prepareReviewInput({ ...mixedInput.input, expectedFiles: 1, files: mixedInput.input.files.slice(1) }, { maxChars: 0 });
+recordNoModelAssessment(binaryOnly.coverage);
+const binaryReport = applyReviewCoverage("No changed text hunks were supplied for review.", binaryOnly.coverage, "binary-only");
+assert.equal(reviewCheckResult(binaryOnly.coverage, false, 0).conclusion, "success");
+assert.ok(!binaryReport.includes("4/5"));
+if (process.env.REVIEW_TEST_EVIDENCE_DIR) {
+  await Bun.write(`${process.env.REVIEW_TEST_EVIDENCE_DIR}/mixed-png-review.md`, mixedReport);
+  await Bun.write(`${process.env.REVIEW_TEST_EVIDENCE_DIR}/binary-only-review.md`, binaryReport);
+  await Bun.write(`${process.env.REVIEW_TEST_EVIDENCE_DIR}/png-assessment.json`, JSON.stringify({ boundary: "Production adapter, preparation, provider adapter and assessment; synthetic GitHub input and mocked model SDK", mixed: mixed.coverage, binaryOnly: binaryOnly.coverage }, null, 2));
+}
 for (const [name, text, finish, complete] of [
   ["valid", valid, "stop", true],
   ["rereview-valid", valid, "stop", true],

--- a/apps/web/lib/__tests__/fixtures/review-attempt-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/review-attempt-harness.ts
@@ -468,6 +468,30 @@ assert.deepEqual(current, sameHeadRequested);
 assert.equal((rows.get(lateSameHeadJob.attemptId)?.coverage as { reviewRequestVersion: number }).reviewRequestVersion, versionB);
 console.log("PASS persisted same-head re-request rejects prior-version worker promotion");
 
+const { fetchGitHubReviewInput } = await import("../../github-review-input");
+const binaryBlob = "c".repeat(40), binaryBase = "2".repeat(40);
+const binaryInput = await fetchGitHubReviewInput({
+  expectedHead: currentHead, maxPatchChars: 1000,
+  fetchDiff: async () => "diff --git a/docs/example.png b/docs/example.png\nnew file mode 100644\nindex 0000000..ccccccc\nBinary files /dev/null and b/docs/example.png differ\n",
+  readJson: async suffix => suffix
+    ? [{ filename: "docs/example.png", status: "added", additions: 0, deletions: 0, sha: binaryBlob }]
+    : { head: { sha: currentHead }, base: { sha: binaryBase }, changed_files: 1 },
+});
+const binaryCoverage = prepareReviewInput(binaryInput.input, { maxChars: 1000 }).coverage;
+binaryCoverage.reviewRequestVersion = currentVersion;
+assert.equal(binaryCoverage.files[0].state, "excluded");
+assert.ok(binaryCoverage.files[0].binaryEvidence);
+const binaryAttempt = "bacdef01-abcd-4bcd-8bcd-abcdef012345";
+await saveReviewAttempt(binaryAttempt, "pr", binaryCoverage, "Binary asset not reviewed");
+const binaryDownload = await GET(new NextRequest("https://example.test/api/review-attempts/" + binaryAttempt, { headers: { authorization: "Bearer owner" } }), { params: Promise.resolve({ id: binaryAttempt }) });
+assert.equal(binaryDownload.status, 200);
+assert.deepEqual((await binaryDownload.json()).coverage, JSON.parse(JSON.stringify(binaryCoverage)));
+const alteredBinaryCoverage = structuredClone(binaryCoverage);
+alteredBinaryCoverage.files[0].binaryEvidence!.rawSectionSha256 = "0".repeat(64);
+await assert.rejects(saveReviewAttempt(binaryAttempt, "pr", alteredBinaryCoverage, "Binary asset not reviewed"), /identity conflict/);
+assert.deepEqual(rows.get(binaryAttempt)?.coverage, JSON.parse(JSON.stringify(binaryCoverage)));
+console.log("PASS binary evidence survives immutable archive/download and cannot be overwritten");
+
 if (process.env.REVIEW_TEST_EVIDENCE_DIR) {
   const download = await request({ authorization: "Bearer owner" });
   await Bun.write(`${process.env.REVIEW_TEST_EVIDENCE_DIR}/attempt-contract.json`, JSON.stringify({

--- a/apps/web/lib/__tests__/github-review-input.test.ts
+++ b/apps/web/lib/__tests__/github-review-input.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "bun:test";
+import { fetchGitHubReviewInput } from "@/lib/github-review-input";
+import { applyReviewCoverage, coverageCounts, prepareReviewInput, reviewCheckResult, sha256, type ReviewInput } from "@/lib/review-coverage";
+import { recordNoModelAssessment } from "@/lib/review-assessment";
+import { parseOctopusIgnore } from "@/lib/octopus-ignore";
+import { buildGeneratedMatcher } from "@/lib/generated-files";
+
+const head = "1".repeat(40), base = "2".repeat(40);
+const blob = "a".repeat(40);
+const png = (filename = "docs/screenshot.png") => ({ filename, status: "added", additions: 0, deletions: 0, sha: blob });
+const binaryDiff = (filename = "docs/screenshot.png") => `diff --git a/${filename} b/${filename}\nnew file mode 100644\nindex 0000000..${blob.slice(0, 7)}\nBinary files /dev/null and b/${filename} differ\n`;
+const modifiedDiff = `diff --git a/docs/screenshot.png b/docs/screenshot.png\nindex bbbbbbb..${blob.slice(0, 7)} 100644\nBinary files a/docs/screenshot.png and b/docs/screenshot.png differ\n`;
+
+async function fetchInput(files: unknown[], rawDiff: string) {
+  return fetchGitHubReviewInput({
+    expectedHead: head, maxPatchChars: 100_000,
+    fetchDiff: async () => rawDiff,
+    readJson: async suffix => suffix ? files : { head: { sha: head }, base: { sha: base }, changed_files: files.length },
+  });
+}
+
+describe("GitHub binary PNG coverage", () => {
+  it("retains two declared PNGs as unreviewed exclusions beside the supplied README", async () => {
+    const patch = "@@ -0,0 +1 @@\n+Product documentation\n";
+    const readme = { filename: "README.md", status: "added", additions: 1, deletions: 0, patch };
+    const rawDiff = "diff --git a/README.md b/README.md\nnew file mode 100644\n--- /dev/null\n+++ b/README.md\n" + patch
+      + binaryDiff("docs/sign-in.png") + binaryDiff("docs/review.png");
+    const fetched = await fetchInput([readme, png("docs/sign-in.png"), png("docs/review.png")], rawDiff);
+    const prepared = prepareReviewInput(fetched.input, { maxChars: 100_000 });
+    expect(coverageCounts(prepared.coverage)).toEqual({ total: 3, supplied: 1, partial: 0, omitted: 0, excluded: 2, unavailable: 0 });
+    expect(prepared.coverage.complete).toBe(true);
+    expect(reviewCheckResult(prepared.coverage, false, 0).conclusion).toBe("failure"); // Model assessment still required.
+    const readmeOnly = await fetchInput([readme], rawDiff.split("diff --git a/docs/")[0]);
+    expect(sha256(prepared.diff)).toBe(sha256(prepareReviewInput(readmeOnly.input, { maxChars: 100_000 }).diff));
+    for (const file of prepared.coverage.files.slice(1)) {
+      expect(file.suppliedChars).toBe(0);
+      expect(file.suppliedSha256).toBeNull();
+      expect(file.hunks).toEqual([]);
+      expect(file.reason).toContain("not reviewed");
+      expect(file.binaryEvidence).toMatchObject({ policy: "github-binary-png-v1", provider: "github", headSha: head, baseSha: base, path: file.path, change: "added", blobSha: blob });
+      expect(file.binaryEvidence?.rawSectionSha256).toBe(sha256(binaryDiff(file.path)));
+    }
+  });
+
+  it("accepts modified regular PNGs with a distinct old blob and a full new blob hash", async () => {
+    const fetched = await fetchInput([{ ...png(), status: "modified" }], modifiedDiff.replace("..aaaaaaa ", `..${blob} `));
+    const prepared = prepareReviewInput(fetched.input, { maxChars: 0 });
+    expect(prepared.coverage.files[0]).toMatchObject({ state: "excluded", suppliedChars: 0, hunks: [], binaryEvidence: { change: "modified", blobSha: blob } });
+    expect(prepared.diff).toBe("");
+    expect(prepared.inventoryDiff).toContain("docs/screenshot.png");
+  });
+
+  it("records excluded-only input without invoking or claiming a model assessment", async () => {
+    const fetched = await fetchInput([png()], binaryDiff());
+    const prepared = prepareReviewInput(fetched.input, { maxChars: 0 });
+    recordNoModelAssessment(prepared.coverage);
+    expect(prepared.coverage.assessment).toMatchObject({ state: "not-required", model: null, requests: [], responseSha256: null });
+    expect(reviewCheckResult(prepared.coverage, false, 0).conclusion).toBe("success");
+    const report = applyReviewCoverage("Overall 5/5", prepared.coverage, "binary-only");
+    expect(report).not.toContain("5/5");
+    expect(report).toContain("excluded files were not reviewed");
+  });
+
+  const invalidMetadata: [string, Record<string, unknown>][] = [
+    ["missing additions", { additions: undefined }], ["missing deletions", { deletions: undefined }],
+    ["nonzero additions", { additions: 1 }], ["negative deletions", { deletions: -1 }],
+    ["string count", { additions: "0" }], ["null count", { deletions: null }],
+    ["missing blob", { sha: undefined }], ["empty blob", { sha: "" }],
+    ["short blob", { sha: "aaaaaaa" }], ["nonhex blob", { sha: "g".repeat(40) }],
+    ["different blob", { sha: "b".repeat(40) }], ["null blob", { sha: "0".repeat(40) }],
+    ["renamed", { status: "renamed" }], ["copied", { status: "copied" }],
+    ["deleted", { status: "removed" }], ["unknown status", { status: "changed" }],
+    ["wrong status", { status: "modified" }], ["previous path", { previous_filename: "old.png" }],
+    ["same previous path", { previous_filename: "docs/screenshot.png" }],
+    ["empty API patch", { patch: "" }], ["null API patch", { patch: null }],
+    ["retained patch overflow", { patch: "x".repeat(100_001) }],
+  ];
+  for (const [name, changes] of invalidMetadata) {
+    it(`does not exclude an image with ${name}`, async () => {
+      const fetched = await fetchInput([{ ...png(), ...changes }], binaryDiff());
+      expect(fetched.input.files[0].binaryEvidence).toBeUndefined();
+      const prepared = prepareReviewInput(fetched.input, { maxChars: 1000 });
+      expect(prepared.coverage.complete).toBe(false);
+      expect(prepared.coverage.files[0].state).toBe("unavailable");
+    });
+  }
+
+  const invalidDiffs: [string, string][] = [
+    ["missing declaration", ""], ["bare marker", "Binary files /dev/null and b/docs/screenshot.png differ\n"],
+    ["missing marker", binaryDiff().split("Binary files")[0]],
+    ["truncated marker", binaryDiff().replace(" differ\n", " diffe")],
+    ["short prefix", binaryDiff().replace("..aaaaaaa", "..aaaaaa")],
+    ["empty prefix", binaryDiff().replace("..aaaaaaa", "..")],
+    ["nonhex prefix", binaryDiff().replace("..aaaaaaa", "..ggggggg")],
+    ["overlong prefix", binaryDiff().replace("..aaaaaaa", ".." + "a".repeat(41))],
+    ["different prefix", binaryDiff().replace("..aaaaaaa", "..bbbbbbb")],
+    ["added old blob", binaryDiff().replace("0000000..", "bbbbbbb..")],
+    ["executable mode", binaryDiff().replace("100644", "100755")],
+    ["symlink mode", binaryDiff().replace("100644", "120000")],
+    ["submodule mode", binaryDiff().replace("100644", "160000")],
+    ["missing mode", binaryDiff().replace("new file mode 100644\n", "")],
+    ["wrong old header", binaryDiff().replace("a/docs/screenshot.png b/", "a/old.png b/")],
+    ["wrong new header", binaryDiff().replace("b/docs/screenshot.png\n", "b/other.png\n")],
+    ["wrong old marker", binaryDiff().replace("/dev/null and", "a/docs/screenshot.png and")],
+    ["wrong new marker", binaryDiff().replace("b/docs/screenshot.png differ", "b/other.png differ")],
+    ["quoted header", binaryDiff().replace("a/docs/screenshot.png b/docs/screenshot.png", '"a/docs/screenshot.png" "b/docs/screenshot.png"')],
+    ["duplicate section", binaryDiff() + binaryDiff()],
+    ["conflicting section", binaryDiff() + binaryDiff().replaceAll("b/docs/screenshot.png", "b/other.png")],
+    ["marker inside hunk", binaryDiff().replace("Binary files", "@@ -0,0 +1 @@\n+Binary files")],
+    ["hunk after marker", binaryDiff() + "@@ -0,0 +1 @@\n+hidden text\n"],
+  ];
+  for (const [name, diff] of invalidDiffs) {
+    it(`does not exclude an image with ${name}`, async () => {
+      const fetched = await fetchInput([png()], diff);
+      expect(fetched.input.files[0].binaryEvidence).toBeUndefined();
+      expect(prepareReviewInput(fetched.input, { maxChars: 1000 }).coverage.files[0].state).toBe("unavailable");
+    });
+  }
+
+  for (const [name, diff] of [
+    ["unchanged old/new prefix", modifiedDiff.replace("bbbbbbb", "aaaaaaa")],
+    ["overlapping old/new prefix", modifiedDiff.replace("bbbbbbb", "aaaaaaaa")],
+    ["executable", modifiedDiff.replace("100644", "100755")],
+    ["missing mode", modifiedDiff.replace(" 100644", "")],
+    ["mode-only change", modifiedDiff.replace("index bbbbbbb..aaaaaaa 100644", "old mode 100755\nnew mode 100644")],
+    ["additional rename metadata", modifiedDiff.replace("index ", "rename from old.png\nrename to docs/screenshot.png\nindex ")],
+  ]) {
+    it(`rejects a modified PNG with ${name}`, async () => {
+      const fetched = await fetchInput([{ ...png(), status: "modified" }], diff);
+      expect(prepareReviewInput(fetched.input, { maxChars: 1000 }).coverage.files[0].state).toBe("unavailable");
+    });
+  }
+
+  for (const path of ["src/validation.ts", "icon.svg", "photo.jpg", "source.png.ts", "../outside.png", "/absolute.png", "docs//empty.png", "docs/./dot.png", "docs/a b.png", 'docs/a"b.png', "docs/a\\b.png", "docs/a\nb.png"]) {
+    it(`does not authorize binary exclusion for ${JSON.stringify(path)}`, async () => {
+      const fetched = await fetchInput([png(path)], binaryDiff(path));
+      const prepared = prepareReviewInput(fetched.input, { maxChars: 1000 });
+      expect(prepared.coverage.complete).toBe(false);
+      expect(prepared.coverage.files[0].state).toBe("unavailable");
+    });
+  }
+
+  it("supplies actual text hunks under a PNG filename instead of applying binary policy", async () => {
+    const patch = "@@ -0,0 +1 @@\n+This is text, not an image\n";
+    const fetched = await fetchInput([{ ...png(), additions: 1, patch }], binaryDiff());
+    const prepared = prepareReviewInput(fetched.input, { maxChars: 1000 });
+    expect(prepared.coverage.files[0].state).toBe("supplied");
+    expect(prepared.coverage.files[0].binaryEvidence).toBeUndefined();
+    expect(prepared.diff).toContain("+This is text, not an image");
+  });
+
+  it("does not treat a source -diff attribute as permission to exclude missing source", async () => {
+    const path = "src/validation.ts";
+    const fetched = await fetchInput([png(path)], binaryDiff(path));
+    const prepared = prepareReviewInput(fetched.input, { maxChars: 1000, generated: buildGeneratedMatcher("src/** -diff\n") });
+    expect(prepared.coverage.files[0].state).toBe("unavailable");
+    expect(prepared.coverage.complete).toBe(false);
+    expect(reviewCheckResult(prepared.coverage, false, 0).conclusion).toBe("failure");
+  });
+
+  const tamperedEvidence: [string, Record<string, unknown>][] = [
+    ["policy", { policy: "untrusted" }], ["provider", { provider: "gitlab" }],
+    ["head", { headSha: "3".repeat(40) }], ["base", { baseSha: "3".repeat(40) }],
+    ["path", { path: "other.png" }], ["change", { change: "modified" }],
+    ["blob", { blobSha: "b".repeat(40) }], ["missing raw section", { rawSection: undefined }],
+    ["changed raw section", { rawSection: binaryDiff().replace("100644", "100755") }],
+    ["missing digest", { rawSectionSha256: undefined }], ["changed digest", { rawSectionSha256: "f".repeat(64) }],
+  ];
+  for (const [name, changes] of tamperedEvidence) {
+    it(`revalidates ${name} evidence at shared preparation`, async () => {
+      const fetched = await fetchInput([png()], binaryDiff());
+      const file = fetched.input.files[0];
+      expect(file.binaryEvidence).toBeDefined();
+      file.binaryEvidence = { ...file.binaryEvidence, ...changes } as typeof file.binaryEvidence;
+      const prepared = prepareReviewInput(fetched.input, { maxChars: 1000 });
+      expect(prepared.coverage.files[0].state).toBe("unavailable");
+      expect(prepared.coverage.files[0].binaryEvidence).toBeUndefined();
+    });
+  }
+
+  const changedBindings: [string, (input: ReviewInput) => void][] = [
+    ["unsupported GitLab", input => { input.provider = "gitlab"; }],
+    ["unsupported Bitbucket", input => { input.provider = "bitbucket"; }],
+    ["missing head", input => { input.headSha = null; }],
+    ["missing base", input => { input.baseSha = null; }],
+    ["different head", input => { input.headSha = "3".repeat(40); }],
+    ["different base", input => { input.baseSha = "3".repeat(40); }],
+    ["source path", input => { input.files[0].path = "src/auth.ts"; }],
+    ["changed metadata count", input => { input.files[0].additions = 1; }],
+    ["retention error", input => { input.files[0].unavailable = "File exceeds retained patch budget"; }],
+    ["removed receipt", input => { input.files[0].binaryEvidence = undefined; }],
+  ];
+  for (const [name, change] of changedBindings) {
+    it(`rejects ${name} after provider classification`, async () => {
+      const fetched = await fetchInput([png()], binaryDiff());
+      change(fetched.input);
+      const prepared = prepareReviewInput(fetched.input, { maxChars: 1000 });
+      expect(prepared.coverage.files[0].state).toBe("unavailable");
+      expect(prepared.coverage.complete).toBe(false);
+    });
+  }
+
+  it("preserves existing repository policy and retains only verified evidence copies", async () => {
+    const fetched = await fetchInput([png()], binaryDiff());
+    const prepared = prepareReviewInput(fetched.input, { maxChars: 1000, ignored: parseOctopusIgnore("docs/*.png") });
+    expect(prepared.coverage.files[0].reason).toBe("Repository .octopusignore policy");
+    const evidence = prepared.coverage.files[0].binaryEvidence;
+    expect(evidence).toEqual(fetched.input.files[0].binaryEvidence);
+    fetched.input.files[0].binaryEvidence!.rawSectionSha256 = "modified after preparation";
+    expect(evidence?.rawSectionSha256).toBe(sha256(binaryDiff()));
+  });
+
+  it("retains the revision-drift barrier while fetching binary files", async () => {
+    let reads = 0;
+    await expect(fetchGitHubReviewInput({
+      expectedHead: head, maxPatchChars: 1000, fetchDiff: async () => binaryDiff(),
+      readJson: async suffix => suffix ? [png()] : { head: { sha: head }, base: { sha: ++reads === 1 ? base : "3".repeat(40) }, changed_files: 1 },
+    })).rejects.toThrow("PR revision changed");
+  });
+});

--- a/apps/web/lib/__tests__/terraform-runtime-secret-refresh.test.ts
+++ b/apps/web/lib/__tests__/terraform-runtime-secret-refresh.test.ts
@@ -98,8 +98,11 @@ if [[ "$*" == *" ps "* ]] && [ "$FAKE_STACK_RUNNING" = "1" ]; then
 elif [[ "$*" == *" ps "* ]] && [ "$FAKE_WEB_RUNNING" = "1" ]; then
   printf 'web\n'
 fi
-if [[ "$*" == *" run "* ]] && [ "$FAKE_REDIS_PROBE_FAIL" = "1" ]; then
-  exit 45
+if [[ "$*" == *" run "* ]]; then
+  /bin/cat >/dev/null
+  if [ "$FAKE_REDIS_PROBE_FAIL" = "1" ]; then
+    exit 45
+  fi
 fi
 if [[ "$*" == *" up "* ]] && [ "$FAKE_DOCKER_UP_FAIL" = "1" ]; then
   exit 42

--- a/apps/web/lib/github-review-input.ts
+++ b/apps/web/lib/github-review-input.ts
@@ -1,4 +1,5 @@
 import { reviewFilePriority, type ReviewInput, type ReviewFileInput } from "@/lib/review-coverage";
+import { createBinaryPngEvidence, indexGitHubBinaryPngSections } from "@/lib/review-binary-assets";
 
 type PullMetadata = { head?: { sha?: string }; base?: { sha?: string }; changed_files?: number };
 type ChangedFile = { filename: string; previous_filename?: string; status: string; patch?: string; additions?: number; deletions?: number; sha?: string };
@@ -22,6 +23,8 @@ export async function fetchGitHubReviewInput(options: {
     options.onDiffError?.(error, { headSha: before.head!.sha!, baseSha: before.base!.sha! });
     throw error;
   });
+  const binarySections = indexGitHubBinaryPngSections(rawDiff);
+  const revision = { provider: "github", headSha: before.head.sha, baseSha: before.base.sha };
   const files: ReviewFileInput[] = [];
   let sourceChars = 0, supportingChars = 0;
   let inventoryComplete = false;
@@ -37,7 +40,9 @@ export async function fetchGitHubReviewInput(options: {
       const patch = typeof file.patch === "string" && file.patch.length <= Math.min(options.maxPatchChars, remaining) ? file.patch : undefined;
       if (source) sourceChars += patch?.length ?? 0;
       else supportingChars += patch?.length ?? 0;
-      files.push({ path: file.filename, previousPath: file.previous_filename, change: file.status, patch, additions: file.additions, deletions: file.deletions, blobSha: file.sha, unavailable: typeof file.patch === "string" && patch === undefined ? "File exceeds retained patch budget" : undefined });
+      const reviewFile: ReviewFileInput = { path: file.filename, previousPath: file.previous_filename, change: file.status, patch, additions: file.additions, deletions: file.deletions, blobSha: file.sha, unavailable: typeof file.patch === "string" && patch === undefined ? "File exceeds retained patch budget" : undefined };
+      if (file.patch === undefined) reviewFile.binaryEvidence = createBinaryPngEvidence(reviewFile, revision, binarySections.get(file.filename));
+      files.push(reviewFile);
     }
     if (response.length < 100 || (expectedFiles !== null && files.length >= expectedFiles)) {
       inventoryComplete = expectedFiles !== null && files.length === expectedFiles;

--- a/apps/web/lib/review-binary-assets.ts
+++ b/apps/web/lib/review-binary-assets.ts
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+
+const policy = "github-binary-png-v1" as const;
+const fullSha = /^[0-9a-f]{40}$/;
+const prefix = /^[0-9a-f]{7,40}$/;
+const digest = (text: string) => createHash("sha256").update(text).digest("hex");
+
+type Revision = { provider: string; headSha: string | null; baseSha: string | null };
+type File = { path: string; previousPath?: string; change: string; patch?: string; additions?: number; deletions?: number; blobSha?: string; unavailable?: string };
+type BinarySection = { path: string; change: "added" | "modified"; newBlobPrefix: string; rawSection: string; rawSectionSha256: string };
+
+export type BinaryPngEvidence = {
+  policy: typeof policy;
+  provider: "github";
+  headSha: string;
+  baseSha: string;
+  path: string;
+  change: "added" | "modified";
+  blobSha: string;
+  rawSection: string;
+  rawSectionSha256: string;
+};
+
+function safePngPath(path: string): boolean {
+  return path.length <= 4096 && /^[a-zA-Z0-9._/-]+\.png$/i.test(path)
+    && path.split("/").every(part => part !== "" && part !== "." && part !== "..");
+}
+
+/** Accept only complete ordinary-file declarations, never a marker in a hunk. */
+function parseBinarySection(rawSection: string): BinarySection | undefined {
+  const lines = rawSection.replace(/\n$/, "").split("\n");
+  const paths = /^diff --git a\/(.+?) b\/(.+)$/.exec(lines[0] ?? "");
+  if (!paths || paths[1] !== paths[2] || !safePngPath(paths[2])) return;
+  const path = paths[2];
+  const added = lines.length === 4 && lines[1] === "new file mode 100644";
+  const modified = lines.length === 3;
+  if (!added && !modified) return;
+  const index = /^index ([0-9a-f]+)\.\.([0-9a-f]+)( 100644)?$/.exec(lines[added ? 2 : 1]);
+  if (!index || !prefix.test(index[1]) || !prefix.test(index[2]) || /^0+$/.test(index[2])) return;
+  if (added) {
+    if (!/^0+$/.test(index[1]) || index[3] !== undefined) return;
+  } else if (/^0+$/.test(index[1]) || index[1].startsWith(index[2]) || index[2].startsWith(index[1]) || index[3] !== " 100644") return;
+  if (lines.at(-1) !== `Binary files ${added ? "/dev/null" : `a/${path}`} and b/${path} differ`) return;
+  return { path, change: added ? "added" : "modified", newBlobPrefix: index[2], rawSection, rawSectionSha256: digest(rawSection) };
+}
+
+/** Index once; any duplicate old/new path invalidates its candidate evidence. */
+export function indexGitHubBinaryPngSections(rawDiff: string): Map<string, BinarySection> {
+  const candidates = new Map<string, BinarySection>();
+  const seen = new Set<string>();
+  const conflicts = new Set<string>();
+  for (const section of rawDiff.split(/(?=^diff --git )/m)) {
+    if (!section) continue;
+    const paths = /^diff --git a\/(.+?) b\/(.+)\n/.exec(section);
+    // Uninterpretable headers could alias another path (for example Git's
+    // quoted path syntax). Do not authorize new exclusions in that case.
+    if (!paths) return new Map();
+    for (const path of new Set([paths[1], paths[2]])) {
+      if (seen.has(path)) { conflicts.add(path); candidates.delete(path); }
+      seen.add(path);
+    }
+    const parsed = parseBinarySection(section);
+    if (parsed && !conflicts.has(parsed.path)) candidates.set(parsed.path, parsed);
+  }
+  return candidates;
+}
+
+/** Bind a provider declaration to independently fetched file/revision metadata. */
+export function createBinaryPngEvidence(file: File, revision: Revision, section: BinarySection | undefined): BinaryPngEvidence | undefined {
+  if (!section || revision.provider !== "github" || !revision.headSha || !revision.baseSha
+    || !fullSha.test(revision.headSha) || !fullSha.test(revision.baseSha)
+    || /^0+$/.test(revision.headSha) || /^0+$/.test(revision.baseSha)
+    || file.previousPath !== undefined || file.patch !== undefined || file.unavailable !== undefined
+    || file.additions !== 0 || file.deletions !== 0 || !file.blobSha || !fullSha.test(file.blobSha)
+    || file.path !== section.path || file.change !== section.change || !file.blobSha.startsWith(section.newBlobPrefix)) return;
+  return {
+    policy, provider: "github", headSha: revision.headSha, baseSha: revision.baseSha,
+    path: file.path, change: section.change, blobSha: file.blobSha,
+    rawSection: section.rawSection, rawSectionSha256: section.rawSectionSha256,
+  };
+}
+
+/** Preparation rechecks the receipt before retaining it in the immutable manifest. */
+export function validateBinaryPngEvidence(file: File, revision: Revision, evidence: BinaryPngEvidence | undefined): BinaryPngEvidence | undefined {
+  if (!evidence || typeof evidence.rawSection !== "string") return;
+  const verified = createBinaryPngEvidence(file, revision, parseBinarySection(evidence.rawSection));
+  if (!verified || (Object.keys(verified) as (keyof BinaryPngEvidence)[]).some(key => evidence[key] !== verified[key])) return;
+  return verified;
+}

--- a/apps/web/lib/review-coverage.ts
+++ b/apps/web/lib/review-coverage.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { Ignore } from "ignore";
 import { buildGeneratedMatcher } from "@/lib/generated-files";
+import { validateBinaryPngEvidence, type BinaryPngEvidence } from "@/lib/review-binary-assets";
 
 const defaultGenerated = buildGeneratedMatcher();
 
@@ -13,6 +14,7 @@ export type ReviewFileInput = {
   deletions?: number;
   blobSha?: string;
   unavailable?: string;
+  binaryEvidence?: BinaryPngEvidence;
 };
 
 export type ReviewInput = {
@@ -30,6 +32,7 @@ export type FileCoverage = {
   previousPath?: string;
   change: string;
   blobSha?: string;
+  binaryEvidence?: BinaryPngEvidence;
   state: "supplied" | "partial" | "omitted" | "excluded" | "unavailable";
   reason?: string;
   patchSha256: string | null;
@@ -134,12 +137,19 @@ export function prepareReviewInput(input: ReviewInput, options: { maxChars: numb
     seen.add(file.path);
     const record: FileCoverage = { path: file.path, previousPath: file.previousPath, change: file.change, blobSha: file.blobSha, state: "omitted", reason: "Review input budget exhausted", patchSha256: file.patch === undefined ? null : sha256(file.patch), suppliedSha256: null, suppliedChars: 0, hunks: [] };
     coverage.files.push(record);
+    const binaryEvidence = validateBinaryPngEvidence(file, input, file.binaryEvidence);
+    if (binaryEvidence) record.binaryEvidence = binaryEvidence;
     if (options.ignored?.ignores(file.path) || (options.generated?.ignores(file.path) && (!isProtectedReviewSource(file.path) || defaultGenerated.ignores(file.path)))) {
       record.state = "excluded";
       record.reason = options.ignored?.ignores(file.path) ? "Repository .octopusignore policy" : "Generated-file policy";
       continue;
     }
     const fileHeader = header(file);
+    if (fileHeader && binaryEvidence) {
+      record.state = "excluded";
+      record.reason = `Declared binary PNG policy (${binaryEvidence.policy}); image content not reviewed`;
+      continue;
+    }
     if (!fileHeader || file.patch === undefined || file.unavailable) {
       record.state = "unavailable";
       record.reason = !fileHeader ? "Path cannot be mapped safely" : file.unavailable ?? "Provider patch missing (binary or too large)";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octopus/web",
-  "version": "1.0.143",
+  "version": "1.0.144",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/docs/review-coverage.md
+++ b/docs/review-coverage.md
@@ -10,6 +10,16 @@ Source, configuration and package/build scripts have priority over test fixtures
 
 Existing `.octopusignore` exclusions are recorded as repository policy. Curated default generated-file exclusions remain explicit. A repository's additional generated labels cannot silently hide source, tests, schemas or configuration; those remain accounted for. Excluded files are not claimed as reviewed.
 
+### Declared binary PNG policy
+
+GitHub changes can include PNG screenshots without text patches. Policy `github-binary-png-v1` records a qualifying PNG as **excluded, image content not reviewed**, while keeping its path in the changed-file inventory. This recognizes GitHub's binary declaration for a PNG path; it does not decode or validate the image bytes, inspect the image visually, or perform a security review of its contents.
+
+The declaration must be an unambiguous, complete raw-diff section for an added or modified same-path `.png` file with regular non-executable mode `100644`. The adapter checks the exact old/new paths, status, explicit zero addition/deletion counts, and a hexadecimal new-blob prefix of at least seven characters against the full GitHub blob SHA. An API patch, patch-retention error, missing metadata or conflicting declaration prevents this exclusion. Renames, copies, deletions, executable files, symlinks, submodules and mode-only changes are outside this policy. Paths must use unquoted ASCII letters, numbers, dots, underscores, hyphens and single directory separators, without `.` or `..` segments. An uninterpretable raw-diff header prevents binary exclusions for that input rather than risking an ambiguous path match.
+
+The GitHub adapter indexes raw sections once and binds each qualifying declaration to its provider, head/base revisions, path, status and blob SHA. Shared preparation revalidates that binding and the raw-section SHA-256 before retaining the declaration and digest in the immutable coverage manifest. Existing revision-drift checks still apply. Recognized images contribute zero supplied characters and zero hunks; their exclusion does not establish model assessment of the remaining text. An excluded-only change uses the existing no-model disposition and receives no numeric quality score.
+
+Other providers and file types retain their existing behavior. A missing or oversized source patch, including source marked `-diff` through Git attributes, remains unavailable and blocks complete coverage unless an existing explicit repository policy already excludes it. This policy adds no ignore patterns or configuration switches and does not change severity thresholds or assessment-completion requirements.
+
 ## Assessment completion and request provenance
 
 Supplied files alone do not establish a completed assessment. The final provider adapters report completion state and capture SHA-256 receipts over their actual SDK request payloads, after model-prefix, caching, thinking and text transformations. Each receipt records whether all requested message contents survived the transformation. The attempt retains these receipts, the selected model, policy/template digests, response-text digest and completion outcome; it does not publish raw prompts, credentials or private source.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octopus",
-  "version": "1.0.143",
+  "version": "1.0.144",
   "devDependencies": {
     "turbo": "^2"
   },


### PR DESCRIPTION
GitHub reviews with changed PNG screenshots previously reported incomplete coverage even when GitHub explicitly declared those paths binary. Record a conservative, revision-bound binary PNG exclusion with durable evidence; the image content is not reviewed. Missing, contradictory or truncated evidence and source files still fail closed. Closes #824.

The real README PR now prepares its unchanged text with two explicit image exclusions; a retained 70-file regression preserves its text and existing exclusion. Adapter-to-preparation and archive/download regressions cover positive and negative cases. Local lint, typecheck, build and the full suite pass (1,384 passed, 16 skipped).

Also repairs an existing validation race in the fake Docker test double by consuming piped probe input. Controlled RED/GREEN reproduction proved the prior SIGPIPE; all fixture assertions and production behavior remain unchanged. Version 1.0.144; no schema or configuration change.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"49088eb8b2093df9bf823a02c9c5cc40abe53d84","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun install --frozen-lockfile --ignore-scripts` resolved missing worktree dependencies; installed directories were removed after testing.</code>
- `REVIEW_TEST_EVIDENCE_DIR=~/.no-mistakes/evidence/01M281C7N4PBTKG4G70NWQS6ZQ bun test ./apps/web/lib/__tests__/github-review-input.test.ts ./apps/web/lib/__tests__/review-coverage.test.ts ./apps/web/lib/__tests__/review-assessment.test.ts ./apps/web/lib/__tests__/review-attempt.test.ts ./apps/web/lib/__tests__/review-input-capacity.test.ts ./apps/web/lib/__tests__/terraform-runtime-secret-refresh.test.ts`
- <code>Reran `review-assessment.test.ts` after correcting the added fixture to use the production no-model report input; passed.</code>
- <code>Ran `github-review-input.test.ts --test-name-pattern &#39;retains two declared PNGs&#39;` with the baseline adapter, observed two unavailable PNGs, restored the candidate adapter, and confirmed the test passed.</code>
- `Inspected generated mixed-input and PNG-only Markdown reports; exercised immutable archive/download handlers with mocked database and authentication.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
