### PR TITLE
feat(cli): let coding agents drive repository onboarding

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -65,6 +65,58 @@ The first invocation of bare `octp` triggers the onboarding wizard:
 
 Each step is small, has phase-state (`running | done | failed | skipped`), and follows the same footer convention: `Enter to continue · Esc to skip · Left to go back`.
 
+## Set up a repository with your AI
+
+Give this prompt to the coding agent already working on your project:
+
+```text
+Set up Octopus for this project using octp onboard --agent --json.
+Install the native CLI if needed. Follow nextAction.argv when a command is
+required. If login prints an approval URL or nextAction.url is returned,
+give me that link and explain the approval needed. Let me complete it.
+Then follow continueWith, waiting retryAfterSeconds between checks.
+Continue until state is ready and summarise the returned analysis.
+If work fails or makes no progress for ten minutes, report the exact state
+and continuation command. Do not claim that opening a link completed setup.
+```
+
+This requires a CLI and server version that include agent onboarding. Older
+servers return an explicit unsupported-server error; use the
+[CLI setup guide](https://octopus-review.ai/docs/cli) for those installations.
+
+```bash
+octp onboard --agent --json
+# Explicit GitHub target, with a named Octopus account:
+octp --account work onboard --agent --json --repo owner/repository
+```
+
+The command runs without a TTY and returns one JSON result per invocation.
+`schemaVersion` is `1`. `state`, `completed`, `nextAction` and `continueWith`
+tell the agent what to do next. Commands are argument arrays, so the agent
+should execute them as arguments without interpolating them into a shell.
+Exit codes: **0** ready, **3** waiting or approval required, **2** invalid input,
+**1** failed. Exit 3 is an expected handoff, not a command failure.
+
+The first run detects the GitHub repository from the current remote. Authentication
+uses `octp login --no-open`, which prints the approval URL and waits for the
+user. The agent keeps that login process running until it finishes, then resumes
+onboarding. Login credentials stay in the existing account store.
+
+For repository access, the command returns the signed GitHub App installation
+link or the existing installation's repository settings link. Once access is
+available, Octopus imports the target repository and the agent follows indexing
+and analysis. Re-running setup reads live server status; completed work is reused.
+Failed jobs remain failed for inspection instead of being retried automatically.
+Deliberately removed repositories require a restore decision.
+
+The first version supports github.com repositories, including self-hosted Octopus
+servers with a configured GitHub App. It keeps existing organisation model and
+billing defaults. It does not configure GitLab/Bitbucket, persist an in-flight login
+across a terminated login process, or make existing server analysis jobs durable
+across server restarts. An organisation owner's pending GitHub approval is described
+at the approval step; the command cannot independently distinguish it from an
+installation that has not yet been completed.
+
 ## Persistence
 
 State lives under `$OCTOPUS_HOME` (default `~/.octopus/`) in three files, all mode `0600` in a mode `0700` directory:

--- a/apps/cli/src/__tests__/agent-onboarding.test.ts
+++ b/apps/cli/src/__tests__/agent-onboarding.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "bun:test";
+import { advanceAgentOnboarding, onboardingExitCode, type OnboardingContext, type OnboardingServices, type Connection } from "../lib/agent-onboarding.js";
+import { detectOnboardingRepository, parseAgentOnboardingArgs } from "../commands/onboard-agent.js";
+
+const context: OnboardingContext = { account: "work", repository: "acme/app", organization: { id: "org-1", name: "Acme" }, baseUrl: "https://octopus-review.ai" };
+const ready = { id: "repo-1", fullName: "acme/app", provider: "github", indexStatus: "indexed", analysisStatus: "analyzed", indexedAt: "2026-09-10T10:00:00Z", analyzedAt: "2026-09-10T11:00:00Z", indexedFiles: 10, totalFiles: 12, analysis: "An API and a worker." };
+function fixture(patch: Record<string, unknown> = {}, connection: Connection = { state: "connected", repoId: "repo-1" }) {
+  const starts: string[] = [];
+  const services: OnboardingServices = {
+    connect: async () => ({ ok: true, data: connection }),
+    status: async () => ({ ok: true, data: { repo: { ...ready, ...patch } } }),
+    start: async (_id, operation) => { starts.push(operation); return { ok: true, data: {} }; },
+  };
+  return { starts, services };
+}
+
+describe("agent onboarding", () => {
+  it("reuses completed work and includes the actual analysis", async () => {
+    const { services, starts } = fixture();
+    for (let n = 0; n < 2; n++) {
+      const result = await advanceAgentOnboarding(context, services);
+      expect(result.state).toBe("ready");
+      expect(result.result?.analysis).toBe(ready.analysis);
+      expect(onboardingExitCode(result)).toBe(0);
+    }
+    expect(starts).toEqual([]);
+  });
+  it("advances index then analysis across independent invocations", async () => {
+    const f = fixture({ indexStatus: "pending", analysisStatus: "pending" });
+    expect((await advanceAgentOnboarding(context, f.services)).state).toBe("indexing");
+    expect(f.starts).toEqual(["index"]);
+    const next = fixture({ analysisStatus: "pending" });
+    expect((await advanceAgentOnboarding(context, next.services)).state).toBe("analyzing");
+    expect(next.starts).toEqual(["analyze"]);
+  });
+  it("joins running work without another POST", async () => {
+    for (const patch of [{ indexStatus: "indexing" }, { analysisStatus: "analyzing" }]) {
+      const f = fixture(patch);
+      const result = await advanceAgentOnboarding(context, f.services);
+      expect(result.retryAfterSeconds).toBe(10);
+      expect(onboardingExitCode(result)).toBe(3);
+      expect(f.starts).toEqual([]);
+    }
+  });
+  it("treats a concurrent start as waiting", async () => {
+    const f = fixture({ analysisStatus: "pending" });
+    f.services.start = async () => ({ ok: false, status: 409, error: "in progress" });
+    expect((await advanceAgentOnboarding(context, f.services)).state).toBe("analyzing");
+  });
+  it("refreshes analysis older than its index", async () => {
+    const f = fixture({ analyzedAt: "2026-09-09T00:00:00Z" });
+    expect((await advanceAgentOnboarding(context, f.services)).state).toBe("analyzing");
+    expect(f.starts).toEqual(["analyze"]);
+  });
+  it("does not restart failed jobs or claim incomplete evidence is ready", async () => {
+    for (const patch of [{ indexStatus: "failed" }, { analysisStatus: "failed" }, { analysis: "" }, { indexedAt: null }, { analysisStatus: "mystery" }, { indexedAt: "invalid" }, { indexedFiles: 0, totalFiles: 0 }, { indexedFiles: 20, totalFiles: 10 }]) {
+      const f = fixture(patch);
+      expect((await advanceAgentOnboarding(context, f.services)).state).toBe("failed");
+      expect(f.starts).toEqual([]);
+    }
+  });
+  it("rejects the wrong repository even when status says completed", async () => {
+    for (const patch of [{ id: "repo-2" }, { fullName: "other/app" }, { provider: "gitlab" }]) {
+      expect((await advanceAgentOnboarding(context, fixture(patch).services)).state).toBe("failed");
+    }
+  });
+  it("returns scoped installation or access links without starting work", async () => {
+    for (const connection of [
+      { state: "installation_required", url: "https://octopus-review.ai/api/github/install?orgId=org-1" },
+      { state: "repository_access_required", url: "https://github.com/organizations/acme/settings/installations/42" },
+    ] as Connection[]) {
+      const f = fixture({}, connection);
+      const result = await advanceAgentOnboarding(context, f.services);
+      expect(result.state).toBe("connection_required");
+      expect(result.nextAction?.kind).toBe("open_url");
+      expect(result.continueWith).toContain("work");
+      expect(f.starts).toEqual([]);
+    }
+  });
+  it("keeps a dismissed repo as an explicit human decision", async () => {
+    const f = fixture({}, { state: "repository_dismissed", url: "https://octopus-review.ai/repositories" });
+    expect((await advanceAgentOnboarding(context, f.services)).state).toBe("repository_dismissed");
+    expect(f.starts).toEqual([]);
+  });
+  it("rejects arbitrary approval links", async () => {
+    for (const url of ["https://evil.test/setup", "javascript:alert(1)", "https://github.com/acme/app", "https://u:p@github.com/settings/installations/1"]) {
+      const f = fixture({}, { state: "repository_access_required", url });
+      expect((await advanceAgentOnboarding(context, f.services)).state).toBe("failed");
+    }
+  });
+  it("gives a login handoff for expired auth and does not echo server errors", async () => {
+    const f = fixture();
+    f.services.connect = async () => ({ ok: false, status: 401, error: "oct_secret_token" });
+    const result = await advanceAgentOnboarding(context, f.services);
+    expect(result.state).toBe("authentication_required");
+    expect(result.nextAction?.argv).toContain("--no-open");
+    expect(JSON.stringify(result)).not.toContain("oct_secret_token");
+    for (const status of [0, 403, 404, 503]) {
+      f.services.connect = async () => ({ ok: false, status, error: "oct_secret_token" });
+      const failed = await advanceAgentOnboarding(context, f.services);
+      expect(failed.state).toBe("failed");
+      expect(JSON.stringify(failed)).not.toContain("oct_secret_token");
+    }
+  });
+});
+
+describe("agent onboarding input", () => {
+  it("rejects typos, duplicate flags, extra arguments and ambiguous names", () => {
+    for (const args of [["--agnt"], ["--json", "--json"], ["extra"], ["--repo"], ["--repo", "app"], ["--repo", "acme/.."], ["--reset"]]) {
+      expect(() => parseAgentOnboardingArgs(args)).toThrow();
+    }
+    expect(parseAgentOnboardingArgs(["--agent", "--json", "--repo", "acme/app"])).toEqual({ repo: "acme/app" });
+  });
+  it("detects HTTPS and SSH GitHub remotes without exposing embedded credentials", () => {
+    for (const url of ["git@github.com:acme/app.git", "https://github.com/acme/app.git", "ssh://git@github.com/acme/app.git"]) {
+      expect(detectOnboardingRepository((args) => args.length === 1 ? "origin" : url)).toBe("acme/app");
+    }
+    for (const url of ["https://secret@github.com/acme/app.git", "https://gitlab.com/acme/app.git"]) {
+      expect(() => detectOnboardingRepository((args) => args.length === 1 ? "origin" : url)).toThrow("github.com remotes");
+    }
+    expect(() => detectOnboardingRepository(() => "upstream\nbackup")).toThrow("unambiguous");
+  });
+});

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -61,7 +61,7 @@ export async function loginCommand(argv: string[]): Promise<number> {
       const verified = await verifyToken(baseUrl, token);
       identity = { token, organization: verified.organization, user: verified.user };
     } else {
-      identity = await runDeviceFlow(baseUrl, { onAuthorizeUrl: (url) => info(c.dim(url)) });
+      identity = await runDeviceFlow(baseUrl, { noOpen: hasFlag(argv, "--no-open"), onAuthorizeUrl: (url) => info(c.dim(url)) });
     }
     // Land the credentials in the active profile (which reflects --account),
     // registering + activating it so `account list` shows it and later commands
@@ -93,6 +93,7 @@ Flags:
                                  (exposes the token via process args (ps) and shell history; for CI prefer 'octp setup-token')
   --api-url <url>                Server base URL (default: Cloud (Octopus hosted), or your saved server)
   --insecure                     Allow sending the token over cleartext HTTP (not recommended)
+  --no-open                      Print the approval URL without opening a browser
   --help, -h                     This help
 `);
 }

--- a/apps/cli/src/commands/onboard-agent.ts
+++ b/apps/cli/src/commands/onboard-agent.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from "node:child_process";
+import { loadCredentials } from "../lib/credentials.js";
+import { loadConfig } from "../lib/config.js";
+import { getActiveProfileName } from "../lib/paths.js";
+import { getJson, postJson, normalizeBaseUrl, isTransportSafe } from "../lib/api.js";
+import { advanceAgentOnboarding, onboardingResult, onboardingExitCode, type Connection, type OnboardingContext } from "../lib/agent-onboarding.js";
+
+export function parseAgentOnboardingArgs(argv: string[]): { repo?: string; help?: boolean } {
+  let repo: string | undefined;
+  const seen = new Set<string>();
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (seen.has(arg)) throw new Error("Duplicate onboarding flag.");
+    seen.add(arg);
+    if (arg === "--repo") {
+      repo = argv[++i];
+      if (!repo || !/^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9_.-]+$/.test(repo) || [".", ".."].includes(repo.split("/")[1])) throw new Error("--repo requires a GitHub owner/repository name.");
+    } else if (arg === "--help" || arg === "-h") return { help: true };
+    else if (arg !== "--agent" && arg !== "--json") throw new Error("Unknown agent onboarding argument. Use --repo owner/name, --json or --help.");
+  }
+  return { repo };
+}
+
+export function detectOnboardingRepository(runGit: (args: string[]) => string | null = (args) => {
+  const result = spawnSync("git", args, { encoding: "utf8", timeout: 5000 });
+  return result.status === 0 ? result.stdout.trim() : null;
+}): string {
+  const remotes = runGit(["remote"])?.split("\n").filter(Boolean) ?? [];
+  const remote = remotes.includes("origin") ? "origin" : remotes.length === 1 ? remotes[0] : null;
+  if (!remote) throw new Error("No unambiguous git remote. Supply --repo owner/name for the intended GitHub repository.");
+  const url = runGit(["remote", "get-url", remote]);
+  // Accept github.com only; never print a raw remote URL that may contain credentials.
+  const match = url?.match(/^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/)([A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9_.-]+?)(?:\.git)?\/?$/i);
+  if (!match || [".", ".."].includes(match[1].split("/")[1])) throw new Error("Agent onboarding currently supports github.com remotes. Supply --repo owner/name only for a GitHub repository.");
+  return match[1];
+}
+
+export async function onboardAgentCommand(argv: string[]): Promise<number> {
+  const context: OnboardingContext = { account: getActiveProfileName(), repository: "", baseUrl: "https://octopus-review.ai" };
+  let parsed: ReturnType<typeof parseAgentOnboardingArgs>;
+  try {
+    parsed = parseAgentOnboardingArgs(argv);
+    if (parsed.help) {
+      console.log("Usage: octp onboard --agent --json [--repo owner/name]\nRuns one resumable setup step for GitHub. Exit 0: ready; 3: waiting/action needed; 2: invalid input; 1: failed.\nFollow nextAction, wait retryAfterSeconds, then execute continueWith. Browser approvals remain with the user.");
+      return 0;
+    }
+    context.repository = parsed.repo ?? detectOnboardingRepository();
+  } catch (error) {
+    console.log(JSON.stringify(onboardingResult(context, "invalid_input", error instanceof Error ? error.message : "Invalid input.")));
+    return 2;
+  }
+  try {
+    const creds = await loadCredentials();
+    const candidate = creds?.baseUrl ?? (await loadConfig()).selfHostedBaseUrl ?? context.baseUrl;
+    const baseUrl = normalizeBaseUrl(candidate);
+    if (!baseUrl || !isTransportSafe(baseUrl)) throw new Error("unsafe_server");
+    context.baseUrl = baseUrl;
+    if (creds) context.organization = { id: creds.orgId, name: creds.orgName };
+    const result = !creds ? (() => {
+      const result = onboardingResult(context, "authentication_required", "Run login, show its approval URL to the user, wait for login to finish, then resume setup.");
+      result.nextAction = { kind: "run_command" as const, argv: ["octp", "--account", context.account, "login", "--no-open", "--api-url", baseUrl] };
+      return result;
+    })() : await advanceAgentOnboarding(context, {
+      connect: () => postJson<Connection>(`${baseUrl}/api/cli/repos/connect`, { fullName: context.repository }, creds.token, { timeoutMs: 30_000 }),
+      status: (id) => getJson(`${baseUrl}/api/cli/repos/${encodeURIComponent(id)}/status`, { headers: { authorization: `Bearer ${creds.token}` }, signal: AbortSignal.timeout(15_000) }),
+      start: (id, operation) => postJson(`${baseUrl}/api/cli/repos/${encodeURIComponent(id)}/${operation}`, {}, creds.token, { timeoutMs: 15_000 }),
+    });
+    console.log(JSON.stringify(result));
+    return onboardingExitCode(result);
+  } catch {
+    console.log(JSON.stringify(onboardingResult(context, "failed", "Could not complete this setup step. Check server connectivity and local account configuration, then resume. No completion is assumed.")));
+    return 1;
+  }
+}

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -6,6 +6,7 @@ import { agentServeCommand } from "./commands/agent-serve.js";
 import { agentWatchCommand } from "./commands/agent-watch.js";
 import { doctorCommand } from "./commands/doctor.js";
 import { reviewCommand } from "./commands/review.js";
+import { onboardAgentCommand } from "./commands/onboard-agent.js";
 import { loginCommand } from "./commands/login.js";
 import { logoutCommand } from "./commands/logout.js";
 import { whoamiCommand } from "./commands/whoami.js";
@@ -64,6 +65,7 @@ function printHelp(): void {
 Usage:
   octp                       Onboarding wizard (first run) or status hint
   octp onboard [--reset]     Run the onboarding wizard
+  octp onboard --agent --json [--repo owner/name]   Resumable GitHub setup for AI agents
 
 Auth & accounts:
   octp login [--token ...]   Sign in (browser device-flow or --token)
@@ -168,6 +170,11 @@ async function main(rawArgv: string[]): Promise<number> {
   }
 
   if (first === "onboard") {
+    if (argv.includes("--agent")) return await onboardAgentCommand(argv.slice(1));
+    if (argv.slice(1).some((arg) => arg !== "--reset")) {
+      console.error("Use octp onboard [--reset] or octp onboard --agent --json [--repo owner/name].");
+      return 2;
+    }
     {
       await renderWizard(argv.includes("--reset"));
       // If signing in under a named account (--account), register + activate it

--- a/apps/cli/src/lib/agent-onboarding.ts
+++ b/apps/cli/src/lib/agent-onboarding.ts
@@ -1,0 +1,144 @@
+import type { ApiResult } from "./api.js";
+
+export type OnboardingState =
+  | "authentication_required" | "connection_required" | "repository_dismissed"
+  | "indexing" | "analyzing" | "ready" | "failed" | "invalid_input";
+
+export interface AgentOnboardingResult {
+  schemaVersion: 1;
+  state: OnboardingState;
+  account: string;
+  repository: string;
+  organization?: { id: string; name: string };
+  message: string;
+  completed: string[];
+  nextAction?: { kind: "run_command" | "open_url" | "retry"; argv?: string[]; url?: string };
+  continueWith: string[];
+  retryAfterSeconds?: number;
+  result?: { indexedFiles: number; totalFiles: number; indexedAt: string; analyzedAt: string; analysis: string };
+}
+
+export type Connection =
+  | { state: "connected"; repoId: string }
+  | { state: "installation_required" | "repository_access_required" | "repository_dismissed"; url: string };
+
+export interface OnboardingServices {
+  connect: () => Promise<ApiResult<Connection>>;
+  status: (id: string) => Promise<ApiResult<unknown>>;
+  start: (id: string, operation: "index" | "analyze") => Promise<ApiResult<unknown>>;
+}
+
+export interface OnboardingContext {
+  account: string;
+  repository: string;
+  organization?: { id: string; name: string };
+  baseUrl: string;
+}
+
+export function onboardingResult(context: OnboardingContext, state: OnboardingState, message: string): AgentOnboardingResult {
+  return {
+    schemaVersion: 1, state, account: context.account, repository: context.repository,
+    ...(context.organization ? { organization: context.organization } : {}),
+    message, completed: [],
+    continueWith: ["octp", "--account", context.account, "onboard", "--agent", "--json", "--repo", context.repository],
+  };
+}
+
+export function onboardingExitCode(result: AgentOnboardingResult): number {
+  if (result.state === "ready") return 0;
+  if (result.state === "invalid_input") return 2;
+  if (result.state === "failed") return 1;
+  return 3;
+}
+
+function approvedUrl(raw: unknown, baseUrl: string): string | null {
+  if (typeof raw !== "string") return null;
+  try {
+    const u = new URL(raw);
+    if (u.username || u.password) return null;
+    const server = new URL(baseUrl);
+    if (u.origin === server.origin && ["/api/github/install", "/repositories"].includes(u.pathname)) return u.href;
+    if (u.origin === "https://github.com" && /^\/(?:settings\/installations\/\d+|organizations\/[A-Za-z0-9-]+\/settings\/installations\/\d+)$/.test(u.pathname)) return u.href;
+  } catch { /* Invalid response URL is not an approval action. */ }
+  return null;
+}
+
+/** Advances at most one background operation. Server status is the checkpoint. */
+export async function advanceAgentOnboarding(context: OnboardingContext, services: OnboardingServices): Promise<AgentOnboardingResult> {
+  const fail = (message: string) => onboardingResult(context, "failed", message);
+  const apiFailure = (status: number, step: string): AgentOnboardingResult => {
+    if (status === 401) {
+      const result = onboardingResult(context, "authentication_required", "Sign in, complete the approval link printed by login, then resume setup.");
+      result.nextAction = { kind: "run_command", argv: ["octp", "--account", context.account, "login", "--no-open", "--api-url", context.baseUrl] };
+      return result;
+    }
+    return fail(status === 404 && step === "connect"
+      ? "This server does not support agent onboarding. Update the server or use the CLI setup guide."
+      : `Could not ${step} (HTTP ${status}). Check account access or server availability, then resume. No completion is assumed.`);
+  };
+
+  const connection = await services.connect();
+  if (!connection.ok) return apiFailure(connection.status, "connect");
+  const data = connection.data;
+  if (!data || typeof data !== "object") return fail("Invalid connection response from the server.");
+  if (data.state !== "connected") {
+    if (!["installation_required", "repository_access_required", "repository_dismissed"].includes(data.state)) return fail("Unknown connection state from the server.");
+    const url = approvedUrl(data.url, context.baseUrl);
+    if (!url) return fail("The server returned an invalid approval link.");
+    const dismissed = data.state === "repository_dismissed";
+    const result = onboardingResult(context, dismissed ? "repository_dismissed" : "connection_required",
+      dismissed ? "This repository was deliberately removed. Decide whether to restore it before continuing."
+        : data.state === "installation_required" ? "Open this link to install or approve the Octopus GitHub App for this organisation. Select the target repository. If an owner must approve it, resume after they do."
+        : "Open this link and grant the existing GitHub App installation access to the target repository, then resume.");
+    result.completed = ["authentication"];
+    result.nextAction = { kind: "open_url", url };
+    result.retryAfterSeconds = 10;
+    return result;
+  }
+  if (typeof data.repoId !== "string" || !data.repoId) return fail("Connection response did not identify a repository.");
+  const status = await services.status(data.repoId);
+  if (!status.ok) return apiFailure(status.status, "read repository status");
+  const raw = status.data as { repo?: Record<string, unknown> } | null;
+  const repo = raw?.repo;
+  if (!repo || repo.id !== data.repoId || repo.provider !== "github" || typeof repo.fullName !== "string" || repo.fullName.toLowerCase() !== context.repository.toLowerCase()) {
+    return fail("The server status did not match the requested GitHub repository.");
+  }
+  if (typeof repo.indexStatus !== "string" || typeof repo.analysisStatus !== "string") return fail("Repository status is incomplete.");
+  if (repo.indexStatus === "failed" || repo.analysisStatus === "failed") {
+    return fail("A repository job failed. Inspect its error before retrying; setup has not restarted the failed job.");
+  }
+  const completed = ["authentication", "connection"];
+  const wait = (state: "indexing" | "analyzing", message: string) => {
+    const result = onboardingResult(context, state, message);
+    result.completed = completed;
+    result.nextAction = { kind: "retry" };
+    result.retryAfterSeconds = 10;
+    return result;
+  };
+  if (repo.indexStatus === "indexing") return wait("indexing", "Indexing is running. Resume to check progress.");
+  if (repo.indexStatus !== "indexed") {
+    if (!["pending", "none"].includes(repo.indexStatus)) return fail("Unrecognised index state. Inspect repository status before continuing.");
+    const started = await services.start(data.repoId, "index");
+    if (!started.ok && started.status !== 409) return apiFailure(started.status, "start indexing");
+    return wait("indexing", "Indexing requested or already running. Resume to verify completion.");
+  }
+  completed.push("indexing");
+  if (repo.analysisStatus === "analyzing") return wait("analyzing", "Analysis is running. Resume to check progress.");
+  if (["analyzed", "done", "completed"].includes(repo.analysisStatus)) {
+    if (typeof repo.analysis !== "string" || !repo.analysis.trim() || typeof repo.indexedAt !== "string" || !Number.isFinite(Date.parse(repo.indexedAt)) || typeof repo.analyzedAt !== "string" || !Number.isFinite(Date.parse(repo.analyzedAt)) || typeof repo.indexedFiles !== "number" || !Number.isFinite(repo.indexedFiles) || typeof repo.totalFiles !== "number" || !Number.isFinite(repo.totalFiles)) {
+      return fail("The server reports completion but the analysis or completion evidence is missing.");
+    }
+    if (repo.indexedFiles < 1 || repo.totalFiles < repo.indexedFiles) return fail("No indexed source files or inconsistent file counts. Inspect repository status before continuing.");
+    if (Date.parse(repo.analyzedAt) >= Date.parse(repo.indexedAt)) {
+      const result = onboardingResult(context, "ready", "The repository is connected, indexed and analysed.");
+      result.completed = [...completed, "analysis"];
+      result.result = { indexedFiles: repo.indexedFiles, totalFiles: repo.totalFiles, indexedAt: repo.indexedAt, analyzedAt: repo.analyzedAt, analysis: repo.analysis };
+      return result;
+    }
+  } else if (!["pending", "none"].includes(repo.analysisStatus)) {
+    return fail("Unrecognised analysis state. Inspect repository status before continuing.");
+  }
+  const started = await services.start(data.repoId, "analyze");
+  if (!started.ok && started.status !== 409) return apiFailure(started.status, "start analysis");
+  return wait("analyzing", "Analysis requested or already running. Resume to verify completion.");
+}

--- a/apps/web/app/api/cli/repos/[id]/analyze/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/analyze/route.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { authenticateApiToken } from "@/lib/api-auth";
 import { prisma } from "@octopus/db";
 import { analyzeRepository } from "@/lib/analyzer";
@@ -17,7 +18,7 @@ export async function POST(
   const { id } = await params;
 
   const repo = await prisma.repository.findFirst({
-    where: { id, organizationId: result.org.id, isActive: true },
+    where: { id, organizationId: result.org.id, isActive: true, dismissedAt: null },
   });
 
   if (!repo) {
@@ -39,10 +40,13 @@ export async function POST(
   // transition, then persist the result. analyzeRepository only RETURNS the
   // analysis text (the status writes live in reviewer.ts) — persist it here so
   // this CLI route is self-contained.
-  await prisma.repository.update({
-    where: { id: repo.id },
+  const claim = await prisma.repository.updateMany({
+    where: { id: repo.id, organizationId: result.org.id, isActive: true, dismissedAt: null, analysisStatus: repo.analysisStatus, analyzedAt: repo.analyzedAt, indexStatus: "indexed", indexedAt: repo.indexedAt },
     data: { analysisStatus: "analyzing" },
   });
+  if (!claim.count) {
+    return Response.json({ error: "Repository state changed or work is already in progress" }, { status: 409 });
+  }
 
   analyzeRepository(repo.id, repo.fullName, result.org.id)
     .then(async (analysis) => {

--- a/apps/web/app/api/cli/repos/[id]/index/route.ts
+++ b/apps/web/app/api/cli/repos/[id]/index/route.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { authenticateApiToken } from "@/lib/api-auth";
 import { prisma } from "@octopus/db";
 import { runIndexingInBackground } from "@/lib/indexing-runner";
@@ -16,7 +17,7 @@ export async function POST(
   const { id } = await params;
 
   const repo = await prisma.repository.findFirst({
-    where: { id, organizationId: result.org.id, isActive: true },
+    where: { id, organizationId: result.org.id, isActive: true, dismissedAt: null },
   });
 
   if (!repo) {
@@ -39,10 +40,13 @@ export async function POST(
   // same shape as a web-triggered one. A fresh AbortController + a no-op log
   // sink are fine here: the CLI polls status rather than subscribing to the
   // pubby channel (its events simply have no listener).
-  await prisma.repository.update({
-    where: { id: repo.id },
+  const claim = await prisma.repository.updateMany({
+    where: { id: repo.id, organizationId: result.org.id, isActive: true, dismissedAt: null, indexStatus: repo.indexStatus, indexedAt: repo.indexedAt },
     data: { indexStatus: "indexing" },
   });
+  if (!claim.count) {
+    return Response.json({ error: "Repository state changed or work is already in progress" }, { status: 409 });
+  }
 
   runIndexingInBackground(
     repo.id,

--- a/apps/web/app/api/cli/repos/connect/route.ts
+++ b/apps/web/app/api/cli/repos/connect/route.ts
@@ -1,0 +1,43 @@
+import "server-only";
+import { prisma } from "@octopus/db";
+import { authenticateApiToken } from "@/lib/api-auth";
+import { getGithubAppConfig } from "@/lib/github-app-config";
+import { getInstallationSettingsUrl, listInstallationRepos } from "@/lib/github";
+import { applyRepositoryEvent } from "@/lib/repo-sync";
+import { connectCliRepository, parseConnectRepository } from "@/lib/cli-repo-connect";
+
+export async function POST(request: Request) {
+  const identity = await authenticateApiToken(request);
+  if (identity instanceof Response) return identity;
+  if (!identity) return Response.json({ error: "Unauthorized" }, { status: 401 });
+  const member = await prisma.organizationMember.findFirst({
+    where: { organizationId: identity.org.id, userId: identity.user.id, deletedAt: null },
+    select: { id: true },
+  });
+  if (!member) return Response.json({ error: "Organisation membership required" }, { status: 403 });
+  const fullName = parseConnectRepository(await request.json().catch(() => null));
+  if (!fullName) return Response.json({ error: "Expected only fullName: GitHub owner/repository" }, { status: 400 });
+
+  try {
+    const result = await connectCliRepository({
+      fullName, organizationId: identity.org.id,
+      installationId: identity.org.githubInstallationId,
+      baseUrl: process.env.BETTER_AUTH_URL || new URL(request.url).origin,
+    }, {
+      find: () => prisma.repository.findFirst({
+        where: { organizationId: identity.org.id, provider: "github", fullName: { equals: fullName, mode: "insensitive" } },
+        select: { id: true, isActive: true, dismissedAt: true, installationId: true },
+      }),
+      appConfigured: async () => Boolean((await getGithubAppConfig())?.slug),
+      settingsUrl: getInstallationSettingsUrl,
+      list: listInstallationRepos,
+      sync: async (installationId, repo) => {
+        await applyRepositoryEvent(identity.org.id, installationId, "created", repo);
+      },
+    });
+    return Response.json(result, { headers: { "Cache-Control": "no-store" } });
+  } catch {
+    // Provider responses may contain private installation details. Keep them out of CLI output.
+    return Response.json({ error: "Could not verify GitHub access or sync the repository. Check the integration and retry." }, { status: 503 });
+  }
+}

--- a/apps/web/lib/__tests__/cli-onboarding-routes.test.ts
+++ b/apps/web/lib/__tests__/cli-onboarding-routes.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+it("enforces membership, tenant scope and atomic job claims for agent onboarding", async () => {
+  const child = Bun.spawn([process.execPath, fileURLToPath(new URL("./fixtures/cli-onboarding-routes-harness.ts", import.meta.url))], { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" });
+  const [code, stdout, stderr] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]);
+  expect(code, `${stdout}\n${stderr}`).toBe(0);
+});

--- a/apps/web/lib/__tests__/cli-repo-connect.test.ts
+++ b/apps/web/lib/__tests__/cli-repo-connect.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, mock } from "bun:test";
+mock.module("server-only", () => ({}));
+import type { ConnectRepositoryServices } from "../cli-repo-connect";
+const { connectCliRepository, parseConnectRepository } = await import("../cli-repo-connect");
+const input = { fullName: "acme/app", organizationId: "org-1", installationId: 42 as number | null, baseUrl: "https://octopus-review.ai" };
+const repo = { id: "repo-1", isActive: true, dismissedAt: null as Date | null, installationId: 42 };
+function fixture() {
+  const calls: string[] = [];
+  const services: ConnectRepositoryServices = {
+    find: async () => repo,
+    appConfigured: async () => true,
+    settingsUrl: async (id) => { calls.push(`settings:${id}`); return `https://github.com/organizations/acme/settings/installations/${id}`; },
+    list: async (id) => { calls.push(`list:${id}`); return [{ id: 1, name: "app", full_name: "acme/app", default_branch: "main" }]; },
+    sync: async (id) => { calls.push(`sync:${id}`); },
+  };
+  return { services, calls };
+}
+describe("CLI repository connection", () => {
+  it("rejects unscoped and malformed requests", () => {
+    for (const value of [null, [], {}, { fullName: "app" }, { fullName: "acme/.." }, { fullName: "acme/app", organizationId: "other" }, { fullName: "acme/app\n" }]) expect(parseConnectRepository(value)).toBeNull();
+    expect(parseConnectRepository({ fullName: "acme/app" })).toBe("acme/app");
+  });
+  it("reuses a connected target without another installation", async () => {
+    const f = fixture();
+    expect(await connectCliRepository(input, f.services)).toEqual({ state: "connected", repoId: "repo-1" });
+    expect(f.calls).toEqual([]);
+  });
+  it("returns the signed install-start route with the token organisation", async () => {
+    const f = fixture();
+    f.services.find = async () => null;
+    const result = await connectCliRepository({ ...input, installationId: null }, f.services);
+    expect(result.state).toBe("installation_required");
+    expect("url" in result && new URL(result.url).searchParams.get("orgId")).toBe("org-1");
+    expect(f.calls).toEqual([]);
+  });
+  it("returns access settings for the existing bound installation", async () => {
+    const f = fixture();
+    f.services.find = async () => null;
+    f.services.list = async () => [];
+    expect((await connectCliRepository(input, f.services)).state).toBe("repository_access_required");
+    expect(f.calls).toEqual(["settings:42"]);
+  });
+  it("imports only the target proven accessible through that installation", async () => {
+    const f = fixture(); let imported = false;
+    f.services.find = async () => imported ? repo : null;
+    f.services.sync = async (id, ghRepo) => { expect(id).toBe(42); expect(ghRepo.full_name).toBe("acme/app"); imported = true; };
+    expect((await connectCliRepository(input, f.services)).state).toBe("connected");
+    expect(f.calls).toEqual(["list:42"]);
+  });
+  it("does not restore a dismissed repository or confuse another installation", async () => {
+    const f = fixture();
+    f.services.find = async () => ({ ...repo, dismissedAt: new Date() });
+    expect((await connectCliRepository(input, f.services)).state).toBe("repository_dismissed");
+    expect(f.calls).toEqual([]);
+    f.services.find = async () => ({ ...repo, installationId: 99 });
+    f.services.list = async () => [];
+    expect((await connectCliRepository(input, f.services)).state).toBe("repository_access_required");
+  });
+  it("does not report a failed import as connected", async () => {
+    const f = fixture(); f.services.find = async () => null;
+    await expect(connectCliRepository(input, f.services)).rejects.toThrow("sync_incomplete");
+    f.services.list = async () => { throw new Error("unavailable"); };
+    await expect(connectCliRepository(input, f.services)).rejects.toThrow("unavailable");
+  });
+});

