### PR TITLE
feat(cli): add user login and per-command organisation selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,9 @@ jobs:
       - name: Test billing auto-reload invariants against PostgreSQL
         run: bun test lib/__tests__/billing.db.test.ts
         working-directory: apps/web
+
+      - name: Test CLI user sessions and organisation isolation against PostgreSQL
+        run: bun test lib/__tests__/cli-user-auth.db.test.ts
+        working-directory: apps/web
+        env:
+          RUN_CLI_AUTH_DB_TESTS: "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Native CLI 0.5.1 finishes writing onboarding JSON before it exits, so coding agents receive complete onboarding results when capturing output through a pipe.
 
+## [1.0.157] - 2026-09-12
+
+### Added
+- Native CLI 0.6.0 signs in once as a user. Use `octp org list --json` and per-command `--org <slug|id>` across current memberships; repository setup infers a unique organisation or returns choices before starting work.
+- CLI browser approval no longer asks new user sessions to select an organisation. Sessions expire after 30 days; logout, revocation and membership removal invalidate derived organisation access. Existing organisation tokens and legacy device clients remain supported.
+- Operators: apply the additive `20260912005000_cli_user_sessions` migration through the normal backup/migration/deploy gates before publishing CLI 0.6.0. The previous app remains compatible with the expanded schema.
+
 ## [1.0.156] - 2026-09-12
 
 ### Fixed

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -93,7 +93,31 @@ Exit codes: **0** ready, **3** waiting or approval required, **2** invalid input
 The first run detects the GitHub repository from the current remote. Authentication
 uses `octp login --no-open`, which prints the approval URL and waits for the
 user. The agent keeps that login process running until it finishes, then resumes
-onboarding. Login credentials stay in the existing account store.
+onboarding. CLI 0.6.0 and server 1.0.157 add user-level login: browser approval does not
+select an organisation. The session expires after 30 days; `octp logout` revokes
+it and its derived organisation credentials. Login credentials stay in the
+existing account store.
+
+```bash
+octp login --no-open
+octp org list --json
+octp --org acme onboard --agent --json --repo acme/app
+octp --org another-org repo list
+```
+
+`--org` accepts an organisation slug or ID for that command only. Without it,
+Octopus uses a unique repository match, then a unique GitHub owner match. If the
+choice remains ambiguous it returns `organization_required`, the available
+`organizations`, and exit 3 before starting work. The agent must ask which one to
+use and retry with `--org`. A single organisation with no GitHub installation can
+start its first installation. A new user with no memberships must create or join
+an organisation first.
+
+`--account` switches saved user profiles; `--org` switches organisations within
+one user's current memberships. Existing organisation tokens continue to work
+for their original organisation. Run `octp login` again to replace one with a
+user session and enable switching. The interactive wizard and `setup-token`
+retain their organisation-scoped flow for compatibility and CI credentials.
 
 For repository access, the command returns the signed GitHub App installation
 link or the existing installation's repository settings link. Once access is

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -106,18 +106,34 @@ octp --org another-org repo list
 ```
 
 `--org` accepts an organisation slug or ID for that command only. Without it,
-Octopus uses a unique repository match, then a unique GitHub owner match. If the
-choice remains ambiguous it returns `organization_required`, the available
-`organizations`, and exit 3 before starting work. The agent must ask which one to
-use and retry with `--org`. A single organisation with no GitHub installation can
-start its first installation. A new user with no memberships must create or join
-an organisation first.
+Octopus uses a unique repository match, then a unique GitHub owner match among
+active, non-dismissed repositories in your current organisations. An explicit
+repository target takes priority over the working directory. If that target
+cannot be resolved uniquely (including a short repository name), choose with
+`--org`; the CLI only consults the current Git remote when no target was supplied.
+Agent onboarding can select a single organisation with no GitHub installation
+to start its first installation.
+
+When a choice is needed, agent onboarding returns `organization_required` and
+the available `organizations` in JSON. Other organisation-scoped commands print
+the choices to stderr. Both exit 3 before starting work. Ask which organisation
+to use and retry with `--org`. A new user with no memberships must create or join
+an organisation in Octopus first.
+
+Local `agent watch` operations remain offline and use `--account` for their
+profile; they do not accept `--org`. Use `--org` with `agent serve` when selecting
+the organisation for an authenticated bridge.
 
 `--account` switches saved user profiles; `--org` switches organisations within
 one user's current memberships. Existing organisation tokens continue to work
 for their original organisation. Run `octp login` again to replace one with a
 user session and enable switching. The interactive wizard and `setup-token`
 retain their organisation-scoped flow for compatibility and CI credentials.
+User login saves only the user secret; organisation credentials stay local to
+the command. Each organisation API authentication checks the parent session's
+expiry and revocation, current membership, and account standing. These credentials
+retain existing organisation-token permissions; the user secret itself cannot
+authenticate an organisation API request.
 
 For repository access, the command returns the signed GitHub App installation
 link or the existing installation's repository settings link. Once access is

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octopus/cli",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "description": "Octopus CLI. Native single-binary distribution via curl/irm. Includes a first-run TUI onboarding wizard.",

--- a/apps/cli/src/OnboardWizard.tsx
+++ b/apps/cli/src/OnboardWizard.tsx
@@ -12,6 +12,7 @@ import { ValidateStep } from "./steps/ValidateStep.js";
 import { RepoStep } from "./steps/RepoStep.js";
 import { DoneStep } from "./steps/DoneStep.js";
 import { loadConfig, type OctopusConfig } from "./lib/config.js";
+import { clearCommandCredentials } from "./lib/credentials.js";
 import { buildSequence } from "./lib/sequence.js";
 
 /**
@@ -180,6 +181,7 @@ export function OnboardWizard({ reset = false }: OnboardWizardProps = {}) {
  * saved config.
  */
 export async function renderWizard(reset = false): Promise<void> {
+  clearCommandCredentials();
   const { waitUntilExit } = render(<OnboardWizard reset={reset} />);
   await waitUntilExit();
 }

--- a/apps/cli/src/__tests__/cli-organizations.test.ts
+++ b/apps/cli/src/__tests__/cli-organizations.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -41,18 +42,18 @@ describe("compiled multi-organisation CLI", () => {
     } finally { server.stop(true); await rm(home, { recursive: true, force: true }); }
   }, 15_000);
   it("switches one user credential by repository or --org, and blocks ambiguity before work", async () => {
-    const calls: { path: string; method: string; auth: string | null }[] = [];
+    const calls: { path: string; method: string; auth: string | null; repo: string | null }[] = [];
     let revoked = false;
     let connectedRepository = "";
     const server = Bun.serve({ hostname: "127.0.0.1", port: 0, async fetch(request) {
       const url = new URL(request.url);
       const auth = request.headers.get("authorization");
-      calls.push({ path: url.pathname, method: request.method, auth });
+      calls.push({ path: url.pathname, method: request.method, auth, repo: url.searchParams.get("repo") });
       if (url.pathname === "/api/cli/organizations") {
         if (auth !== `Bearer ${userToken}` || revoked) return Response.json({ error: "Sign in again" }, { status: 401 });
         if (request.method === "GET") return Response.json({ organizations: ["alpha", "beta"].map((slug) => ({
           id: slug, slug, name: slug, hasInstallation: true,
-          matchesRepository: url.searchParams.get("repo") === `${slug}/app`, matchesOwner: false,
+          matchesRepository: url.searchParams.get("repo") === "shared/app" || url.searchParams.get("repo") === `${slug}/app`, matchesOwner: false,
         })) });
         const body = await request.json() as { organization: keyof typeof childTokens };
         const slug = body.organization;
@@ -100,6 +101,40 @@ describe("compiled multi-organisation CLI", () => {
         expect(JSON.parse(result.out)).toMatchObject({ state: "organization_required", organizations: [{ slug: "alpha" }, { slug: "beta" }] });
         expect(calls.every((call) => call.path === "/api/cli/organizations" && call.method === "GET")).toBe(true);
       }
+      for (const args of [["init", "--quiet"], ["remote", "add", "origin", "https://github.com/alpha/app.git"]]) {
+        expect(spawnSync("git", args, { cwd: home }).status).toBe(0);
+      }
+      for (const args of [
+        ["review", "https://github.com/shared/app/pull/12"],
+        ["review", "--format", "json", "https://github.com/shared/app/pull/12"],
+        ["review", "--pr", "https://github.com/shared/app/pull/12"],
+        ["analyze-deps", "https://github.com/shared/app"],
+        ["analyze-deps", "https://github.com/shared/app/tree/main"],
+      ]) {
+        calls.length = 0;
+        const ambiguous = await run(args);
+        expect(ambiguous.code).toBe(3);
+        expect(ambiguous.err).toContain("--org alpha");
+        expect(ambiguous.err).toContain("--org beta");
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toMatchObject({ method: "GET", repo: "shared/app" });
+        calls.length = 0;
+        await run(["--org", "beta", ...args]);
+        expect(calls.some((call) => call.method === "POST" && call.path === "/api/cli/organizations")).toBe(true);
+        expect(calls.some((call) => call.auth === `Bearer ${childTokens.beta}`)).toBe(true);
+      }
+      calls.length = 0;
+      await run(["review", "--since", "main", "--format", "json", "12"]);
+      expect(calls[0].repo).toBe("alpha/app");
+      for (const args of [["agent", "watch", "--list"], ["agent", "watch", "--remove"]]) {
+        calls.length = 0;
+        expect((await run(args)).code).toBe(0);
+        expect(calls).toHaveLength(0);
+        const invalid = await run(["--org", "alpha", ...args]);
+        expect(invalid.code).toBe(2);
+        expect(invalid.err).toContain("Local agent watch");
+        expect(calls).toHaveLength(0);
+      }
       revoked = true;
       calls.length = 0;
       const denied = await run(["--org", "alpha", "onboard", "--agent", "--json", "--repo", "alpha/app"]);
@@ -107,6 +142,10 @@ describe("compiled multi-organisation CLI", () => {
       expect(JSON.parse(denied.out).state).toBe("authentication_required");
       expect(calls).toHaveLength(1);
       expect(await readFile(join(home, "profiles", "default", "credentials"), "utf8")).toBe(credential);
+      server.stop(true);
+      expect((await run(["agent", "watch", "--list"])).code).toBe(0);
+      expect((await run(["agent", "watch", "--remove"])).code).toBe(0);
+
     } finally { server.stop(true); await rm(home, { recursive: true, force: true }); }
   }, 30_000);
 });

--- a/apps/cli/src/__tests__/cli-organizations.test.ts
+++ b/apps/cli/src/__tests__/cli-organizations.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+let binaryHome: string;
+let binary: string;
+const userToken = `oct_u_${"1".repeat(64)}`;
+const childTokens = { alpha: `oct_${"a".repeat(64)}`, beta: `oct_${"b".repeat(64)}` };
+beforeAll(async () => {
+  binaryHome = await mkdtemp(join(tmpdir(), "octp-org-binary-"));
+  binary = join(binaryHome, "octp");
+  const build = Bun.spawn([process.execPath, "build", fileURLToPath(new URL("../index.tsx", import.meta.url)), "--compile", "--outfile", binary], { stdout: "pipe", stderr: "pipe" });
+  const [code, out, err] = await Promise.all([build.exited, new Response(build.stdout).text(), new Response(build.stderr).text()]);
+  if (code) throw new Error(`Build failed: ${out}${err}`);
+}, 30_000);
+afterAll(async () => { await rm(binaryHome, { recursive: true, force: true }); });
+
+describe("compiled multi-organisation CLI", () => {
+  it("signs in without an organisation and stores only the user session", async () => {
+    let requestedScope: unknown;
+    const server = Bun.serve({ hostname: "127.0.0.1", port: 0, async fetch(request) {
+      const path = new URL(request.url).pathname;
+      if (path === "/api/cli/auth/device") {
+        requestedScope = await request.json();
+        return Response.json({ scope: "user", deviceCode: "d".repeat(40), expiresAt: new Date(Date.now() + 60_000).toISOString() });
+      }
+      if (path === "/api/cli/auth/poll") return Response.json({ status: "approved", scope: "user", token: userToken, organization: null, user: { name: "Test User", email: "user@example.test" } });
+      return new Response("Unexpected request", { status: 500 });
+    } });
+    const home = await mkdtemp(join(tmpdir(), "octp-org-login-"));
+    try {
+      const child = Bun.spawn([binary, "login", "--no-open", "--api-url", `http://127.0.0.1:${server.port}`], { cwd: home, env: { ...process.env, OCTOPUS_HOME: home }, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+      const [code, out, err] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]);
+      expect(code).toBe(0);
+      expect(requestedScope).toEqual({ scope: "user" });
+      expect(out + err).not.toContain(userToken);
+      expect(out + err).toContain("user@example.test");
+      expect(JSON.parse(await readFile(join(home, "profiles", "default", "credentials"), "utf8"))).toMatchObject({ kind: "user", token: userToken, orgId: "", orgSlug: "" });
+    } finally { server.stop(true); await rm(home, { recursive: true, force: true }); }
+  }, 15_000);
+  it("switches one user credential by repository or --org, and blocks ambiguity before work", async () => {
+    const calls: { path: string; method: string; auth: string | null }[] = [];
+    let revoked = false;
+    let connectedRepository = "";
+    const server = Bun.serve({ hostname: "127.0.0.1", port: 0, async fetch(request) {
+      const url = new URL(request.url);
+      const auth = request.headers.get("authorization");
+      calls.push({ path: url.pathname, method: request.method, auth });
+      if (url.pathname === "/api/cli/organizations") {
+        if (auth !== `Bearer ${userToken}` || revoked) return Response.json({ error: "Sign in again" }, { status: 401 });
+        if (request.method === "GET") return Response.json({ organizations: ["alpha", "beta"].map((slug) => ({
+          id: slug, slug, name: slug, hasInstallation: true,
+          matchesRepository: url.searchParams.get("repo") === `${slug}/app`, matchesOwner: false,
+        })) });
+        const body = await request.json() as { organization: keyof typeof childTokens };
+        const slug = body.organization;
+        return Response.json({ token: childTokens[slug], organization: { id: slug, slug, name: slug } });
+      }
+      const selected = Object.entries(childTokens).find(([, token]) => auth === `Bearer ${token}`)?.[0];
+      if (!selected) return Response.json({ error: "Wrong credential scope" }, { status: 401 });
+      if (url.pathname === "/api/cli/repos/connect") {
+        connectedRepository = (await request.json() as { fullName: string }).fullName;
+        return Response.json({ state: "connected", repoId: `${selected}-repo` });
+      }
+      if (url.pathname === `/api/cli/repos/${selected}-repo/status`) return Response.json({ repo: {
+        id: `${selected}-repo`, fullName: connectedRepository, provider: "github", indexStatus: "indexed", analysisStatus: "analyzed",
+        indexedAt: "2026-09-12T00:00:00Z", analyzedAt: "2026-09-12T00:01:00Z", indexedFiles: 10, totalFiles: 10, analysis: `${selected} analysis`,
+      } });
+      return Response.json({ error: "Unexpected request" }, { status: 404 });
+    } });
+    const home = await mkdtemp(join(tmpdir(), "octp-org-user-"));
+    const credential = JSON.stringify({ kind: "user", baseUrl: `http://127.0.0.1:${server.port}`, token: userToken, orgId: "", orgSlug: "", orgName: "", approvedAt: "2026-09-12" });
+    await writeFile(join(home, "credentials"), credential, { mode: 0o600 });
+    async function run(args: string[]) {
+      const child = Bun.spawn([binary, ...args], { cwd: home, env: { ...process.env, OCTOPUS_HOME: home }, stdin: "ignore", stdout: "pipe", stderr: "pipe" });
+      const [code, out, err] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]);
+      expect(out + err).not.toContain(userToken);
+      for (const token of Object.values(childTokens)) expect(out + err).not.toContain(token);
+      return { code, out, err };
+    }
+    try {
+      const list = await run(["org", "list", "--json"]);
+      expect(list.code).toBe(0);
+      expect(JSON.parse(list.out).organizations).toHaveLength(2);
+      for (const slug of ["alpha", "beta"]) {
+        const result = await run(["onboard", "--agent", "--json", "--repo", `${slug}/app`]);
+        expect(result.code).toBe(0);
+        expect(JSON.parse(result.out)).toMatchObject({ state: "ready", result: { analysis: `${slug} analysis` } });
+        expect(JSON.parse(result.out).continueWith).toContain(slug);
+      }
+      const explicit = await run(["--org", "beta", "onboard", "--agent", "--json", "--repo", "alpha/app"]);
+      expect(explicit.code).toBe(0);
+      expect(JSON.parse(explicit.out).result.analysis).toBe("beta analysis");
+      for (const args of [[], ["--org", "missing"]]) {
+        calls.length = 0;
+        const result = await run([...args, "onboard", "--agent", "--json", "--repo", "unknown/app"]);
+        expect(result.code).toBe(3);
+        expect(JSON.parse(result.out)).toMatchObject({ state: "organization_required", organizations: [{ slug: "alpha" }, { slug: "beta" }] });
+        expect(calls.every((call) => call.path === "/api/cli/organizations" && call.method === "GET")).toBe(true);
+      }
+      revoked = true;
+      calls.length = 0;
+      const denied = await run(["--org", "alpha", "onboard", "--agent", "--json", "--repo", "alpha/app"]);
+      expect(denied.code).toBe(3);
+      expect(JSON.parse(denied.out).state).toBe("authentication_required");
+      expect(calls).toHaveLength(1);
+      expect(await readFile(join(home, "profiles", "default", "credentials"), "utf8")).toBe(credential);
+    } finally { server.stop(true); await rm(home, { recursive: true, force: true }); }
+  }, 30_000);
+});

