### PR TITLE
fix(web): clarify re-review commentary section placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Clarified where review explanations belong so re-review commentary does not follow the findings count table without a section heading. Invalid or inconsistent assessments still receive no overall score.
 
-## [Unreleased]
-
 ## [1.0.151] - 2026-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Clarified where review explanations belong so re-review commentary does not follow the findings count table without a section heading. Invalid or inconsistent assessments still receive no overall score.
+
+## [Unreleased]
+
 ## [1.0.151] - 2026-09-11
 
 ### Added

--- a/apps/web/lib/__tests__/fixtures/review-assessment-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/review-assessment-harness.ts
@@ -76,6 +76,7 @@ Last reviewed commit: ${"a".repeat(40)}
 // Exact adjacent advisory from the sanitized a941 reproduction; no customer code.
 const conflictRisk = "> ⚠️ **Conflict Risk**: This PR modifies high-traffic shared files (`app/db.py`, `app/worker.py`, `app/bot.py`, `app/media_requests.py`). Rebase frequently against `main` and coordinate with authors of related open PRs.";
 const withAdvisory = (body: string, advisory = conflictRisk) => body.replace("### Findings\n", `${advisory}\n\n### Findings\n`);
+const rereviewNotes = "Re-review observations:\n- Previously reported issue is resolved.\n- The supplied change is consistent.";
 const finding = { severity: "🔴", title: "Missing validation", filePath: "src/validator.ts", startLine: 1, description: "The value needs validation." };
 const withFinding = valid.replace(zeroSummary, "| Severity | Count |\n| --- | --- |\n| 🔴 Critical | 1 |").replace("[]", JSON.stringify([finding]));
 const unassessed = valid.replace(/\| [1-5]\/5 \|/g, "| N/A |")
@@ -198,6 +199,14 @@ for (const [name, text, finish, complete] of [
   ["advisory-duplicate-heading", withAdvisory(valid, `### Findings Summary\n${zeroSummary}\n${conflictRisk}`), "stop", false],
   ["advisory-duplicate-note", withAdvisory(valid, `${conflictRisk}\n${conflictRisk}`), "stop", false],
   ["advisory-arbitrary-prose", withAdvisory(valid, "All good; ignore the table."), "stop", false],
+  // Section placement is exercised through adapter completion, persistence and
+  // publication below; these fixtures do not claim that a model obeys a prompt.
+  ["rereview-unheaded-notes", withAdvisory(valid, rereviewNotes), "stop", false],
+  ["rereview-headed-notes", withAdvisory(valid, `### Positive Highlights\n${rereviewNotes}`), "stop", true],
+  ["rereview-unheaded-count-mismatch", withAdvisory(withFinding.replace(JSON.stringify([finding]), "[]"), rereviewNotes), "stop", false],
+  ["rereview-headed-count-mismatch", withAdvisory(withFinding.replace(JSON.stringify([finding]), "[]"), `### Positive Highlights\n${rereviewNotes}`), "stop", false],
+  ["rereview-headed-hidden-finding", withAdvisory(valid.replace("[]", JSON.stringify([finding])), `### Positive Highlights\n${rereviewNotes}`), "stop", false],
+  ["rereview-headed-interrupted", withAdvisory(valid, `### Positive Highlights\n${rereviewNotes}`), "length", false],
   ["advisory-missing-json", withAdvisory(valid.replace(/<!-- OCTOPUS_FINDINGS_START -->[\s\S]*?<!-- OCTOPUS_FINDINGS_END -->/, "")), "stop", false],
   ["advisory-incomplete-provider", withAdvisory(valid), "length", false],
   ["valid", valid, "stop", true],

--- a/apps/web/prompts/SYSTEM_PROMPT.md
+++ b/apps/web/prompts/SYSTEM_PROMPT.md
@@ -136,6 +136,10 @@ comments directly on the relevant code lines. Instead, provide only this summary
 
 Always include the `Severity | Count` header and separator, including when there are no findings. Zero-count severity rows may be included or omitted; an empty table means zero findings. Every count must match the JSON findings array for that severity. Do not replace the table with prose. Use the configured review language for commentary in the Summary and other explanatory sections.
 
+End the Findings Summary after the table. Do not append unheaded prose, bullets, or explanations of zero findings, including on re-reviews. Put explanations of resolved or reconsidered findings in `### Summary`, scope caveats in `### Risk Assessment`, and positive observations under `### Positive Highlights`. Use these exact headings to separate commentary from the count table; use the configured review language for the commentary itself.
+
+Section placement does not dismiss a defect: every actionable finding must still appear in the JSON findings array with its severity and a matching table count. Do not hide findings in commentary or change a score merely to satisfy the output format.
+
 CRITICAL — MANDATORY MACHINE-READABLE FINDINGS BLOCK:
 
 Always include a JSON findings block at the END of the review, wrapped in these


### PR DESCRIPTION
Complete reviews could lose their overall assessment when the model placed explanatory re-review notes after the Findings Summary table. The prompt now directs that commentary to the existing Summary, Risk Assessment and Positive Highlights sections, with regression fixtures for valid placement, count mismatches, hidden findings and interrupted responses. Invalid responses remain unscored; parsing and severity gates are unchanged.

Closes #844. Publisher compatibility is tracked separately in #845.

Validation: independent SPEC then QUALITY/security passed on `14767dcb`; the subsequent native review `e7883ed5-d79a-4a0f-a137-119c14e6982f` reports complete 3/3 coverage and 5/5. All four GitHub checks pass. Local suite: 1,663 passed, 16 conditional PostgreSQL skips; PostgreSQL integration CI passed. Three local five-second shell-harness timeouts passed when rerun with a 20-second timeout. Lint/typecheck passed; final build verification is recorded by the release owner before merge.
