### PR TITLE
fix(web): prefer active repositories during CLI onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Native CLI 0.5.1 finishes writing onboarding JSON before it exits, so coding agents receive complete onboarding results when capturing output through a pipe.
 
+## [1.0.156] - 2026-09-12
+
+### Fixed
+- CLI onboarding reuses the active repository when an inactive historical record shares its GitHub name, avoiding a failed connection or an unnecessary access prompt. Dismissed-only repositories remain dismissed. No database migration is required.
+
 ## [1.0.155] - 2026-09-11
 
 ### Fixed

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -100,7 +100,9 @@ link or the existing installation's repository settings link. Once access is
 available, Octopus imports the target repository and the agent follows indexing
 and analysis. Re-running setup reads live server status; completed work is reused.
 Failed jobs remain failed for inspection instead of being retried automatically.
-Deliberately removed repositories require a restore decision.
+An active repository record takes precedence over inactive history with the same
+GitHub name in the organisation. If only a dismissed record remains, setup requires
+a restore decision.
 If work fails or makes no progress for ten minutes, report the exact state and
 continuation command. Opening an approval link does not prove setup completed.
 

--- a/apps/web/app/api/cli/repos/connect/route.ts
+++ b/apps/web/app/api/cli/repos/connect/route.ts
@@ -26,6 +26,9 @@ export async function POST(request: Request) {
     }, {
       find: () => prisma.repository.findFirst({
         where: { organizationId: identity.org.id, provider: "github", fullName: { equals: fullName, mode: "insensitive" } },
+        // Repository names are not unique: an inactive historical row may share
+        // the live repo's name after a transfer or recreation on GitHub.
+        orderBy: [{ isActive: "desc" }, { updatedAt: "desc" }, { id: "asc" }],
         select: { id: true, isActive: true, dismissedAt: true, installationId: true },
       }),
       appConfigured: async () => Boolean((await getGithubAppConfig())?.slug),

--- a/apps/web/lib/__tests__/fixtures/cli-onboarding-routes-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/cli-onboarding-routes-harness.ts
@@ -67,12 +67,39 @@ const historicalRepo = { ...activeRepo, id: "old-repo", isActive: false, updated
 for (const historical of [historicalRepo, { ...historicalRepo, dismissedAt: new Date() }]) {
   repositoryRows = [historical, activeRepo];
   const connected = await connect.POST(request());
+  const body = await connected.json();
+  console.log(JSON.stringify({ scenario: historical.dismissedAt ? "dismissed history plus active" : "inactive history plus active", method: "POST", path: "/api/cli/repos/connect", request: { fullName: "acme/app" }, status: connected.status, body, syncs }));
   expect(connected.status).toBe(200);
-  expect(await connected.json()).toEqual({ state: "connected", repoId: "repo-1" });
+  expect(body).toEqual({ state: "connected", repoId: "repo-1" });
 }
 repositoryRows = [{ ...historicalRepo, dismissedAt: new Date() }];
-expect(await (await connect.POST(request())).json()).toMatchObject({ state: "repository_dismissed" });
+const dismissedResponse = await connect.POST(request());
+const dismissedBody = await dismissedResponse.json();
+console.log(JSON.stringify({ scenario: "dismissed only", status: dismissedResponse.status, body: dismissedBody, syncs }));
+expect(dismissedResponse.status).toBe(200);
+expect(dismissedBody).toMatchObject({ state: "repository_dismissed" });
 expect(syncs).toBe(0);
+// Newer active rows win; equal timestamps use the stable ID tie-breaker.
+for (const rows of [
+  [activeRepo, { ...activeRepo, id: "repo-new", updatedAt: new Date("2026-09-12T10:00:00Z") }],
+  [{ ...activeRepo, id: "repo-z" }, activeRepo],
+  [{ ...activeRepo, id: "foreign", organizationId: "org-other", updatedAt: new Date("2026-09-13T10:00:00Z") },
+    { ...activeRepo, id: "other-provider", provider: "gitlab", updatedAt: new Date("2026-09-13T10:00:00Z") }, activeRepo],
+]) {
+  repositoryRows = rows;
+  const result = await connect.POST(request({ fullName: "ACME/App" }));
+  const body = await result.json();
+  console.log(JSON.stringify({ scenario: "deterministic scoped lookup", candidateIds: rows.map(row => row.id), status: result.status, body }));
+  expect(result.status).toBe(200);
+  expect(body).toEqual({ state: "connected", repoId: rows.some(row => row.id === "repo-new") ? "repo-new" : "repo-1" });
+}
+expect(syncs).toBe(0);
+repositoryRows = [{ ...activeRepo, installationId: 99 }];
+const wrongInstallation = await connect.POST(request());
+const wrongInstallationBody = await wrongInstallation.json();
+console.log(JSON.stringify({ scenario: "wrong installation cannot connect", status: wrongInstallation.status, body: wrongInstallationBody }));
+expect(wrongInstallation.status).toBe(503);
+expect(wrongInstallationBody).not.toHaveProperty("repoId");
 repositoryRows = [activeRepo];
 
 // A lost compare-and-set must not start a second job.

--- a/apps/web/lib/__tests__/fixtures/cli-onboarding-routes-harness.ts
+++ b/apps/web/lib/__tests__/fixtures/cli-onboarding-routes-harness.ts
@@ -5,20 +5,39 @@ let identity: unknown = { org, user: { id: "user-1" } };
 let member: unknown = { id: "member-1" };
 const claimCount = 0;
 let starts = 0;
+let syncs = 0;
 const readArgs: unknown[] = [];
 const claimArgs: unknown[] = [];
+const activeRepo = { id: "repo-1", organizationId: "org-1", provider: "github", fullName: "acme/app", isActive: true, dismissedAt: null as Date | null, installationId: 42, indexStatus: "indexed", analysisStatus: "pending", indexedAt: new Date("2026-09-11T10:00:00Z"), analyzedAt: null, updatedAt: new Date("2026-09-11T10:00:00Z") };
+let repositoryRows = [activeRepo];
+type Lookup = { where: { organizationId: string; provider?: string; fullName?: { equals: string }; id?: string }; orderBy?: Array<Record<string, "asc" | "desc">> };
 const db = {
   organizationMember: { findFirst: async (args: unknown) => { readArgs.push(args); return member; } },
   repository: {
-    findFirst: async (args: unknown) => { readArgs.push(args); return { id: "repo-1", fullName: "acme/app", isActive: true, dismissedAt: null, installationId: 42, indexStatus: "indexed", analysisStatus: "pending", indexedAt: new Date("2026-09-11T10:00:00Z"), analyzedAt: null }; },
+    findFirst: async (args: Lookup) => {
+      readArgs.push(args);
+      const rows = repositoryRows.filter((row) => row.organizationId === args.where.organizationId
+        && (!args.where.id || row.id === args.where.id)
+        && (!args.where.provider || row.provider === args.where.provider)
+        && (!args.where.fullName || row.fullName.toLowerCase() === args.where.fullName.equals.toLowerCase()));
+      for (const order of [...(args.orderBy ?? [])].reverse()) {
+        const [field, direction] = Object.entries(order)[0];
+        rows.sort((a, b) => {
+          const left = a[field as keyof typeof a]; const right = b[field as keyof typeof b];
+          if (left === right) return 0;
+          return (left! < right! ? -1 : 1) * (direction === "asc" ? 1 : -1);
+        });
+      }
+      return rows[0] ?? null;
+    },
     updateMany: async (args: unknown) => { claimArgs.push(args); return { count: claimCount }; },
   },
 };
 mock.module("@octopus/db", () => ({ prisma: db }));
 mock.module("@/lib/api-auth", () => ({ authenticateApiToken: async () => identity }));
 mock.module("@/lib/github-app-config", () => ({ getGithubAppConfig: async () => ({ slug: "octopus" }) }));
-mock.module("@/lib/github", () => ({ getInstallationSettingsUrl: async () => "https://github.com/settings/installations/42", listInstallationRepos: async () => [] }));
-mock.module("@/lib/repo-sync", () => ({ applyRepositoryEvent: async () => { throw new Error("Unexpected sync"); } }));
+mock.module("@/lib/github", () => ({ getInstallationSettingsUrl: async () => "https://github.com/settings/installations/42", listInstallationRepos: async () => [{ id: 123, name: "app", full_name: "acme/app", default_branch: "main" }] }));
+mock.module("@/lib/repo-sync", () => ({ applyRepositoryEvent: async () => { syncs++; } }));
 mock.module("@/lib/analyzer", () => ({ analyzeRepository: async () => { starts++; return "analysis"; } }));
 mock.module("@/lib/events/bus", () => ({ eventBus: { emit: () => {} } }));
 mock.module("@/lib/indexing-runner", () => ({ runIndexingInBackground: () => { starts++; } }));
@@ -41,6 +60,20 @@ const response = await connect.POST(request());
 expect(response.status).toBe(200);
 expect(await response.json()).toEqual({ state: "connected", repoId: "repo-1" });
 expect(readArgs.at(-1)).toMatchObject({ where: { organizationId: "org-1", provider: "github", fullName: { equals: "acme/app", mode: "insensitive" } } });
+
+// GitHub names can be reused: an inactive historical row must not hide the live one.
+// Deliberately put the inactive row first, matching the production failure.
+const historicalRepo = { ...activeRepo, id: "old-repo", isActive: false, updatedAt: new Date("2026-09-12T10:00:00Z") };
+for (const historical of [historicalRepo, { ...historicalRepo, dismissedAt: new Date() }]) {
+  repositoryRows = [historical, activeRepo];
+  const connected = await connect.POST(request());
+  expect(connected.status).toBe(200);
+  expect(await connected.json()).toEqual({ state: "connected", repoId: "repo-1" });
+}
+repositoryRows = [{ ...historicalRepo, dismissedAt: new Date() }];
+expect(await (await connect.POST(request())).json()).toMatchObject({ state: "repository_dismissed" });
+expect(syncs).toBe(0);
+repositoryRows = [activeRepo];
 
 // A lost compare-and-set must not start a second job.
 const index = await import("../../../app/api/cli/repos/[id]/index/route");

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octopus/web",
-  "version": "1.0.155",
+  "version": "1.0.156",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octopus",
-  "version": "1.0.155",
+  "version": "1.0.156",
   "devDependencies": {
     "turbo": "^2"
   },


### PR DESCRIPTION
CLI onboarding could return HTTP 503 when an inactive historical repository shared the active repository’s GitHub name. The connection lookup now prefers active records with deterministic tie-breakers, so it reuses the live repository without an unnecessary import. Dismissed-only repositories and existing tenant, membership and installation checks retain their behaviour.

Regression coverage reproduces HTTP 503 before the fix and HTTP 200 after it, with no sync. It also covers dismissed history, stable ordering, tenant/provider isolation and installation rejection. Local lint, typecheck and build passed; the full suite passed with a 20-second test timeout after unrelated shell tests timed out under concurrent load. App version 1.0.156; no schema, infrastructure or CLI binary changes.

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"dac4654d86c5c2a3890022a95b126caeafaffd5b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->