--- a/apps/web/lib/__tests__/fixtures/cli-onboarding-routes-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/cli-onboarding-routes-harness.ts
@@ -1,0 +1,54 @@
+import { expect, mock } from "bun:test";
+mock.module("server-only", () => ({}));
+const org = { id: "org-1", githubInstallationId: 42 };
+let identity: unknown = { org, user: { id: "user-1" } };
+let member: unknown = { id: "member-1" };
+const claimCount = 0;
+let starts = 0;
+const readArgs: unknown[] = [];
+const claimArgs: unknown[] = [];
+const db = {
+  organizationMember: { findFirst: async (args: unknown) => { readArgs.push(args); return member; } },
+  repository: {
+    findFirst: async (args: unknown) => { readArgs.push(args); return { id: "repo-1", fullName: "acme/app", isActive: true, dismissedAt: null, installationId: 42, indexStatus: "indexed", analysisStatus: "pending", indexedAt: new Date("2026-09-11T10:00:00Z"), analyzedAt: null }; },
+    updateMany: async (args: unknown) => { claimArgs.push(args); return { count: claimCount }; },
+  },
+};
+mock.module("@octopus/db", () => ({ prisma: db }));
+mock.module("@/lib/api-auth", () => ({ authenticateApiToken: async () => identity }));
+mock.module("@/lib/github-app-config", () => ({ getGithubAppConfig: async () => ({ slug: "octopus" }) }));
+mock.module("@/lib/github", () => ({ getInstallationSettingsUrl: async () => "https://github.com/settings/installations/42", listInstallationRepos: async () => [] }));
+mock.module("@/lib/repo-sync", () => ({ applyRepositoryEvent: async () => { throw new Error("Unexpected sync"); } }));
+mock.module("@/lib/analyzer", () => ({ analyzeRepository: async () => { starts++; return "analysis"; } }));
+mock.module("@/lib/events/bus", () => ({ eventBus: { emit: () => {} } }));
+mock.module("@/lib/indexing-runner", () => ({ runIndexingInBackground: () => { starts++; } }));
+const connect = await import("../../../app/api/cli/repos/connect/route");
+const request = (body = { fullName: "acme/app" }) => new Request("https://octopus-review.ai/api/cli/repos/connect", { method: "POST", body: JSON.stringify(body) });
+identity = null;
+expect((await connect.POST(request())).status).toBe(401);
+expect(readArgs).toHaveLength(0);
+identity = Response.json({ error: "held" }, { status: 403 });
+expect((await connect.POST(request())).status).toBe(403);
+expect(readArgs).toHaveLength(0);
+identity = { org, user: { id: "user-1" } };
+member = null;
+expect((await connect.POST(request())).status).toBe(403);
+expect(readArgs).toHaveLength(1);
+expect(readArgs[0]).toEqual({ where: { organizationId: "org-1", userId: "user-1", deletedAt: null }, select: { id: true } });
+member = { id: "member-1" };
+expect((await connect.POST(request({ fullName: "../other" }))).status).toBe(400);
+const response = await connect.POST(request());
+expect(response.status).toBe(200);
+expect(await response.json()).toEqual({ state: "connected", repoId: "repo-1" });
+expect(readArgs.at(-1)).toMatchObject({ where: { organizationId: "org-1", provider: "github", fullName: { equals: "acme/app", mode: "insensitive" } } });
+
+// A lost compare-and-set must not start a second job.
+const index = await import("../../../app/api/cli/repos/[id]/index/route");
+const analyze = await import("../../../app/api/cli/repos/[id]/analyze/route");
+const params = { params: Promise.resolve({ id: "repo-1" }) };
+expect((await index.POST(request() as never, params)).status).toBe(409);
+expect((await analyze.POST(request() as never, params)).status).toBe(409);
+expect(starts).toBe(0);
+expect(claimArgs[0]).toMatchObject({ where: { id: "repo-1", organizationId: "org-1", isActive: true, dismissedAt: null, indexStatus: "indexed", indexedAt: new Date("2026-09-11T10:00:00Z") } });
+expect(claimArgs[1]).toMatchObject({ where: { id: "repo-1", organizationId: "org-1", isActive: true, dismissedAt: null, indexStatus: "indexed", analysisStatus: "pending", analyzedAt: null } });
+console.log("Scoped connect route and concurrent job claims passed");