--- a/apps/cli/src/__tests__/cli-organizations.test.ts
+++ b/apps/cli/src/__tests__/cli-organizations.test.ts
@@ -44,6 +44,8 @@ describe("compiled multi-organisation CLI", () => {
   it("switches one user credential by repository or --org, and blocks ambiguity before work", async () => {
     const calls: { path: string; method: string; auth: string | null; repo: string | null }[] = [];
     let revoked = false;
+    let availableSlugs = ["alpha", "beta"];
+    let hasInstallation = true;
     let connectedRepository = "";
     const server = Bun.serve({ hostname: "127.0.0.1", port: 0, async fetch(request) {
       const url = new URL(request.url);
@@ -51,8 +53,8 @@ describe("compiled multi-organisation CLI", () => {
       calls.push({ path: url.pathname, method: request.method, auth, repo: url.searchParams.get("repo") });
       if (url.pathname === "/api/cli/organizations") {
         if (auth !== `Bearer ${userToken}` || revoked) return Response.json({ error: "Sign in again" }, { status: 401 });
-        if (request.method === "GET") return Response.json({ organizations: ["alpha", "beta"].map((slug) => ({
-          id: slug, slug, name: slug, hasInstallation: true,
+        if (request.method === "GET") return Response.json({ organizations: availableSlugs.map((slug) => ({
+          id: slug, slug, name: slug, hasInstallation,
           matchesRepository: url.searchParams.get("repo") === "shared/app" || url.searchParams.get("repo") === `${slug}/app`, matchesOwner: false,
         })) });
         const body = await request.json() as { organization: keyof typeof childTokens };
@@ -61,6 +63,11 @@ describe("compiled multi-organisation CLI", () => {
       }
       const selected = Object.entries(childTokens).find(([, token]) => auth === `Bearer ${token}`)?.[0];
       if (!selected) return Response.json({ error: "Wrong credential scope" }, { status: 401 });
+      if (url.pathname === "/api/cli/repos") return Response.json({ repos: [
+        { id: "shared-repo", name: "app", fullName: "shared/app", provider: "github" },
+        { id: "local-repo", name: "app", fullName: "alpha/app", provider: "github" },
+      ] });
+      if (url.pathname === "/api/cli/chat") return new Response('data: {"type":"delta","text":"Answer"}\ndata: [DONE]\n', { headers: { "content-type": "text/event-stream" } });
       if (url.pathname === "/api/cli/repos/connect") {
         connectedRepository = (await request.json() as { fullName: string }).fullName;
         return Response.json({ state: "connected", repoId: `${selected}-repo` });
@@ -105,6 +112,11 @@ describe("compiled multi-organisation CLI", () => {
         expect(spawnSync("git", args, { cwd: home }).status).toBe(0);
       }
       for (const args of [
+        ["chat", "-p", "Summarize", "shared/app"],
+        ["chat", "--print", "Summarize", "shared/app"],
+        ["repo", "--", "index", "shared/app"],
+        ["repo", "index", "--", "shared/app"],
+        ["repo", "--", "analyze", "shared/app"],
         ["review", "https://github.com/shared/app/pull/12"],
         ["review", "--format", "json", "https://github.com/shared/app/pull/12"],
         ["review", "--pr", "https://github.com/shared/app/pull/12"],
@@ -123,6 +135,42 @@ describe("compiled multi-organisation CLI", () => {
         expect(calls.some((call) => call.method === "POST" && call.path === "/api/cli/organizations")).toBe(true);
         expect(calls.some((call) => call.auth === `Bearer ${childTokens.beta}`)).toBe(true);
       }
+      const shortTargets = [
+        ["chat", "-p", "Summarize", "app"],
+        ["chat", "app", "--print", "Summarize"],
+        ["repo", "--", "index", "app"],
+        ["repo", "analyze", "--", "app"],
+      ];
+      for (const args of shortTargets) {
+        calls.length = 0;
+        const result = await run(args);
+        expect(result.code).toBe(3);
+        expect(result.err).toContain("--org alpha");
+        expect(result.err).toContain("--org beta");
+        expect(calls).toEqual([{ path: "/api/cli/organizations", method: "GET", auth: `Bearer ${userToken}`, repo: null }]);
+        calls.length = 0;
+        await run(["--org", "beta", ...args]);
+        expect(calls.some((call) => call.method === "POST" && call.auth === `Bearer ${childTokens.beta}` && call.path !== "/api/cli/organizations")).toBe(true);
+      }
+      availableSlugs = ["alpha"];
+      hasInstallation = false;
+      for (const args of [shortTargets[0], ["chat", "-p", "Summarize", "unknown/app"]]) {
+        calls.length = 0;
+        expect((await run(args)).code).toBe(3);
+        expect(calls).toHaveLength(1);
+        expect(calls[0].method).toBe("GET");
+      }
+      availableSlugs = ["alpha", "beta"];
+      hasInstallation = true;
+      calls.length = 0;
+      expect((await run(["chat", "-p", "Summarize"])).code).toBe(0);
+      expect(calls[0].repo).toBe("alpha/app");
+      const credentialPath = join(home, "profiles", "default", "credentials");
+      await writeFile(credentialPath, JSON.stringify({ ...JSON.parse(credential), kind: undefined, token: childTokens.alpha, orgId: "alpha", orgSlug: "alpha" }));
+      calls.length = 0;
+      expect((await run(shortTargets[0])).code).toBe(0);
+      expect(calls.every((call) => call.path !== "/api/cli/organizations" && call.auth === `Bearer ${childTokens.alpha}`)).toBe(true);
+      await writeFile(credentialPath, credential);
       calls.length = 0;
       await run(["review", "--since", "main", "--format", "json", "12"]);
       expect(calls[0].repo).toBe("alpha/app");

--- a/apps/cli/src/__tests__/organizations.test.ts
+++ b/apps/cli/src/__tests__/organizations.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { chooseOrganization, resolveOrganization, type OrganizationChoice } from "../lib/organizations.js";
+
+const a: OrganizationChoice = { id: "org-a", slug: "alpha", name: "Alpha", hasInstallation: true };
+const b: OrganizationChoice = { id: "org-b", slug: "beta", name: "Beta", hasInstallation: true };
+
+describe("command organisation selection", () => {
+  it("prefers an explicit slug or ID over repository matches", () => {
+    expect(chooseOrganization([a, { ...b, matchesRepository: true }], "alpha", "beta/app")).toEqual(a);
+    expect(chooseOrganization([a, b], "org-b")).toEqual(b);
+    expect(chooseOrganization([a, b], "missing")).toBeUndefined();
+  });
+  it("prefers an exact repository over an owner match", () => {
+    const exact = { ...b, matchesRepository: true };
+    expect(chooseOrganization([{ ...a, matchesOwner: true }, exact], undefined, "beta/app")).toEqual(exact);
+  });
+  it("never guesses between duplicate repositories or owners", () => {
+    expect(chooseOrganization([a, b].map((org) => ({ ...org, matchesRepository: true })))).toBeUndefined();
+    expect(chooseOrganization([a, b].map((org) => ({ ...org, matchesOwner: true })))).toBeUndefined();
+    expect(chooseOrganization([a, b])).toBeUndefined();
+  });
+  it("allows first installation but does not infer an unrelated installed org", () => {
+    expect(chooseOrganization([a], undefined, "unknown/app")).toBeUndefined();
+    expect(chooseOrganization([{ ...a, hasInstallation: false }], undefined, "unknown/app")?.id).toBe(a.id);
+    expect(chooseOrganization([a])?.id).toBe(a.id);
+  });
+  it("keeps legacy tokens scoped and requires login before switching", async () => {
+    const credentials = { baseUrl: "https://example.com", token: "legacy", orgId: a.id, orgSlug: a.slug, orgName: a.name, approvedAt: "2026-09-12" };
+    expect(await resolveOrganization(credentials, a.slug)).toEqual({ ok: true, credentials, userSession: false });
+    expect(await resolveOrganization(credentials, b.slug)).toMatchObject({ ok: false, state: "authentication_required" });
+  });
+});

--- a/apps/cli/src/__tests__/organizations.test.ts
+++ b/apps/cli/src/__tests__/organizations.test.ts
@@ -24,6 +24,13 @@ describe("command organisation selection", () => {
     expect(chooseOrganization([{ ...a, hasInstallation: false }], undefined, "unknown/app")?.id).toBe(a.id);
     expect(chooseOrganization([a])?.id).toBe(a.id);
   });
+  it("requires repository evidence for an explicit target even with one membership", () => {
+    expect(chooseOrganization([a], undefined, undefined, true)).toBeUndefined();
+    expect(chooseOrganization([{ ...a, hasInstallation: false }], undefined, "unknown/app", true)).toBeUndefined();
+    expect(chooseOrganization([a], "alpha", undefined, true)).toEqual(a);
+    const exact = { ...b, matchesRepository: true };
+    expect(chooseOrganization([a, exact], undefined, "beta/app", true)).toEqual(exact);
+  });
   it("keeps legacy tokens scoped and requires login before switching", async () => {
     const credentials = { baseUrl: "https://example.com", token: "legacy", orgId: a.id, orgSlug: a.slug, orgName: a.name, approvedAt: "2026-09-12" };
     expect(await resolveOrganization(credentials, a.slug)).toEqual({ ok: true, credentials, userSession: false });

--- a/apps/cli/src/__tests__/wizard-credentials.test.ts
+++ b/apps/cli/src/__tests__/wizard-credentials.test.ts
@@ -1,0 +1,45 @@
+import { expect, it } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+it("wizard entry clears command scope before rendering and uses newly saved approval", async () => {
+  const home = await mkdtemp(join(tmpdir(), "octp-wizard-credentials-"));
+  try {
+    const script = `
+      import { mock, expect } from "bun:test";
+      import * as ink from "ink";
+      import { loadCredentials, loadStoredCredentials, saveCredentials, setCommandCredentials } from "./src/lib/credentials";
+      const saved = { baseUrl: "http://localhost", token: "stored", orgId: "stored", orgSlug: "stored", orgName: "Stored", approvedAt: "2026-09-12" };
+      const approved = { ...saved, token: "beta", orgId: "beta" };
+      const active = { ...saved, token: "alpha", orgId: "alpha" };
+      await saveCredentials(saved);
+      let renders = 0;
+      mock.module("ink", () => ({ ...ink, render: () => {
+        renders++;
+        return { waitUntilExit: async () => {
+          expect(await loadCredentials()).toEqual(saved);
+          expect(await loadStoredCredentials()).toEqual(saved);
+          await saveCredentials(approved);
+          expect(await loadCredentials()).toEqual(approved);
+        } };
+      } }));
+      const { renderWizard } = await import("./src/OnboardWizard");
+      for (const reset of [false, true]) {
+        await saveCredentials(saved);
+        setCommandCredentials(active);
+        expect(await loadCredentials()).toEqual(active);
+        await renderWizard(reset);
+        expect(await loadStoredCredentials()).toEqual(approved);
+      }
+      expect(renders).toBe(2);
+    `;
+    const child = Bun.spawn([process.execPath, "-e", script], {
+      cwd: new URL("../..", import.meta.url).pathname,
+      env: { ...process.env, OCTOPUS_HOME: home },
+      stdout: "pipe", stderr: "pipe",
+    });
+    const [code, out, err] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]);
+    expect({ code, output: out + err }).toEqual({ code: 0, output: "" });
+  } finally { await rm(home, { recursive: true, force: true }); }
+});

--- a/apps/cli/src/commands/analyze-deps.ts
+++ b/apps/cli/src/commands/analyze-deps.ts
@@ -1,6 +1,6 @@
 import { loadCredentials } from "../lib/credentials.js";
 import { streamSse } from "../lib/api.js";
-import { positionals } from "../lib/args.js";
+import { dependencyRepositoryArgument } from "../lib/command-arguments.js";
 import {
   c,
   heading,
@@ -120,7 +120,7 @@ export async function analyzeDepsCommand(argv: string[]): Promise<number> {
     return 2;
   }
 
-  const repoUrl = positionals(argv)[0];
+  const repoUrl = dependencyRepositoryArgument(argv);
   if (!repoUrl || repoUrl.trim().length === 0) {
     error("Missing <repo-url>.");
     printHelp();

--- a/apps/cli/src/commands/chat.ts
+++ b/apps/cli/src/commands/chat.ts
@@ -1,7 +1,8 @@
 import { createInterface } from "node:readline";
 import { loadCredentials } from "../lib/credentials.js";
 import { streamData } from "../lib/api.js";
-import { hasFlag, flagValue, positionals } from "../lib/args.js";
+import { hasFlag, flagValue } from "../lib/args.js";
+import { chatArguments } from "../lib/command-arguments.js";
 import { resolveRepo } from "../lib/repo-resolver.js";
 import { error, info, c, sanitizeTerminal } from "../lib/output.js";
 import { renderWizard } from "../OnboardWizard.js";
@@ -50,10 +51,8 @@ export async function chatCommand(argv: string[]): Promise<number> {
 
   const printMsg = flagValue(argv, "-p") ?? flagValue(argv, "--print");
   const isPrintFlag = hasFlag(argv, "-p", "--print");
-  const isGlobal = hasFlag(argv, "-g", "--global");
+  const { global: isGlobal, repository: repoArg } = chatArguments(argv);
   const isPipeline = isPrintFlag || !process.stdin.isTTY;
-
-  const repoArg = positionals(argv, ["-p", "--print"])[0];
 
   let repoId: string | null = null;
   let label = "your organization";

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -65,7 +65,7 @@ export async function doctorCommand(_argv: string[]): Promise<number> {
       `${sanitizeTerminal(creds.orgName)} (${sanitizeTerminal(creds.orgSlug)}) on ${sanitizeTerminal(creds.baseUrl)}`,
     );
 
-    // Live token check — hits /api/cli/me with the saved bearer.
+    // Check the endpoint for the credential's scope without sending user secrets to org APIs.
     const res = await getJson(`${creds.baseUrl}${creds.kind === "user" ? "/api/cli/auth/user" : "/api/cli/me"}`, {
       headers: { authorization: `Bearer ${creds.token}` },
     });

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -66,7 +66,7 @@ export async function doctorCommand(_argv: string[]): Promise<number> {
     );
 
     // Live token check — hits /api/cli/me with the saved bearer.
-    const res = await getJson(`${creds.baseUrl}/api/cli/me`, {
+    const res = await getJson(`${creds.baseUrl}${creds.kind === "user" ? "/api/cli/auth/user" : "/api/cli/me"}`, {
       headers: { authorization: `Bearer ${creds.token}` },
     });
     if (res.ok) line("ok", "token", "accepted by server");

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -59,9 +59,9 @@ export async function loginCommand(argv: string[]): Promise<number> {
         return 2;
       }
       const verified = await verifyToken(baseUrl, token);
-      identity = { token, organization: verified.organization, user: verified.user };
+      identity = { token, ...verified };
     } else {
-      identity = await runDeviceFlow(baseUrl, { noOpen: hasFlag(argv, "--no-open"), onAuthorizeUrl: (url) => info(c.dim(url)) });
+      identity = await runDeviceFlow(baseUrl, { userSession: true, noOpen: hasFlag(argv, "--no-open"), onAuthorizeUrl: (url) => info(c.dim(url)) });
     }
     // Land the credentials in the active profile (which reflects --account),
     // registering + activating it so `account list` shows it and later commands
@@ -72,7 +72,7 @@ export async function loginCommand(argv: string[]): Promise<number> {
     await setActiveProfile(profileName);
     const email = identity.user.email ? ` (${sanitizeTerminal(identity.user.email)})` : "";
     success(
-      `Logged in as ${sanitizeTerminal(identity.user.name)}${email} — org: ${sanitizeTerminal(identity.organization.name)} [account: ${sanitizeTerminal(profileName)}]`,
+      `Logged in as ${sanitizeTerminal(identity.user.name)}${email}${identity.kind === "user" ? "" : ` — org: ${sanitizeTerminal(identity.organization.name)}`} [account: ${sanitizeTerminal(profileName)}]`,
     );
     return 0;
   } catch (err) {

--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -1,3 +1,4 @@
+import { del } from "../lib/api.js";
 import { loadCredentials, clearCredentials } from "../lib/credentials.js";
 import { hasFlag } from "../lib/args.js";
 import { success, error, info, sanitizeTerminal } from "../lib/output.js";
@@ -14,8 +15,15 @@ export async function logoutCommand(argv: string[]): Promise<number> {
     return 0;
   }
   try {
+    if (creds.kind === "user") {
+      const revoked = await del(`${creds.baseUrl}/api/cli/auth/user`, creds.token, { timeoutMs: 15_000 });
+      if (!revoked.ok && revoked.status !== 401) {
+        error("Could not revoke the CLI session. Check connectivity and retry logout.");
+        return 1;
+      }
+    }
     await clearCredentials();
-    success(`Signed out of ${sanitizeTerminal(creds.orgName)}.`);
+    success(creds.kind === "user" ? "Signed out. CLI session revoked." : `Signed out of ${sanitizeTerminal(creds.orgName)}.`);
     return 0;
   } catch (e) {
     // clearCredentials re-throws non-ENOENT — the token is still on disk.

--- a/apps/cli/src/commands/onboard-agent.ts
+++ b/apps/cli/src/commands/onboard-agent.ts
@@ -1,4 +1,6 @@
-import { spawnSync } from "node:child_process";
+import { detectOnboardingRepository } from "../lib/git-repository.js";
+export { detectOnboardingRepository } from "../lib/git-repository.js";
+import { resolveOrganization, getOrganizationOverride } from "../lib/organizations.js";
 import { loadCredentials } from "../lib/credentials.js";
 import { loadConfig } from "../lib/config.js";
 import { getActiveProfileName } from "../lib/paths.js";
@@ -32,19 +34,6 @@ export function parseAgentOnboardingArgs(argv: string[]): { repo?: string; help?
   return { repo };
 }
 
-export function detectOnboardingRepository(runGit: (args: string[]) => string | null = (args) => {
-  const result = spawnSync("git", args, { encoding: "utf8", timeout: 5000 });
-  return result.status === 0 ? result.stdout.trim() : null;
-}): string {
-  const remotes = runGit(["remote"])?.split("\n").filter(Boolean) ?? [];
-  const remote = remotes.includes("origin") ? "origin" : remotes.length === 1 ? remotes[0] : null;
-  if (!remote) throw new Error("No unambiguous git remote. Supply --repo owner/name for the intended GitHub repository.");
-  const url = runGit(["remote", "get-url", remote]);
-  // Accept github.com only; never print a raw remote URL that may contain credentials.
-  const match = url?.match(/^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/)([A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9_.-]+?)(?:\.git)?\/?$/i);
-  if (!match || [".", ".."].includes(match[1].split("/")[1])) throw new Error("Agent onboarding currently supports github.com remotes. Supply --repo owner/name only for a GitHub repository.");
-  return match[1];
-}
 
 export async function onboardAgentCommand(argv: string[]): Promise<number> {
   const context: OnboardingContext = { account: getActiveProfileName(), repository: "", baseUrl: "https://octopus-review.ai" };
@@ -61,12 +50,25 @@ export async function onboardAgentCommand(argv: string[]): Promise<number> {
     return 2;
   }
   try {
-    const creds = await loadCredentials();
+    let creds = await loadCredentials();
     const candidate = creds?.baseUrl ?? (await loadConfig()).selfHostedBaseUrl ?? context.baseUrl;
     const baseUrl = normalizeBaseUrl(candidate);
     if (!baseUrl || !isTransportSafe(baseUrl)) throw new Error("unsafe_server");
     context.baseUrl = baseUrl;
-    if (creds) context.organization = { id: creds.orgId, name: creds.orgName };
+    context.org = getOrganizationOverride();
+    if (creds) {
+      const resolved = await resolveOrganization(creds, context.org, context.repository);
+      if (!resolved.ok) {
+        const result = onboardingResult(context, resolved.state, resolved.message);
+        result.organizations = resolved.organizations;
+        if (resolved.state === "authentication_required") result.nextAction = { kind: "run_command", argv: ["octp", "--account", context.account, "login", "--no-open", "--api-url", baseUrl] };
+        await writeResult(result);
+        return onboardingExitCode(result);
+      }
+      creds = resolved.credentials;
+      context.organization = { id: creds.orgId, name: creds.orgName };
+      if (resolved.userSession) context.org = creds.orgSlug;
+    }
     const result = !creds ? (() => {
       const result = onboardingResult(context, "authentication_required", "Run login, show its approval URL to the user, wait for login to finish, then resume setup.");
       result.nextAction = { kind: "run_command" as const, argv: ["octp", "--account", context.account, "login", "--no-open", "--api-url", baseUrl] };

--- a/apps/cli/src/commands/org.ts
+++ b/apps/cli/src/commands/org.ts
@@ -1,0 +1,19 @@
+import { loadStoredCredentials } from "../lib/credentials.js";
+import { listOrganizations } from "../lib/organizations.js";
+import { sanitizeTerminal } from "../lib/output.js";
+
+export async function orgCommand(argv: string[]): Promise<number> {
+  if (argv.includes("--help") || argv.includes("-h")) { console.log("Usage: octp org list [--json]\nSelect per command with --org <slug>. Sign in once with octp login."); return 0; }
+  if (argv[0] !== "list" || argv.slice(1).some((a) => a !== "--json")) { console.error("Usage: octp org list [--json]"); return 2; }
+  const creds = await loadStoredCredentials();
+  if (!creds || creds.kind !== "user") { console.error("Run octp login to sign in as a user and list your organisations."); return 2; }
+  const response = await listOrganizations(creds);
+  if (!response.ok) { console.error(response.error); return 1; }
+  if (argv.includes("--json")) {
+    await new Promise<void>((resolve, reject) => process.stdout.write(`${JSON.stringify({ organizations: response.organizations })}\n`, (err) => err ? reject(err) : resolve()));
+  } else {
+    for (const org of response.organizations) console.log(`${sanitizeTerminal(org.slug)}\t${sanitizeTerminal(org.name)}`);
+    if (!response.organizations.length) console.log("No organisations available. Create or join one in Octopus.");
+  }
+  return 0;
+}

--- a/apps/cli/src/commands/repo.ts
+++ b/apps/cli/src/commands/repo.ts
@@ -13,7 +13,7 @@ import { loadCredentials, type Credentials } from "../lib/credentials.js";
 import { getJson, postJson } from "../lib/api.js";
 import { resolveRepo } from "../lib/repo-resolver.js";
 import { c, success, error, info, heading, table, sanitizeTerminal } from "../lib/output.js";
-import { positionals } from "../lib/args.js";
+import { repoArguments } from "../lib/command-arguments.js";
 import type { ApiRepo } from "../lib/types.js";
 
 const POLL_INTERVAL_MS = 3000;
@@ -95,9 +95,9 @@ export async function repoCommand(argv: string[]): Promise<number> {
     return 2;
   }
 
-  const [sub, repoArg] = positionals(argv);
+  const { subcommand: sub, repository: repoArg } = repoArguments(argv);
 
-  switch (sub ?? "list") {
+  switch (sub) {
     case "list":
       return await listRepos(creds.baseUrl, creds.token);
     case "status":

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -4,9 +4,8 @@ import { loadCredentials, type Credentials } from "../lib/credentials.js";
 import { loadConfig } from "../lib/config.js";
 import { getJson, postJson } from "../lib/api.js";
 import { ensureRepoIndexed } from "../lib/local-index.js";
-import { parsePrArg, prTerms, localizeMessage } from "../lib/pr-url.js";
+import { parsePrArg, prTerms, localizeMessage, reviewPrArgument } from "../lib/pr-url.js";
 import { resolveRepo } from "../lib/repo-resolver.js";
-import { positionals } from "../lib/args.js";
 import { sanitizeTerminal } from "../lib/output.js";
 
 /**
@@ -90,7 +89,7 @@ export async function reviewCommand(argv: string[]): Promise<number> {
   // server-side review of an existing PR (posted as comments) — distinct from
   // the local working-tree diff review below. A positional arg (one that isn't
   // a flag value) signals PR intent.
-  const prArg = flagValue(argv, "--pr") ?? positionals(argv, ["--since", "--format", "--pr"])[0];
+  const prArg = reviewPrArgument(argv);
   if (prArg) {
     return await reviewPr(creds, prArg);
   }

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -19,6 +19,13 @@ export async function whoamiCommand(argv: string[]): Promise<number> {
     error("Not signed in. Run `octp login`.");
     return 2;
   }
+  if (creds.kind === "user") {
+    const identity = await getJson<{ user: { name: string; email: string } }>(`${creds.baseUrl}/api/cli/auth/user`, { headers: { authorization: `Bearer ${creds.token}` }, signal: AbortSignal.timeout(15_000) });
+    if (!identity.ok) { error("Session expired or unavailable. Run octp login again."); return 1; }
+    info(`${sanitizeTerminal(identity.data.user.name)} <${sanitizeTerminal(identity.data.user.email)}>`);
+    info("User session. Use octp org list or --org <slug> for an organisation.");
+    return 0;
+  }
   const res = await getJson<Me>(`${creds.baseUrl}/api/cli/me`, {
     headers: { authorization: `Bearer ${creds.token}` },
   });

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -19,6 +19,9 @@ import { analyzeDepsCommand } from "./commands/analyze-deps.js";
 import { skillsCommand } from "./commands/skills.js";
 import { updateCommand } from "./commands/update.js";
 import { chatCommand } from "./commands/chat.js";
+import { orgCommand } from "./commands/org.js";
+import { setOrganizationOverride } from "./lib/organizations.js";
+import { ORGANIZATION_COMMANDS, prepareCommandOrganization } from "./lib/command-organization.js";
 import { accountCommand } from "./commands/account.js";
 import { ensureProfilesMigrated, isValidProfileName, ensureProfile, setActiveProfile } from "./lib/profile.js";
 import { setActiveProfileOverride } from "./lib/paths.js";
@@ -73,6 +76,7 @@ Auth & accounts:
   octp whoami                Show the signed-in user + org
   octp setup-token           Print a token to stdout (for CI/CD)
   octp account <list|set|show|remove>   Manage signed-in accounts (profiles)
+  octp org list [--json]      List organisations available to your user
 
 Reviews:
   octp review [--staged|--since <ref>]   Review local changes pre-PR
@@ -96,7 +100,8 @@ Agent & ops:
   octp update [--check]      Update the CLI
 
 Flags:
-  --account <name>           Use a specific account for one command (e.g. --account work)
+  --account <name>           Use a specific user/account profile for one command
+  --org <slug|id>            Select an organisation (otherwise infer from the repository)
   --version, -v              Print version
   --help, -h                 Print this help
   (run \`octp <command> --help\` for command-specific flags)
@@ -129,7 +134,22 @@ async function main(rawArgv: string[]): Promise<number> {
     argv = stripValueFlag(stripValueFlag(rawArgv, "--account"), "--profile");
   }
 
+  // Admin commands already own an unrelated --org flag; leave their grammar intact.
+  let orgFlag: string | undefined;
+  if (argv[0] !== "admin") {
+    if (argv.some((arg) => arg.startsWith("--org="))) { console.error("Use --org <slug>, with a space before the value."); return 2; }
+    orgFlag = flagValue(argv, "--org");
+    if (argv.filter((a) => a === "--org").length > 1 || (argv.includes("--org") && (!orgFlag || !/^[A-Za-z0-9_-]{1,128}$/.test(orgFlag)))) {
+      console.error("--org requires one organisation slug or ID.");
+      return 2;
+    }
+    if (orgFlag) { setOrganizationOverride(orgFlag); argv = stripValueFlag(argv, "--org"); }
+  }
   const first = argv[0];
+  if (orgFlag && !ORGANIZATION_COMMANDS.includes(first) && !["onboard", "whoami", "doctor"].includes(first)) {
+    console.error("Use --org with a repository command, onboard, whoami, or doctor after signing in.");
+    return 2;
+  }
 
   if (first === "--version" || first === "-v") {
     console.log(VERSION);
@@ -170,6 +190,7 @@ async function main(rawArgv: string[]): Promise<number> {
   }
 
   if (first === "onboard") {
+    if (orgFlag && !argv.includes("--agent")) { console.error("Use --org with octp onboard --agent --json."); return 2; }
     if (argv.includes("--agent")) return await onboardAgentCommand(argv.slice(1));
     if (argv.slice(1).some((arg) => arg !== "--reset")) {
       console.error("Use octp onboard [--reset] or octp onboard --agent --json [--repo owner/name].");
@@ -187,6 +208,8 @@ async function main(rawArgv: string[]): Promise<number> {
     }
   }
 
+  const organizationExit = await prepareCommandOrganization(argv, orgFlag);
+  if (organizationExit) return organizationExit;
   const rest = argv.slice(1);
   switch (first) {
     case "login":
@@ -217,6 +240,8 @@ async function main(rawArgv: string[]): Promise<number> {
       return await updateCommand(rest);
     case "doctor":
       return await doctorCommand(rest);
+    case "org":
+      return await orgCommand(rest);
     case "account":
     case "profile":
       return await accountCommand(rest);

--- a/apps/cli/src/index.tsx
+++ b/apps/cli/src/index.tsx
@@ -21,7 +21,7 @@ import { updateCommand } from "./commands/update.js";
 import { chatCommand } from "./commands/chat.js";
 import { orgCommand } from "./commands/org.js";
 import { setOrganizationOverride } from "./lib/organizations.js";
-import { ORGANIZATION_COMMANDS, prepareCommandOrganization } from "./lib/command-organization.js";
+import { isOrganizationCommand, prepareCommandOrganization } from "./lib/command-organization.js";
 import { accountCommand } from "./commands/account.js";
 import { ensureProfilesMigrated, isValidProfileName, ensureProfile, setActiveProfile } from "./lib/profile.js";
 import { setActiveProfileOverride } from "./lib/paths.js";
@@ -146,8 +146,8 @@ async function main(rawArgv: string[]): Promise<number> {
     if (orgFlag) { setOrganizationOverride(orgFlag); argv = stripValueFlag(argv, "--org"); }
   }
   const first = argv[0];
-  if (orgFlag && !ORGANIZATION_COMMANDS.includes(first) && !["onboard", "whoami", "doctor"].includes(first)) {
-    console.error("Use --org with a repository command, onboard, whoami, or doctor after signing in.");
+  if (orgFlag && !isOrganizationCommand(argv) && !["onboard", "whoami", "doctor"].includes(first)) {
+    console.error("Use --org with a repository command, agent serve, onboard, whoami, or doctor after signing in. Local agent watch operations use --account.");
     return 2;
   }
 

--- a/apps/cli/src/lib/agent-onboarding.ts
+++ b/apps/cli/src/lib/agent-onboarding.ts
@@ -1,7 +1,7 @@
 import type { ApiResult } from "./api.js";
 
 export type OnboardingState =
-  | "authentication_required" | "connection_required" | "repository_dismissed"
+  | "organization_required" | "authentication_required" | "connection_required" | "repository_dismissed"
   | "indexing" | "analyzing" | "ready" | "failed" | "invalid_input";
 
 export interface AgentOnboardingResult {
@@ -10,6 +10,7 @@ export interface AgentOnboardingResult {
   account: string;
   repository: string;
   organization?: { id: string; name: string };
+  organizations?: Array<{ id: string; slug: string; name: string }>;
   message: string;
   completed: string[];
   nextAction?: { kind: "run_command" | "open_url" | "retry"; argv?: string[]; url?: string };
@@ -29,6 +30,7 @@ export interface OnboardingServices {
 }
 
 export interface OnboardingContext {
+  org?: string;
   account: string;
   repository: string;
   organization?: { id: string; name: string };
@@ -40,7 +42,7 @@ export function onboardingResult(context: OnboardingContext, state: OnboardingSt
     schemaVersion: 1, state, account: context.account, repository: context.repository,
     ...(context.organization ? { organization: context.organization } : {}),
     message, completed: [],
-    continueWith: ["octp", "--account", context.account, "onboard", "--agent", "--json", "--repo", context.repository],
+    continueWith: ["octp", "--account", context.account, ...(context.org ? ["--org", context.org] : []), "onboard", "--agent", "--json", "--repo", context.repository],
   };
 }
 

--- a/apps/cli/src/lib/api.ts
+++ b/apps/cli/src/lib/api.ts
@@ -91,10 +91,10 @@ async function jsonRequest<T>(url: string, init: RequestInit): Promise<ApiResult
   return { ok: true, data: parsed as T };
 }
 
-export async function del<T>(url: string, bearerToken?: string): Promise<ApiResult<T>> {
+export async function del<T>(url: string, bearerToken?: string, options: PostJsonOptions = {}): Promise<ApiResult<T>> {
   const headers: Record<string, string> = { "user-agent": USER_AGENT };
   if (bearerToken) headers.authorization = `Bearer ${bearerToken}`;
-  return await jsonRequest<T>(url, { method: "DELETE", headers });
+  return await jsonRequest<T>(url, { method: "DELETE", headers, ...(options.timeoutMs ? { signal: AbortSignal.timeout(options.timeoutMs) } : {}) });
 }
 
 export type StreamResult = { ok: true } | { ok: false; status: number; error: string };

--- a/apps/cli/src/lib/auth.ts
+++ b/apps/cli/src/lib/auth.ts
@@ -11,7 +11,7 @@ import type { Credentials } from "./credentials.js";
  *   POST /api/cli/auth/verify        → { user, organization }   (token paste)
  */
 
-const MAX_POLL_ATTEMPTS = 200;
+const MAX_POLL_ATTEMPTS = 450;
 const POLL_INTERVAL_MS = 2000;
 const REQUEST_TIMEOUT_MS = 15_000;
 
@@ -22,12 +22,14 @@ export function isValidTokenFormat(token: string): boolean {
 }
 
 export interface AuthIdentity {
+  kind?: "user";
   token: string;
   organization: { id: string; slug: string; name: string };
   user: { name: string; email: string };
 }
 
 export interface DeviceFlowOptions {
+  userSession?: boolean;
   /** Don't open the browser automatically (the URL is still surfaced via onAuthorizeUrl). */
   noOpen?: boolean;
   /** Receives the authorize URL — callers decide stdout vs stderr vs silent. */
@@ -90,6 +92,7 @@ export async function runDeviceFlow(
   try {
     deviceRes = await fetch(`${baseUrl}/api/cli/auth/device`, {
       method: "POST",
+      ...(options.userSession ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify({ scope: "user" }) } : {}),
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
   } catch (e) {
@@ -106,6 +109,7 @@ export async function runDeviceFlow(
   }
 
   const deviceData = (await deviceRes.json()) as Record<string, unknown>;
+  if (options.userSession && deviceData.scope !== "user") throw new Error("This server needs an update for user-level CLI login. Existing organisation tokens remain supported with --token.");
   const deviceCode = deviceData.deviceCode;
   const expiresAt = deviceData.expiresAt;
   if (typeof deviceCode !== "string" || typeof expiresAt !== "string") {
@@ -145,12 +149,17 @@ export async function runDeviceFlow(
     if (!pollRes.ok) continue;
 
     const data = (await pollRes.json()) as {
+      scope?: string;
       status?: string;
       token?: string;
       organization?: { id: string; slug: string; name: string };
       user?: { name?: string; email?: string };
     };
-    if (data.status === "approved" && data.token && data.organization) {
+    if (data.status === "approved" && data.token && options.userSession && data.scope === "user") {
+      if (!/^oct_u_[a-f0-9]{64}$/.test(data.token)) throw new Error("Invalid CLI user credential response.");
+      return { kind: "user", token: data.token, organization: { id: "", slug: "", name: "" }, user: { name: data.user?.name ?? "Unknown User", email: data.user?.email ?? "" } };
+    }
+    if (data.status === "approved" && data.token && data.organization && !options.userSession) {
       return {
         token: data.token,
         organization: data.organization,
@@ -165,14 +174,16 @@ export async function runDeviceFlow(
 export async function verifyToken(
   baseUrl: string,
   token: string,
-): Promise<{ organization: { id: string; slug: string; name: string }; user: { name: string; email: string } }> {
+): Promise<Omit<AuthIdentity, "token">> {
   const res = await postJson<{
+    scope?: string;
     user: { id: string; name: string; email: string };
     organization: { id: string; name: string; slug: string };
   }>(`${baseUrl}/api/cli/auth/verify`, {}, token, { timeoutMs: REQUEST_TIMEOUT_MS });
   if (!res.ok) throw new Error(res.error || "Invalid token");
   return {
-    organization: res.data.organization,
+    ...(res.data.scope === "user" ? { kind: "user" as const } : {}),
+    organization: res.data.organization ?? { id: "", slug: "", name: "" },
     user: { name: res.data.user.name, email: res.data.user.email },
   };
 }
@@ -180,6 +191,7 @@ export async function verifyToken(
 /** Assemble a Credentials record from a completed auth + base URL. */
 export function buildCredentials(baseUrl: string, id: AuthIdentity): Credentials {
   return {
+    ...(id.kind ? { kind: id.kind } : {}),
     baseUrl,
     token: id.token,
     orgId: id.organization.id,

--- a/apps/cli/src/lib/auth.ts
+++ b/apps/cli/src/lib/auth.ts
@@ -3,12 +3,9 @@ import { postJson } from "./api.js";
 import type { Credentials } from "./credentials.js";
 
 /**
- * Headless auth for the operational commands. Extracted so `login`,
- * `setup-token`, and the onboarding wizard share one device-flow
- * implementation. Endpoints:
- *   POST /api/cli/auth/device        → { deviceCode, expiresAt }
- *   GET  /api/cli/auth/poll?...      → { status, token, organization, user }
- *   POST /api/cli/auth/verify        → { user, organization }   (token paste)
+ * Shared device flow: login opts into user sessions; setup-token and the
+ * wizard retain organisation approval. Do not silently downgrade a requested
+ * user session when talking to an older server.
  */
 
 const MAX_POLL_ATTEMPTS = 450;

--- a/apps/cli/src/lib/command-arguments.ts
+++ b/apps/cli/src/lib/command-arguments.ts
@@ -1,0 +1,17 @@
+import { hasFlag, positionals } from "./args.js";
+
+export function chatArguments(argv: string[]) {
+  return {
+    repository: positionals(argv, ["-p", "--print"])[0],
+    global: hasFlag(argv, "-g", "--global"),
+  };
+}
+
+export function repoArguments(argv: string[]) {
+  const [subcommand, repository] = positionals(argv);
+  return { subcommand: subcommand ?? "list", repository };
+}
+
+export function dependencyRepositoryArgument(argv: string[]): string | undefined {
+  return positionals(argv)[0];
+}

--- a/apps/cli/src/lib/command-organization.ts
+++ b/apps/cli/src/lib/command-organization.ts
@@ -1,22 +1,45 @@
-import { flagValue } from "./args.js";
+import { flagValue, positionals } from "./args.js";
 import { loadStoredCredentials, setCommandCredentials } from "./credentials.js";
 import { resolveOrganization } from "./organizations.js";
 import { detectOnboardingRepository } from "./git-repository.js";
+import { parsePrArg, reviewPrArgument } from "./pr-url.js";
 import { sanitizeTerminal } from "./output.js";
 
-export const ORGANIZATION_COMMANDS = ["repo", "review", "chat", "knowledge", "usage", "analyze-deps", "agent"];
+export const ORGANIZATION_COMMANDS = ["repo", "review", "chat", "knowledge", "usage", "analyze-deps"];
+
+export function isOrganizationCommand(argv: string[]): boolean {
+  return ORGANIZATION_COMMANDS.includes(argv[0]) || (argv[0] === "agent" && argv[1] === "serve");
+}
 
 export async function prepareCommandOrganization(argv: string[], orgFlag?: string): Promise<number> {
   const first = argv[0];
-  if ((ORGANIZATION_COMMANDS.includes(first) || (orgFlag && ["whoami", "doctor"].includes(first))) && !argv.includes("--help") && !argv.includes("-h")) {
+  if ((isOrganizationCommand(argv) || (orgFlag && ["whoami", "doctor"].includes(first))) && !argv.includes("--help") && !argv.includes("-h")) {
     const saved = await loadStoredCredentials();
     if (saved) {
       let repository = flagValue(argv, "--repo");
       const positional = first === "repo" ? argv[2] : first === "chat" ? argv[1] : undefined;
       if (!repository && positional && /^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9_.-]+$/.test(positional)) repository = positional;
-      const prUrl = flagValue(argv, "--pr");
-      if (!repository && prUrl) repository = prUrl.match(/^https:\/\/github\.com\/([A-Za-z0-9-]+\/[A-Za-z0-9_.-]+)\/pull\/\d+\/?$/)?.[1];
-      if (!repository) { try { repository = detectOnboardingRepository(); } catch { /* No project: require explicit choice when needed. */ } }
+      let useRemote = true;
+      if (first === "review") {
+        const target = reviewPrArgument(argv.slice(1));
+        if (target) {
+          const parsed = parsePrArg(target);
+          if (!parsed.ok) { console.error(sanitizeTerminal(parsed.error)); return 2; }
+          repository = parsed.repoFullName;
+        }
+      } else if (first === "analyze-deps") {
+        const target = positionals(argv.slice(1))[0];
+        useRemote = !target;
+        if (target) {
+          try {
+            const url = new URL(target.trim());
+            const parts = url.pathname.split("/").filter(Boolean);
+            if (url.hostname !== "github.com" || parts.length < 2) throw new Error();
+            repository = parts.slice(0, 2).join("/");
+          } catch { console.error("Invalid GitHub repository URL."); return 2; }
+        }
+      }
+      if (!repository && useRemote) { try { repository = detectOnboardingRepository(); } catch { /* No project: require explicit choice when needed. */ } }
       const resolved = await resolveOrganization(saved, orgFlag, repository);
       if (!resolved.ok) {
         console.error(sanitizeTerminal(resolved.message));

--- a/apps/cli/src/lib/command-organization.ts
+++ b/apps/cli/src/lib/command-organization.ts
@@ -1,4 +1,4 @@
-import { flagValue, positionals } from "./args.js";
+import { chatArguments, repoArguments, dependencyRepositoryArgument } from "./command-arguments.js";
 import { loadStoredCredentials, setCommandCredentials } from "./credentials.js";
 import { resolveOrganization } from "./organizations.js";
 import { detectOnboardingRepository } from "./git-repository.js";
@@ -16,31 +16,41 @@ export async function prepareCommandOrganization(argv: string[], orgFlag?: strin
   if ((isOrganizationCommand(argv) || (orgFlag && ["whoami", "doctor"].includes(first))) && !argv.includes("--help") && !argv.includes("-h")) {
     const saved = await loadStoredCredentials();
     if (saved) {
-      let repository = flagValue(argv, "--repo");
-      const positional = first === "repo" ? argv[2] : first === "chat" ? argv[1] : undefined;
-      if (!repository && positional && /^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9_.-]+$/.test(positional)) repository = positional;
-      let useRemote = true;
-      if (first === "review") {
-        const target = reviewPrArgument(argv.slice(1));
-        if (target) {
-          const parsed = parsePrArg(target);
-          if (!parsed.ok) { console.error(sanitizeTerminal(parsed.error)); return 2; }
-          repository = parsed.repoFullName;
+      let repository: string | undefined;
+      let explicitRepository = false;
+      if (saved.kind === "user" && !orgFlag) {
+        const args = argv.slice(1);
+        if (first === "chat") {
+          const target = chatArguments(args);
+          if (!target.global) repository = target.repository;
+          explicitRepository = repository !== undefined;
+        } else if (first === "repo") {
+          const target = repoArguments(args);
+          if (["status", "index", "analyze"].includes(target.subcommand)) repository = target.repository;
+          explicitRepository = repository !== undefined;
+        } else if (first === "review") {
+          const target = reviewPrArgument(args);
+          if (target) {
+            const parsed = parsePrArg(target);
+            if (!parsed.ok) { console.error(sanitizeTerminal(parsed.error)); return 2; }
+            repository = parsed.repoFullName;
+            explicitRepository = repository !== undefined;
+          }
+        } else if (first === "analyze-deps") {
+          const target = dependencyRepositoryArgument(args);
+          explicitRepository = target !== undefined;
+          if (target) {
+            try {
+              const url = new URL(target.trim());
+              const parts = url.pathname.split("/").filter(Boolean);
+              if (url.hostname === "github.com" && parts.length >= 2) repository = parts.slice(0, 2).join("/");
+            } catch { repository = undefined; }
+          }
         }
-      } else if (first === "analyze-deps") {
-        const target = positionals(argv.slice(1))[0];
-        useRemote = !target;
-        if (target) {
-          try {
-            const url = new URL(target.trim());
-            const parts = url.pathname.split("/").filter(Boolean);
-            if (url.hostname !== "github.com" || parts.length < 2) throw new Error();
-            repository = parts.slice(0, 2).join("/");
-          } catch { console.error("Invalid GitHub repository URL."); return 2; }
-        }
+        if (repository !== undefined && (repository.length > 140 || !/^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9_.-]+$/.test(repository) || [".", ".."].includes(repository.split("/")[1]))) repository = undefined;
+        if (!explicitRepository) { try { repository = detectOnboardingRepository(); } catch { /* No project: require explicit choice when needed. */ } }
       }
-      if (!repository && useRemote) { try { repository = detectOnboardingRepository(); } catch { /* No project: require explicit choice when needed. */ } }
-      const resolved = await resolveOrganization(saved, orgFlag, repository);
+      const resolved = await resolveOrganization(saved, orgFlag, repository, explicitRepository);
       if (!resolved.ok) {
         console.error(sanitizeTerminal(resolved.message));
         for (const org of resolved.organizations ?? []) console.error(`  --org ${sanitizeTerminal(org.slug)}  ${sanitizeTerminal(org.name)}`);

--- a/apps/cli/src/lib/command-organization.ts
+++ b/apps/cli/src/lib/command-organization.ts
@@ -1,0 +1,30 @@
+import { flagValue } from "./args.js";
+import { loadStoredCredentials, setCommandCredentials } from "./credentials.js";
+import { resolveOrganization } from "./organizations.js";
+import { detectOnboardingRepository } from "./git-repository.js";
+import { sanitizeTerminal } from "./output.js";
+
+export const ORGANIZATION_COMMANDS = ["repo", "review", "chat", "knowledge", "usage", "analyze-deps", "agent"];
+
+export async function prepareCommandOrganization(argv: string[], orgFlag?: string): Promise<number> {
+  const first = argv[0];
+  if ((ORGANIZATION_COMMANDS.includes(first) || (orgFlag && ["whoami", "doctor"].includes(first))) && !argv.includes("--help") && !argv.includes("-h")) {
+    const saved = await loadStoredCredentials();
+    if (saved) {
+      let repository = flagValue(argv, "--repo");
+      const positional = first === "repo" ? argv[2] : first === "chat" ? argv[1] : undefined;
+      if (!repository && positional && /^[A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9_.-]+$/.test(positional)) repository = positional;
+      const prUrl = flagValue(argv, "--pr");
+      if (!repository && prUrl) repository = prUrl.match(/^https:\/\/github\.com\/([A-Za-z0-9-]+\/[A-Za-z0-9_.-]+)\/pull\/\d+\/?$/)?.[1];
+      if (!repository) { try { repository = detectOnboardingRepository(); } catch { /* No project: require explicit choice when needed. */ } }
+      const resolved = await resolveOrganization(saved, orgFlag, repository);
+      if (!resolved.ok) {
+        console.error(sanitizeTerminal(resolved.message));
+        for (const org of resolved.organizations ?? []) console.error(`  --org ${sanitizeTerminal(org.slug)}  ${sanitizeTerminal(org.name)}`);
+        return resolved.state === "organization_required" ? 3 : 1;
+      }
+      setCommandCredentials(resolved.credentials);
+    }
+  }
+  return 0;
+}

--- a/apps/cli/src/lib/credentials.ts
+++ b/apps/cli/src/lib/credentials.ts
@@ -9,6 +9,8 @@ import { ensureOctopusHome, getCredentialsPath } from "./paths.js";
  * File: ~/.octopus/credentials, mode 0600.
  */
 export type Credentials = {
+  /** User login is unbound; org fields stay empty until command-local resolution. */
+  kind?: "user";
   /** API base URL — `https://octopus-review.ai` for hosted, custom for self-hosted. */
   baseUrl: string;
   /** Long-lived API token returned by the approve flow. */
@@ -28,7 +30,14 @@ export type Credentials = {
  * Load credentials. Returns null when the file is missing, unreadable, or
  * has the wrong shape — never throws. Callers treat null as "not signed in."
  */
+let commandCredentials: Credentials | undefined;
+export function setCommandCredentials(value: Credentials): void { commandCredentials = value; }
+
 export async function loadCredentials(): Promise<Credentials | null> {
+  return commandCredentials ?? await loadStoredCredentials();
+}
+
+export async function loadStoredCredentials(): Promise<Credentials | null> {
   try {
     const raw = await readFile(getCredentialsPath(), "utf8");
     const parsed = JSON.parse(raw) as unknown;
@@ -76,6 +85,7 @@ function isCredentials(value: unknown): value is Credentials {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
   return (
+    (v.kind === undefined || v.kind === "user") &&
     typeof v.baseUrl === "string" &&
     typeof v.token === "string" &&
     typeof v.orgId === "string" &&

--- a/apps/cli/src/lib/credentials.ts
+++ b/apps/cli/src/lib/credentials.ts
@@ -13,9 +13,9 @@ export type Credentials = {
   kind?: "user";
   /** API base URL — `https://octopus-review.ai` for hosted, custom for self-hosted. */
   baseUrl: string;
-  /** Long-lived API token returned by the approve flow. */
+  /** User-session secret or organisation token; never log this value. */
   token: string;
-  /** Org context at the time of approval. */
+  /** Empty for user sessions; otherwise the approved or command-selected org. */
   orgId: string;
   orgSlug: string;
   orgName: string;
@@ -26,10 +26,6 @@ export type Credentials = {
   approvedAt: string;
 };
 
-/**
- * Load credentials. Returns null when the file is missing, unreadable, or
- * has the wrong shape — never throws. Callers treat null as "not signed in."
- */
 let commandCredentials: Credentials | undefined;
 export function setCommandCredentials(value: Credentials): void { commandCredentials = value; }
 export function clearCommandCredentials(): void { commandCredentials = undefined; }
@@ -38,6 +34,10 @@ export async function loadCredentials(): Promise<Credentials | null> {
   return commandCredentials ?? await loadStoredCredentials();
 }
 
+/**
+ * Read the saved profile, bypassing command-local organisation credentials.
+ * Missing, unreadable, or malformed files return null ("not signed in").
+ */
 export async function loadStoredCredentials(): Promise<Credentials | null> {
   try {
     const raw = await readFile(getCredentialsPath(), "utf8");

--- a/apps/cli/src/lib/credentials.ts
+++ b/apps/cli/src/lib/credentials.ts
@@ -32,6 +32,7 @@ export type Credentials = {
  */
 let commandCredentials: Credentials | undefined;
 export function setCommandCredentials(value: Credentials): void { commandCredentials = value; }
+export function clearCommandCredentials(): void { commandCredentials = undefined; }
 
 export async function loadCredentials(): Promise<Credentials | null> {
   return commandCredentials ?? await loadStoredCredentials();

--- a/apps/cli/src/lib/git-repository.ts
+++ b/apps/cli/src/lib/git-repository.ts
@@ -1,0 +1,16 @@
+import { spawnSync } from "node:child_process";
+
+export function detectOnboardingRepository(runGit: (args: string[]) => string | null = (args) => {
+  const result = spawnSync("git", args, { encoding: "utf8", timeout: 5000 });
+  return result.status === 0 ? result.stdout.trim() : null;
+}): string {
+  const remotes = runGit(["remote"])?.split("\n").filter(Boolean) ?? [];
+  const remote = remotes.includes("origin") ? "origin" : remotes.length === 1 ? remotes[0] : null;
+  if (!remote) throw new Error("No unambiguous git remote. Supply --repo owner/name for the intended GitHub repository.");
+  const url = runGit(["remote", "get-url", remote]);
+  // Accept github.com only; never print a raw remote URL that may contain credentials.
+  const match = url?.match(/^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https:\/\/github\.com\/)([A-Za-z0-9][A-Za-z0-9-]*\/[A-Za-z0-9_.-]+?)(?:\.git)?\/?$/i);
+  if (!match || [".", ".."].includes(match[1].split("/")[1])) throw new Error("Agent onboarding currently supports github.com remotes. Supply --repo owner/name only for a GitHub repository.");
+  return match[1];
+}
+

--- a/apps/cli/src/lib/git-repository.ts
+++ b/apps/cli/src/lib/git-repository.ts
@@ -13,4 +13,3 @@ export function detectOnboardingRepository(runGit: (args: string[]) => string | 
   if (!match || [".", ".."].includes(match[1].split("/")[1])) throw new Error("Agent onboarding currently supports github.com remotes. Supply --repo owner/name only for a GitHub repository.");
   return match[1];
 }
-

--- a/apps/cli/src/lib/organizations.ts
+++ b/apps/cli/src/lib/organizations.ts
@@ -1,0 +1,55 @@
+import { getJson, postJson, normalizeBaseUrl, isTransportSafe } from "./api.js";
+import type { Credentials } from "./credentials.js";
+
+export interface OrganizationChoice {
+  id: string;
+  slug: string;
+  name: string;
+  matchesRepository?: boolean;
+  matchesOwner?: boolean;
+  hasInstallation?: boolean;
+}
+let organizationOverride: string | undefined;
+export function setOrganizationOverride(value: string): void { organizationOverride = value; }
+export function getOrganizationOverride(): string | undefined { return organizationOverride; }
+
+export function chooseOrganization(choices: OrganizationChoice[], explicit?: string, repo?: string): OrganizationChoice | undefined {
+  if (explicit) return choices.find((org) => org.id === explicit || org.slug === explicit);
+  const exact = choices.filter((org) => org.matchesRepository);
+  if (exact.length) return exact.length === 1 ? exact[0] : undefined;
+  const owners = choices.filter((org) => org.matchesOwner);
+  if (owners.length) return owners.length === 1 ? owners[0] : undefined;
+  if (choices.length === 1 && (!repo || !choices[0].hasInstallation)) return choices[0];
+  return undefined;
+}
+
+export async function listOrganizations(creds: Credentials, repo?: string) {
+  const base = normalizeBaseUrl(creds.baseUrl);
+  if (!base || base !== creds.baseUrl || !isTransportSafe(base)) return { ok: false as const, status: 0, error: "Unsafe server URL in saved credentials." };
+  const response = await getJson<{ organizations: OrganizationChoice[] }>(`${base}/api/cli/organizations${repo ? `?repo=${encodeURIComponent(repo)}` : ""}`, { headers: { authorization: `Bearer ${creds.token}` }, signal: AbortSignal.timeout(15_000) });
+  if (!response.ok) return response;
+  const rows = response.data?.organizations;
+  if (!Array.isArray(rows) || rows.some((org) => !org || typeof org.id !== "string" || typeof org.slug !== "string" || typeof org.name !== "string" || [org.matchesRepository, org.matchesOwner, org.hasInstallation].some((value) => value !== undefined && typeof value !== "boolean"))) return { ok: false as const, status: 0, error: "Invalid organization response." };
+  return { ok: true as const, organizations: rows };
+}
+
+export async function resolveOrganization(creds: Credentials, explicit?: string, repo?: string): Promise<
+  { ok: true; credentials: Credentials; userSession: boolean } |
+  { ok: false; state: "organization_required" | "authentication_required" | "failed"; message: string; organizations?: OrganizationChoice[] }
+> {
+  if (creds.kind !== "user") {
+    if (explicit && explicit !== creds.orgId && explicit !== creds.orgSlug) return { ok: false, state: "authentication_required", message: "This saved token is bound to another organisation. Run octp login once to enable --org switching." };
+    return { ok: true, credentials: creds, userSession: false };
+  }
+  const response = await listOrganizations(creds, repo);
+  if (!response.ok) return { ok: false, state: response.status === 401 ? "authentication_required" : "failed", message: `Could not list organisations: ${response.error}` };
+  const choice = chooseOrganization(response.organizations, explicit, repo);
+  if (!choice) return {
+    ok: false, state: "organization_required", organizations: response.organizations.map(({ id, slug, name }) => ({ id, slug, name })),
+    message: explicit ? "The requested organisation is not available to this user. Select an available --org slug." : response.organizations.length ? "Select an organisation with --org <slug>, then retry. No work has started." : "No organisations are available. Create or join one in Octopus, then retry.",
+  };
+  const scoped = await postJson<{ token: string; organization: { id: string; slug: string; name: string } }>(`${creds.baseUrl}/api/cli/organizations`, { organization: choice.id }, creds.token, { timeoutMs: 15_000 });
+  if (!scoped.ok) return { ok: false, state: scoped.status === 401 ? "authentication_required" : "failed", message: `Could not select organisation: ${scoped.error}` };
+  if (!scoped.data || !/^oct_[a-f0-9]{64}$/.test(scoped.data.token) || scoped.data.organization?.id !== choice.id || scoped.data.organization?.slug !== choice.slug) return { ok: false, state: "failed", message: "Invalid organisation credential response." };
+  return { ok: true, userSession: true, credentials: { ...creds, kind: undefined, token: scoped.data.token, orgId: choice.id, orgSlug: choice.slug, orgName: choice.name } };
+}

--- a/apps/cli/src/lib/organizations.ts
+++ b/apps/cli/src/lib/organizations.ts
@@ -13,13 +13,13 @@ let organizationOverride: string | undefined;
 export function setOrganizationOverride(value: string): void { organizationOverride = value; }
 export function getOrganizationOverride(): string | undefined { return organizationOverride; }
 
-export function chooseOrganization(choices: OrganizationChoice[], explicit?: string, repo?: string): OrganizationChoice | undefined {
+export function chooseOrganization(choices: OrganizationChoice[], explicit?: string, repo?: string, requireRepositoryMatch = false): OrganizationChoice | undefined {
   if (explicit) return choices.find((org) => org.id === explicit || org.slug === explicit);
   const exact = choices.filter((org) => org.matchesRepository);
   if (exact.length) return exact.length === 1 ? exact[0] : undefined;
   const owners = choices.filter((org) => org.matchesOwner);
   if (owners.length) return owners.length === 1 ? owners[0] : undefined;
-  if (choices.length === 1 && (!repo || !choices[0].hasInstallation)) return choices[0];
+  if (!requireRepositoryMatch && choices.length === 1 && (!repo || !choices[0].hasInstallation)) return choices[0];
   return undefined;
 }
 
@@ -33,7 +33,7 @@ export async function listOrganizations(creds: Credentials, repo?: string) {
   return { ok: true as const, organizations: rows };
 }
 
-export async function resolveOrganization(creds: Credentials, explicit?: string, repo?: string): Promise<
+export async function resolveOrganization(creds: Credentials, explicit?: string, repo?: string, requireRepositoryMatch = false): Promise<
   { ok: true; credentials: Credentials; userSession: boolean } |
   { ok: false; state: "organization_required" | "authentication_required" | "failed"; message: string; organizations?: OrganizationChoice[] }
 > {
@@ -43,7 +43,7 @@ export async function resolveOrganization(creds: Credentials, explicit?: string,
   }
   const response = await listOrganizations(creds, repo);
   if (!response.ok) return { ok: false, state: response.status === 401 ? "authentication_required" : "failed", message: `Could not list organisations: ${response.error}` };
-  const choice = chooseOrganization(response.organizations, explicit, repo);
+  const choice = chooseOrganization(response.organizations, explicit, repo, requireRepositoryMatch);
   if (!choice) return {
     ok: false, state: "organization_required", organizations: response.organizations.map(({ id, slug, name }) => ({ id, slug, name })),
     message: explicit ? "The requested organisation is not available to this user. Select an available --org slug." : response.organizations.length ? "Select an organisation with --org <slug>, then retry. No work has started." : "No organisations are available. Create or join one in Octopus, then retry.",

--- a/apps/cli/src/lib/pr-url.ts
+++ b/apps/cli/src/lib/pr-url.ts
@@ -1,3 +1,9 @@
+import { flagValue, positionals } from "./args.js";
+
+export function reviewPrArgument(argv: string[]): string | undefined {
+  return flagValue(argv, "--pr") ?? positionals(argv, ["--since", "--format", "--pr"])[0];
+}
+
 /**
  * Parse a PR/MR identifier for `octp review --pr`. Accepts a bare number or a
  * GitHub / Bitbucket / GitLab (incl. self-hosted, nested subgroups) URL.

--- a/apps/web/app/(auth)/cli/authorize/page.tsx
+++ b/apps/web/app/(auth)/cli/authorize/page.tsx
@@ -24,6 +24,8 @@ function AuthorizeContent() {
   const searchParams = useSearchParams();
   const code = searchParams.get("code");
 
+  const [userScope, setUserScope] = React.useState(false);
+  const [userEmail, setUserEmail] = React.useState("");
   const [orgs, setOrgs] = React.useState<Organization[]>([]);
   const [selectedOrgId, setSelectedOrgId] = React.useState<string>("");
   const [loading, setLoading] = React.useState(true);
@@ -36,13 +38,18 @@ function AuthorizeContent() {
 
     const abortController = new AbortController();
 
-    fetch("/api/cli/auth/orgs", { signal: abortController.signal })
-      .then((res) => {
-        if (!res.ok) throw new Error("Failed to load organizations");
-        return res.json() as Promise<{ organizations: Organization[] }>;
+    fetch(`/api/cli/auth/orgs?device_code=${encodeURIComponent(code)}`, { signal: abortController.signal })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({})) as { error?: string };
+          throw new Error(body.error ?? "Could not load CLI approval. Run octp login again.");
+        }
+        return res.json() as Promise<{ organizations: Organization[]; scope?: string; user?: { email: string } }>;
       })
       .then((data) => {
         setOrgs(data.organizations);
+        setUserScope(data.scope === "user");
+        setUserEmail(data.user?.email ?? "");
         if (data.organizations.length === 1) {
           setSelectedOrgId(data.organizations[0].id);
         }
@@ -59,7 +66,7 @@ function AuthorizeContent() {
   }, [code]);
 
   async function handleAuthorize() {
-    if (!selectedOrgId || !code) return;
+    if ((!userScope && !selectedOrgId) || !code) return;
 
     setApproving(true);
     setError(null);
@@ -68,7 +75,7 @@ function AuthorizeContent() {
       const res = await fetch("/api/cli/auth/approve", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ deviceCode: code, organizationId: selectedOrgId }),
+        body: JSON.stringify(userScope ? { deviceCode: code } : { deviceCode: code, organizationId: selectedOrgId }),
       });
 
       if (!res.ok) {
@@ -125,7 +132,7 @@ function AuthorizeContent() {
           </div>
           <CardTitle>Authorize Octopus CLI</CardTitle>
           <CardDescription>
-            Select an organization to grant CLI access.
+            {userScope ? "Sign in once. Choose your organisation from the CLI for each project." : "Approve this CLI session."}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -133,11 +140,16 @@ function AuthorizeContent() {
             <div className="flex items-center justify-center py-6">
               <IconLoader2 className="text-muted-foreground size-5 animate-spin" />
             </div>
-          ) : orgs.length === 0 ? (
+          ) : userScope ? (
+            <div className="space-y-3 text-sm">
+              <p className="break-words font-medium">{userEmail}</p>
+              <p className="text-muted-foreground">Allow this CLI session to access the organisations you belong to. Your current permissions apply, and you can revoke the session with <code>octp logout</code>.</p>
+            </div>
+          ) : orgs.length === 0 ? (error ? null : (
             <p className="text-muted-foreground text-center text-sm">
               You are not a member of any organization.
             </p>
-          ) : (
+          )) : (
             <div className="space-y-2">
               {orgs.map((org) => (
                 <button
@@ -157,14 +169,14 @@ function AuthorizeContent() {
             </div>
           )}
           {error && (
-            <p className="mt-3 text-center text-sm text-red-500">{error}</p>
+            <p role="alert" className="mt-3 text-center text-sm text-red-500">{error}</p>
           )}
         </CardContent>
-        {orgs.length > 0 && !loading && (
+        {(userScope || orgs.length > 0) && !loading && (
           <CardFooter>
             <Button
               className="w-full"
-              disabled={!selectedOrgId || approving}
+              disabled={(!userScope && !selectedOrgId) || approving}
               onClick={handleAuthorize}
             >
               {approving ? (

--- a/apps/web/app/(landing)/docs/cli/page.tsx
+++ b/apps/web/app/(landing)/docs/cli/page.tsx
@@ -57,7 +57,7 @@ export default function CLIPage() {
         <CodeBlock>octp onboard --agent --json</CodeBlock>
         <Paragraph>
           Run this from the project directory, or supply <Mono>--repo owner/name</Mono>.
-          Use <Mono>--account name</Mono> to select an existing Octopus account profile.
+          Use <Mono>--account name</Mono> to select a saved user profile, and <Mono>--org slug</Mono> to choose an organisation for one command.
         </Paragraph>
         <Paragraph>
           If sign-in is needed, the AI runs the returned login command with <Mono>--no-open</Mono>,
@@ -80,6 +80,19 @@ export default function CLIPage() {
           browser window for authentication.
         </Paragraph>
         <CodeBlock>octp login</CodeBlock>
+        <p className="text-[#a0a0a0]">
+          CLI 0.6.0 with server 1.0.157 signs you in once without selecting an organisation in the browser.
+          Your session lasts 30 days. Run <Mono>octp logout</Mono> to revoke it.
+        </p>
+        <CodeBlock>{`octp org list --json
+octp --org acme onboard --agent --json --repo acme/app
+octp --org another-org repo list`}</CodeBlock>
+        <p className="text-[#a0a0a0]">
+          Without <Mono>--org</Mono>, repository setup uses a unique repository or GitHub owner match.
+          If it cannot choose safely, it returns <Mono>organization_required</Mono> with your available organisations
+          before starting work. Choose one and retry. Existing organisation tokens keep their original scope;
+          run <Mono>octp login</Mono> again to enable switching.
+        </p>
         <Paragraph>You can also authenticate with an API token directly:</Paragraph>
         <CodeBlock>octp login --token oct_your_token_here</CodeBlock>
         <Paragraph>
@@ -340,7 +353,7 @@ octp skills install --codex`}</CodeBlock>
       {/* Profiles */}
       <Section title="Multiple Profiles">
         <Paragraph>
-          Use profiles to switch between different accounts or organizations:
+          Use profiles for different users or servers. Within one user account, switch organisations with --org:
         </Paragraph>
         <CodeBlock>{`octp login --profile work
 octp login --profile personal

--- a/apps/web/app/(landing)/docs/cli/page.tsx
+++ b/apps/web/app/(landing)/docs/cli/page.tsx
@@ -97,7 +97,7 @@ octp --org another-org repo list`}</CodeBlock>
         <CodeBlock>octp login --token oct_your_token_here</CodeBlock>
         <Paragraph>
           Need a token for CI/CD or a script? Use <Mono>setup-token</Mono>. It
-          runs the same browser approval flow but prints the token to stdout
+          uses organisation-scoped browser approval and prints the token to stdout
           (progress messages go to stderr) so it can be captured directly:
         </Paragraph>
         <CodeBlock>{`# Print token to stdout

--- a/apps/web/app/(landing)/docs/security-overview/page.tsx
+++ b/apps/web/app/(landing)/docs/security-overview/page.tsx
@@ -75,7 +75,7 @@ export default function SecurityOverviewPage() {
           <li><strong>Authentication</strong> — Better Auth with GitHub OAuth, Google OAuth, Microsoft / Entra ID OAuth, and magic-link email. Passwords are not used; we have no password store.</li>
           <li><strong>Session management</strong> — short-lived bearer tokens with refresh; sessions revocable from <code>/settings/sessions</code>.</li>
           <li><strong>Role-based access</strong> — per-organisation roles (owner / admin / member); the audit log records role transitions.</li>
-          <li><strong>CLI tokens</strong> — issued via the device-code flow, scoped to one organisation, revocable per-token.</li>
+          <li><strong>CLI tokens</strong> — see the <a href="https://github.com/octopusreview/octopus/blob/master/apps/cli/README.md#set-up-a-repository-with-your-ai" className="underline">CLI authentication contract</a> for user sessions, organisation-scoped credentials, and revocation.</li>
           <li><strong>Webhook secrets</strong> — set per-organisation; every inbound payload is verified via HMAC signature (GitHub, Bitbucket) or per-organisation hook-token comparison (GitLab).</li>
         </UL>
       </Section>

--- a/apps/web/app/api/cli/auth/approve/route.ts
+++ b/apps/web/app/api/cli/auth/approve/route.ts
@@ -1,99 +1,56 @@
+import "server-only";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { generateApiToken, hashToken, getTokenPrefix } from "@/lib/api-auth";
+import { generateCliUserToken } from "@/lib/cli-user-auth";
 import { getAccountStanding, ACCOUNT_HOLD_MESSAGE } from "@/lib/account-standing";
 
 export async function POST(request: Request) {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session) {
-    return Response.json({ error: "Not authenticated" }, { status: 401 });
+  if (request.headers.get("origin") !== new URL(process.env.BETTER_AUTH_URL || request.url).origin) {
+    return Response.json({ error: "Invalid request origin" }, { status: 403 });
   }
-
-  const body = await request.json();
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return Response.json({ error: "Not authenticated" }, { status: 401 });
+  const body = await request.json().catch(() => null);
   const deviceCode = typeof body?.deviceCode === "string" ? body.deviceCode.trim() : "";
   const organizationId = typeof body?.organizationId === "string" ? body.organizationId.trim() : "";
+  if (!/^[0-9a-f]{40}$/.test(deviceCode)) return Response.json({ error: "Invalid device code" }, { status: 400 });
+  const authSession = await prisma.cliAuthSession.findUnique({ where: { deviceCode } });
+  if (!authSession || authSession.status !== "pending") return Response.json({ error: "Invalid or already used device code" }, { status: 400 });
+  if (authSession.expiresAt <= new Date()) return Response.json({ error: "Device code expired" }, { status: 410 });
+  const user = await prisma.user.findUnique({ where: { id: session.user.id }, select: { bannedAt: true } });
+  if (!user || user.bannedAt) return Response.json({ error: "Account is unavailable" }, { status: 403 });
+  const userScope = authSession.scope === "user";
+  const allowedKeys = userScope ? ["deviceCode"] : ["deviceCode", "organizationId"];
+  if (Object.keys(body).some((key) => !allowedKeys.includes(key)) || (!userScope && !organizationId)) return Response.json({ error: "Invalid approval request" }, { status: 400 });
 
-  if (!deviceCode || !organizationId) {
-    return Response.json({ error: "Missing deviceCode or organizationId" }, { status: 400 });
+  let org: { id: string; name: string; slug: string } | null = null;
+  if (!userScope) {
+    const member = await prisma.organizationMember.findFirst({
+      where: { userId: session.user.id, organizationId, deletedAt: null, organization: { deletedAt: null, bannedAt: null } },
+      select: { organization: { select: { id: true, name: true, slug: true } } },
+    });
+    if (!member) return Response.json({ error: "Not a member of this organization" }, { status: 403 });
+    if ((await getAccountStanding({ userId: session.user.id, orgId: organizationId })).held) return Response.json({ error: ACCOUNT_HOLD_MESSAGE }, { status: 403 });
+    org = member.organization;
   }
-
-  if (!/^[0-9a-f]{40}$/.test(deviceCode)) {
-    return Response.json({ error: "Invalid device code format" }, { status: 400 });
-  }
-
-  // Verify the auth session exists and is pending
-  const authSession = await prisma.cliAuthSession.findUnique({
-    where: { deviceCode },
+  const rawToken = userScope ? generateCliUserToken() : generateApiToken();
+  const approved = await prisma.$transaction(async (tx) => {
+    // One claimant mints one token. Expiry and pending state are checked under
+    // the same transaction as token creation; concurrent approvals cannot win.
+    const claim = await tx.cliAuthSession.updateMany({
+      where: { id: authSession.id, status: "pending", expiresAt: { gt: new Date() } },
+      data: { status: "approved", token: rawToken, orgId: org?.id ?? null, orgSlug: org?.slug ?? null, orgName: org?.name ?? null, userName: session.user.name, userEmail: session.user.email },
+    });
+    if (!claim.count) return false;
+    if (userScope) {
+      await tx.cliUserToken.create({ data: { tokenHash: hashToken(rawToken), userId: session.user.id, expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) } });
+    } else {
+      await tx.orgApiToken.create({ data: { name: `CLI (${session.user.name ?? session.user.email})`, tokenHash: hashToken(rawToken), tokenPrefix: getTokenPrefix(rawToken), organizationId: org!.id, createdById: session.user.id } });
+    }
+    return true;
   });
-
-  if (!authSession || authSession.status !== "pending") {
-    return Response.json({ error: "Invalid or already used device code" }, { status: 400 });
-  }
-
-  if (authSession.expiresAt < new Date()) {
-    return Response.json({ error: "Device code expired" }, { status: 410 });
-  }
-
-  // Verify org membership
-  const member = await prisma.organizationMember.findFirst({
-    where: {
-      userId: session.user.id,
-      organizationId,
-      deletedAt: null,
-    },
-  });
-  if (!member) {
-    return Response.json({ error: "Not a member of this organization" }, { status: 403 });
-  }
-
-  // Account-standing gate (issue #788): the signup farm minted its tokens
-  // through this device flow — held accounts with no product signal get a
-  // clear, actionable refusal instead of a token.
-  const standing = await getAccountStanding({
-    userId: session.user.id,
-    orgId: organizationId,
-  });
-  if (standing.held) {
-    return Response.json({ error: ACCOUNT_HOLD_MESSAGE }, { status: 403 });
-  }
-
-  const org = await prisma.organization.findUnique({
-    where: { id: organizationId },
-    select: { id: true, name: true, slug: true },
-  });
-  if (!org) {
-    return Response.json({ error: "Organization not found" }, { status: 404 });
-  }
-
-  // Create the API token
-  const rawToken = generateApiToken();
-  const tokenHash = hashToken(rawToken);
-  const tokenPrefix = getTokenPrefix(rawToken);
-
-  await prisma.orgApiToken.create({
-    data: {
-      name: `CLI (${session.user.name ?? session.user.email})`,
-      tokenHash,
-      tokenPrefix,
-      organizationId,
-      createdById: session.user.id,
-    },
-  });
-
-  // Mark session as approved with the raw token
-  await prisma.cliAuthSession.update({
-    where: { id: authSession.id },
-    data: {
-      status: "approved",
-      token: rawToken,
-      orgId: org.id,
-      orgSlug: org.slug,
-      orgName: org.name,
-      userName: session.user.name,
-      userEmail: session.user.email,
-    },
-  });
-
-  return Response.json({ success: true });
+  if (!approved) return Response.json({ error: "Device code expired or was already approved" }, { status: 409 });
+  return Response.json({ success: true }, { headers: { "Cache-Control": "no-store" } });
 }

--- a/apps/web/app/api/cli/auth/device/route.ts
+++ b/apps/web/app/api/cli/auth/device/route.ts
@@ -1,6 +1,19 @@
+import "server-only";
 import { prisma } from "@octopus/db";
 
-export async function POST() {
+export async function POST(request: Request) {
+  const body = await request.text();
+  let scope = "organization";
+  if (body) {
+    try {
+      const parsed = JSON.parse(body);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("invalid_scope");
+      if (Object.keys(parsed).length) {
+        if (Object.keys(parsed).length !== 1 || parsed.scope !== "user") throw new Error("invalid_scope");
+        scope = "user";
+      }
+    } catch { return Response.json({ error: "Invalid device scope." }, { status: 400 }); }
+  }
   // Simple rate limit: max 10 device codes created in the last minute
   const recentCount = await prisma.cliAuthSession.count({
     where: { createdAt: { gte: new Date(Date.now() - 60_000) } },
@@ -16,15 +29,16 @@ export async function POST() {
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
 
-  // Expires in 5 minutes
-  const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+  // User approval allows 15 minutes; legacy clients keep their 5-minute window.
+  const expiresAt = new Date(Date.now() + (scope === "user" ? 15 : 5) * 60 * 1000);
 
   await prisma.cliAuthSession.create({
-    data: { deviceCode, expiresAt },
+    data: { deviceCode, expiresAt, scope },
   });
 
   return Response.json({
     deviceCode,
+    scope,
     expiresAt: expiresAt.toISOString(),
   });
 }

--- a/apps/web/app/api/cli/auth/orgs/route.ts
+++ b/apps/web/app/api/cli/auth/orgs/route.ts
@@ -1,12 +1,21 @@
+import "server-only";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { prisma } from "@octopus/db";
 import { createOrgForUser } from "@/lib/org-create";
 
-export async function GET() {
+export async function GET(request: Request) {
   const session = await auth.api.getSession({ headers: await headers() });
   if (!session) {
     return Response.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const deviceCode = new URL(request.url).searchParams.get("device_code");
+  if (deviceCode !== null) {
+    if (!/^[0-9a-f]{40}$/.test(deviceCode)) return Response.json({ error: "Invalid device code" }, { status: 400 });
+    const device = await prisma.cliAuthSession.findUnique({ where: { deviceCode } });
+    if (!device || device.expiresAt <= new Date() || device.status !== "pending") return Response.json({ error: "Device code expired or already used. Run octp login again." }, { status: 410 });
+    if (device.scope === "user") return Response.json({ scope: "user", organizations: [], user: { name: session.user.name, email: session.user.email } }, { headers: { "Cache-Control": "no-store" } });
   }
 
   let memberships = await prisma.organizationMember.findMany({

--- a/apps/web/app/api/cli/auth/poll/route.ts
+++ b/apps/web/app/api/cli/auth/poll/route.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { prisma } from "@octopus/db";
 import { NextRequest } from "next/server";
 
@@ -28,7 +29,7 @@ export async function GET(request: NextRequest) {
 
     // Atomic clear — only succeed if token still exists (prevents double-read race)
     const updated = await prisma.cliAuthSession.updateMany({
-      where: { id: session.id, token: { not: null } },
+      where: { id: session.id, status: "approved", expiresAt: { gt: new Date() }, token: { not: null } },
       data: { token: null },
     });
 
@@ -39,7 +40,8 @@ export async function GET(request: NextRequest) {
     return Response.json({
       status: "approved",
       token,
-      organization: {
+      scope: session.scope,
+      organization: session.scope === "user" ? null : {
         id: session.orgId,
         slug: session.orgSlug,
         name: session.orgName,
@@ -48,7 +50,7 @@ export async function GET(request: NextRequest) {
         name: session.userName,
         email: session.userEmail,
       },
-    });
+    }, { headers: { "Cache-Control": "no-store" } });
   }
 
   return Response.json({ status: "pending" });

--- a/apps/web/app/api/cli/auth/user/route.ts
+++ b/apps/web/app/api/cli/auth/user/route.ts
@@ -1,0 +1,16 @@
+import "server-only";
+import { prisma } from "@octopus/db";
+import { authenticateCliUser } from "@/lib/cli-user-auth";
+
+export async function GET(request: Request) {
+  const identity = await authenticateCliUser(request);
+  if (!identity) return Response.json({ error: "Invalid or expired CLI session." }, { status: 401 });
+  return Response.json({ user: { name: identity.user.name, email: identity.user.email } }, { headers: { "Cache-Control": "no-store" } });
+}
+
+export async function DELETE(request: Request) {
+  const identity = await authenticateCliUser(request);
+  if (!identity) return Response.json({ error: "Invalid or expired CLI session." }, { status: 401 });
+  await prisma.cliUserToken.update({ where: { id: identity.token.id }, data: { deletedAt: new Date() } });
+  return Response.json({ success: true }, { headers: { "Cache-Control": "no-store" } });
+}

--- a/apps/web/app/api/cli/auth/user/route.ts
+++ b/apps/web/app/api/cli/auth/user/route.ts
@@ -1,6 +1,5 @@
 import "server-only";
-import { prisma } from "@octopus/db";
-import { authenticateCliUser } from "@/lib/cli-user-auth";
+import { authenticateCliUser, revokeCliUserSession } from "@/lib/cli-user-auth";
 
 export async function GET(request: Request) {
   const identity = await authenticateCliUser(request);
@@ -9,8 +8,6 @@ export async function GET(request: Request) {
 }
 
 export async function DELETE(request: Request) {
-  const identity = await authenticateCliUser(request);
-  if (!identity) return Response.json({ error: "Invalid or expired CLI session." }, { status: 401 });
-  await prisma.cliUserToken.update({ where: { id: identity.token.id }, data: { deletedAt: new Date() } });
+  if (!await revokeCliUserSession(request)) return Response.json({ error: "Invalid CLI session." }, { status: 401 });
   return Response.json({ success: true }, { headers: { "Cache-Control": "no-store" } });
 }

--- a/apps/web/app/api/cli/auth/verify/route.ts
+++ b/apps/web/app/api/cli/auth/verify/route.ts
@@ -1,6 +1,12 @@
+import { authenticateCliUser } from "@/lib/cli-user-auth";
 import { authenticateApiToken } from "@/lib/api-auth";
 
 export async function POST(request: Request) {
+  if (request.headers.get("authorization")?.startsWith("Bearer oct_u_")) {
+    const identity = await authenticateCliUser(request);
+    if (!identity) return Response.json({ error: "Invalid or expired CLI session" }, { status: 401 });
+    return Response.json({ scope: "user", organization: null, user: { id: identity.user.id, name: identity.user.name, email: identity.user.email } }, { headers: { "Cache-Control": "no-store" } });
+  }
   const result = await authenticateApiToken(request);
   if (result instanceof Response) return result; // account-standing hold (403), pass through
   if (!result) {

--- a/apps/web/app/api/cli/organizations/route.ts
+++ b/apps/web/app/api/cli/organizations/route.ts
@@ -1,0 +1,58 @@
+import "server-only";
+import { prisma } from "@octopus/db";
+import { authenticateCliUser, deriveCliOrgToken, hashCliToken } from "@/lib/cli-user-auth";
+import { getAccountStanding, ACCOUNT_HOLD_MESSAGE } from "@/lib/account-standing";
+import { parseConnectRepository } from "@/lib/cli-repo-connect";
+
+const noStore = { headers: { "Cache-Control": "no-store" } };
+
+export async function GET(request: Request) {
+  const identity = await authenticateCliUser(request);
+  if (!identity) return Response.json({ error: "Sign in again with octp login." }, { status: 401, ...noStore });
+  const repo = new URL(request.url).searchParams.get("repo");
+  if (repo !== null && !parseConnectRepository({ fullName: repo })) return Response.json({ error: "Invalid repository." }, { status: 400, ...noStore });
+  const memberships = await prisma.organizationMember.findMany({
+    where: { userId: identity.user.id, deletedAt: null, organization: { deletedAt: null, bannedAt: null } },
+    select: { organization: { select: { id: true, slug: true, name: true, githubInstallationId: true } } },
+    orderBy: { organization: { slug: "asc" } },
+  });
+  const orgIds = memberships.map((m) => m.organization.id);
+  const repositories = repo && orgIds.length ? await prisma.repository.findMany({
+    where: { organizationId: { in: orgIds }, provider: "github", isActive: true, dismissedAt: null, fullName: { startsWith: `${repo.split("/")[0]}/`, mode: "insensitive" } },
+    select: { organizationId: true, fullName: true },
+  }) : [];
+  return Response.json({
+    user: { name: identity.user.name, email: identity.user.email },
+    organizations: memberships.map(({ organization: org }) => ({
+      id: org.id, slug: org.slug, name: org.name, hasInstallation: org.githubInstallationId !== null,
+      matchesRepository: repositories.some((r) => r.organizationId === org.id && r.fullName.toLowerCase() === repo?.toLowerCase()),
+      matchesOwner: repositories.some((r) => r.organizationId === org.id),
+    })),
+  }, noStore);
+}
+
+export async function POST(request: Request) {
+  const identity = await authenticateCliUser(request);
+  if (!identity) return Response.json({ error: "Sign in again with octp login." }, { status: 401, ...noStore });
+  const body: unknown = await request.json().catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body) || Object.keys(body).length !== 1 || !("organization" in body) || typeof body.organization !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(body.organization)) {
+    return Response.json({ error: "Supply an organization ID or slug." }, { status: 400, ...noStore });
+  }
+  const member = await prisma.organizationMember.findFirst({
+    where: { userId: identity.user.id, deletedAt: null, organization: { deletedAt: null, bannedAt: null, OR: [{ id: body.organization }, { slug: body.organization }] } },
+    include: { organization: true },
+  });
+  if (!member) return Response.json({ error: "Organization is not available to this user." }, { status: 403, ...noStore });
+  const org = member.organization;
+  const standing = await getAccountStanding({ userId: identity.user.id, orgId: org.id });
+  if (standing.held) return Response.json({ error: ACCOUNT_HOLD_MESSAGE }, { status: 403, ...noStore });
+  const rawToken = deriveCliOrgToken(identity.raw, org.id);
+  // A revoked child stays revoked; choosing an org must never undo revocation.
+  const token = await prisma.orgApiToken.upsert({
+    where: { cliUserTokenId_organizationId: { cliUserTokenId: identity.token.id, organizationId: org.id } },
+    create: { name: "CLI user session", tokenHash: hashCliToken(rawToken), tokenPrefix: `${rawToken.slice(0, 8)}...`, createdById: identity.user.id, organizationId: org.id, cliUserTokenId: identity.token.id, expiresAt: identity.token.expiresAt },
+    update: {},
+  });
+  if (token.deletedAt) return Response.json({ error: "CLI access to this organization was revoked. Sign in again." }, { status: 403, ...noStore });
+  return Response.json({ token: rawToken, organization: { id: org.id, slug: org.slug, name: org.name } }, noStore);
+}

--- a/apps/web/components/landing-agent-prompt.tsx
+++ b/apps/web/components/landing-agent-prompt.tsx
@@ -9,7 +9,7 @@ Read the project's Git remote to identify the repository. If it is ambiguous, as
 
 Install or update octp using the official instructions at https://octopus-review.ai/docs/cli (macOS/Linux: https://octopus-review.ai/install.sh; Windows: https://octopus-review.ai/install.ps1). Check octp --help, then run octp onboard --agent --json from this project.
 
-Follow the returned nextAction and continueWith instructions. If sign-in is required, run the supplied login command with --no-open, show me its approval URL, and keep the login process running while I approve. For GitHub App installation, organisation authorisation or repository access, give me the exact approval URL returned by octp. After approval, continue through the CLI.
+Follow the returned nextAction and continueWith instructions. If sign-in is required, run the supplied login command with --no-open, show me its approval URL, and keep the login process running while I approve. Login signs me in as a user without choosing an organisation. Let octp infer the organisation from the repository. If it returns organization_required, show me the available organisations and retry with --org <slug> after I choose; never guess. Use octp org list --json to inspect my memberships. For GitHub App installation, organisation authorisation or repository access, give me the exact approval URL returned by octp. After approval, continue through the CLI.
 
 Let octp connect this repository, start or join indexing and analysis, and check progress using retryAfterSeconds. Continue until it reports ready or a specific blocker. Report the actual repository, indexing and analysis results. Keep existing organisation settings and never print credentials. Use the browser only for the approvals I need to make.`;
 

--- a/apps/web/lib/__tests__/cli-user-auth.db.test.ts
+++ b/apps/web/lib/__tests__/cli-user-auth.db.test.ts
@@ -108,6 +108,29 @@ suite("CLI user sessions with PostgreSQL", () => {
     expect(await apiAuth.authenticateApiToken(request("/api/cli/me", other.token))).toBeNull();
     expect((await exchange(raw)).status).toBe(401);
   });
+  it("revokes by possession during a ban or after expiry without restoring access", async () => {
+    for (const state of ["banned", "expired"]) {
+      const { raw, row } = await session();
+      const { token } = await (await exchange(raw)).json();
+      try {
+        if (state === "banned") await prisma.user.update({ where: { id: userId }, data: { bannedAt: new Date() } });
+        else await prisma.cliUserToken.update({ where: { id: row.id }, data: { expiresAt: new Date(0) } });
+        expect((await userRoute.GET(request("/api/cli/auth/user", raw))).status).toBe(401);
+        expect((await exchange(raw)).status).toBe(401);
+        expect((await userRoute.DELETE(request("/api/cli/auth/user", raw))).status).toBe(200);
+        expect((await prisma.cliUserToken.findUniqueOrThrow({ where: { id: row.id } })).deletedAt).not.toBeNull();
+      } finally {
+        await prisma.user.update({ where: { id: userId }, data: { bannedAt: null } });
+      }
+      expect((await userRoute.GET(request("/api/cli/auth/user", raw))).status).toBe(401);
+      expect((await exchange(raw)).status).toBe(401);
+      expect(await apiAuth.authenticateApiToken(request("/api/cli/me", token))).toBeNull();
+      expect((await userRoute.DELETE(request("/api/cli/auth/user", raw))).status).toBe(200);
+    }
+    for (const raw of [undefined, "oct_invalid", userAuth.generateCliUserToken()]) {
+      expect((await userRoute.DELETE(request("/api/cli/auth/user", raw))).status).toBe(401);
+    }
+  });
   it("keeps legacy approvals organisation-scoped and refuses expired approval", async () => {
     const deviceCode = randomUUID().replaceAll("-", "") + "87654321";
     const device = await prisma.cliAuthSession.create({ data: { deviceCode, expiresAt: new Date(Date.now() + 60_000), userEmail: `${userId}@example.test` } });

--- a/apps/web/lib/__tests__/cli-user-auth.db.test.ts
+++ b/apps/web/lib/__tests__/cli-user-auth.db.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
+import { NextRequest } from "next/server";
+import { randomUUID } from "node:crypto";
+
+const enabled = process.env.RUN_CLI_AUTH_DB_TESTS === "1";
+if (enabled && !/(^|[-_])test($|[-_])/.test(new URL(process.env.DATABASE_URL ?? "http://invalid").pathname.slice(1))) throw new Error("CLI auth tests require a dedicated test database");
+const fixture = randomUUID().replaceAll("-", "");
+const userId = `cli_test_${fixture}`;
+const orgIds = [0, 1, 2].map((n) => `cli_test_${fixture}_${n}`);
+let held = false;
+if (enabled) {
+  mock.module("server-only", () => ({}));
+  mock.module("next/headers", () => ({ headers: async () => new Headers() }));
+  mock.module("@/lib/auth", () => ({ auth: { api: { getSession: async () => ({ user: { id: userId, name: "CLI Test", email: `${userId}@example.test` } }) } } }));
+  mock.module("@/lib/account-standing", () => ({ getAccountStanding: async () => ({ held }), ACCOUNT_HOLD_MESSAGE: "Account held", isHeldRiskBand: () => false, orgHasProductSignal: async () => true }));
+}
+let prisma: (typeof import("@octopus/db"))["prisma"];
+let userAuth: typeof import("@/lib/cli-user-auth");
+let apiAuth: typeof import("@/lib/api-auth");
+let organizations: typeof import("@/app/api/cli/organizations/route");
+let approval: typeof import("@/app/api/cli/auth/approve/route");
+let deviceRoute: typeof import("@/app/api/cli/auth/device/route");
+let poll: typeof import("@/app/api/cli/auth/poll/route");
+let userRoute: typeof import("@/app/api/cli/auth/user/route");
+if (enabled) {
+  ({ prisma } = await import("@octopus/db"));
+  userAuth = await import("@/lib/cli-user-auth");
+  apiAuth = await import("@/lib/api-auth");
+  organizations = await import("@/app/api/cli/organizations/route");
+  approval = await import("@/app/api/cli/auth/approve/route");
+  deviceRoute = await import("@/app/api/cli/auth/device/route");
+  poll = await import("@/app/api/cli/auth/poll/route");
+  userRoute = await import("@/app/api/cli/auth/user/route");
+}
+function request(path: string, token?: string, body?: unknown, origin = "http://localhost") {
+  return new Request(`http://localhost${path}`, { method: body === undefined ? "GET" : "POST", headers: { origin, ...(token ? { authorization: `Bearer ${token}` } : {}), "content-type": "application/json" }, ...(body === undefined ? {} : { body: JSON.stringify(body) }) });
+}
+async function session() {
+  const raw = userAuth.generateCliUserToken();
+  const row = await prisma.cliUserToken.create({ data: { userId, tokenHash: userAuth.hashCliToken(raw), expiresAt: new Date(Date.now() + 60_000) } });
+  return { raw, row };
+}
+async function exchange(raw: string, org = orgIds[0]) {
+  return organizations.POST(request("/api/cli/organizations", raw, { organization: org }));
+}
+const suite = enabled ? describe : describe.skip;
+suite("CLI user sessions with PostgreSQL", () => {
+  beforeAll(async () => {
+    await prisma.user.create({ data: { id: userId, name: "CLI Test", email: `${userId}@example.test` } });
+    for (const id of orgIds) await prisma.organization.create({ data: { id, slug: id, name: id } });
+    for (const organizationId of orgIds.slice(0, 2)) await prisma.organizationMember.create({ data: { userId, organizationId, role: "member" } });
+  });
+  afterAll(async () => {
+    await prisma.cliAuthSession.deleteMany({ where: { userEmail: `${userId}@example.test` } });
+    await prisma.organization.deleteMany({ where: { id: { in: orgIds } } });
+    await prisma.user.delete({ where: { id: userId } });
+    await prisma.$disconnect();
+  });
+  it("retains empty-body and empty-object legacy device requests while accepting user scope", async () => {
+    for (const body of [undefined, {}, { scope: "user" }]) {
+      const response = await deviceRoute.POST(new Request("http://localhost/api/cli/auth/device", { method: "POST", ...(body === undefined ? {} : { body: JSON.stringify(body) }) }));
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.scope).toBe(body && "scope" in body ? "user" : "organization");
+      await prisma.cliAuthSession.delete({ where: { deviceCode: data.deviceCode } });
+    }
+    expect((await deviceRoute.POST(request("/api/cli/auth/device", undefined, { scope: "admin" }))).status).toBe(400);
+  });
+  it("lists only current memberships, exchanges each scope once, and never accepts user credentials as org tokens", async () => {
+    const { raw, row } = await session();
+    const list = await organizations.GET(request("/api/cli/organizations", raw));
+    expect(list.status).toBe(200);
+    expect((await list.json()).organizations.map((org: { id: string }) => org.id)).toEqual(orgIds.slice(0, 2));
+    expect(await apiAuth.authenticateApiToken(request("/api/cli/me", raw))).toBeNull();
+    expect((await exchange(raw, orgIds[2])).status).toBe(403);
+    const first = await (await exchange(raw)).json();
+    const again = await (await exchange(raw)).json();
+    const second = await (await exchange(raw, orgIds[1])).json();
+    expect(first.token).toBe(again.token);
+    expect(second.token).not.toBe(first.token);
+    expect(await prisma.orgApiToken.count({ where: { cliUserTokenId: row.id } })).toBe(2);
+    const auth = await apiAuth.authenticateApiToken(request("/api/cli/me", first.token));
+    expect(auth && !(auth instanceof Response) && auth.org.id).toBe(orgIds[0]);
+    held = true;
+    expect((await exchange(raw)).status).toBe(403);
+    held = false;
+  });
+  it("rejects removed membership, banned users, revoked children and revoked/expired parents", async () => {
+    const { raw, row } = await session();
+    const { token } = await (await exchange(raw)).json();
+    const check = () => apiAuth.authenticateApiToken(request("/api/cli/me", token));
+    await prisma.organizationMember.updateMany({ where: { userId, organizationId: orgIds[0] }, data: { deletedAt: new Date() } });
+    expect(await check()).toBeNull();
+    expect((await exchange(raw)).status).toBe(403);
+    await prisma.organizationMember.updateMany({ where: { userId, organizationId: orgIds[0] }, data: { deletedAt: null } });
+    await prisma.user.update({ where: { id: userId }, data: { bannedAt: new Date() } });
+    expect(await check()).toBeNull();
+    expect((await exchange(raw)).status).toBe(401);
+    await prisma.user.update({ where: { id: userId }, data: { bannedAt: null } });
+    await prisma.cliUserToken.update({ where: { id: row.id }, data: { expiresAt: new Date(0) } });
+    expect(await check()).toBeNull();
+    await prisma.cliUserToken.update({ where: { id: row.id }, data: { expiresAt: new Date(Date.now() + 60_000) } });
+    await prisma.orgApiToken.updateMany({ where: { cliUserTokenId: row.id }, data: { deletedAt: new Date() } });
+    expect((await exchange(raw)).status).toBe(403);
+    expect(await check()).toBeNull();
+    const other = await (await exchange(raw, orgIds[1])).json();
+    expect((await userRoute.DELETE(request("/api/cli/auth/user", raw))).status).toBe(200);
+    expect(await apiAuth.authenticateApiToken(request("/api/cli/me", other.token))).toBeNull();
+    expect((await exchange(raw)).status).toBe(401);
+  });
+  it("keeps legacy approvals organisation-scoped and refuses expired approval", async () => {
+    const deviceCode = randomUUID().replaceAll("-", "") + "87654321";
+    const device = await prisma.cliAuthSession.create({ data: { deviceCode, expiresAt: new Date(Date.now() + 60_000), userEmail: `${userId}@example.test` } });
+    expect((await approval.POST(request("/api/cli/auth/approve", undefined, { deviceCode }))).status).toBe(400);
+    expect((await approval.POST(request("/api/cli/auth/approve", undefined, { deviceCode, organizationId: orgIds[2] }))).status).toBe(403);
+    expect((await approval.POST(request("/api/cli/auth/approve", undefined, { deviceCode, organizationId: orgIds[0] }))).status).toBe(200);
+    const granted = await (await poll.GET(new NextRequest(`http://localhost/api/cli/auth/poll?device_code=${deviceCode}`))).json();
+    expect(granted).toMatchObject({ scope: "organization", organization: { id: orgIds[0] } });
+    const legacy = await apiAuth.authenticateApiToken(request("/api/cli/me", granted.token));
+    expect(legacy && !(legacy instanceof Response) && legacy.token.cliUserTokenId).toBeNull();
+    await prisma.cliAuthSession.update({ where: { id: device.id }, data: { status: "pending", expiresAt: new Date(0) } });
+    expect((await approval.POST(request("/api/cli/auth/approve", undefined, { deviceCode, organizationId: orgIds[0] }))).status).toBe(410);
+  });
+  it("approves without an org, rejects tampering/CSRF, and mints and polls only once under concurrency", async () => {
+    const deviceCode = randomUUID().replaceAll("-", "") + "12345678";
+    const device = await prisma.cliAuthSession.create({ data: { deviceCode, scope: "user", expiresAt: new Date(Date.now() + 60_000), userEmail: `${userId}@example.test` } });
+    expect((await approval.POST(request("/api/cli/auth/approve", undefined, { deviceCode }, "https://evil.test"))).status).toBe(403);
+    expect((await approval.POST(request("/api/cli/auth/approve", undefined, { deviceCode, organizationId: orgIds[0] }))).status).toBe(400);
+    const before = await prisma.cliUserToken.count({ where: { userId } });
+    const results = await Promise.all([0, 1].map(() => approval.POST(request("/api/cli/auth/approve", undefined, { deviceCode }))));
+    expect(results.filter((result) => result.status === 200)).toHaveLength(1);
+    expect(await prisma.cliUserToken.count({ where: { userId } })).toBe(before + 1);
+    const approved = await prisma.cliAuthSession.findUniqueOrThrow({ where: { id: device.id } });
+    expect(approved.orgId).toBeNull();
+    const responses = await Promise.all([0, 1].map(() => poll.GET(new NextRequest(`http://localhost/api/cli/auth/poll?device_code=${deviceCode}`))));
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+    const grants = bodies.filter((body) => body.token);
+    expect(grants).toHaveLength(1);
+    expect(grants[0]).toMatchObject({ scope: "user", organization: null });
+    expect(grants[0].token).toMatch(/^oct_u_[a-f0-9]{64}$/);
+    expect((await prisma.cliAuthSession.findUniqueOrThrow({ where: { id: device.id } })).token).toBeNull();
+  });
+});

--- a/apps/web/lib/api-auth.ts
+++ b/apps/web/lib/api-auth.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { prisma } from "@octopus/db";
 import { createHash } from "crypto";
 import {
@@ -24,6 +25,7 @@ export async function authenticateApiToken(request: Request) {
     include: {
       organization: true,
       createdBy: true,
+      cliUserToken: true,
     },
   });
 
@@ -34,6 +36,17 @@ export async function authenticateApiToken(request: Request) {
   // Check expiration
   if (apiToken.expiresAt && apiToken.expiresAt < new Date()) {
     return null;
+  }
+
+  // User-session child tokens follow current membership and parent revocation.
+  if (apiToken.cliUserTokenId) {
+    const parent = apiToken.cliUserToken;
+    if (!parent || parent.deletedAt || parent.expiresAt <= new Date() || parent.userId !== apiToken.createdById || apiToken.createdBy.bannedAt) return null;
+    const member = await prisma.organizationMember.findFirst({
+      where: { organizationId: apiToken.organizationId, userId: apiToken.createdById, deletedAt: null },
+      select: { id: true },
+    });
+    if (!member) return null;
   }
 
   // Check if org is banned

--- a/apps/web/lib/cli-user-auth.ts
+++ b/apps/web/lib/cli-user-auth.ts
@@ -1,0 +1,25 @@
+import "server-only";
+import { prisma } from "@octopus/db";
+import { createHash, createHmac, randomBytes } from "node:crypto";
+
+export const CLI_USER_TOKEN_PREFIX = "oct_u_";
+export const hashCliToken = (token: string) => createHash("sha256").update(token).digest("hex");
+export const generateCliUserToken = () => `${CLI_USER_TOKEN_PREFIX}${randomBytes(32).toString("hex")}`;
+
+/** This credential authenticates a person, never an organisation API request. */
+export async function authenticateCliUser(request: Request) {
+  const header = request.headers.get("authorization");
+  const raw = header?.startsWith("Bearer ") ? header.slice(7) : "";
+  if (!/^oct_u_[a-f0-9]{64}$/.test(raw)) return null;
+  const token = await prisma.cliUserToken.findUnique({
+    where: { tokenHash: hashCliToken(raw) },
+    include: { user: true },
+  });
+  if (!token || token.deletedAt || token.expiresAt <= new Date() || token.user.bannedAt) return null;
+  return { token, user: token.user, raw };
+}
+
+/** Derive a stable child secret so org selection does not mint unbounded tokens. */
+export function deriveCliOrgToken(userToken: string, orgId: string): string {
+  return `oct_${createHmac("sha256", userToken).update(`octopus-cli-org-v1:${orgId}`).digest("hex")}`;
+}

--- a/apps/web/lib/cli-user-auth.ts
+++ b/apps/web/lib/cli-user-auth.ts
@@ -8,18 +8,33 @@ export const generateCliUserToken = () => `${CLI_USER_TOKEN_PREFIX}${randomBytes
 
 /** This credential authenticates a person, never an organisation API request. */
 export async function authenticateCliUser(request: Request) {
-  const header = request.headers.get("authorization");
-  const raw = header?.startsWith("Bearer ") ? header.slice(7) : "";
-  if (!/^oct_u_[a-f0-9]{64}$/.test(raw)) return null;
+  const tokenHash = cliUserTokenHash(request);
+  if (!tokenHash) return null;
   const token = await prisma.cliUserToken.findUnique({
-    where: { tokenHash: hashCliToken(raw) },
+    where: { tokenHash },
     include: { user: true },
   });
   if (!token || token.deletedAt || token.expiresAt <= new Date() || token.user.bannedAt) return null;
-  return { token, user: token.user, raw };
+  return { token, user: token.user, raw: request.headers.get("authorization")!.slice(7) };
 }
 
 /** Derive a stable child secret so org selection does not mint unbounded tokens. */
 export function deriveCliOrgToken(userToken: string, orgId: string): string {
   return `oct_${createHmac("sha256", userToken).update(`octopus-cli-org-v1:${orgId}`).digest("hex")}`;
+}
+
+function cliUserTokenHash(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  const raw = header?.startsWith("Bearer ") ? header.slice(7) : "";
+  return /^oct_u_[a-f0-9]{64}$/.test(raw) ? hashCliToken(raw) : null;
+}
+
+export async function revokeCliUserSession(request: Request): Promise<boolean> {
+  const tokenHash = cliUserTokenHash(request);
+  if (!tokenHash) return false;
+  const result = await prisma.cliUserToken.updateMany({
+    where: { tokenHash },
+    data: { deletedAt: new Date() },
+  });
+  return result.count > 0;
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octopus/web",
-  "version": "1.0.156",
+  "version": "1.0.157",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "apps/cli": {
       "name": "@octopus/cli",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "ink": "^6.8.0",
         "ink-select-input": "^6.2.0",
@@ -27,7 +27,7 @@
     },
     "apps/web": {
       "name": "@octopus/web",
-      "version": "1.0.154",
+      "version": "1.0.157",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.91.1",
         "@aws-sdk/client-s3": "^3.1030.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octopus",
-  "version": "1.0.156",
+  "version": "1.0.157",
   "devDependencies": {
     "turbo": "^2"
   },

--- a/packages/db/prisma/migrations/20260912005000_cli_user_sessions/migration.sql
+++ b/packages/db/prisma/migrations/20260912005000_cli_user_sessions/migration.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "cli_user_tokens" (
+  "id" TEXT NOT NULL,
+  "tokenHash" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "deletedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "cli_user_tokens_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "cli_user_tokens_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+CREATE UNIQUE INDEX "cli_user_tokens_tokenHash_key" ON "cli_user_tokens"("tokenHash");
+CREATE INDEX "cli_user_tokens_userId_idx" ON "cli_user_tokens"("userId");
+ALTER TABLE "org_api_tokens" ADD COLUMN "cliUserTokenId" TEXT;
+ALTER TABLE "org_api_tokens" ADD CONSTRAINT "org_api_tokens_cliUserTokenId_fkey" FOREIGN KEY ("cliUserTokenId") REFERENCES "cli_user_tokens"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+CREATE UNIQUE INDEX "org_api_tokens_cliUserTokenId_organizationId_key" ON "org_api_tokens"("cliUserTokenId", "organizationId");
+ALTER TABLE "cli_auth_sessions" ADD COLUMN "scope" TEXT NOT NULL DEFAULT 'organization';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -50,6 +50,7 @@ model User {
   deletedKnowledgeDocs  KnowledgeDocument[] @relation("DeletedKnowledgeDocs")
   knowledgeAuditLogs    KnowledgeAuditLog[]
   createdApiTokens      OrgApiToken[] @relation("CreatedApiTokens")
+  cliUserTokens         CliUserToken[]
   packageAnalyses       PackageAnalysis[]
   safePackageRequests   SafePackageRequest[]
   packageDeepDives      PackageDeepDive[]
@@ -911,15 +912,35 @@ model OrgApiToken {
   createdById    String
   createdBy      User @relation("CreatedApiTokens", fields: [createdById], references: [id], onDelete: Cascade)
 
+  cliUserTokenId String?
+  cliUserToken   CliUserToken? @relation(fields: [cliUserTokenId], references: [id], onDelete: Cascade)
+
   localAgents    LocalAgent[]
+
+  @@unique([cliUserTokenId, organizationId])
 
   @@index([tokenHash])
   @@map("org_api_tokens")
 }
 
+model CliUserToken {
+  id         String   @id @default(cuid())
+  tokenHash  String   @unique
+  userId     String
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  expiresAt  DateTime
+  deletedAt  DateTime?
+  createdAt  DateTime @default(now())
+  orgTokens  OrgApiToken[]
+
+  @@index([userId])
+  @@map("cli_user_tokens")
+}
+
 model CliAuthSession {
   id         String   @id @default(cuid())
   deviceCode String   @unique
+  scope      String   @default("organization")
   status     String   @default("pending") // pending | approved | expired
   token      String?  // raw token, cleared after CLI polls it
   orgId      String?


### PR DESCRIPTION
CLI login currently binds credentials to one organisation, forcing users to sign in again when projects belong to different organisations. This adds a user session: `octp login` approves the signed-in user without an organisation selector, `octp org list --json` lists current memberships, and `--org <slug|id>` selects an organisation for one command.

Repository commands infer a unique organisation from the actual command target or, when no target was supplied, the current Git remote. Ambiguous targets stop before repository work. Shared argument parsers cover positional PR URLs, flags before repository names and short targets. Local watch-list commands remain usable offline.

User sessions expire after 30 days and derive organisation-scoped credentials without replacing the saved user secret. Organisation access checks parent revocation/expiry and current membership. Logout revokes by possession even during a ban or after expiry. Legacy organisation tokens, the interactive wizard and CI `setup-token` remain supported; entering the wizard clears any command-local credential override. Homepage prompt, CLI docs and security docs explain the new flow.

Validation:
- No-mistakes review passed after fixing all five findings; focused compiled CLI and real PostgreSQL regressions passed.
- Linux ARM64 binary tested in an isolated Docker container with networking disabled: login without an organisation, switching, ambiguity blocking and offline watch operations.
- Actual approval component checked in Chrome with isolated API fixtures, including emitted approval body and success state.
- Exact SQL migration applied to the deployed schema in a dedicated PostgreSQL17 container; Prisma reported no schema difference afterward.
- Final reviewed head b923de63 passed local lint, typecheck, full test suite, production build and six real PostgreSQL auth tests (60 assertions). All five PR checks are green, including PostgreSQL CI and Octopus4/5 with zero findings. New PostgreSQL auth tests are included in CI.

Release: app1.0.157 and CLI0.6.0. Apply additive migration `20260912005000_cli_user_sessions` through normal backup/migration/deploy gates, verify the server rollout, then publish the five native CLI binaries and checksums. Previous app versions remain compatible with the expanded schema. No stack/config changes or backup-gate bypasses are included. Live published-CLI acceptance follows release.