--- a/apps/web/lib/cli-repo-connect.ts
+++ b/apps/web/lib/cli-repo-connect.ts
@@ -1,0 +1,59 @@
+import "server-only";
+
+export function parseConnectRepository(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const object = value as Record<string, unknown>;
+  if (Object.keys(object).length !== 1 || typeof object.fullName !== "string") return null;
+  const name = object.fullName;
+  if (name.length > 140 || !/^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9_.-]+$/.test(name)) return null;
+  if ([".", ".."].includes(name.split("/")[1])) return null;
+  return name;
+}
+
+interface RepositoryConnectionRow {
+  id: string;
+  isActive: boolean;
+  dismissedAt: Date | null;
+  installationId: number | null;
+}
+interface InstallationRepository {
+  id: number;
+  name: string;
+  full_name: string;
+  default_branch: string;
+}
+export interface ConnectRepositoryServices {
+  find: () => Promise<RepositoryConnectionRow | null>;
+  appConfigured: () => Promise<boolean>;
+  settingsUrl: (id: number) => Promise<string>;
+  list: (id: number) => Promise<InstallationRepository[]>;
+  sync: (id: number, repo: InstallationRepository) => Promise<void>;
+}
+
+/** Resolves access only within the token's bound organisation/installation. */
+export async function connectCliRepository(
+  input: { fullName: string; organizationId: string; installationId: number | null; baseUrl: string },
+  services: ConnectRepositoryServices,
+) {
+  const existing = await services.find();
+  const repositoriesUrl = new URL("/repositories", input.baseUrl).href;
+  if (existing?.dismissedAt) return { state: "repository_dismissed" as const, url: repositoriesUrl };
+  if (!input.installationId) {
+    if (!(await services.appConfigured())) throw new Error("github_app_not_configured");
+    const url = new URL("/api/github/install", input.baseUrl);
+    url.searchParams.set("orgId", input.organizationId);
+    url.searchParams.set("returnTo", "/repositories");
+    return { state: "installation_required" as const, url: url.href };
+  }
+  if (existing?.isActive && existing.installationId === input.installationId) return { state: "connected" as const, repoId: existing.id };
+
+  // Installation-scoped listing proves access; matching a public repo by name alone does not.
+  const repos = await services.list(input.installationId);
+  const repo = repos.find((r) => r.full_name.toLowerCase() === input.fullName.toLowerCase());
+  if (!repo) return { state: "repository_access_required" as const, url: await services.settingsUrl(input.installationId) };
+  await services.sync(input.installationId, repo);
+  const imported = await services.find();
+  if (imported?.dismissedAt) return { state: "repository_dismissed" as const, url: repositoriesUrl };
+  if (!imported?.isActive || imported.installationId !== input.installationId) throw new Error("repository_sync_incomplete");
+  return { state: "connected" as const, repoId: imported.id };
+}

--- a/apps/web/lib/github.ts
+++ b/apps/web/lib/github.ts
@@ -65,6 +65,24 @@ export async function createAppJwt(): Promise<string> {
   return `${header}.${payload}.${signature}`;
 }
 
+/** Browser settings URL for an installation belonging to this GitHub App. */
+export async function getInstallationSettingsUrl(installationId: number): Promise<string> {
+  const jwt = await createAppJwt();
+  const res = await fetchWithRetry(`${GITHUB_API}/app/installations/${installationId}`, {
+    headers: { Authorization: `Bearer ${jwt}`, Accept: "application/vnd.github+json" },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error("Could not read GitHub installation settings");
+  const data = await res.json();
+  if (data.id !== installationId || typeof data.html_url !== "string") throw new Error("Invalid installation response");
+  const url = new URL(data.html_url);
+  const validPath = new RegExp(`^/(?:settings/installations/${installationId}|organizations/[A-Za-z0-9-]+/settings/installations/${installationId})$`);
+  if (url.origin !== "https://github.com" || url.username || url.password || !validPath.test(url.pathname) || url.search || url.hash) {
+    throw new Error("Invalid installation settings URL");
+  }
+  return url.href;
+}
+
 export async function getInstallationPermissions(
   installationId: number,
 ): Promise<Record<string, string>> {

--- a/docs/agent-onboarding-plan.md
+++ b/docs/agent-onboarding-plan.md
@@ -1,0 +1,88 @@
+# AI-driven Octopus onboarding
+
+Implementation proposal • 11 September 2026 • source baseline f88fb33
+
+## First implementation
+
+The current branch implements the non-TTY agent command, direct installation/access
+links, scoped target import and live-state continuation through index and analysis.
+It uses the existing login process with `--no-open`, rather than persisted device
+sessions. It adds atomic claims to the existing start routes. Dedicated pending-owner
+approval detection and durable analysis jobs remain future work. See
+[the CLI guide](../apps/cli/README.md#set-up-a-repository-with-your-ai) for the exact
+implemented contract; the broader design below is the target, not a claim of release.
+
+## The experience
+
+The developer pastes one prompt into the AI session already working on their project. The agent installs octp, identifies the current repository and handles setup. The developer opens a direct link only when sign-in, GitHub authorisation or a real choice needs them. The agent checks the result and continues until the repository is indexed and analysed.
+
+Keep the native CLI installers visible. The primary entry point is “Give your AI this prompt. Let it handle the rest.” Defer model and BYOK choices when the organisation already has a usable default. Preserve an explicit self-hosted path.
+
+## What the code already does
+
+Sign-in prints an approval URL and polls for completion. The GitHub App callback verifies access, imports authorised repositories and queues pending indexes. Repository index and analyse commands both poll status.
+
+The missing connection is orchestration. RepoStep loads repositories once and offers a browser link, but does not poll for the target repo after approval. The standalone resolver returns “not connected” with a suggestion to list repos. The wizard can finish with preferences saved while the repository is still disconnected. Repository output is human text, so agents do not have a stable next-action contract.
+
+These are source findings at f88fb33, with CLI package version 0.4.0. They are not a completed fresh-account browser test or proof that every change is in the distributed binary.
+
+## One resumable command
+
+Proposed interface: octp onboard --agent --json. It runs without an interactive terminal and emits one versioned JSON result. Existing octp onboard keeps its interactive wizard. The agent command checks server capabilities before starting and reports an unsupported version explicitly.
+
+Identify the target by provider, host and full repository name from the current remote. Reuse the active Octopus account, but make account and organisation identity visible. If multiple remotes or organisations leave the target ambiguous, return a choice instead of silently picking the first one.
+
+Each invocation discovers live state and advances available work until it needs a person or a background job. Return state, target, completed steps, next action, approval URL when applicable, expiry, retry interval and a continuation command. Use exit 0 for ready, 3 for actionable waiting, 2 for invalid input or a required choice, and 1 for a failure. These are new command semantics; existing exit codes remain unchanged.
+
+Store resumable state beneath OCTOPUS_HOME, scoped to server, account, organisation and repository. Keep credentials and device-flow secrets in protected storage, separate from preferences and JSON output. Re-running the same command resumes that target. An optional bounded wait mode can poll; the agent can always use short invocations and keep talking to the developer.
+
+## Bring the right approval link
+
+When sign-in is required, return the existing device approval URL. Split the shared device-flow helper into begin, poll and complete operations so the command can exit and resume without issuing a new login request every time.
+
+When GitHub access is missing, ask the server for the next authorised action. For a new installation, reuse the signed install-start route with the intended Octopus organisation. For an existing installation that excludes the target repo, return its verified repository-access settings URL. Do not force another install when access is already sufficient.
+
+Add a narrow connection-status API that distinguishes installation required, organisation approval pending, repository access required, repository syncing and ready. Scope responses to the caller and exact target. Preserve browser session, membership, signed state and installation-ownership checks. Existing browser authentication may still be required after CLI sign-in.
+
+After approval, verify that the target repository is imported and accessible. A completed browser redirect alone is not success. Preserve deliberately dismissed repositories; offer an explicit restore decision instead of reactivating them. If GitHub requires an organisation owner, explain that and keep the continuation available. Never claim that sending an approval request grants access.
+
+## Finish the work and recover cleanly
+
+If indexing was queued by the callback or is running, follow it. Otherwise enqueue through the existing singleton repository-index job. Use an atomic claim for any new start path so retries and two agents do not create duplicate work. Treat an already-running response as progress, not a failed onboarding.
+
+Wait for indexing to reach its successful terminal state before analysis. Reuse a completed analysis when it is current; otherwise start it once. Add durable analysis execution and a run identifier before promising reliable recovery across a server rollout. The current CLI analysis route starts work in the request process; local CLI checkpoints cannot make that server work durable.
+
+Finish with the target repository, index counts, completion timestamps and the actual architecture analysis. The status API already selects the analysis text, but the terminal status command currently prints purpose and summary only. Return the full analysis in agent output, with a bounded preview for the person.
+
+Expired links produce a fresh approval step. Network interruptions preserve progress. Revoked access, account restrictions and unavailable credits produce specific actions. Timeouts report waiting or an unresolved job, never ready. Do not silently switch accounts, providers or billing settings. GitLab, Bitbucket and self-hosted servers receive capability-specific guidance rather than a Cloud GitHub URL.
+
+## Implement in this order
+
+1. Add the agent command, strict argument validation, versioned output and a testable state reducer. Separate device-flow start/poll/complete and keep the current wizard working.
+2. Add server connection status and approval-link resolution. Reuse installation verification and repository sync; expose pending approval and missing target access clearly.
+3. Connect durable indexing and analysis, retry-safe job claims and result retrieval. Add restart recovery and exact-target completion checks.
+4. Update the prompt to use the released command. Add a browser completion message telling the developer their agent will continue. Keep the fallback prompt until the native release and deployed APIs support the new contract.
+
+The CLI lives in apps/cli: its scoped AGENTS.md explicitly identifies it as the replacement native CLI. The root note about the old npm package is stale. Keep application and CLI releases separate, then verify the installed binary against the deployed API before claiming the flow is live.
+
+## Verification and success criteria
+
+Cover a new account, existing installation, missing selected repo, owner approval pending, wrong organisation, ambiguous remotes, dismissed repo, expired login, revoked token and interrupted network. Run commands without a TTY and assert machine-readable output never contains tokens.
+
+Interrupt the agent after each phase, rerun the same command, and prove completed work is reused. Test two concurrent agents, an already-running index, server restart during analysis and delayed repository sync. Mock provider boundaries in automated tests; use a dedicated consented test organisation for the complete browser journey.
+
+Before submitting implementation, run repository lint, typecheck, tests and build, plus CLI compile checks. Measure time to first completed analysis, manual navigation steps, repeated prompts and recovery success. The desired result is zero manual Octopus dashboard navigation for the supported GitHub path, with only the approvals required by account state.
+
+## Source evidence
+
+- [CLI entry point](../apps/cli/src/index.tsx)
+- [Device flow](../apps/cli/src/lib/auth.ts)
+- [Repository wizard](../apps/cli/src/steps/RepoStep.tsx)
+- [Repository commands](../apps/cli/src/commands/repo.ts)
+- [Repository resolver](../apps/cli/src/lib/repo-resolver.ts)
+- [Wizard completion](../apps/cli/src/steps/DoneStep.tsx)
+- [Signed install route](../apps/web/app/api/github/install/route.ts)
+- [GitHub callback](../apps/web/app/api/github/callback/route.ts)
+- [Durable index job](../apps/web/lib/repository-index-job.ts)
+- [Analysis route](../apps/web/app/api/cli/repos/[id]/analyze/route.ts)
+- [Status result](../apps/web/app/api/cli/repos/[id]/status/route.ts)


### PR DESCRIPTION
A coding agent setting up a new repository currently has to navigate the interactive wizard or send the developer to the dashboard when repository access is missing. `octp onboard --agent --json` now returns the next command or exact approval link, then resumes from live repository status until indexing and analysis are complete.

The connection endpoint checks the token creator’s organisation membership, uses the organisation’s bound GitHub installation, preserves dismissed repositories and imports only a target found in the installation’s accessible repository list. Existing installations return their repository-access settings link. New installs reuse the signed browser authorisation route. `octp login --no-open` lets the agent relay the approval URL without opening a local browser. Atomic start claims prevent competing CLI requests from launching duplicate index or analysis work.

The command keeps account identity and continuation arguments explicit, reuses completed work, returns the actual analysis, and does not treat an opened link or incomplete result as success. Native installers and the interactive wizard remain available. The CLI README includes a prompt developers can paste into their existing AI session.

Validation:
- Repository lint, typecheck and build passed. The isolated build emitted missing local auth/database configuration diagnostics; no live account was used.
- Workspace tests: 1,684 passed, 16 skipped. The root package has no test script, so tests ran with `bun run --filter '*' test`. Focused checks were rerun after the final evidence guard and claim adjustment.
- Native macOS ARM64 build passed. A compiled-binary smoke against a local test server covered login URL, repository approval, repeated polling, one index start, one analysis start, and repeatable ready output without token disclosure.
- Gitleaks staged scan: no leaks. Semgrep: 74 TypeScript rules across the four new production files, zero findings.

Scope: github.com repositories, including self-hosted Octopus with a configured GitHub App. This does not persist an interrupted login process, independently identify pending owner approval, or make existing server analysis jobs durable across rollouts. Failed jobs remain available for inspection. The CLI binary and server API both need release before the new prompt can be used publicly; fresh-account browser onboarding remains to be verified.
